### PR TITLE
DeviceTwin: Modifying testcases of dttype

### DIFF
--- a/edge/pkg/devicetwin/dttype/types_helper_test.go
+++ b/edge/pkg/devicetwin/dttype/types_helper_test.go
@@ -599,33 +599,42 @@ func TestBuildDeviceTwinResult(t *testing.T) {
 
 // TestBuildErrorResult is function to test BuildErrorResult().
 func TestBuildErrorResult(t *testing.T) {
-	result := Result{BaseMessage: BaseMessage{Timestamp: time.Now().UnixNano() / 1e6,
+	result := Result{BaseMessage: BaseMessage{
 		EventID: ""},
 		Code:   1,
 		Reason: ""}
-	bytesResult, _ := json.Marshal(result)
 	tests := []struct {
 		name    string
 		para    Parameter
-		want    []byte
+		want    Result
 		wantErr error
 	}{
 		{
 			name:    "BuildErrorResultTest",
 			para:    Parameter{EventID: "", Code: 1, Reason: ""},
-			want:    bytesResult,
+			want:    result,
 			wantErr: nil,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := BuildErrorResult(test.para)
+			gotResult := Result{}
+			json.Unmarshal(got, &gotResult)
 			if !reflect.DeepEqual(err, test.wantErr) {
 				t.Errorf("BuildErrorResult() error = %v, wantErr %v", err, test.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildErrorResult() = %v, want %v", got, test.want)
+			if !reflect.DeepEqual(gotResult.EventID, test.want.EventID) {
+				t.Errorf("BuildErrorResult() error EventID = %v, want = %v", gotResult.EventID, test.want.EventID)
+				return
+			}
+			if !reflect.DeepEqual(gotResult.Reason, test.want.Reason) {
+				t.Errorf("BuildErrorResult() error Reason = %v, want = %v", gotResult.Reason, test.want.Reason)
+				return
+			}
+			if !reflect.DeepEqual(gotResult.Code, test.want.Code) {
+				t.Errorf("BuildErrorResult() error Code = %v, want = %v", gotResult.Code, test.want.Code)
 			}
 		})
 	}
@@ -761,7 +770,8 @@ func TestBuildDeviceTwinDocument(t *testing.T) {
 	twinDoc := make(map[string]*TwinDoc)
 	doc := TwinDoc{LastState: &MsgTwin{Metadata: &TypeMetadata{"updated"}}, CurrentState: &MsgTwin{Metadata: &TypeMetadata{"deleted"}}}
 	twinDoc["SensorTag"] = &doc
-	devTwinDoc := DeviceTwinDocument{BaseMessage: BaseMessage{EventID: "", Timestamp: time.Now().UnixNano() / 1e6}, Twin: twinDoc}
+	timeStamp := time.Now().UnixNano() / 1e6
+	devTwinDoc := DeviceTwinDocument{BaseMessage: BaseMessage{EventID: "", Timestamp: timeStamp}, Twin: twinDoc}
 	bytesdevTwinDoc, _ := json.Marshal(devTwinDoc)
 	tests := []struct {
 		name        string
@@ -772,7 +782,7 @@ func TestBuildDeviceTwinDocument(t *testing.T) {
 	}{
 		{
 			name:        "BuildDeviceTwinDocumentTest",
-			baseMessage: BaseMessage{EventID: "", Timestamp: time.Now().UnixNano() / 1e6},
+			baseMessage: BaseMessage{EventID: "", Timestamp: timeStamp},
 			twins:       twinDoc,
 			want:        bytesdevTwinDoc,
 			wantBool:    true,
@@ -780,12 +790,12 @@ func TestBuildDeviceTwinDocument(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, got1 := BuildDeviceTwinDocument(test.baseMessage, test.twins)
+			got, gotBool := BuildDeviceTwinDocument(test.baseMessage, test.twins)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("BuildDeviceTwinDocument() got = %v, want %v", got, test.want)
 			}
-			if got1 != test.wantBool {
-				t.Errorf("BuildDeviceTwinDocument() got1 = %v, want %v", got1, test.wantBool)
+			if gotBool != test.wantBool {
+				t.Errorf("BuildDeviceTwinDocument() gotBool = %v, want %v", gotBool, test.wantBool)
 			}
 		})
 	}

--- a/edge/pkg/devicetwin/dttype/types_test.go
+++ b/edge/pkg/devicetwin/dttype/types_test.go
@@ -30,7 +30,6 @@ import (
 func TestSetEventID(t *testing.T) {
 	tests := []struct {
 		name      string
-		timestamp int64
 		eventID   string
 	}{
 		{

--- a/edge/pkg/edgehub/common/http/http_test.go
+++ b/edge/pkg/edgehub/common/http/http_test.go
@@ -17,61 +17,19 @@ limitations under the License.
 package http
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
 	"reflect"
-	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/kubeedge/kubeedge/edge/pkg/common/util"
-	common "github.com/kubeedge/kubeedge/edge/pkg/edgehub/common"
 )
 
 const (
-	CesMetricDataURL = "https://huaweicloud.com/V1.0"
-	CertFile         = "/tmp/kubeedge/testData/edge.crt"
-	KeyFile          = "/tmp/kubeedge/testData/edge.key"
+	CertFile = "/tmp/kubeedge/testData/edge.crt"
+	KeyFile  = "/tmp/kubeedge/testData/edge.key"
 )
-
-//TestBuildRequest() tests the building of a proper http Requests
-func TestBuildRequest(t *testing.T) {
-	_, err := BuildRequest(http.MethodPost, CesMetricDataURL, nil, "")
-	if err != nil {
-		t.Fatalf("Failed to build http request , error is %v", err.Error())
-	}
-}
-
-//TestBuildRequestInvalidMethod() tests the validation of incorrect HTTP methods
-func TestBuildRequestInvalidMethod(t *testing.T) {
-	_, err := BuildRequest("#$%@!@", CesMetricDataURL, nil, "")
-	if err == nil {
-		t.Fatalf("Failed to validate incorrect HTTP method")
-	}
-}
-
-//TestBuildRequestWithToken() tests the building of HTTP requests with token
-func TestBuildRequestWithToken(t *testing.T) {
-	req, err := BuildRequest(http.MethodPost, CesMetricDataURL, nil, "abc")
-	if err != nil {
-		t.Fatalf("Failed to build request with token , error is %v", err.Error())
-	}
-	assert.NotNil(t, req.Header.Get("Content-Type"))
-}
-
-//TestBuildRequestWithBody() tests the building of HTTP requests with a body present
-func TestBuildRequestWithBody(t *testing.T) {
-	body, _ := ioutil.ReadFile("request.json")
-	ioBody := bytes.NewReader(body)
-	_, err := BuildRequest(http.MethodPost, CesMetricDataURL, ioBody, "abc")
-	if err != nil {
-		t.Fatalf("Failed to build request with token , error is %v", err.Error())
-	}
-}
 
 //TestNewHttpClient() tests the creation of a new HTTP client
 func TestNewHttpClient(t *testing.T) {
@@ -79,20 +37,6 @@ func TestNewHttpClient(t *testing.T) {
 	if httpClient == nil {
 		t.Fatal("Failed to build HTTP client")
 	}
-}
-
-//TestSendRequest() tests the send functionality of HTTP requests
-func TestSendRequest(t *testing.T) {
-	body, _ := ioutil.ReadFile("request.json")
-	ioBody := bytes.NewReader(body)
-	req, err := BuildRequest(http.MethodPost, CesMetricDataURL, ioBody, "abc")
-	if err != nil {
-		t.Fatalf("Failed to build request with token , error is %v", err.Error())
-	}
-	resp, err := SendRequest(req, NewHTTPClient())
-	assert.NotNil(t, resp)
-	common.AssertIntEqual(t, strconv.Itoa(http.StatusNotFound), strconv.Itoa(resp.StatusCode), "return code not match")
-
 }
 
 //TestNewHTTPSclient() tests the creation of a new HTTPS client with proper values


### PR DESCRIPTION
This commit modifies some of testcases in types_helper.go and types.go. Also it removes some unwanted code from edgehub/common/http/http_test.go

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR fixes some flaky test cases in devicetwin/dttype and edgehub/common/http