### PR TITLE
edged: added correct return for configmaps

### DIFF
--- a/pkg/edged/volume_host.go
+++ b/pkg/edged/volume_host.go
@@ -122,7 +122,9 @@ func (evh *edgedVolumeHost) GetWriter() io.Writer                         { retu
 func (evh *edgedVolumeHost) GetHostName() string                          { return evh.edge.hostname }
 func (evh *edgedVolumeHost) GetCloudProvider() cloudprovider.Interface    { return nil }
 func (evh *edgedVolumeHost) GetConfigMapFunc() func(namespace, name string) (*api.ConfigMap, error) {
-	return nil
+	return func(namespace, name string) (*api.ConfigMap, error) {
+		return evh.edge.metaClient.ConfigMaps(namespace).Get(name)
+	}
 }
 func (evh *edgedVolumeHost) GetExec(pluginName string) mount.Exec          { return nil }
 func (evh *edgedVolumeHost) GetHostIP() (net.IP, error)                    { return nil, nil }


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
Changed hardcoded nil to correct return for config maps. It is needed to create pods having config-maps

