### PR TITLE
doc: run script in the right dir

### DIFF
--- a/build/edge/README.md
+++ b/build/edge/README.md
@@ -5,8 +5,9 @@ container and MQTT Broker, so make sure that docker engine listening on
 `/var/run/docker.sock` which will then mount into the edge container.
 
 + Check the container runtime environment
-  ```
-  ./build/edge/run_daemon.sh prepare
+  ```bash
+  cd build/edge
+  ./run_daemon.sh prepare
   ```
 
 + Set container parameters
@@ -25,7 +26,7 @@ container and MQTT Broker, so make sure that docker engine listening on
   | keyfile         | /etc/kubeedge/edge/certs/edge.key |                           |
 
   ```shell
-  ./build/edge/run_daemon.sh set \
+  ./run_daemon.sh set \
   		    cloudhub=0.0.0.0:10000 \
           edgename=edgeNode \
           edge_core_image="kubeedge/edgecore:latest" \
@@ -39,7 +40,7 @@ container and MQTT Broker, so make sure that docker engine listening on
 + Build image
 
   ```
-  ./build/edge/run_daemon.sh build
+  ./run_daemon.sh build
   ```
 
 + **(Optional)** If the performance of the edge is not enough, you can cross-compile the image of the edge on the cloud and load the image on the edge.
@@ -47,18 +48,18 @@ container and MQTT Broker, so make sure that docker engine listening on
   - Set the CPU type
 
     ```
-    ./build/edge/run_daemon.sh set arch=arm64v8 qemu_arch=aarch
+    ./run_daemon.sh set arch=arm64v8 qemu_arch=aarch
     ```
   - Build image
     ```
-    ./build/edge/run_daemon.sh build
+    ./run_daemon.sh build
     ```
   - Save image
     ```
-    ./build/edge/run_daemon.sh save 
+    ./run_daemon.sh save
     ```
 
 + Start container
   ```
-  ./build/edge/run_daemon.sh up
+  ./run_daemon.sh up
   ```


### PR DESCRIPTION
`.env` is located in the `build/edge` dir, should run the script
in the right dir, or else we will see the below error message.

sed: can't read .env: No such file or directory

Signed-off-by: Dave Chen <dave.chen@arm.com>

/kind bug
/kind documentation
