### PR TITLE
Fixed restart issue of mapper

### DIFF
--- a/device/bluetooth_mapper/configuration/config.go
+++ b/device/bluetooth_mapper/configuration/config.go
@@ -35,7 +35,7 @@ import (
 var CONFIG_FILE_PATH = "configuration/config.yaml"
 
 //CONFIG_MAP_PATH contains the location of the configuration file
-var CONFIG_MAP_PATH = "/opt/kubeedge/device_profile.json"
+var CONFIG_MAP_PATH = "/opt/kubeedge/deviceProfile.json"
 
 //Config is the global configuration used by all the modules of the mapper
 var Config *BLEConfig

--- a/device/bluetooth_mapper/deployment.yaml
+++ b/device/bluetooth_mapper/deployment.yaml
@@ -22,7 +22,6 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /opt/kubeedge/
-          subPath: device_profile.json
       nodeSelector:
         bluetooth: "true"      
       volumes:


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR fixes the restart issue of bluetooth mapper, which was caused due to the mismatch of name with the file present in the config map and the file expected by the mapper.

**Which issue(s) this PR fixes**:
Fixes #491

