### PR TITLE
Don't treat master as a edge node

### DIFF
--- a/build/node.json
+++ b/build/node.json
@@ -4,7 +4,8 @@
   "metadata": {
     "name": "fb4ebb70-2783-42b8-b3ef-63e2fd6d242e",
     "labels": {
-      "name": "edge-node"
+      "name": "edge-node",
+      "node-role.kubernetes.io/edge": ""
     }
   }
 }

--- a/cloud/pkg/controller/controller/downstream.go
+++ b/cloud/pkg/controller/controller/downstream.go
@@ -179,7 +179,7 @@ func (dc *DownstreamController) syncEdgeNodes(stop chan struct{}) {
 		case e := <-dc.nodeManager.Events():
 			node, ok := e.Object.(*v1.Node)
 			if !ok {
-				log.LOGGER.Warnf("object type: %T unsupported", node)
+				log.LOGGER.Warnf("Object type: %T unsupported", node)
 				continue
 			}
 			switch e.Type {
@@ -191,11 +191,11 @@ func (dc *DownstreamController) syncEdgeNodes(stop chan struct{}) {
 				dc.lc.DeleteNode(node.ObjectMeta.Name)
 			default:
 				// unsupported operation, no need to send to any node
-				log.LOGGER.Warnf("node event type: %s unsupported", e.Type)
+				log.LOGGER.Warnf("Node event type: %s unsupported", e.Type)
 				break
 			}
 		case <-stop:
-			log.LOGGER.Infof("stop syncNodes")
+			log.LOGGER.Infof("Stop syncNodes")
 			running = false
 		}
 	}

