### PR TITLE
fix cloudpart cannot run in container

### DIFF
--- a/build/cloud/05-configmap.yaml
+++ b/build/cloud/05-configmap.yaml
@@ -20,9 +20,9 @@ data:
     cloudhub:
       address: 0.0.0.0
       port: 10000
-      ca: /etc/kubeedge/cloud/certs/ca.crt
-      cert: /etc/kubeedge/cloud/certs/cloud.crt
-      key: /etc/kubeedge/cloud/certs/cloud.key
+      ca: /etc/kubeedge/certs/rootCA.crt
+      cert: /etc/kubeedge/certs/edge.crt
+      key: /etc/kubeedge/certs/edge.key
       keepalive-interval: 30
       write-timeout: 30
       node-limit: 10

--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       containers:
       - name: edgecontroller
         image: kubeedge/edgecontroller:v0.2
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 10000
           name: cloudhub
@@ -65,7 +65,7 @@ spec:
         - name: conf
           mountPath: /etc/kubeedge/cloud/conf
         - name: certs
-          mountPath: /etc/kubeedge/cloud/certs
+          mountPath: /etc/kubeedge/certs
         - name: kubeconfig
           mountPath: /etc/kubeedge/cloud
           subPath: kubeconfig.yaml

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -10,7 +10,7 @@ FROM alpine:3.9
 
 ENV GOARCHAIUS_CONFIG_PATH /etc/kubeedge/cloud
 
-VOLUME ["/etc/kubeedge/cloud/certs", "/etc/kubeedge/cloud/conf"]
+VOLUME ["/etc/kubeedge/certs", "/etc/kubeedge/cloud/conf"]
 
 COPY --from=builder /usr/local/bin/edgecontroller /usr/local/bin/edgecontroller
 

--- a/cloud/edgecontroller/pkg/devicecontroller/types/device.go
+++ b/cloud/edgecontroller/pkg/devicecontroller/types/device.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtclient"
-)
-
 //Device the struct of device
 type Device struct {
 	ID          string              `json:"id,omitempty"`
@@ -109,24 +105,4 @@ type TwinDoc struct {
 type DeviceTwinUpdate struct {
 	BaseMessage
 	Twin map[string]*MsgTwin `json:"twin"`
-}
-
-//DealTwinResult the result of dealing twin
-type DealTwinResult struct {
-	Add        []dtclient.DeviceTwin
-	Delete     []dtclient.DeviceDelete
-	Update     []dtclient.DeviceTwinUpdate
-	Result     map[string]*MsgTwin
-	SyncResult map[string]*MsgTwin
-	Document   map[string]*TwinDoc
-	Err        error
-}
-
-//DealAttrResult the result of dealing attr
-type DealAttrResult struct {
-	Add    []dtclient.DeviceAttr
-	Delete []dtclient.DeviceDelete
-	Update []dtclient.DeviceAttrUpdate
-	Result map[string]*MsgAttr
-	Err    error
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the kubeedge cloud part image can not be running in container.
Firstly it is because the cloud part is refering to some device types definition in the edge codes.
when we build the cloud part image, the edge part codes will be invovled into the cloud part image.
The sqlite is required for edge but not for cloud.
currently becase of some edge device types are referred by cloud part
so that the cloud part image will require sqlite.
we need to let the common device type definition into the common folder.

Another reason is about the deployment yamls like the modified files in this pr.

**Which issue(s) this PR fixes**: #396
