### PR TITLE
Fix nits in the doc - arch for arm64 is not correct

### DIFF
--- a/build/edge/README.md
+++ b/build/edge/README.md
@@ -48,7 +48,7 @@ container and MQTT Broker, so make sure that docker engine listening on
   - Set the CPU type
 
     ```
-    ./run_daemon.sh set arch=arm64v8 qemu_arch=aarch
+    ./run_daemon.sh set arch=arm64v8 qemu_arch=aarch64
     ```
   - Build image
     ```

--- a/build/edge/README_zh.md
+++ b/build/edge/README_zh.md
@@ -46,7 +46,7 @@
   - 设置CPU类型
 
     ```
-    ./run_daemon.sh set arch=arm64v8 qemu_arch=aarch
+    ./run_daemon.sh set arch=arm64v8 qemu_arch=aarch64
     ```
 
   - 编译镜像


### PR DESCRIPTION
See: https://github.com/multiarch/qemu-user-static/releases

Signed-off-by: Dave Chen <dave.chen@arm.com>


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

 /kind documentation


