### PR TITLE
Convert sqlite_test and device_db_test in devicetwin/dtclient to table driven tests

### DIFF
--- a/pkg/devicetwin/dtclient/sqlite_test.go
+++ b/pkg/devicetwin/dtclient/sqlite_test.go
@@ -19,6 +19,7 @@ package dtclient
 import (
 	"testing"
 
+	"github.com/astaxie/beego/orm"
 	"github.com/golang/mock/gomock"
 )
 
@@ -27,151 +28,282 @@ func TestSaveTwin(t *testing.T) {
 	//Initialize Global Variables (Mocks)
 	initMocks(t)
 	InitDBTable()
-	twin := Twin{
-		DeviceID:   "TestDeviceID",
-		DeviceName: "TestName",
-		Expected:   "TestExpected",
-		Actual:     "TestActual",
+
+	cases := []struct {
+		// name is name of the testcase
+		name string
+		// returnInt is first return of mock interface ormerMock
+		returnInt int64
+		// returnErr is second return of mock interface ormerMock which is also expected error
+		returnErr error
+	}{{
+		// Success Case
+		name:      "SuccessCase",
+		returnInt: int64(1),
+		returnErr: nil,
+	}, {
+		// Failure Case
+		name:      "FailureCase",
+		returnInt: int64(1),
+		returnErr: failedDBOperationErr,
+	},
 	}
 
-	// Success Case
-	ormerMock.EXPECT().Insert(gomock.Any()).Return(int64(1), nil).Times(1)
-	err := SaveTwin(&twin)
-	t.Run("SaveTwinSuccessCase", func(t *testing.T) {
-		if err != nil {
-			t.Errorf("Save Twin Case failed : wanted error nil and got error %v", err)
-		}
-	})
-
-	// Failure Case
-	ormerMock.EXPECT().Insert(gomock.Any()).Return(int64(1), failedDBOperationErr).Times(1)
-	err = SaveTwin(&twin)
-	t.Run("SaveTwinFailCase", func(t *testing.T) {
-		want := failedDBOperationErr
-		if want != err {
-			t.Errorf("Save Twin Case failed : wanted %v and got %v", want, err)
-		}
-	})
+	// run the test cases
+	for _, test := range cases {
+		ormerMock.EXPECT().Insert(gomock.Any()).Return(test.returnInt, test.returnErr).Times(1)
+		err := SaveTwin(&Twin{})
+		t.Run(test.name, func(t *testing.T) {
+			if test.returnErr != err {
+				t.Errorf("SaveTwin case failed: wanted error %v and got error %v", test.returnErr, err)
+			}
+		})
+	}
 }
 
 // TestDeleteTwinByID is function to test DeleteTwinByID
 func TestDeleteTwinByID(t *testing.T) {
-	// Failure case
-	querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySeterMock).Times(1)
-	querySeterMock.EXPECT().Delete().Return(int64(1), failedDBOperationErr).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	err := DeleteTwinByID("test")
-	t.Run("DeleteTwinByIDFailure", func(t *testing.T) {
-		want := failedDBOperationErr
-		if want != err {
-			t.Errorf("DeleteTwinByID Case failed : wanted %v and got %v", want, err)
-		}
-	})
+	cases := []struct {
+		// name is name of the testcase
+		name string
+		// filterReturn is the return of mock interface querySeterMock's filter function
+		filterReturn orm.QuerySeter
+		// deleteReturnInt is the first return of mock interface querySeterMock's delete function
+		deleteReturnInt int64
+		// deleteReturnErr is the second return of mock interface querySeterMocks's delete function also expected error
+		deleteReturnErr error
+		// queryTableReturn is the return of mock interface ormerMock's QueryTable function
+		queryTableReturn orm.QuerySeter
+	}{{
+		// Success Case
+		name:             "SuccessCase",
+		filterReturn:     querySeterMock,
+		deleteReturnInt:  int64(1),
+		deleteReturnErr:  nil,
+		queryTableReturn: querySeterMock,
+	}, {
+		// Failure Case
+		name:             "FailureCase",
+		filterReturn:     querySeterMock,
+		deleteReturnInt:  int64(0),
+		deleteReturnErr:  failedDBOperationErr,
+		queryTableReturn: querySeterMock,
+	},
+	}
 
-	// Success Case
-	querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySeterMock).Times(1)
-	querySeterMock.EXPECT().Delete().Return(int64(1), nil).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	err = DeleteTwinByID("test")
-	t.Run("DeleteTwinByIDSuccess", func(t *testing.T) {
-		if err != nil {
-			t.Errorf("DeleteTwinByID Case failed : wanted err nil and got err %v", err)
-		}
-	})
+	// run the test cases
+	for _, test := range cases {
+		querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(1)
+		querySeterMock.EXPECT().Delete().Return(test.deleteReturnInt, test.deleteReturnErr).Times(1)
+		ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
+		err := DeleteTwinByID("test")
+		t.Run(test.name, func(t *testing.T) {
+			if test.deleteReturnErr != err {
+				t.Errorf("DeleteTwinByID case failed: wanted %v and got %v", test.deleteReturnErr, err)
+			}
+		})
+	}
 }
 
 // TestUpdateTwinField is function to test UpdateTwinField
 func TestUpdateTwinField(t *testing.T) {
-	// Failure Case
-	querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySeterMock).Times(1)
-	querySeterMock.EXPECT().Update(gomock.Any()).Return(int64(1), failedDBOperationErr).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	err := UpdateTwinField("test", "test", "test")
-	t.Run("UpdateTwinFieldFailure", func(t *testing.T) {
-		want := failedDBOperationErr
-		if want != err {
-			t.Errorf("UpdateTwinField Case failed : wanted %v and got %v", want, err)
-		}
-	})
+	cases := []struct {
+		// name is name of the testcase
+		name string
+		// filterReturn is the return of mock interface querySeterMock's filter function
+		filterReturn orm.QuerySeter
+		// updateReturnInt is the first return of mock interface querySeterMock's update function
+		updateReturnInt int64
+		// updateReturnErr is the second return of mock interface querySeterMocks's update function also expected error
+		updateReturnErr error
+		// queryTableReturn is the return of mock interface ormerMock's QueryTable function
+		queryTableReturn orm.QuerySeter
+	}{{
+		// Success Case
+		name:             "SuccessCase",
+		filterReturn:     querySeterMock,
+		updateReturnInt:  int64(1),
+		updateReturnErr:  nil,
+		queryTableReturn: querySeterMock,
+	}, {
+		// Failure Case
+		name:             "FailureCase",
+		filterReturn:     querySeterMock,
+		updateReturnInt:  int64(0),
+		updateReturnErr:  failedDBOperationErr,
+		queryTableReturn: querySeterMock,
+	},
+	}
+
+	// run the test cases
+	for _, test := range cases {
+		querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(1)
+		querySeterMock.EXPECT().Update(gomock.Any()).Return(test.updateReturnInt, test.updateReturnErr).Times(1)
+		ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
+		err := UpdateTwinField("test", "test", "test")
+		t.Run(test.name, func(t *testing.T) {
+			if test.updateReturnErr != err {
+				t.Errorf("UpdateTwinField case failed: wanted %v and got %v", test.updateReturnErr, err)
+			}
+		})
+	}
 }
 
 // TestUpdateTwinFields is function to test UpdateTwinFields
 func TestUpdateTwinFields(t *testing.T) {
-	// Failure Case
-	querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySeterMock).Times(1)
-	querySeterMock.EXPECT().Update(gomock.Any()).Return(int64(1), failedDBOperationErr).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	err := UpdateTwinFields("test", make(map[string]interface{}))
-	t.Run("UpdateTwinFieldsFailure", func(t *testing.T) {
-		want := failedDBOperationErr
-		if want != err {
-			t.Errorf("UpdateTwinFields Case failed : wanted %v and got %v", want, err)
-		}
-	})
+	cases := []struct {
+		// name is name of the testcase
+		name string
+		// filterReturn is the return of mock interface querySeterMock's filter function
+		filterReturn orm.QuerySeter
+		// updateReturnInt is the first return of mock interface querySeterMock's update function
+		updateReturnInt int64
+		// updateReturnErr is the second return of mock interface querySeterMocks's update function also expected error
+		updateReturnErr error
+		// queryTableReturn is the return of mock interface ormerMock's QueryTable function
+		queryTableReturn orm.QuerySeter
+	}{{
+		// Success Case
+		name:             "SuccessCase",
+		filterReturn:     querySeterMock,
+		updateReturnInt:  int64(1),
+		updateReturnErr:  nil,
+		queryTableReturn: querySeterMock,
+	}, {
+		// Failure Case
+		name:             "FailureCase",
+		filterReturn:     querySeterMock,
+		updateReturnInt:  int64(0),
+		updateReturnErr:  failedDBOperationErr,
+		queryTableReturn: querySeterMock,
+	},
+	}
+
+	// run the test cases
+	for _, test := range cases {
+		querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(1)
+		querySeterMock.EXPECT().Update(gomock.Any()).Return(test.updateReturnInt, test.updateReturnErr).Times(1)
+		ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
+		err := UpdateTwinFields("test", make(map[string]interface{}))
+		t.Run(test.name, func(t *testing.T) {
+			if test.updateReturnErr != err {
+				t.Errorf("UpdateTwinFields case failed: wanted %v and got %v", test.updateReturnErr, err)
+			}
+		})
+	}
 }
 
 // TestQueryTwin is function to test QueryTwin
 func TestQueryTwin(t *testing.T) {
-	// Failure case
-	querySeterMock.EXPECT().All(gomock.Any()).Return(int64(1), failedDBOperationErr).Times(1)
-	querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySeterMock).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	device, err := QueryTwin("test", "test")
-	t.Run("QueryTwinCheckError", func(t *testing.T) {
-		want := failedDBOperationErr
-		if want != err {
-			t.Errorf("QueryTwin Case failed : wanted %v and got %v", want, err)
-		}
-	})
+	cases := []struct {
+		// name is name of the testcase
+		name string
+		// filterReturn is the return of mock interface querySeterMock's filter function
+		filterReturn orm.QuerySeter
+		// allReturnInt is the first return of mock interface querySeterMock's all function
+		allReturnInt int64
+		// allReturnErr is the second return of mock interface querySeterMocks's all function also expected error
+		allReturnErr error
+		// queryTableReturn is the return of mock interface ormerMock's QueryTable function
+		queryTableReturn orm.QuerySeter
+	}{{
+		// Success Case
+		name:             "SuccessCase",
+		filterReturn:     querySeterMock,
+		allReturnInt:     int64(1),
+		allReturnErr:     nil,
+		queryTableReturn: querySeterMock,
+	}, {
+		// Failure Case
+		name:             "FailureCase",
+		filterReturn:     querySeterMock,
+		allReturnInt:     int64(0),
+		allReturnErr:     failedDBOperationErr,
+		queryTableReturn: querySeterMock,
+	},
+	}
 
