### PR TITLE
docs: Added instructions to cross compile for ARM archit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeed
 cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
 make # or `make edge_core`
 ```
+KubeEdge can also be cross compiled to run on ARM based processors.
+Please click [Cross Compilation](docs/setup/cross-compilation.md) for the instructions.
 
 ### Run Edge
 

--- a/docs/setup/cross-compilation.md
+++ b/docs/setup/cross-compilation.md
@@ -1,0 +1,19 @@
+# Cross Compiling KubeEdge 
+
+#### Cross compiling for ARM Architecture from x86 Architecture 
+
+Clone KubeEdge
+
+```shell
+# Build and run KubeEdge on a ARMv6 target device.
+
+git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
+cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
+sudo apt-get install gcc-arm-linux-gnueabi
+export GOARCH=arm
+export GOOS="linux"
+export GOARM=6                             #Pls give the appropriate arm version of your device                               
+export CGO_ENABLED=1
+export CC=arm-linux-gnueabi-gcc
+make # or `make edge_core`
+```


### PR DESCRIPTION
**What type of PR is this?**
kind documentation

**What this PR does / why we need it**:
This PR gives instructions on how to cross compile Kubeedge for ARM based devices from x86 devices

**Which issue(s) this PR fixes**:
Fixes #160 

