### PR TITLE
when edge register into cloud, cloud send all info to edge

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -84,6 +84,11 @@ func (q *ChannelEventQueue) dispatchMessage() {
 			log.LOGGER.Warnf("node id is not found in the message")
 			continue
 		}
+		_, ok := q.channelPool.Load(nodeID)
+		if !ok {
+			rChannel := make(chan model.Event, rChanBufSize)
+			q.channelPool.LoadOrStore(nodeID, rChannel)
+		}
 		rChannel, err := q.getRChannel(nodeID)
 		if err != nil {
 			log.LOGGER.Infof("fail to get dispatch channel for %s", nodeID)

--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -115,15 +115,14 @@ func (q *ChannelEventQueue) getRChannel(nodeID string) (chan model.Event, error)
 // Connect allocates rChannel for given project and group
 func (q *ChannelEventQueue) Connect(info *model.HubInfo) error {
 	_, ok := q.channelPool.Load(info.NodeID)
-	if ok {
-		return fmt.Errorf("edge node %s is already connected", info.NodeID)
-	}
-	// allocate a new rchannel with default buffer size
-	rChannel := make(chan model.Event, rChanBufSize)
-	_, ok = q.channelPool.LoadOrStore(info.NodeID, rChannel)
-	if ok {
-		// rchannel is already allocated
-		return fmt.Errorf("edge node %s is already connected", info.NodeID)
+	if !ok {
+		// allocate a new rchannel with default buffer size
+		rChannel := make(chan model.Event, rChanBufSize)
+		_, ok = q.channelPool.LoadOrStore(info.NodeID, rChannel)
+		if ok {
+			// rchannel is already allocated
+			return fmt.Errorf("edge node %s is already connected", info.NodeID)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:

when edgecontroller first started , and  edge_core sencond started after many hours or days.
edgecontroller first get all pods and then send to the relevant host channelPool
```
type ChannelEventQueue struct {
	ctx         *context.Context
	channelPool sync.Map
}
```
but if now , edge_core not started, the relevant host channelpool can not find, so edgecontroller can not send full ammount event to edge_core, this will result in loss of pod information.

so we need save these events in advance.

but maybe we need merge this events to Remove old duplicates.
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #455 
FIxes #260

**Special notes for your reviewer**:
