### PR TITLE
Provide user with an option to compile a smaller size binary for edge_core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ edge_integration_test:
 edge_cross_build:
 	cd edge && $(MAKE) cross_build
 
+.PHONY: edge_small_build
+edge_small_build:
+	cd edge && $(MAKE) small_build
+
 .PHONY: edgecontroller
 edgecontroller:
 	cd cloud/edgecontroller && $(MAKE)

--- a/README.md
+++ b/README.md
@@ -245,7 +245,25 @@ make # or `make edge_core`
 ```
 
 KubeEdge can also be cross compiled to run on ARM based processors.
-Please click [Cross Compilation](docs/setup/cross-compilation.md) for the instructions.
+Please follow the instructions given below or click [Cross Compilation](docs/setup/cross-compilation.md) for detailed instructions.
+
+```shell
+cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
+make edge_cross_build
+```
+
+KubeEdge can also be compiled with a small binary size. Please follow the below steps to build a binary of lesser size:
+
+```shell
+apt-get install upx-ucl
+cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
+make edge_small_build
+```
+
+**Note:** If you are using the smaller version of the binary, it is compressed using upx, therefore the possible side effects of using upx compressed binaries like more RAM usage, 
+lower performance, whole code of program being loaded instead of it being on-demand, not allowing sharing of memory which may cause the code to be loaded to memory 
+more than once etc. are applicable here as well.
+
 
 ## Run KubeEdge
 

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -37,3 +37,8 @@ cross_build:
 	export CGO_ENABLED=1
 	export CC=arm-linux-gnueabi-gcc
 	go build cmd/edge_core.go
+
+.PHONY: small_build
+small_build:
+	go build -ldflags="-w -s -extldflags -static" cmd/edge_core.go
+	upx-ucl --best edge_core


### PR DESCRIPTION
**What type of PR is this?**

 /kind feature


**What this PR does / why we need it**:
This PR provides user with an option to create a smaller size (compressed) binary for edge_core, which would be useful when required to run on low resource devices.

**Which issue(s) this PR fixes**:

Fixes # 208

**Special notes for your reviewer**:
