### PR TITLE
141: Code implemented for cleanup. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 
 sudo: true
 
+env:
+  - CONTINUOUS_INTEGRATION=true
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-sudo: required
+sudo: true
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 
 export GOARCHAIUS_CONFIG_PATH=$(CURDIR)
 test:
-	find ${TEST_DIR} -name "*_test.go"|xargs -i dirname {}|uniq|xargs -i go test ${T} {}
+	find ${TEST_DIR} -name "*_test.go"|xargs -i dirname {}|uniq|xargs -i sudo -E env "PATH=${PATH}" go test ${T} {}
 
 # verify
 .PHONY: verify

--- a/pkg/edged/containers/container_manager.go
+++ b/pkg/edged/containers/container_manager.go
@@ -1,13 +1,13 @@
 // +build linux
 
 /*
-Copyright 2015 The Kubernetes Authors.
+Copyright 2019 The KubeEdge Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package containers : containerManager is derived from "k8s.io/kubernetes/pkg/kubelet/cm/container_manager_linux.go"
-// runed extra interface  and changed most of the realization
 package containers
 
 import (
@@ -58,9 +56,8 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/edged/securitycontext"
 )
 
-//Pod details constants
+//Pod constants required by the manager
 const (
-	// Taken from lmctfy https://github.com/google/lmctfy/blob/master/lmctfy/controllers/cpu_controller.cc
 	minShares     = 2
 	sharesPerCPU  = 1024
 	milliCPUToCPU = 1000
@@ -166,7 +163,7 @@ const (
 //NewContainerManager initialises and returns a container manager object
 func NewContainerManager(runtimeService cri.RuntimeService, livenessManager proberesults.Manager, containerBackOff *flowcontrol.Backoff, devicePluginEnabled bool, gpuManager gpu.GPUManager, interfaceName string) (ContainerManager, error) {
 	var devicePluginManager deviceplugin.Manager
-	var err error
+	var cmErr error
 	cm := &containerManager{
 		Mock:                     new(testing.Mock),
 		runtimeService:           runtimeService,
@@ -178,13 +175,13 @@ func NewContainerManager(runtimeService cri.RuntimeService, livenessManager prob
 		livenessManager:          livenessManager,
 	}
 	if devicePluginEnabled {
-		devicePluginManager, err = deviceplugin.NewManagerImpl()
+		devicePluginManager, cmErr = deviceplugin.NewManagerImpl()
 	} else {
-		devicePluginManager, err = deviceplugin.NewManagerStub()
+		devicePluginManager, cmErr = deviceplugin.NewManagerStub()
 	}
 
-	if err != nil {
-		return nil, err
+	if cmErr != nil {
+		return nil, cmErr
 	}
 	cm.devicePluginManager = devicePluginManager
 	return cm, nil

--- a/pkg/edged/containers/container_manager_test.go
+++ b/pkg/edged/containers/container_manager_test.go
@@ -1,0 +1,98 @@
+package containers
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kubeedge/kubeedge/pkg/edged/apis/runtime/cri"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/util/flowcontrol"
+	"k8s.io/kubernetes/pkg/kubelet/gpu"
+	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
+)
+
+// edged socket is the path of the edged registry socket
+var kubePath = "/var/lib/kubelet"
+var pluginPath = kubePath + "/device-plugins/"
+
+func tearDownTestNewContainerManager(t *testing.T) {
+	if _, serr := os.Stat(pluginPath); serr == nil {
+		merr := os.RemoveAll(kubePath)
+		if merr != nil {
+			t.Fatalf("removeAll %s directory failed: %s", kubePath, merr.Error())
+			os.Exit(1)
+		}
+	} else {
+		t.Fatalf("stat of %s path failed: %s", pluginPath, serr.Error())
+		os.Exit(1)
+	}
+}
+
+func TestNewContainerManager(t *testing.T) {
+
+	cases := []struct {
+		// name is name of the testcase
+		name string
+		// testcase Identifier
+		testID int
+		// container runtime service
+		runtimeService cri.RuntimeService
+		// container probe manager
+		livenessManager proberesults.Manager
+		// containerBackOff for flow control
+		containerBackOff *flowcontrol.Backoff
+		// Enable device plugin it is either true or false
+		devicePluginEnabled bool
+		// GPU manager instance
+		gpuManager gpu.GPUManager
+		// interface name
+		interfaceName string
+		// returnErr is second return of mock interface ormerMock which is also expected error
+		returnErr string
+	}{{
+		name:                "NewContainerManager - SuccessCase with device plugin enabled",
+		testID:              1,
+		runtimeService:      nil,
+		livenessManager:     proberesults.NewManager(),
+		containerBackOff:    flowcontrol.NewBackOff(10*time.Second, 300*time.Second),
+		devicePluginEnabled: true,
+		gpuManager:          gpu.NewGPUManagerStub(),
+		interfaceName:       "docker0",
+		returnErr:           "",
+	}, {
+		name:                "NewContainerManager - SuccessCase with device plugin disabled",
+		testID:              2,
+		runtimeService:      nil,
+		livenessManager:     proberesults.NewManager(),
+		containerBackOff:    flowcontrol.NewBackOff(10*time.Second, 300*time.Second),
+		devicePluginEnabled: false,
+		gpuManager:          gpu.NewGPUManagerStub(),
+		interfaceName:       "docker0",
+		returnErr:           "",
+	},
+	// There aren't any kind of failure scenario, unless system calls are mocked to stat and create directory.
+	// It would be an un-necessary effort to create mocks for those functions.
+	// Hence for this function failure scenario is not covered.
+	}
+
+	// run the test cases
+	for _, test := range cases {
+		result, err := NewContainerManager(test.runtimeService, test.livenessManager, test.containerBackOff, test.devicePluginEnabled, test.gpuManager, test.interfaceName)
+		assert.NotEmptyf(t, result, "container Manager object creation for testID %d failed", test.testID)
+		assert.Emptyf(t, err, "container Manager object creation for testID %d failed", test.testID)
+		if err != nil {
+			t.Fatalf("test failed due to error %s", err.Error())
+		}
+
+		if test.devicePluginEnabled == true {
+			// While creating newContainerManager instance, it creates directory structure of pluginapi edgeD Socket path("/var/lib/xxxx/device-plugins/") if it didn't exist.
+			// Checking this paths creation as well for UT verification, before teardown (cleanup of filesystem from UT residuals)
+			_, serr := os.Stat(pluginPath)
+			assert.Emptyf(t, serr, "pluginapi edgeD Socket path creation for testID %d failed", test.testID)
+
+			tearDownTestNewContainerManager(t)
+		}
+	}
+}

--- a/pkg/edged/containers/container_manager_test.go
+++ b/pkg/edged/containers/container_manager_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package containers
 
 import (


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
 /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
This PR starts the process of clean in edged module and also adds UT cases for the file which aren't present.

**Which issue(s) this PR fixes**:
Fixes #141 

**Special notes for your reviewer**:

Cleanup shall be done part by part. It will be done function by function, so that there are no major changes for one push. Helps in maintaining the sanity of the functionality and review process.
Currently only done for kubeedge\pkg\edged\containers\container_manager.go - NewContainerManager()

Compilation and UT report:
root@ubuntu1804VM:/home/ubuntu/gopath/src/github.com/kubeedge/kubeedge# make
go build cmd/edge_core.go
root@ubuntu1804VM:/home/ubuntu/gopath/src/github.com/kubeedge/kubeedge# make test
find "./pkg/" -name "*_test.go"|xargs -i dirname {}|uniq|xargs -i go test  {}
ok  	github.com/kubeedge/kubeedge/pkg/edgehub	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/edgehub/common/http	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/edgehub/config	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/eventbus/common/util	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/edged/containers	0.025s
ok  	github.com/kubeedge/kubeedge/pkg/edged/dockertools	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/devicetwin	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/devicetwin/dtclient	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/devicetwin/dtcommon	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/devicetwin/dtmodule	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/metamanager	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/metamanager/dao	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/metamanager	(cached)
ok  	github.com/kubeedge/kubeedge/pkg/common/dbm	(cached)

Golint report:
root@ubuntu1804VM:/home/ubuntu/gopath/src/github.com/kubeedge/kubeedge# make verify
bash -x hack/verify.sh
+ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/go/bin:/root/gopath/bin:/usr/local/go/bin:/home/ubuntu/gopath/bin:/home/ubuntu/gopath/src/github.com/kubeedge/kubeedge/bin
+ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/go/bin:/root/gopath/bin:/usr/local/go/bin:/home/ubuntu/gopath/bin:/home/ubuntu/gopath/src/github.com/kubeedge/kubeedge/bin
+ gometalinter --disable-all --enable=gofmt --enable=misspell --exclude=vendor ./...
+ '[' 0 '!=' 0 ']'



