### PR TITLE
Fixing README.md to execute UT and IT correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ If you are using HuaweiCloud IEF, then the edge node you created should be runni
 ### Run Edge Unit Tests
 
  ```shell
- make test
+ make edge_test
  ```
  To run unit tests of a package individually 
  ```shell
@@ -165,8 +165,7 @@ If you are using HuaweiCloud IEF, then the edge node you created should be runni
 ### Run Edge Integration Tests
 
 ```shell 
-cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
-make integration_test
+make edge_integration_test
 ```
 
 ### Details and use cases of integration test framework


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind bug

**What this PR does / why we need it**:
README.md was showing incorrect execution steps for running UT and IT.
We have modified the README.md to show correct steps.

**Which issue(s) this PR fixes**:
Fixes #167 

**Special notes for your reviewer**:
None