### PR TITLE
Build edgeimage with `docker-compose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ cloudimage:
 
 .PHONY: edgeimage
 edgeimage:
-	docker build -t kubeedge/edgecore:${IMAGE_TAG} -f build/edge/Dockerfile .
+	cd build/edge && ./run_daemon.sh build

--- a/build/edge/kubernetes/README.md
+++ b/build/edge/kubernetes/README.md
@@ -10,6 +10,15 @@ will be used, so place these files to somewhere you can kubectl with.
 First, ensure your k8s cluster can pull edge core image. If the
 image not exist. We can make one, and push to your registry.
 
+- Check the container runtime environment
+
+```bash
+cd $GOPATH/src/github.com/kubeedge/kubeedge/build/edge
+./run_daemon.sh prepare
+```
+
+- Build edge core image
+
 ```bash
 cd $GOPATH/src/github.com/kubeedge/kubeedge
 make edgeimage

--- a/build/edge/kubernetes/README_zh.md
+++ b/build/edge/kubernetes/README_zh.md
@@ -6,6 +6,15 @@
 
 首先， 确保 k8s 集群可以拉到 edge core 镜像。如果没有， 可以构建一个，然后推到集群能拉到的 registry 上。
 
+- 检查容器运行环境
+
+```bash
+  cd $GOPATH/src/github.com/kubeedge/kubeedge/build/edge
+  ./run_daemon.sh prepare
+```
+
+- 构建edge core镜像
+
 ```bash
 cd $GOPATH/src/github.com/kubeedge/kubeedge
 make edgeimage


### PR DESCRIPTION
docker compose use the dockerfile for cross-build which needs the bianry
from `qemu-user-static`.

Since kubeedge also supports to build edgecore image from dockerfile directly,
which currently lack of the feature of cross-build, solely copy the binary
doesn't work for cross-build.

This change decouples two files, and the support of cross build for `make edgeimage`
will be addressed in another patch.

Fix: #443

Signed-off-by: Dave Chen <dave.chen@arm.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
> /kind bug

Fixes #443

