### PR TITLE
use value interface of goarchaius config framework to get mqtt mode

### DIFF
--- a/edge/pkg/eventbus/event_bus.go
+++ b/edge/pkg/eventbus/event_bus.go
@@ -34,14 +34,11 @@ type eventbus struct {
 }
 
 func init() {
-	mode := config.CONFIG.GetConfigurationByKey("mqtt.mode")
-	if mode == nil {
+	mode, err := config.CONFIG.GetValue("mqtt.mode").ToInt()
+	if err != nil || mode > externalMqttMode || mode < internalMqttMode {
 		mode = internalMqttMode
 	}
-	if mode.(int) > externalMqttMode || mode.(int) < internalMqttMode {
-		panic("mqtt.mode should be one of [0,1,2]")
-	}
-	edgeEventHubModule := eventbus{mqttMode: mode.(int)}
+	edgeEventHubModule := eventbus{mqttMode: mode}
 	core.Register(&edgeEventHubModule)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

Use value interface of goarchaius config framework to get mqtt mode. The original logic cast directly to int, it may panic if the underneath value is not an int, this happens when using environment variable overwriting config entry, the value always be a string. The value interface of goarchaius provides many handy `ToXX` methods that can handle this well.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #249 

**Special notes for your reviewer**:

The `mqtt.mode` config entry was config by yaml by default, the yaml content is parsed into a

```golang
map[string]interface{}
```

so with `mqtt.mode` key, we can get the int value. However if we overwrite this config entry by environment variable, with the same key, we got a string literal of the number.