### PR TITLE
docs: [ Fix #436 ] : Apply device CRDs before running cloud.

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -83,6 +83,12 @@ The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/cert
     + cloudhub.cert
     + cloudhub.key
 
++ Create device model and device CRDs.
+    ```shell
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
+    kubectl create -f devices_v1alpha1_devicemodel.yaml
+    kubectl create -f devices_v1alpha1_device.yaml
+    ```
 + Run cloud
     ```shell
     cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds a step to apply device model and device instance CRDs before running the cloud component.

**Which issue(s) this PR fixes**:
Fixes #436 

**Special notes for your reviewer**:
NONE