-	// Success case
+	// fakeTwin is used to set the argument of All function
 	fakeTwin := new([]Twin)
 	fakeTwinArray := make([]Twin, 1)
 	fakeTwinArray[0] = Twin{DeviceID: "Test"}
 	fakeTwin = &fakeTwinArray
-	querySeterMock.EXPECT().All(gomock.Any()).SetArg(0, *fakeTwin).Return(int64(1), nil).Times(1)
-	querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySeterMock).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	device, err = QueryTwin("test", "test")
-	t.Run("QueryTwinSuccessCase", func(t *testing.T) {
-		if err != nil {
-			t.Errorf("QueryTwin Case Failed,Expected a error nil and got %v", err)
-		}
-		want := 1
-		if want != len(*device) {
-			t.Errorf("QueryTwin Case failed wanted length %v and got length %v", want, len(*device))
-		}
-	})
+
+	// run the test cases
+	for _, test := range cases {
+		querySeterMock.EXPECT().All(gomock.Any()).SetArg(0, *fakeTwin).Return(test.allReturnInt, test.allReturnErr).Times(1)
+		querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(1)
+		ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
+		twin, err := QueryTwin("test", "test")
+		t.Run(test.name, func(t *testing.T) {
+			// check err
+			if test.allReturnErr != err {
+				t.Errorf("QueryTwin case failed: wanted error %v and got error %v", test.allReturnErr, err)
+				return
+			}
+
+			if err == nil {
+				if len(*twin) != 1 {
+					t.Errorf("QueryTwin case failed: wanted length 1 and got length %v", len(*twin))
+				}
+			}
+		})
+	}
 }
 
 // TestQueryTwinAll is function to test QueryTwinAll
 func TestQueryTwinAll(t *testing.T) {
-	// Failure case
-	querySeterMock.EXPECT().All(gomock.Any()).Return(int64(1), failedDBOperationErr).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	device, err := QueryTwinAll()
-	t.Run("QueryTwinAllCheckError", func(t *testing.T) {
-		want := failedDBOperationErr
-		if want != err {
-			t.Errorf("QueryTwinAll Case failed : wanted %v and got %v", want, err)
-		}
-	})
+	cases := []struct {
+		// name is name of the testcase
+		name string
+		// filterReturn is the return of mock interface querySeterMock's filter function
+		filterReturn orm.QuerySeter
+		// allReturnInt is the first return of mock interface querySeterMock's all function
+		allReturnInt int64
+		// allReturnErr is the second return of mock interface querySeterMocks's all function also expected error
+		allReturnErr error
+		// queryTableReturn is the return of mock interface ormerMock's QueryTable function
+		queryTableReturn orm.QuerySeter
+	}{{
+		// Success Case
+		name:             "SuccessCase",
+		filterReturn:     querySeterMock,
+		allReturnInt:     int64(1),
+		allReturnErr:     nil,
+		queryTableReturn: querySeterMock,
+	}, {
+		// Failure Case
+		name:             "FailureCase",
+		filterReturn:     querySeterMock,
+		allReturnInt:     int64(0),
+		allReturnErr:     failedDBOperationErr,
+		queryTableReturn: querySeterMock,
+	},
+	}
 
-	// Success case
+	// fakeTwin is used to set the argument of All function
 	fakeTwin := new([]Twin)
 	fakeTwinArray := make([]Twin, 1)
 	fakeTwinArray[0] = Twin{DeviceID: "Test"}
 	fakeTwin = &fakeTwinArray
-	querySeterMock.EXPECT().All(gomock.Any()).SetArg(0, *fakeTwin).Return(int64(1), nil).Times(1)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySeterMock).Times(1)
-	device, err = QueryTwinAll()
-	t.Run("QueryTwinAllSuccessCase", func(t *testing.T) {
-		if err != nil {
-			t.Errorf("QueryTwinAll Case Failed,Expected a error nil and got %v", err)
-		}
-		want := 1
-		if want != len(*device) {
-			t.Errorf("QueryTwinAll Case failed wanted length %v and got length %v", want, len(*device))
-		}
-	})
+
+	// run the test cases
+	for _, test := range cases {
+		querySeterMock.EXPECT().All(gomock.Any()).SetArg(0, *fakeTwin).Return(test.allReturnInt, test.allReturnErr).Times(1)
+		querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(1)
+		ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
+		twin, err := QueryTwinAll()
+		t.Run(test.name, func(t *testing.T) {
+			if test.allReturnErr != err {
+				t.Errorf("QueryTwinAll case failed: wanted error %v and got error %v", test.allReturnErr, err)
+				return
+			}
+
+			if err == nil {
+				if len(*twin) != 1 {
+					t.Errorf("QueryTwinAll case failed: wanted length 1 and got length %v", len(*twin))
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Convert sqlite_test.go and device_db_test.go in devicetwin/dtclient to table driven tests.