--- a/cloud/pkg/controller/controller/downstream.go
+++ b/cloud/pkg/controller/controller/downstream.go
@@ -287,7 +287,7 @@ func NewDownstreamController() (*DownstreamController, error) {
 
 	nodesManager, err := manager.NewNodesManager(cli, v1.NamespaceAll)
 	if err != nil {
-		log.LOGGER.Warnf("create nodes manager failed with error: %s", err)
+		log.LOGGER.Warnf("Create nodes manager failed with error: %s", err)
 		return nil, err
 	}
 

--- a/cloud/pkg/controller/controller/downstream.go
+++ b/cloud/pkg/controller/controller/downstream.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
@@ -28,6 +29,9 @@ type DownstreamController struct {
 	secretManager *manager.SecretManager
 	secretStop    chan struct{}
 
+	nodeManager *manager.NodesManager
+	nodesStop   chan struct{}
+
 	lc *manager.LocationCache
 }
 
@@ -39,6 +43,9 @@ func (dc *DownstreamController) syncPod(stop chan struct{}) {
 			pod, ok := e.Object.(*v1.Pod)
 			if !ok {
 				log.LOGGER.Warnf("object type: %T unsupported", pod)
+				continue
+			}
+			if !dc.lc.IsEdgeNode(pod.Spec.NodeName) {
 				continue
 			}
 			msg := model.NewMessage("")
@@ -165,6 +172,35 @@ func (dc *DownstreamController) syncSecret(stop chan struct{}) {
 	}
 }
 
+func (dc *DownstreamController) syncEdgeNodes(stop chan struct{}) {
+	running := true
+	for running {
+		select {
+		case e := <-dc.nodeManager.Events():
+			node, ok := e.Object.(*v1.Node)
+			if !ok {
+				log.LOGGER.Warnf("object type: %T unsupported", node)
+				continue
+			}
+			switch e.Type {
+			case watch.Added:
+				dc.lc.UpdateEdgeNode(node.ObjectMeta.Name)
+			case watch.Modified:
+				continue
+			case watch.Deleted:
+				dc.lc.DeleteNode(node.ObjectMeta.Name)
+			default:
+				// unsupported operation, no need to send to any node
+				log.LOGGER.Warnf("node event type: %s unsupported", e.Type)
+				break
+			}
+		case <-stop:
+			log.LOGGER.Infof("stop syncNodes")
+			running = false
+		}
+	}
+}
+
 // Start DownstreamController
 func (dc *DownstreamController) Start() error {
 	log.LOGGER.Infof("start downstream controller")
@@ -180,6 +216,10 @@ func (dc *DownstreamController) Start() error {
 	dc.secretStop = make(chan struct{})
 	go dc.syncSecret(dc.secretStop)
 
+	// nodes
+	dc.nodesStop = make(chan struct{})
+	go dc.syncEdgeNodes(dc.nodesStop)
+
 	return nil
 }
 
@@ -189,17 +229,29 @@ func (dc *DownstreamController) Stop() error {
 	dc.podStop <- struct{}{}
 	dc.configMapStop <- struct{}{}
 	dc.secretStop <- struct{}{}
+	dc.nodesStop <- struct{}{}
 	return nil
 }
 
 // initLocating to know configmap and secret should send to which nodes
 func (dc *DownstreamController) initLocating() error {
+	set := labels.Set{"node-role.kubernetes.io/edge": ""}
+	selector := labels.SelectorFromSet(set)
+	nodes, err := dc.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return err
+	}
+	for _, node := range nodes.Items {
+		dc.lc.UpdateEdgeNode(node.ObjectMeta.Name)
+	}
 	pods, err := dc.kubeClient.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 	for _, p := range pods.Items {
-		dc.lc.AddOrUpdatePod(p)
+		if dc.lc.IsEdgeNode(p.Spec.NodeName) {
+			dc.lc.AddOrUpdatePod(p)
+		}
 	}
 
 	return nil
@@ -233,13 +285,19 @@ func NewDownstreamController() (*DownstreamController, error) {
 		return nil, err
 	}
 
+	nodesManager, err := manager.NewNodesManager(cli, v1.NamespaceAll)
+	if err != nil {
+		log.LOGGER.Warnf("create nodes manager failed with error: %s", err)
+		return nil, err
+	}
+
 	ml, err := messagelayer.NewMessageLayer()
 	if err != nil {
 		log.LOGGER.Warnf("create message layer failed with error: %s", err)
 		return nil, err
 	}
 
-	dc := &DownstreamController{kubeClient: cli, podManager: podManager, configmapManager: configMapManager, secretManager: secretManager, messageLayer: ml, lc: lc}
+	dc := &DownstreamController{kubeClient: cli, podManager: podManager, configmapManager: configMapManager, secretManager: secretManager, nodeManager: nodesManager, messageLayer: ml, lc: lc}
 	if err := dc.initLocating(); err != nil {
 		return nil, err
 	}

--- a/cloud/pkg/controller/controller/downstream.go
+++ b/cloud/pkg/controller/controller/downstream.go
@@ -235,7 +235,7 @@ func (dc *DownstreamController) Stop() error {
 
 // initLocating to know configmap and secret should send to which nodes
 func (dc *DownstreamController) initLocating() error {
-	set := labels.Set{"node-role.kubernetes.io/edge": ""}
+	set := labels.Set{manager.NodeRoleKey: manager.NodeRoleValue}
 	selector := labels.SelectorFromSet(set)
 	nodes, err := dc.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: selector.String()})
 	if err != nil {

--- a/cloud/pkg/controller/manager/location.go
+++ b/cloud/pkg/controller/manager/location.go
@@ -124,7 +124,7 @@ func (lc *LocationCache) IsEdgeNode(nodeName string) bool {
 //UpdateEdgeNode is to maintain edge nodes name upto-date by querying kubernetes client
 func (lc *LocationCache) UpdateEdgeNode(nodeName string) {
 	lc.edgeNodes = append(lc.edgeNodes, nodeName)
-	log.LOGGER.Infof("\n edge node updated : %v \n", lc.edgeNodes)
+	log.LOGGER.Infof("Edge nodes updated : %v \n", lc.edgeNodes)
 }
 
 // DeleteConfigMap from cache

--- a/cloud/pkg/controller/manager/location.go
+++ b/cloud/pkg/controller/manager/location.go
@@ -4,11 +4,14 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/kubeedge/beehive/pkg/common/log"
 	"k8s.io/api/core/v1"
 )
 
 // LocationCache cache the map of node, pod, configmap, secret
 type LocationCache struct {
+	//edgeNodes is a list of valid edge nodes
+	edgeNodes []string
 	// configMapNode is a map, key is namespace/configMapName, value is nodeName
 	configMapNode sync.Map
 	// secretNode is a map, key is namespace/secretName, value is nodeName
@@ -55,7 +58,6 @@ func (lc *LocationCache) newNodes(oldNodes []string, node string) []string {
 // AddOrUpdatePod add pod to node, pod to configmap, configmap to pod, pod to secret, secret to pod relation
 func (lc *LocationCache) AddOrUpdatePod(pod v1.Pod) {
 	configMaps, secrets := lc.PodConfigMapsAndSecrets(pod)
-
 	for _, c := range configMaps {
 		configMapKey := fmt.Sprintf("%s/%s", pod.Namespace, c)
 		// update configMapPod
@@ -109,6 +111,22 @@ func (lc *LocationCache) SecretNodes(namespace, name string) (nodes []string) {
 	return
 }
 
+//IsEdgeNode checks weather node is edge node or not
+func (lc *LocationCache) IsEdgeNode(nodeName string) bool {
+	for _, node := range lc.edgeNodes {
+		if node == nodeName {
+			return true
+		}
+	}
+	return false
+}
+
+//UpdateEdgeNode is to maintain edge nodes name upto-date by querying kubernetes client
+func (lc *LocationCache) UpdateEdgeNode(nodeName string) {
+	lc.edgeNodes = append(lc.edgeNodes, nodeName)
+	log.LOGGER.Infof("\n edge node updated : %v \n", lc.edgeNodes)
+}
+
 // DeleteConfigMap from cache
 func (lc *LocationCache) DeleteConfigMap(namespace, name string) {
 	lc.configMapNode.Delete(fmt.Sprintf("%s/%s", namespace, name))
@@ -117,4 +135,13 @@ func (lc *LocationCache) DeleteConfigMap(namespace, name string) {
 // DeleteSecret from cache
 func (lc *LocationCache) DeleteSecret(namespace, name string) {
 	lc.secretNode.Delete(fmt.Sprintf("%s/%s", namespace, name))
+}
+
+// DeleteNode from cache
+func (lc *LocationCache) DeleteNode(name string) {
+	for i, v := range lc.edgeNodes {
+		if v == name {
+			lc.edgeNodes = append(lc.edgeNodes[:i], lc.edgeNodes[i+1:]...)
+		}
+	}
 }

--- a/cloud/pkg/controller/manager/node.go
+++ b/cloud/pkg/controller/manager/node.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	NodeRoleKey = "node-role.kubernetes.io/edge"
+	NodeRoleKey   = "node-role.kubernetes.io/edge"
 	NodeRoleValue = ""
 )
 

--- a/cloud/pkg/controller/manager/node.go
+++ b/cloud/pkg/controller/manager/node.go
@@ -9,6 +9,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const (
+	NodeRoleKey = "node-role.kubernetes.io/edge"
+	NodeRoleValue = ""
+)
+
 // NodesManager manage all events of nodes by SharedInformer
 type NodesManager struct {
 	events chan watch.Event
@@ -21,7 +26,7 @@ func (nm *NodesManager) Events() chan watch.Event {
 
 // NewNodesManager create NodesManager by kube clientset and namespace
 func NewNodesManager(kubeClient *kubernetes.Clientset, namespace string) (*NodesManager, error) {
-	set := labels.Set{"node-role.kubernetes.io/edge": ""}
+	set := labels.Set{NodeRoleKey: NodeRoleValue}
 	selector := labels.SelectorFromSet(set)
 	optionModifier := func(options *metav1.ListOptions) {
 		options.LabelSelector = selector.String()

--- a/cloud/pkg/controller/manager/node.go
+++ b/cloud/pkg/controller/manager/node.go
@@ -1,0 +1,38 @@
+package manager
+
+import (
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NodesManager manage all events of nodes by SharedInformer
+type NodesManager struct {
+	events chan watch.Event
+}
+
+// Events return the channel save events from watch nodes change
+func (nm *NodesManager) Events() chan watch.Event {
+	return nm.events
+}
+
+// NewNodesManager create NodesManager by kube clientset and namespace
+func NewNodesManager(kubeClient *kubernetes.Clientset, namespace string) (*NodesManager, error) {
+	set := labels.Set{"node-role.kubernetes.io/edge": ""}
+	selector := labels.SelectorFromSet(set)
+	optionModifier := func(options *metav1.ListOptions) {
+		options.LabelSelector = selector.String()
+	}
+	lw := cache.NewFilteredListWatchFromClient(kubeClient.CoreV1().RESTClient(), "nodes", namespace, optionModifier)
+	events := make(chan watch.Event)
+	rh := NewCommonResourceEventHandler(events)
+	si := cache.NewSharedInformer(lw, &v1.Node{}, 0)
+	si.AddEventHandler(rh)
+	stopNever := make(chan struct{})
+	go si.Run(stopNever)
+
+	return &NodesManager{events: events}, nil
+}

--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -110,6 +110,22 @@ The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/cert
 We have provided a sample node.json to add a node in kubernetes. Please make sure edge-node is added in kubernetes. Run below steps to add edge-node.
 
 + Modify the `$GOPATH/src/github.com/kubeedge/kubeedge/build/node.json` file and change `metadata.name` to the name of the edge node
++ Make sure role is set to edge for the node. For this a key of the form `"node-role.kubernetes.io/edge"` must be present in `labels` tag of `metadata`.
++ Please ensure to add the label `node-role.kubernetes.io/edge` to the `build/node.json` file.
+    ```script
+    {
+      "kind": "Node",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "fb4ebb70-2783-42b8-b3ef-63e2fd6d242e",
+        "labels": {
+          "name": "edge-node",
+          "node-role.kubernetes.io/edge": ""
+        }
+      }
+    }
+    ```
++ If role is not set for the node, the pods, configmaps and secrets created/updated in the cloud cannot be synced with the node they are targeted for.
 + Deploy node
     ```shell
     kubectl apply -f $GOPATH/src/github.com/kubeedge/kubeedge/build/node.json

--- a/tests/e2e/utils/node.go
+++ b/tests/e2e/utils/node.go
@@ -60,7 +60,7 @@ func DeRegisterNodeFromMaster(nodehandler, nodename string) error {
 func GenerateNodeReqBody(nodeid, nodeselector string) (error, map[string]interface{}) {
 	var temp map[string]interface{}
 
-	body := fmt.Sprintf(`{"kind": "Node","apiVersion": "v1","metadata": {"name": "%s","labels": {"name": "edgenode", "disktype":"%s"}}}`, nodeid, nodeselector)
+	body := fmt.Sprintf(`{"kind": "Node","apiVersion": "v1","metadata": {"name": "%s","labels": {"name": "edgenode", "disktype":"%s", "node-role.kubernetes.io/edge": ""}}}`, nodeid, nodeselector)
 	err := json.Unmarshal([]byte(body), &temp)
 	if err != nil {
 		Failf("Unmarshal body failed: %v", err)


### PR DESCRIPTION
Change in file downstream.go and location.go files to send only message down to cloudhub
which has role set as edge.
Fixes issue #244

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
To fix the issue for channelq error to not find master in the channelQ.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #244 

**Special notes for your reviewer**:
Also changing format of node.json to detect the role of node as edge.
