### PR TITLE
fix wrong way when get node id in funciton dispatchMessage

### DIFF
--- a/cloud/edgecontroller/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/edgecontroller/pkg/cloudhub/channelq/channelq.go
@@ -72,9 +72,10 @@ func (q *ChannelEventQueue) dispatchMessage() {
 		}
 		resource := msg.Router.Resource
 		tokens := strings.Split(resource, "/")
+		numOfTokens := len(tokens)
 		var nodeID string
 		for i, token := range tokens {
-			if token == "node" && i+1 < len(token) {
+			if token == "node" && i+1 < numOfTokens {
 				nodeID = tokens[i+1]
 			}
 		}


### PR DESCRIPTION
we need the length of slice instead of string when get node id
from  msg.Router.Resource

**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

