### PR TITLE
Fixed flaky unit test in edgehub/config

### DIFF
--- a/edge/pkg/common/util/config.go
+++ b/edge/pkg/common/util/config.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path"
@@ -78,8 +77,18 @@ func GenerateTestYaml(test interface{}, path, filename string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(path+"/"+filename+".yaml", data, 0777)
+	fp, err := os.Create(path + "/" + filename + ".yaml")
 	if err != nil {
+		return err
+	}
+	_, err = fp.Write(data)
+	if err != nil {
+		return err
+	}
+	if err = fp.Sync(); err != nil {
+		return err
+	}
+	if err = fp.Close(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
 /kind failing-test

**What this PR does / why we need it**:

This PR fixes a flaky unit test that was present in edgehub/config. This will improve our code quality by ensuring that this test case does not fail in the CI while PRs are being raised.

**Which issue(s) this PR fixes**:

Fixes #263

**Special notes for your reviewer**:
The issue seems to have been caused when the configuration file mentioned within the test is trying to be loaded before the successful creation of the config file. This issue was occurring randomly since, in the normal execution scenario the file is created pretty quickly and hence this panic is not observed. This is solved by ensuring that the file is loaded only after providing sufficient time for its creation.