### PR TITLE
Added the proposals folder to the exclude list in readthedocs config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [u'_build', 'proposals', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR adds the `proposals` folder to the exclude list in the readthedocs configuration. Currently the proposals folder also gets parsed and added to the document tree but there is no link to the pages as we have not added it to the TOC. Excluding the folder will make sure that the proposals are not generated and are kept only in the docs folder.

/assign @rohitsardesai83 @m1093782566 