### PR TITLE
Kectl Cloud init and reset code

### DIFF
--- a/kectl/app/cmd/cloud/init.go
+++ b/kectl/app/cmd/cloud/init.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2019 The Kubeedge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/kubeedge/kubeedge/kectl/app/cmd/options"
+	"github.com/kubeedge/kubeedge/kectl/app/cmd/util"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	cloudInitLongDescription = `
+kectl init command bootstraps KubeEdge's cloud component.
+It checks if the pre-requisites are installed already,
+If not installed, this command will help in download,
+install and execute on the host.
+`
+	cloudInitExample = `
+kectl cloud init  --docker-version= --kubernetes-version=<version> --kubeedge-version<version> --docker-version=<version>
+`
+)
+
+type FlagData struct {
+	Val    interface{}
+	DefVal interface{}
+}
+
+// NewCloudInit represents the kubeedge cloud init command
+func NewCloudInit(out io.Writer, init *options.InitOptions) *cobra.Command {
+	if init == nil {
+		init = newInitOptions()
+		fmt.Println("init is %v", init)
+	}
+
+	tools := make(map[string]util.ToolsInstallerCloud, 0)
+	flagVals := make(map[string]FlagData, 0)
+	var cmd = &cobra.Command{
+		Use:     "init",
+		Short:   "Bootstraps cloud component. Checks and install (if required) the pre-requisites.",
+		Long:    cloudInitLongDescription,
+		Example: cloudInitExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO: Work your own magic here
+			fmt.Println("cloud init called")
+			fmt.Println("Print: " + strings.Join(args, " "))
+			checkFlags := func(f *pflag.Flag) {
+				AddToolVals(f, flagVals)
+			}
+			cmd.Flags().VisitAll(checkFlags)
+			Add2ToolsList(tools, flagVals, init)
+			Execute(tools)
+		},
+	}
+
+	addJoinOtherFlags(cmd, init)
+	return cmd
+}
+
+//newInitOptions will initialise new instance of options everytime
+func newInitOptions() *options.InitOptions {
+	var opts *options.InitOptions
+	opts = &options.InitOptions{}
+	opts.DockerVersion = options.DefaultDockerVersion
+	opts.KubeedgeVersion = options.DefaultKubeEdgeVersion
+	opts.Kubernetesversion = options.DefaultK8SVersion
+
+	return opts
+}
+
+func addJoinOtherFlags(cmd *cobra.Command, initOpts *options.InitOptions) {
+
+	cmd.Flags().StringVar(&initOpts.KubeedgeVersion, options.KubeedgeVersion, initOpts.KubeedgeVersion,
+		"Use this key to download and use the required KubeEdge version")
+	cmd.Flags().StringVar(&initOpts.DockerVersion, options.DockerVersion, initOpts.DockerVersion,
+		"Use this key to download and use the required Docker version")
+	cmd.Flags().StringVar(&initOpts.Kubernetesversion, options.Kubernetesversion, initOpts.Kubernetesversion,
+		"Use this key to download and use the required Kubernetes version")
+}
+
+func Add2ToolsList(toolList map[string]util.ToolsInstallerCloud, flagData map[string]FlagData, initOptions *options.InitOptions) {
+	var kubeVer, dockerVer, k8sVer string
+	flgData, ok := flagData[options.KubeedgeVersion]
+	fmt.Println("flagdata kubeedgeversion is %v", flgData)
+	if ok {
+		fmt.Println(options.KubeedgeVersion, "VAL:", flgData.Val.(string), "DEFVAL:", flgData.DefVal.(string))
+		kubeVer = CheckIfAvailable(flgData.Val.(string), flgData.DefVal.(string))
+	} else {
+		kubeVer = initOptions.KubeedgeVersion
+	}
+	fmt.Println(options.KubeedgeVersion, "VAL:", kubeVer, "DEFVAL:", flgData.DefVal.(string))
+	toolList["Cloud"] = &util.KubeCloudInstTool{Common: util.Common{ToolVersion: kubeVer}}
+
+	flgData, ok = flagData[options.DockerVersion]
+	fmt.Println("flagdata docker is %v", flgData)
+	if ok {
+		fmt.Println(options.DockerVersion, "VAL:", flgData.Val.(string), "DEFVAL:", flgData.DefVal.(string))
+		dockerVer = CheckIfAvailable(flgData.Val.(string), flgData.DefVal.(string))
+	} else {
+		dockerVer = initOptions.DockerVersion
+	}
+	fmt.Println(options.DockerVersion, "VAL:", dockerVer, "DEFVAL:", flgData.DefVal.(string))
+	toolList["Docker"] = &util.DockerInstTool{Common: util.Common{ToolVersion: dockerVer}, DefaultToolVer: flgData.DefVal.(string)}
+
+	flgData, ok = flagData[options.Kubernetesversion]
+	if ok {
+		fmt.Println(options.Kubernetesversion, "VAL:", flgData.Val.(string), "DEFVAL:", flgData.DefVal.(string))
+		k8sVer = CheckIfAvailable(flgData.Val.(string), flgData.DefVal.(string))
+	} else {
+		k8sVer = initOptions.Kubernetesversion
+	}
+	fmt.Println(options.Kubernetesversion, "VAL:", k8sVer, "DEFVAL:", flgData.DefVal.(string))
+	toolList["Kubernetes"] = &util.K8SInstTool{Common: util.Common{ToolVersion: k8sVer}, IsEdgeNode: false, DefaultToolVer: flgData.DefVal.(string)}
+
+	fmt.Println(toolList)
+}
+
+func AddToolVals(f *pflag.Flag, flagData map[string]FlagData) {
+	fmt.Println(f.Name, "VAL:", f.Value, "DEFVAL:", f.DefValue)
+	flagData[f.Name] = FlagData{Val: f.Value.String(), DefVal: f.DefValue}
+}
+
+func Execute(toolList map[string]util.ToolsInstallerCloud) {
+	fmt.Println("in execute")
+	//Install all the required tools
+	for name, tool := range toolList {
+		fmt.Println("name is %v tool is %v", name, tool)
+		if name != "Cloud" {
+			err := tool.InstallTools()
+			if err != nil {
+				fmt.Println(err.Error())
+				continue
+			}
+		}
+	}
+	err := toolList["Cloud"].InstallTools()
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+}
+
+func CheckIfAvailable(val, deval string) string {
+	if val == "" {
+		return deval
+	}
+	return val
+}

