### PR TITLE
[Issue#319] Fix the nil pointer exception for missing config string

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -67,7 +67,6 @@ func (a *cloudHub) Start(c *context.Context) {
 	}
 
 	if len(errs) > 0 {
-		//  TBD : add code for to sync graceful exit of modules
 		log.LOGGER.Errorf("cloudhub failed with errors : %v", errs)
 		os.Exit(1)
 	}

--- a/cloud/pkg/cloudhub/config/default.go
+++ b/cloud/pkg/cloudhub/config/default.go
@@ -1,0 +1,8 @@
+package config
+
+// Default constants definitions for cloudhub configuration
+const (
+	DefaultCAFile   = "cloudhubca.crt"
+	DefaultCertFile = "cloudhub.crt"
+	DefaultKeyFile  = "cloudhub.key"
+)

--- a/cloud/pkg/cloudhub/wsserver/server.go
+++ b/cloud/pkg/cloudhub/wsserver/server.go
@@ -370,16 +370,16 @@ func (f *FilterWriter) Write(p []byte) (n int, err error) {
 }
 
 // StartCloudHub starts the cloud hub service
-func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue) {
+func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue) error {
 	// init certificate
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(config.Ca)
 	if !ok {
-		panic(fmt.Errorf("fail to load ca content"))
+		return fmt.Errorf("fail to load ca content")
 	}
 	cert, err := tls.X509KeyPair(config.Cert, config.Key)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	tlsConfig := tls.Config{
 		ClientCAs:    pool,
@@ -412,4 +412,6 @@ func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue) {
 	}
 	bhLog.LOGGER.Infof("Start cloud hub service")
 	go s.ListenAndServeTLS("", "")
+
+	return nil
 }

--- a/cloud/pkg/controller/controller.go
+++ b/cloud/pkg/controller/controller.go
@@ -37,7 +37,7 @@ func (ctl *Controller) Start(c *bcontext.Context) {
 	config.Context = c
 	upstream, err := controller.NewUpstreamController()
 	if err != nil {
-		log.LOGGER.Warnf("new upstream controller failed with error: %s", err)
+		log.LOGGER.Errorf("new upstream controller failed with error: %s", err)
 		os.Exit(1)
 	}
 	upstream.Start()

--- a/cloud/pkg/devicecontroller/module.go
+++ b/cloud/pkg/devicecontroller/module.go
@@ -1,6 +1,7 @@
 package devicecontroller
 
 import (
+	"os"
 	"time"
 
 	"github.com/kubeedge/beehive/pkg/common/log"
@@ -39,14 +40,15 @@ func (dctl *DeviceController) Start(c *bcontext.Context) {
 	dctl.stopChan = make(chan bool)
 	downstream, err := controller.NewDownstreamController()
 	if err != nil {
-		log.LOGGER.Warnf("New downstream controller failed with error: %s", err)
-		return
+		log.LOGGER.Errorf("New downstream controller failed with error: %s", err)
+		os.Exit(1)
 	}
 	upstream, err := controller.NewUpstreamController(downstream)
 	if err != nil {
-		log.LOGGER.Warnf("new upstream controller failed with error: %s", err)
-		return
+		log.LOGGER.Errorf("new upstream controller failed with error: %s", err)
+		os.Exit(1)
 	}
+
 	downstream.Start()
 	// wait for downstream controller to start and load deviceModels and devices
 	time.Sleep(1 * time.Second)

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -3,11 +3,13 @@ package edged
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"os"
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -169,12 +171,12 @@ func (e *edged) Start(c *context.Context) {
 	e.context = c
 	if err := e.initializeModules(); err != nil {
 		log.LOGGER.Errorf("initialize module error: %v", err)
-		return
+		os.Exit(1)
 	}
 	err := e.makePodDir()
 	if err != nil {
 		log.LOGGER.Errorf("create pod dir [%s] failed: %v", e.getPodsDir(), err)
-		return
+		os.Exit(1)
 	}
 	e.metaClient = metaclient.New(c)
 	e.statusManager = status.NewManager(e.kubeClient, e.podManager, utilpod.NewPodDeleteSafety(), e.metaClient)

--- a/edge/pkg/eventbus/event_bus.go
+++ b/edge/pkg/eventbus/event_bus.go
@@ -3,6 +3,7 @@ package eventbus
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/256dpi/gomqtt/packet"
 	"github.com/kubeedge/beehive/pkg/common/config"
@@ -56,7 +57,8 @@ func (eb *eventbus) Start(c *context.Context) {
 
 	nodeID := config.CONFIG.GetConfigurationByKey("edgehub.controller.node-id")
 	if nodeID == nil {
-		panic("node id not configured")
+		log.LOGGER.Errorf("node id not configured")
+		os.Exit(1)
 	}
 
 	mqttBus.NodeID = nodeID.(string)
@@ -99,14 +101,16 @@ func (eb *eventbus) Start(c *context.Context) {
 		}
 
 		if qos.(int) < int(packet.QOSAtMostOnce) || qos.(int) > int(packet.QOSExactlyOnce) || sessionQueueSize.(int) <= 0 {
-			panic("mqtt.qos must be one of [0,1,2] or mqtt.session-queue-size must > 0")
+			log.LOGGER.Errorf("mqtt.qos must be one of [0,1,2] or mqtt.session-queue-size must > 0")
+			os.Exit(1)
 		}
 		// launch an internal mqtt server only
 		mqttServer = mqttBus.NewMqttServer(sessionQueueSize.(int), internalMqttURL.(string), retain.(bool), qos.(int))
 		mqttServer.InitInternalTopics()
 		err := mqttServer.Run()
 		if err != nil {
-			panic(fmt.Sprintf("Launch mqtt broker failed, %s", err.Error()))
+			log.LOGGER.Errorf("Launch mqtt broker failed, %s", err.Error())
+			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The PR fixes nil pointer exception when there is no config found for cloudhub certificates and key file path. Initializes with default path values.

**Which issue(s) this PR fixes**:

Fixes #319 

**Special notes for your reviewer**:
Fix for graceful exit is now implemented with os.Exit(1) so that testcases can be enhanced for configuration validations.
A more robust framework needs to reworked w.r.t to beehive implementation and module implementations require to be adapted for error returns.