### PR TITLE
Fixed a broken link to the cloudhub documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeedge/kubeedge)](https://goreportcard.com/report/github.com/kubeedge/kubeedge)
 [![LICENSE](https://img.shields.io/github/license/kubeedge/kubeedge.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/blob/master/LICENSE)
 [![Releases](https://img.shields.io/github/release/kubeedge/kubeedge/all.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/releases)
+[![Documentation Status](https://readthedocs.org/projects/kubeedge/badge/?version=latest)](https://kubeedge.readthedocs.io/en/latest/?badge=latest)
 
 
 <img src="./docs/images/KubeEdge_logo.png">

--- a/README_zh.md
+++ b/README_zh.md
@@ -3,6 +3,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeedge/kubeedge)](https://goreportcard.com/report/github.com/kubeedge/kubeedge)
 [![LICENSE](https://img.shields.io/github/license/kubeedge/kubeedge.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/blob/master/LICENSE)
 [![Releases](https://img.shields.io/github/release/kubeedge/kubeedge/all.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/releases)
+[![Documentation Status](https://readthedocs.org/projects/kubeedge/badge/?version=latest)](https://kubeedge.readthedocs.io/en/latest/?badge=latest)
 
 
 ![logo](./docs/images/KubeEdge_logo.png)

--- a/docs/modules/kubeedge.md
+++ b/docs/modules/kubeedge.md
@@ -27,7 +27,7 @@ KubeEdge is composed of these components:
 
 - **Edged:** an agent that runs on edge nodes and manages containerized applications.
 - **[EdgeHub](edge/edgehub.html):** a web socket client responsible for interacting with Cloud Service for edge computing (like Edge Controller as in the KubeEdge Architecture). This includes syncing cloud-side resource updates to the edge and reporting edge-side host and device status changes to the cloud.
-- **[CloudHub](cloud/CloudHub.html):**: A web socket server responsible for watching changes at the cloud side, caching and sending messages to EdgeHub. 
+- **[CloudHub](cloud/cloudhub.html):**: A web socket server responsible for watching changes at the cloud side, caching and sending messages to EdgeHub. 
 - **[EdgeController](cloud/controller.html)**: an extended kubernetes controller which manages edge nodes and pods metadata so that the data can be targeted to a specific edge node.   
 - **[EventBus](edge/eventbus.html):** an MQTT client to interact with MQTT servers (mosquitto), offering publish and subscribe capabilities to other components.
 - **[DeviceTwin](edge/devicetwin.html):** responsible for storing device status and syncing device status to the cloud. It also provides query interfaces for applications.


### PR DESCRIPTION
**What type of PR is this?**
 /kind documentation


**What this PR does / why we need it**:
The link to the Cloud Hub page under General Concepts -> KubeEdge was broken due to the change in filename. Fixed the broken link.

Also added the documentation build badges to both the Readme files.
**Special notes for your reviewer**:
None

/assign @m1093782566 @rohitsardesai83 