--- a/kectl/app/cmd/cloud/reset.go
+++ b/kectl/app/cmd/cloud/reset.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Kubeedge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/kubeedge/kubeedge/kectl/app/cmd/util"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cloudResetLongDescription = `
+cloud reset command will tear down KubeEdge 
+cloud component and stop K8S master node
+`
+	cloudResetExample = `
+kectl cloud reset 
+`
+)
+
+// NewCloudReset represents KubeEdge's cloud components reset command
+func NewCloudReset(out io.Writer) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "reset",
+		Short: "Teardowns cloud component",
+		Long:  cloudResetLongDescription,
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO: Work your own magic here
+			fmt.Println("cloud reset called")
+			TearDownEdgeNode()
+		},
+		Example: cloudResetExample,
+		Args:    cobra.NoArgs,
+	}
+
+	return cmd
+}
+
+//TearDoen nodes will do kubeadm reset and kill edgecontroller
+func TearDownEdgeNode() {
+	cloud := &util.KubeCloudInstTool{Common: util.Common{}}
+	cloud.ResetKubernetes()
+	cloud.KillEdgeController()
+	fmt.Println("Reset is sucessful")
+}

--- a/kectl/app/cmd/cloud/reset.go
+++ b/kectl/app/cmd/cloud/reset.go
@@ -27,11 +27,11 @@ import (
 
 var (
 	cloudResetLongDescription = `
-cloud reset command will tear down KubeEdge 
+cloud reset command will tear down KubeEdge
 cloud component and stop K8S master node
 `
 	cloudResetExample = `
