### PR TITLE
remove keepalive

### DIFF
--- a/edge/pkg/edgehub/controller.go
+++ b/edge/pkg/edgehub/controller.go
@@ -104,7 +104,6 @@ func (ehc *Controller) Start(ctx *context.Context) {
 		ehc.pubConnectInfo(true)
 		go ehc.routeToEdge()
 		go ehc.routeToCloud()
-		go ehc.keepalive()
 
 		// wait the stop singal
 		// stop authinfo manager/websocket connection
@@ -248,21 +247,6 @@ func (ehc *Controller) routeToCloud() {
 			ehc.stopChan <- struct{}{}
 			return
 		}
-	}
-}
-
-func (ehc *Controller) keepalive() {
-	for {
-		msg := model.NewMessage("").
-			BuildRouter(ModuleNameEdgeHub, "resource", "node", "keepalive").
-			FillBody("ping")
-		err := ehc.chClient.Send(*msg)
-		if err != nil {
-			log.LOGGER.Errorf("websocket write error: %v", err)
-			ehc.stopChan <- struct{}{}
-			return
-		}
-		time.Sleep(ehc.config.HeartbeatPeriod)
 	}
 }
 

--- a/edge/pkg/edgehub/controller_test.go
+++ b/edge/pkg/edgehub/controller_test.go
@@ -548,41 +548,6 @@ func TestRouteToCloud(t *testing.T) {
 	}
 }
 
-//TestKeepalive() tests whether ping message sent to the cloud at regular intervals happens properly
-func TestKeepalive(t *testing.T) {
-	initMocks(t)
-	tests := []struct {
-		name       string
-		controller Controller
-	}{
-		{"Heartbeat failure Case", Controller{
-			config: &config.ControllerConfig{
-				PlacementURL: testServer.URL + "/proper_request",
-				ProjectID:    "foo",
-				NodeID:       "bar",
-			},
-			chClient: mockAdapter,
-			stopChan: make(chan struct{}),
-		}},
-	}
-	edgeHubConfig := config.GetConfig()
-	edgeHubConfig.WSConfig = config.WebSocketConfig{
-		CertFilePath: CertFile,
-		KeyFilePath:  KeyFile,
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockAdapter.EXPECT().Send(gomock.Any()).Return(nil).Times(1)
-			mockAdapter.EXPECT().Send(gomock.Any()).Return(errors.New("Connection Refused")).Times(1)
-			go tt.controller.keepalive()
-			got := <-tt.controller.stopChan
-			if got != struct{}{} {
-				t.Errorf("TestKeepalive() StopChan = %v, want %v", got, struct{}{})
-			}
-		})
-	}
-}
-
 //TestPubConnectInfo() checks the connection information sent to the required group
 func TestPubConnectInfo(t *testing.T) {
 	initMocks(t)


### PR DESCRIPTION
the keepalive message of the websocket client is not used and creates a warning in the cloud part.
fix #256

/kind cleanup

Fixes #256
