### PR TITLE
use the `nginx` image which supports `ARM` as well

### DIFF
--- a/build/deployment.yaml
+++ b/build/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.7.9
+        image: nginx:1.15.12
         ports:
         - containerPort: 80
           hostPort: 80


### PR DESCRIPTION
$ docker run -it --rm nginx:1.15.12 bash
root@ba3a785ab028:/#

$ docker run -it --rm nginx:1.7.9 bash
qemu: uncaught target signal 11 (Segmentation fault) - core dumped

`1.15.12` is the latest stable nginx release

Signed-off-by: Dave Chen <dave.chen@arm.com>

**What type of PR is this?**

/kind cleanup
