### PR TITLE
Check the return value for orm.RegisterDataBase()

### DIFF
--- a/pkg/common/dbm/db.go
+++ b/pkg/common/dbm/db.go
@@ -42,8 +42,12 @@ func init() {
 		dataSource = "edge.db"
 	}
 
-	orm.RegisterDriver(driverName, orm.DRSqlite)
-	orm.RegisterDataBase(dbName, driverName, dataSource)
+	if err := orm.RegisterDriver(driverName, orm.DRSqlite); err != nil {
+		log.LOGGER.Fatalf("Failed to register driver: %v", err)
+	}
+	if err := orm.RegisterDataBase(dbName, driverName, dataSource); err != nil {
+		log.LOGGER.Fatalf("Failed to register db: %v", err)
+	}
 }
 
 func InitDBManager() {


### PR DESCRIPTION
I compile kubeedge with the command below:
```bash
env GOOS=linux GOARCH=arm GOARM=5 go build cmd/edge_core.go
```
But it warns that `must have one register DataBase alias named Default`, which is pretty misleading.
After checking the return value for orm.RegisterDataBase(), I get the root case below:
```
Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work.
```