### PR TITLE
Add info for go 1.12 for go mod and gopath

### DIFF
--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -153,6 +153,12 @@ openssl req -new -key kubeedge.key -out kubeedge.csr
 openssl x509 -req -in kubeedge.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out kubeedge.crt -days 500 -sha256 
 ```
 ## Build  
+**Info**
+If your are running go 1.12 or higher make sure to disable go mod and set GOPATH.
+```shell
+export GO111MODULE=off
+export GOPATH=$HOME/go
+```
 ### Clone KubeEdge
 
 ```shell


### PR DESCRIPTION
This is adds documentation for go version >= 1.12.0 where go111modules is set to "on" per default. This will run into problems downloading dependencies.

Added small info for exporting go111modules=off and setting GOPATH=$HOME/go. 

Note: GOPATH could be different and could thus lead to issues.