-kectl cloud reset 
+kectl cloud reset
 `
 )
 
@@ -44,7 +44,7 @@ func NewCloudReset(out io.Writer) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			// TODO: Work your own magic here
 			fmt.Println("cloud reset called")
-			TearDownEdgeNode()
+			TearDownCloud()
 		},
 		Example: cloudResetExample,
 		Args:    cobra.NoArgs,
@@ -53,10 +53,10 @@ func NewCloudReset(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-//TearDoen nodes will do kubeadm reset and kill edgecontroller
-func TearDownEdgeNode() {
+//Tear Down nodes will do kubeadm reset and kill edgecontroller
+func TearDownCloud() {
 	cloud := &util.KubeCloudInstTool{Common: util.Common{}}
-	cloud.ResetKubernetes()
 	cloud.KillEdgeController()
+	cloud.ResetKubernetes()
 	fmt.Println("Reset is sucessful")
 }

--- a/kectl/app/cmd/common.go
+++ b/kectl/app/cmd/common.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Kubeedge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+//Constants used by installers
+const (
+	KubeCloudCertificatePath   = "/etc/kubeedge/kubeedge/certificates/"
+	KubeControllerConfig       = "/etc/kubeedge/kubeedge/cloud/conf/controller.yaml"
+	KubeCloudBinaryName        = "edgecontroller"
+	KubeCloudApiserverYamlPath = "/etc/kubernetes/manifests/kube-apiserver.yaml"
+	KubeCloudReplaceIndex      = 25
+	KubeCloudReplaceString     = "    - --insecure-bind-address=0.0.0.0\n"
+)
+
+type ToolsInstallerCloud interface {
+	InstallTools() error
+}

--- a/kectl/app/cmd/util/cloudinstaller.go
+++ b/kectl/app/cmd/util/cloudinstaller.go
@@ -1,0 +1,261 @@
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"time"
+)
+
+type KubeCloudInstTool struct {
+	Common
+}
+
+func (cu *KubeCloudInstTool) InstallTools() error {
+	cu.SetOSInterface(GetOSInterface())
+	cu.SetKubeEdgeVersion(cu.ToolVersion)
+
+	err := cu.InstallKubeEdge()
+	if err != nil {
+
+		return err
+	}
+	fmt.Println("Installation of kubeedge package is sucessfull")
+	err = cu.generatecertificates()
+	if err != nil {
+		fmt.Println(" in err")
+		return err
+	}
+	fmt.Println("Certificates got genertaed and its kept in /etc/kubeedge/kubeedge certificates folder")
+	err = cu.tarcertificates()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Certificates got Tared and kept /etc/kubeedge/kubeedge/certificates folder Please copy the certificates to the respective edge node")
+
+	err = cu.startkubernetescluster()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Kubernetes cluster started")
+	err = cu.apiserverHealthcheck()
+	if err != nil {
+		return err
+	}
+	fmt.Println("")
+	err = cu.updatemanifests()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Updation of manifests is sucessful")
+
+	err = cu.updatecontrolleryaml()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Updation of controller yaml is sucess")
+
+	time.Sleep(10 * time.Second)
+	err = cu.RunEdgeController()
+	if err != nil {
+		return err
+	}
+	fmt.Println("Edgecontroller started")
+
+	return nil
+}
+
+//Certifcates ca,cert will be generated in /etc/kubeedge/kubeedge/certificates
+func (cu *KubeCloudInstTool) generatecertificates() error {
+	cmd := &Command{Cmd: exec.Command("bash", "-x", "/etc/kubeedge/kubeedge/tools/certgen.sh", "genCertAndKey", "edge")}
+	err := cmd.ExecuteCmdShowOutput()
+	stdout := cmd.GetStdOutput()
+	errout := cmd.GetStdErr()
+	if err != nil || errout != "" {
+		return fmt.Errorf("%s", "certificates not installed")
+		fmt.Println("in error")
+	}
+	fmt.Println(stdout)
+	return nil
+}
+
+//certificates tar file will be generated in /etc/kubeedge/kubeedge
+func (cu *KubeCloudInstTool) tarcertificates() error {
+
+	cmd := &Command{Cmd: exec.Command("sh", "-c", "tar -cvzf certificates.tar certificates")}
+	cmd.Cmd.Dir = KubeEdgeConfigPath + "kubeedge" // or whatever directory it's in
+	err := cmd.ExecuteCmdShowOutput()
+	stdout := cmd.GetStdOutput()
+	errout := cmd.GetStdErr()
+	if err != nil || errout != "" {
+		return fmt.Errorf("%s", "certificates not tared")
+		fmt.Println("in error")
+	}
+	fmt.Println(stdout)
+	return nil
+}
+
+//controller yaml ca and cert path will be replaces
+func (cu *KubeCloudInstTool) updatecontrolleryaml() error {
+
+	filetoReplace := fmt.Sprintf("sed -i 's|ca: .*|ca: %sca/rootCA.crt|g' %s && sed -i 's|cert: .*|cert: %scerts/edge.crt|g' %s && sed -i 's|key: .*|key: %scerts/edge.key|g' %s ", KubeCloudCertificatePath, KubeControllerConfig, KubeCloudCertificatePath, KubeControllerConfig, KubeCloudCertificatePath, KubeControllerConfig)
+	cmd := &Command{Cmd: exec.Command("sh", "-c", filetoReplace)}
+	//cmd := &Command{Cmd: exec.Command("sh", "-c","sed -i 's|ca: .*|ca: ca/rootCA.crt|g' ",KubeCloudCertificatePath,KubeControllerConfig)}       // or whatever directory it's in
+	err := cmd.ExecuteCmdShowOutput()
+	stdout := cmd.GetStdOutput()
+	errout := cmd.GetStdErr()
+	if err != nil || errout != "" {
+		return fmt.Errorf("%s", "Update controller yaml failed", errout)
+		fmt.Println("in error")
+	}
+	fmt.Println(stdout)
+	return nil
+}
+
+//kubeadm init will be called and cluster will be started
+func (cu *KubeCloudInstTool) startkubernetescluster() error {
+	fmt.Println("in start kubernetes cluster")
+	var install bool
+	cmd := &Command{Cmd: exec.Command("sh", "-c", "kubeadm version")}
+	cmd.ExecuteCommand()
+	str := cmd.GetStdOutput()
+	if str != "" {
+		install = true
+	} else {
+		install = false
+	}
+	if install == true {
+		cmd := &Command{Cmd: exec.Command("sh", "-c", "swapoff -a && kubeadm init")}
+		err := cmd.ExecuteCmdShowOutput()
+		stdout := cmd.GetStdOutput()
+		errout := cmd.GetStdErr()
+		if err != nil || errout != "" {
+			fmt.Errorf("kubernetes Installation failed:%s", stdout)
+		}
+
+		cmd = &Command{Cmd: exec.Command("sh", "-c", "rm  $HOME/.kube/config && mkdir -p $HOME/.kube && echo y |  cp -i /etc/kubernetes/admin.conf $HOME/.kube/config &&  sudo chown $(id -u):$(id -g) $HOME/.kube/config")}
+		err = cmd.ExecuteCmdShowOutput()
+		stdout = cmd.GetStdOutput()
+		errout = cmd.GetStdErr()
+		if err != nil || errout != "" {
+			fmt.Errorf("kubernetes Installation failed:%s", stdout)
+		}
+	}
+	return nil
+}
+
+//Kubernetes Manifests file will be updated by necessary parameters
+func (cu *KubeCloudInstTool) updatemanifests() error {
+
+	input, err := ioutil.ReadFile(KubeCloudApiserverYamlPath)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	output := bytes.Replace(input, []byte("insecure-port=0"), []byte("insecure-port=8080"), -1)
+
+	if err = ioutil.WriteFile(KubeCloudApiserverYamlPath, output, 0666); err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	lines, err := file2lines(KubeCloudApiserverYamlPath)
+	if err != nil {
+		return err
+	}
+
+	fileContent := ""
+	for i, line := range lines {
+		if i == KubeCloudReplaceIndex {
+			fileContent += KubeCloudReplaceString
+		}
+		fileContent += line
+		fileContent += "\n"
+	}
+
+	ioutil.WriteFile(KubeCloudApiserverYamlPath, []byte(fileContent), 0644)
+	return nil
+
+}
+
+func file2lines(filePath string) ([]string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return linesFromReader(f)
+}
+
+func linesFromReader(r io.Reader) ([]string, error) {
+	var lines []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return lines, nil
+}
+
+//starts the Edgecontroller
+func (u *KubeCloudInstTool) RunEdgeController() error {
+
+	filetoCopy := fmt.Sprintf("rm /usr/local/bin/%s && cp %s/kubeedge/cloud/%s /usr/local/bin/.", KubeCloudBinaryName, KubeEdgeConfigPath, KubeCloudBinaryName)
+	cmd := &Command{Cmd: exec.Command("sh", "-c", filetoCopy)}
+	err := cmd.ExecuteCmdShowOutput()
+	errout := cmd.GetStdErr()
+	if err != nil || errout != "" {
+		fmt.Println("in error")
+		return fmt.Errorf("%s", errout)
+
+	}
+	binExec := fmt.Sprintf("chmod +x /usr/local/bin/%s && %s > %s/kubeedge/cloud/%s.log 2>&1 &", KubeCloudBinaryName, KubeCloudBinaryName, KubeEdgeConfigPath, KubeCloudBinaryName)
+	cmd = &Command{Cmd: exec.Command("sh", "-c", binExec)}
+	fmt.Println("binexec is %v", binExec)
+	cmd.Cmd.Env = os.Environ()
+	env := fmt.Sprintf("GOARCHAIUS_CONFIG_PATH=%skubeedge/cloud", KubeEdgeConfigPath)
+	cmd.Cmd.Env = append(cmd.Cmd.Env, env)
+	err = cmd.ExecuteCmdShowOutput()
+	errout = cmd.GetStdErr()
+	if err != nil || errout != "" {
+		return fmt.Errorf("%s", errout)
+	}
+	fmt.Println(cmd.GetStdOutput())
+	return nil
+}
+
+//checks the health of Api server
+func (cu *KubeCloudInstTool) apiserverHealthcheck() error {
+
+	return nil
+}
+
+//kubeadm reset will be called
+func (u *KubeCloudInstTool) ResetKubernetes() error {
+	binExec := fmt.Sprintf("echo 'y' | kubeadm reset && sudo rm -rf ~/.kube")
+	cmd := &Command{Cmd: exec.Command("sh", "-c", binExec)}
+	err := cmd.ExecuteCmdShowOutput()
+	errout := cmd.GetStdErr()
+	if err != nil || errout != "" {
+		return fmt.Errorf("kubernetes installation failed %s", errout)
+		println("in error")
+	}
+	return nil
+}
+
+//kills edgecontroller
+func (u *KubeCloudInstTool) KillEdgeController() error {
+	binExec := fmt.Sprintf("kill -9 $(ps aux | grep '[e]%s' | awk '{print $2}') && pkill -9 apiserver", KubeCloudBinaryName[1:])
+	cmd := &Command{Cmd: exec.Command("sh", "-c", binExec)}
+	cmd.ExecuteCommand()
+	fmt.Println("Edgecontroller is stopped, For logs visit", KubeEdgeConfigPath+"kubeedge/cloud")
+	return nil
+}

--- a/kectl/app/cmd/util/common.go
+++ b/kectl/app/cmd/util/common.go
@@ -16,28 +16,12 @@ limitations under the License.
 
 package util
 
-import (
-	"bytes"
-	"errors"
-	"fmt"
-	"io"
-	"net"
-	"os"
-	"os/exec"
-	"strings"
-	"sync"
-)
-
 //Constants used by installers
 const (
-	KubeCloudCertificatePath   = "/etc/kubeedge/kubeedge/certificates/"
+	KubeCloudCertificatePath   = "/etc/kubeedge/"
 	KubeControllerConfig       = "/etc/kubeedge/kubeedge/cloud/conf/controller.yaml"
 	KubeCloudBinaryName        = "edgecontroller"
 	KubeCloudApiserverYamlPath = "/etc/kubernetes/manifests/kube-apiserver.yaml"
 	KubeCloudReplaceIndex      = 25
 	KubeCloudReplaceString     = "    - --insecure-bind-address=0.0.0.0\n"
 )
-
-type ToolsInstallerCloud interface {
-	InstallTools() error
-}

--- a/kectl/app/cmd/util/ubuntuinstaller.go
+++ b/kectl/app/cmd/util/ubuntuinstaller.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+//ResetKubernetes will call Kubeadm reset
+func (u *KubeCloudInstTool) ResetKubernetes() error {
+
+	binExec := fmt.Sprintf("echo 'y' | kubeadm reset &&  rm -rf ~/.kube")
+	cmd := &Command{Cmd: exec.Command("sh", "-c", binExec)}
+	err := cmd.ExecuteCmdShowOutput()
+	errout := cmd.GetStdErr()
+	if err != nil || errout != "" {
+		return fmt.Errorf("kubernetes reset failed %s", errout)
+	}
+	return nil
+}
+
+// KillEdgeController forcefully kills the EdgeController process
+func (u *KubeCloudInstTool) KillEdgeController() error {
+
+	binExec := fmt.Sprintf("kill -9 $(ps aux | grep '[e]%s' | awk '{print $2}') && pkill -9 apiserver", KubeCloudBinaryName[1:])
+	cmd := &Command{Cmd: exec.Command("sh", "-c", binExec)}
+	cmd.ExecuteCommand()
+	fmt.Println("Edgecontroller is stopped, For logs visit", KubeEdgePath+"kubeedge/cloud")
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
Implementation of cloud init and reset

 /kind feature


**What this PR does / why we need it**:
Implements cloud Init and Reset
**Which issue(s) this PR fixes**:
Fixes #342 

*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
Special notes for your reviewer:

    1.This PR is raised for cloud node commands like, "kectl cloud init" and "kectl cloud reset" on ubuntu OS.
    2.Code comments are yet to be added every where.
    3.Error handling and some function(check apiserver health ) must be implemented and is in progress
    4.Cloud commands like "kectl cloud init" and "kectl cloud reset" will be added to this PR soon.
    5.There will be lot of debug fmt.Println's, please ignore them as of now. It will be removed soon.
    6. Lints will fail, so please ignore for now.
    7.E2E will be soon tested
    8. These PR must be merged ,after  edge join and edge reset PR is merged
    9. Certgen.sh script must be placed in release package(kubeedge-v0.2.1-linux-amd64.tar.gz) in /etc/kubeedge/kubeedge/tools folder otherwise installation fails for first time saying certificates not generated

