### PR TITLE
Distinguish debugging information between controller and devicecontroller

### DIFF
--- a/cloud/pkg/controller/config/kube.go
+++ b/cloud/pkg/controller/config/kube.go
@@ -31,51 +31,51 @@ var KubeUpdateNodeFrequency time.Duration
 
 func init() {
 	if km, err := config.CONFIG.GetValue("controller.kube.master").ToString(); err != nil {
-		log.LOGGER.Errorf("kube master not set")
+		log.LOGGER.Errorf("Controller kube master not set")
 	} else {
 		KubeMaster = km
 	}
-	log.LOGGER.Infof("kube master: %s", KubeMaster)
+	log.LOGGER.Infof("Controller kube master: %s", KubeMaster)
 
 	if kc, err := config.CONFIG.GetValue("controller.kube.kubeconfig").ToString(); err != nil {
-		log.LOGGER.Errorf("kube config not set")
+		log.LOGGER.Errorf("Controller kube config not set")
 	} else {
 		KubeConfig = kc
 	}
-	log.LOGGER.Infof("kube config: %s", KubeConfig)
+	log.LOGGER.Infof("Controller kube config: %s", KubeConfig)
 
 	if kn, err := config.CONFIG.GetValue("controller.kube.namespace").ToString(); err != nil {
 		KubeNamespace = constants.DefaultKubeNamespace
 	} else {
 		KubeNamespace = kn
 	}
-	log.LOGGER.Infof("kube namespace: %s", KubeNamespace)
+	log.LOGGER.Infof("Controller kube namespace: %s", KubeNamespace)
 
 	if kct, err := config.CONFIG.GetValue("controller.kube.content_type").ToString(); err != nil {
 		KubeContentType = constants.DefaultKubeContentType
 	} else {
 		KubeContentType = kct
 	}
-	log.LOGGER.Infof("kube content type: %s", KubeContentType)
+	log.LOGGER.Infof("Controller kube content type: %s", KubeContentType)
 
 	if kqps, err := config.CONFIG.GetValue("controller.kube.qps").ToFloat64(); err != nil {
 		KubeQPS = constants.DefaultKubeQPS
 	} else {
 		KubeQPS = float32(kqps)
 	}
-	log.LOGGER.Infof("kube QPS: %f", KubeQPS)
+	log.LOGGER.Infof("Controller kube QPS: %f", KubeQPS)
 
 	if kb, err := config.CONFIG.GetValue("controller.kube.burst").ToInt(); err != nil {
 		KubeBurst = constants.DefaultKubeBurst
 	} else {
 		KubeBurst = kb
 	}
-	log.LOGGER.Infof("kube burst: %d", KubeBurst)
+	log.LOGGER.Infof("Controller kube burst: %d", KubeBurst)
 
 	if kuf, err := config.CONFIG.GetValue("controller.kube.node_update_frequency").ToInt64(); err != nil {
 		KubeUpdateNodeFrequency = constants.DefaultKubeUpdateNodeFrequency * time.Second
 	} else {
 		KubeUpdateNodeFrequency = time.Duration(kuf) * time.Second
 	}
-	log.LOGGER.Infof("kube update frequency: %v", KubeUpdateNodeFrequency)
+	log.LOGGER.Infof("Controller kube update frequency: %v", KubeUpdateNodeFrequency)
 }

--- a/cloud/pkg/devicecontroller/config/kube.go
+++ b/cloud/pkg/devicecontroller/config/kube.go
@@ -26,44 +26,44 @@ var KubeBurst int
 
 func init() {
 	if km, err := config.CONFIG.GetValue("devicecontroller.kube.master").ToString(); err != nil {
-		log.LOGGER.Errorf("Kube master not set")
+		log.LOGGER.Errorf("Devicecontroller kube master not set")
 	} else {
 		KubeMaster = km
 	}
-	log.LOGGER.Infof("Kube master: %s", KubeMaster)
+	log.LOGGER.Infof("Devicecontroller kube master: %s", KubeMaster)
 
 	if kc, err := config.CONFIG.GetValue("devicecontroller.kube.kubeconfig").ToString(); err != nil {
-		log.LOGGER.Errorf("Kube config not set")
+		log.LOGGER.Errorf("Devicecontroller kube config not set")
 	} else {
 		KubeConfig = kc
 	}
-	log.LOGGER.Infof("Kube config: %s", KubeConfig)
+	log.LOGGER.Infof("Devicecontroller kube config: %s", KubeConfig)
 
 	if kn, err := config.CONFIG.GetValue("devicecontroller.kube.namespace").ToString(); err != nil {
 		KubeNamespace = constants.DefaultKubeNamespace
 	} else {
 		KubeNamespace = kn
 	}
-	log.LOGGER.Infof("Kube namespace: %s", KubeNamespace)
+	log.LOGGER.Infof("Devicecontroller kube namespace: %s", KubeNamespace)
 
 	if kct, err := config.CONFIG.GetValue("devicecontroller.kube.content_type").ToString(); err != nil {
 		KubeContentType = constants.DefaultKubeContentType
 	} else {
 		KubeContentType = kct
 	}
-	log.LOGGER.Infof("Kube content type: %s", KubeContentType)
+	log.LOGGER.Infof("Devicecontroller kube content type: %s", KubeContentType)
 
 	if kqps, err := config.CONFIG.GetValue("devicecontroller.kube.qps").ToFloat64(); err != nil {
 		KubeQPS = constants.DefaultKubeQPS
 	} else {
 		KubeQPS = float32(kqps)
 	}
-	log.LOGGER.Infof("Kube QPS: %f", KubeQPS)
+	log.LOGGER.Infof("Devicecontroller kube QPS: %f", KubeQPS)
 
 	if kb, err := config.CONFIG.GetValue("controller.kube.burst").ToInt(); err != nil {
 		KubeBurst = constants.DefaultKubeBurst
 	} else {
 		KubeBurst = kb
 	}
-	log.LOGGER.Infof("Kube burst: %d", KubeBurst)
+	log.LOGGER.Infof("Devicecontroller kube burst: %d", KubeBurst)
 }


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

/kind cleanup

**What this PR does / why we need it**:
when edgecontroller start, it will output such logs
```
2019-05-08 08:51:58.808 +08:00 INFO core/module.go:41 module cloudhub registered
...

2019-05-08 08:51:58.812 +08:00 INFO config/kube.go:45 kube config: /root/.kube/config
2019-05-08 08:51:58.812 +08:00 INFO config/kube.go:52 kube namespace:
2019-05-08 08:51:58.812 +08:00 INFO config/kube.go:59 kube content type: application/vnd.kubernetes.protobuf
...
2019-05-08 08:51:58.831 +08:00 INFO core/module.go:41 module controller registered
...
2019-05-08 08:51:58.832 +08:00 ERROR config/kube.go:29 Kube master not set
2019-05-08 08:51:58.832 +08:00 INFO config/kube.go:33 Kube master:
2019-05-08 08:51:58.832 +08:00 ERROR config/kube.go:36 Kube config not set
```
It is often misleading in kubemaster and kube config.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Distinguish debugging information between controller and devicecontroller

