### PR TITLE
certs: use the script to generate the keys and certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,11 @@ To use KubeEdge in double mqtt or external mode, you need to make sure that [mos
 
 RootCA certificate and a cert/key pair is required to have a setup for KubeEdge. Same cert/key pair can be used in both cloud and edge.
 
-```shell
-# Generete Root Key
-openssl genrsa -des3 -out rootCA.key 4096
-# Generate Root Certificate
-openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt
-# Generate Key
-openssl genrsa -out edge.key 2048
-# Generate csr, Fill required details after running the command
-openssl req -new -key edge.key -out edge.csr
-# Generate Certificate
-openssl x509 -req -in edge.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out edge.crt -days 500 -sha256 
+```bash
+# $GOPATH/src/github.com/kubeedge/kubeedge/build/tools/certgen.sh genCertAndKey edge
 ```
+
+The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/certs` respectively.
 
 ## Run KubeEdge
 

--- a/build/tools/certgen.sh
+++ b/build/tools/certgen.sh
@@ -6,13 +6,13 @@ readonly certPath=${CERT_PATH:-/etc/kubeedge/certs}
 readonly subject=${SUBJECT:-/C=CN/ST=Zhejiang/L=Hangzhou/O=KubeEdge/CN=kubeedge.io}
 
 genCA() {
-    openssl genrsa -des3 -out ${caPath}/ca.key -passout pass:kubeedge.io 4096
-    openssl req -x509 -new -nodes -key ${caPath}/ca.key -sha256 -days 3650 \
-    -subj ${subject} -passin pass:kubeedge.io -out ${caPath}/ca.crt
+    openssl genrsa -des3 -out ${caPath}/rootCA.key -passout pass:kubeedge.io 4096
+    openssl req -x509 -new -nodes -key ${caPath}/rootCA.key -sha256 -days 3650 \
+    -subj ${subject} -passin pass:kubeedge.io -out ${caPath}/rootCA.crt
 }
 
 ensureCA() {
-    if [ ! -e ${caPath}/ca.key ] || [ ! -e ${caPath}/ca.crt ]; then
+    if [ ! -e ${caPath}/rootCA.key ] || [ ! -e ${caPath}/rootCA.crt ]; then
         genCA
     fi
 }
@@ -32,12 +32,12 @@ genCertAndKey() {
     local name=$1
     openssl genrsa -out ${certPath}/${name}.key 2048
     openssl req -new -key ${certPath}/${name}.key -subj ${subject} -out ${certPath}/${name}.csr
-    openssl x509 -req -in ${certPath}/${name}.csr -CA ${caPath}/ca.crt -CAkey ${caPath}/ca.key \
+    openssl x509 -req -in ${certPath}/${name}.csr -CA ${caPath}/rootCA.crt -CAkey ${caPath}/rootCA.key \
     -CAcreateserial -passin pass:kubeedge.io -out ${certPath}/${name}.crt -days 365 -sha256
 }
 
 buildSecret() {
-    local name="cloud"
+    local name="edge"
     genCertAndKey ${name} > /dev/null 2>&1
     cat <<EOF
 apiVersion: v1
@@ -49,11 +49,11 @@ metadata:
     k8s-app: kubeedge
     kubeedge: edgecontroller
 stringData:
-  ca.crt: |
-$(pr -T -o 4 ${caPath}/ca.crt)
-  cloud.crt: |
+  rootCA.crt: |
+$(pr -T -o 4 ${caPath}/rootCA.crt)
+  edge.crt: |
 $(pr -T -o 4 ${certPath}/${name}.crt)
-  cloud.key: |
+  edge.key: |
 $(pr -T -o 4 ${certPath}/${name}.key)
 
 EOF

--- a/cloud/edgecontroller/conf/controller.yaml
+++ b/cloud/edgecontroller/conf/controller.yaml
@@ -10,9 +10,9 @@ controller:
 cloudhub:
   address: 0.0.0.0
   port: 10000
-  ca: /tmp/rootCA.crt
-  cert: /tmp/edge.crt
-  key: /tmp/edge.key
+  ca: /etc/kubeedge/ca/rootCA.crt
+  cert: /etc/kubeedge/certs/edge.crt
+  key: /etc/kubeedge/certs/edge.key
   keepalive-interval: 30
   write-timeout: 30
   node-limit: 10

--- a/edge/conf/edge.yaml
+++ b/edge/conf/edge.yaml
@@ -9,8 +9,8 @@ mqtt:
 edgehub:
     websocket:
         url: wss://0.0.0.0:10000/e632aba927ea4ac2b575ec1603d56f10/fb4ebb70-2783-42b8-b3ef-63e2fd6d242e/events
-        certfile: /tmp/edge.crt
-        keyfile: /tmp/edge.key
+        certfile: /etc/kubeedge/certs/edge.crt
+        keyfile: /etc/kubeedge/certs/edge.key
         handshake-timeout: 30 #second
         write-deadline: 15 # second
         read-deadline: 15 # second


### PR DESCRIPTION
There is script which can be reused to generated the keys and certs,
no need to manually generated those files, and manual steps for
certs generation missed some inputs and is error prone.

Also update some configuration for easier installtion, so that
there is no need to update them manually

Signed-off-by: Dave Chen <dave.chen@arm.com>

**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
make it easy to create the certs/keys for installation

