### PR TITLE
Added Device CRD sample for CC2650 Bluetooth device

### DIFF
--- a/build/crd-samples/devices/CC2650-device-instance.yaml
+++ b/build/crd-samples/devices/CC2650-device-instance.yaml
@@ -1,0 +1,37 @@
+  
+apiVersion: devices.kubeedge.io/v1alpha1
+kind: Device
+metadata:
+  name: sensor-tag-instance-01
+  labels:
+    description: TISimplelinkSensorTag
+    manufacturer: TexasInstruments
+    model: cc2650-sensortag
+spec:
+  deviceModelRef:
+    name: cc2650-sensortag
+  protocol:
+    bluetooth:
+      macAddress: "BC:6A:29:AE:CC:96"   #pls note it is optional to provide MAC address
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+      - key: ''
+        operator: In
+        values:
+        - edge-node1          #pls give your edge node name
+status:
+  twins:
+    - propertyName: temperature-enable
+      desired:
+        metadata:
+          timestamp: '1550049403598'
+          type: string
+        value: 'ON'
+    - propertyName: io-data
+      desired:
+        metadata:
+          timestamp: '1550049403598'
+          type: int
+        value: "3"
+

--- a/build/crd-samples/devices/CC2650-device-instance.yaml
+++ b/build/crd-samples/devices/CC2650-device-instance.yaml
@@ -23,15 +23,4 @@ spec:
 status:
   twins:
     - propertyName: temperature-enable
-      desired:
-        metadata:
-          timestamp: '1550049403598'
-          type: string
-        value: 'ON'
     - propertyName: io-data
-      desired:
-        metadata:
-          timestamp: '1550049403598'
-          type: int
-        value: "3"
-

--- a/build/crd-samples/devices/CC2650-device-model.yaml
+++ b/build/crd-samples/devices/CC2650-device-model.yaml
@@ -1,0 +1,81 @@
+apiVersion: devices.kubeedge.io/v1alpha1
+kind: DeviceModel
+metadata:
+ name: cc2650-sensortag
+ namespace: default
+spec:
+ properties:
+  - name: temperature
+    description: temperature in degree celsius
+    type:
+     int:
+      accessMode: Read
+      maximum: 100
+      unit: degree celsius
+  - name: temperature-enable
+    description: enable data collection of temperature sensor
+    type:
+      string:
+        accessMode: ReadWrite
+        defaultValue: 'ON'
+  - name: io-config-initialize
+    description: initialize io-config with value 0
+    type:
+     int:
+      accessMode: ReadWrite
+      defaultValue: 0
+  - name: io-data-initialize
+    description:  initialize io-data with value 0
+    type:
+     int:
+      accessMode: ReadWrite
+      defaultValue: 0
+  - name: io-config
+    description: register activation of io-config 
+    type:
+     int:
+      accessMode: ReadWrite
+      defaultValue: 1
+  - name: io-data
+    description: data field to control io-control
+    type:
+     int:
+      accessMode: ReadWrite
+      defaultValue: 0
+ propertyVisitors:
+  - propertyName: temperature
+    bluetooth:
+     characteristicUUID: f000aa0104514000b000000000000000
+     dataConverter:
+      startIndex: 1
+      endIndex: 0
+      shiftRight: 2
+      orderOfOperations:
+      - operationType: Multiply
+        operationValue: 0.03125
+  - propertyName: temperature-enable
+    bluetooth:
+     characteristicUUID: f000aa0204514000b000000000000000
+     dataWrite:
+      ON: [1]
+      OFF: [0]
+  - propertyName: io-config-initialize
+    bluetooth:
+     characteristicUUID: f000aa6604514000b000000000000000
+  - propertyName: io-data-initialize
+    bluetooth:
+     characteristicUUID: f000aa6504514000b000000000000000
+  - propertyName: io-config
+    bluetooth:
+     characteristicUUID: f000aa6604514000b000000000000000
+  - propertyName: io-data
+    bluetooth:
+     characteristicUUID: f000aa6504514000b000000000000000
+     dataWrite:
+      Red: [1]
+      Green: [2]
+      RedGreen: [3]
+      Buzzer: [4]
+      BuzzerRed: [5]
+      BuzzerGreen: [6]
+      BuzzerRedGreen: [7]


### PR DESCRIPTION

**What type of PR is this?**
 /kind api-change

**What this PR does / why we need it**:
This PR contains device model & device instance defined for TI CC2650 bluetooth device (currently using IR temperature & IO-Data control feature). The user can make use of this directly to make use of the bluetooth mapper, if they have this device or they can use this as reference to create CRDs for their bluetooth device 

**Which issue(s) this PR fixes**:

Fixes #461 

**Special notes for your reviewer**:
