### PR TITLE
GOPATH can be empty, it will cause unclear error like "directory not …

### DIFF
--- a/hack/setup_for_IEF.sh
+++ b/hack/setup_for_IEF.sh
@@ -22,6 +22,11 @@ fi
 NODE_CONFIG_FILE=$1
 SRC_DIR=${GOPATH}/src/github.com/kubeedge/kubeedge
 
+if [ -z "${GOPATH}" ]; then
+    echo "Please export GOPATH"
+    exit 1
+fi
+
 echo "make new dir for certs..."
 if [ ! -d kubeedge_work_dir ]; then
 	mkdir kubeedge_work_dir


### PR DESCRIPTION
…found", so give explicit error