### PR TITLE
Removing the Unused data structure from config

### DIFF
--- a/pkg/edgehub/config/config.go
+++ b/pkg/edgehub/config/config.go
@@ -42,14 +42,6 @@ type ControllerConfig struct {
 	NodeID          string
 }
 
-//DISClientConfig is Huawei data injection service
-type DISClientConfig struct {
-	APIGatewayURL string
-	APIVersion    string
-	RegionID      string
-	ProjectID     string
-}
-
 //EdgeHubConfig edge hub configuration object containing web socket and controller configuration
 type EdgeHubConfig struct {
 	WSConfig  WebSocketConfig


### PR DESCRIPTION
Removing the Unused data structure from config
DisClientconfig structure is unused .Hence , removing the unused code