### PR TITLE
Makefile changes to make both cloud and edge_core binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ install: true
 jobs:
   include:
     - stage: "Test Jobs"                # naming the Tests stage
-      script: make edge_core
-      name: "build edge"            # names the first Tests stage job
+      script: make 
+      name: "builds cloud and edge components"            # names the first Tests stage job
     - script: make edge_verify
       name: "verify edge"     # names the second Tests stage job
     - script: make edge_test
@@ -31,7 +31,5 @@ jobs:
       name: "integration test edge"     # names the fourth Tests stage job
     - script: make edge_cross_build
       name: "cross build edge"     # names the fifth Tests stage job
-    - script: make edgecontroller
-      name: "build edgecontroller"     # names the sixth Tests stage job
     - script: make e2e_test
       name: "e2e_test"     # names the seventh Tests stage job

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,22 @@
-# make edge_core
-.PHONY: edge_core
-edge_core:
+# make all builds both cloud and edge binaries
+.PHONY: all  
+ifeq ($(WHAT),)
+all:
+	cd cloud/edgecontroller && $(MAKE)
 	cd edge && $(MAKE)
+else ifeq ($(WHAT),cloud)
+# make all what=cloud, build cloud binary
+all:
+	cd cloud/edgecontroller && $(MAKE)
+else ifeq ($(WHAT),edge)
+all:
+# make all what=edge, build edge binary
+	cd edge && $(MAKE)
+else
+# invalid entry
+all:
+	@echo $S"invalid option please choose to build either cloud, edge or both"
+endif
 
 # unit tests
 .PHONY: edge_test
@@ -24,10 +39,6 @@ edge_cross_build:
 .PHONY: edge_small_build
 edge_small_build:
 	cd edge && $(MAKE) small_build
-
-.PHONY: edgecontroller
-edgecontroller:
-	cd cloud/edgecontroller && $(MAKE)
 
 .PHONY: e2e_test
 e2e_test:

--- a/README.md
+++ b/README.md
@@ -138,11 +138,18 @@ cd $GOPATH/src/github.com/kubeedge/kubeedge
 
 #### Run as a binary
 
++ Build Cloud and edge
+
+    ```shell
+    cd $GOPATH/src/github.com/kubeedge/kubeedge
+     make 
+    ```
+
 + Build Cloud
 
     ```shell
-    cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud/edgecontroller
-    make # or `make edgecontroller`
+    cd $GOPATH/src/github.com/kubeedge/kubeedge
+     make all WHAT=cloud
     ```
 
 + The path to the generated certificates should be updated in `$GOPATH/src/github.com/kubeedge/kubeedge/cloud/edgecontroller/conf/controller.yaml`. Please update the correct paths for the following :
@@ -179,8 +186,8 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
 + Build Edge
 
     ```shell
-    cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
-    make # or `make edge_core`
+    cd $GOPATH/src/github.com/kubeedge/kubeedge
+    make all WHAT=edge
     ```
 
     KubeEdge can also be cross compiled to run on ARM based processors.

--- a/tests/e2e/scripts/execute.sh
+++ b/tests/e2e/scripts/execute.sh
@@ -25,8 +25,7 @@ if [ ! -d "/var/lib/edged" ]; then
 fi
 
 #run the edge_core and edgecontroller bin to run the E2E
-make edge_core
-make edgecontroller
+make #builds cloud and edge_core components
 sleep 2s
 #Kill the process if it exists
 sudo pkill edgecontroller


### PR DESCRIPTION
These changes will build both cloud and edge binaries when you do make

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
This PR will build both cloud and edge binaries

 /kind test



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- Running make builds only edge_core
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #338 

**Special notes for your reviewer**:
