### PR TITLE
Fix inappropriate logic of context_channel_test.go

### DIFF
--- a/common/beehive/pkg/core/context/context_channel_test.go
+++ b/common/beehive/pkg/core/context/context_channel_test.go
@@ -19,8 +19,8 @@ func TestSendSync(t *testing.T) {
 		fmt.Printf("resp: %v, error: %v\n", resp, err)
 	}()
 
-	msg := coreContext.Receive("test_dest")
-	fmt.Printf("receive msg: %v\n", msg)
+	msg, err := coreContext.Receive("test_dest")
+	fmt.Printf("receive msg, error: %v\n", msg, err)
 	resp := msg.NewRespByMessage(&msg, "how are you")
 	coreContext.SendResp(*resp)
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

As coreContext.Receive returns (model.Message, error), return param should contain them all.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #211 

**Special notes for your reviewer**:
