### PR TITLE
doc: optimize slack url in readme and readme_zn

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,4 +353,4 @@ If you have questions, feel free to reach out to us in the following ways:
 
 - [mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 
-- [slack](kubeedge.slack.com)
+- [slack](https://kubeedge.slack.com)

--- a/README_zh.md
+++ b/README_zh.md
@@ -354,4 +354,4 @@ make edge_integration_test
 
 - [mailing list](https://groups.google.com/forum/#!forum/kubeedge)
 
-- [slack](kubeedge.slack.com)
+- [slack](https://kubeedge.slack.com)


### PR DESCRIPTION

**What type of PR is this?**

> /kind documentation

**What this PR does / why we need it**:

url without protocol header will redirect to a 404 page in github, add protocol header to fix it.
