### PR TITLE
Automated cherry pick of #450: docs: [ Fix #436 ] : Apply device CRDs before running cloud.

### DIFF
--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -83,6 +83,12 @@ The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/cert
     + cloudhub.cert
     + cloudhub.key
 
++ Create device model and device CRDs.
+    ```shell
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
+    kubectl create -f devices_v1alpha1_devicemodel.yaml
+    kubectl create -f devices_v1alpha1_device.yaml
+    ```
 + Run cloud
     ```shell
     cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud


### PR DESCRIPTION
Cherry pick of #450 on release-0.3.

#450: docs: [ Fix #436 ] : Apply device CRDs before running cloud.