### PR TITLE
#320 create folder for generating ca and certs if not exist

### DIFF
--- a/build/tools/certgen.sh
+++ b/build/tools/certgen.sh
@@ -17,12 +17,23 @@ ensureCA() {
     fi
 }
 
+ensureFolder() {
+    if [ ! -d ${caPath} ]; then
+        mkdir -p ${caPath}
+    fi
+    if [ ! -d ${certPath} ]; then
+        mkdir -p ${certPath}
+    fi
+}
+
 genCertAndKey() {
+    ensureFolder
     ensureCA
     local name=$1
     openssl genrsa -out ${certPath}/${name}.key 2048
     openssl req -new -key ${certPath}/${name}.key -subj ${subject} -out ${certPath}/${name}.csr
-    openssl x509 -req -in ${certPath}/${name}.csr -CA ${caPath}/ca.crt -CAkey ${caPath}/ca.key -CAcreateserial -passin pass:kubeedge.io -out ${certPath}/${name}.crt -days 365 -sha256
+    openssl x509 -req -in ${certPath}/${name}.csr -CA ${caPath}/ca.crt -CAkey ${caPath}/ca.key \
+    -CAcreateserial -passin pass:kubeedge.io -out ${certPath}/${name}.crt -days 365 -sha256
 }
 
 buildSecret() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

Generate ca or certs failed by using `certgen.sh` if the folders to store ca or certs not exist. So Make these folders if not exist.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #320

**Special notes for your reviewer**:

e.g.

```shell
# default location: CA -> /etc/kubeedge/ca, Certs -> /etc/kubeedge/certs
build/tools/certgen.sh genCertAndKey edge

# customized location:
CA_PATH=/Users/lizhen/Downloads/ca CERT_PATH=/Users/lizhen/Downloads/certs build/tools/certgen.sh genCertAndKey edge

# customize cert subject
SUBJECT="/C=US/ST=Washington/L=Seattle/O=KubeEdge/CN=kubeedge.io" build/tools/certgen.sh genCertAndKey edge
```
