### PR TITLE
Added code to avoid panic in devicecontroller/downstream.go

### DIFF
--- a/cloud/edgecontroller/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/edgecontroller/pkg/devicecontroller/controller/downstream.go
@@ -341,13 +341,13 @@ func addDeviceInstanceAndProtocol(device *v1alpha1.Device, deviceProfile *types.
 		deviceProtocol.Name = protocol
 		deviceProtocol.Protocol = OPCUA
 		deviceProtocol.ProtocolConfig = device.Spec.Protocol.OpcUA
-	} else if device.Spec.Protocol.Modbus.RTU != nil {
+	} else if device.Spec.Protocol.Modbus != nil && device.Spec.Protocol.Modbus.RTU != nil {
 		protocol = ModbusRTU + "-" + device.Name
 		deviceInstance.Protocol = protocol
 		deviceProtocol.Name = protocol
 		deviceProtocol.Protocol = ModbusRTU
 		deviceProtocol.ProtocolConfig = device.Spec.Protocol.Modbus.RTU
-	} else if device.Spec.Protocol.Modbus.TCP != nil {
+	} else if device.Spec.Protocol.Modbus != nil && device.Spec.Protocol.Modbus.TCP != nil {
 		protocol = ModbusTCP + "-" + device.Name
 		deviceInstance.Protocol = protocol
 		deviceProtocol.Name = protocol


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR fixes the panic issue, faced when trying to create device instance without modbus configurations
 
**Which issue(s) this PR fixes**:
Fixes #413
