### PR TITLE
Fixed some errors in the document

### DIFF
--- a/build/edge/README.md
+++ b/build/edge/README.md
@@ -34,7 +34,7 @@ container and MQTT Broker, so make sure that docker engine listening on
           qemu_arch=x86_64 \
           certpath=/etc/kubeedge/edge/certs \
           certfile=/etc/kubeedge/edge/certs/edge.crt \
-          keyfile=/etc/kubeedge/edge/certs/edge.ke
+          keyfile=/etc/kubeedge/edge/certs/edge.key
   ```
 
 + Build image

--- a/build/edge/README_zh.md
+++ b/build/edge/README_zh.md
@@ -5,7 +5,8 @@
 
 + 检查容器运行环境
   ```
-  ./build/edge/run_daemon.sh prepare
+  cd $GOPATH/src/github.com/kubeedge/kubeedge/build/edge
+  ./run_daemon.sh prepare
   ```
 
 + 设置容器参数


### PR DESCRIPTION
## fix errors  in "build/edge/README.md" 
```
modify "edge.ke" to "edge.key"
```


## fix errors in  "build/edge/README_zh.md"
old:
```
./build/edge/run_daemon.sh prepare
```
new:
```
cd $GOPATH/src/github.com/kubeedge/kubeedge/build/edge
./run_daemon.sh prepare
```

because in scripts `run_daemon.sh prepare`  line 62 `.env` using current directory! 
so if u execute old scripts, it will not  find the file `.env` .