### PR TITLE
fix the wrong port for nginx

### DIFF
--- a/build/deployment.yaml
+++ b/build/deployment.yaml
@@ -18,5 +18,5 @@ spec:
       - name: nginx
         image: nginx:1.7.9
         ports:
-        - containerPort: 90
-          hostPort: 90
+        - containerPort: 80
+          hostPort: 80


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`nginx` has its default port defined as '80' instead of '90', using
'90' here make it unable to access the service, got 'Connection
refused' error message.

Better to resolve the limitation on 'The hostPort must be equal to
containerPort and can not be 0', this will solve the occupation of
a well-known port.

