### PR TITLE
Changed exit status bluetooth mapper on bad configuration and Fixed a typo in bluetooth mapper README

### DIFF
--- a/device/bluetooth_mapper/README.md
+++ b/device/bluetooth_mapper/README.md
@@ -39,7 +39,7 @@ cd $GOPATH/src/github.com/kubeedge/kubeedge/device/bluetooth_mapper
 #    1. Replace <edge_node_name> with the name of your edge node at spec.template.spec.voluems.configMap.name
 #    2. Replace <your_dockerhub_username> with your dockerhub username at spec.template.spec.containers.image
 
-kubectl create -f deplyment.yaml
+kubectl create -f deployment.yaml
 ```
 
 ## Modules

--- a/device/bluetooth_mapper/configuration/config.yaml
+++ b/device/bluetooth_mapper/configuration/config.yaml
@@ -18,7 +18,7 @@ action-manager:
       perform-immediately: true
       device-property-name: io-data-initialize      #property-name defined in the device model
     - name: IOConfiguration
-      perform-immediately: false
+      perform-immediately: true
       device-property-name: io-config                #property-name defined in the device model
     - name: IOData
       perform-immediately: false

--- a/device/bluetooth_mapper/main.go
+++ b/device/bluetooth_mapper/main.go
@@ -47,7 +47,7 @@ func main() {
 	err := BleConfig.Load()
 	if err != nil {
 		glog.Errorf("Error in loading configuration: %s", err)
-		return
+		os.Exit(1)
 	}
 	bleController := controller.ControllerConfig{
 		Watcher:       BleConfig.Watcher,


### PR DESCRIPTION

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR fixes a typo in bluetooth mapper README and ensures that the mapper returns status 1 instead of status report when the program exits due to bad configuration, which will make it easier for user to debug incase something goes wrong.
 
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #474 