### PR TITLE
set websocket as default protocal

### DIFF
--- a/cloud/pkg/cloudhub/common/util/config.go
+++ b/cloud/pkg/cloudhub/common/util/config.go
@@ -11,6 +11,10 @@ func init() {
 	HubConfig = &Config{}
 	HubConfig.ProtocolWebsocket, _ = config.CONFIG.GetValue("cloudhub.protocol_websocket").ToBool()
 	HubConfig.ProtocolQuic, _ = config.CONFIG.GetValue("cloudhub.protocol_quic").ToBool()
+	if !HubConfig.ProtocolWebsocket && !HubConfig.ProtocolQuic {
+		HubConfig.ProtocolWebsocket = true
+	}
+
 	HubConfig.Address, _ = config.CONFIG.GetValue("cloudhub.address").ToString()
 	HubConfig.Port, _ = config.CONFIG.GetValue("cloudhub.port").ToInt()
 	HubConfig.QuicPort, _ = config.CONFIG.GetValue("cloudhub.quic_port").ToInt()

--- a/cloud/pkg/cloudhub/wsserver/server.go
+++ b/cloud/pkg/cloudhub/wsserver/server.go
@@ -1,12 +1,9 @@
 package wsserver
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -16,14 +13,12 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 
-	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/channelq"
-	hubio "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/io"
-	emodel "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/model"
-	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/util"
-
 	bhLog "github.com/kubeedge/beehive/pkg/common/log"
 	"github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/channelq"
+	hubio "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/io"
+	emodel "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/model"
 )
 
 // ExitCode exit code
@@ -367,51 +362,4 @@ func (f *FilterWriter) Write(p []byte) (n int, err error) {
 		return 0, nil
 	}
 	return os.Stderr.Write(p)
-}
-
-// StartCloudHub starts the cloud hub service
-func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue) error {
-	// init certificate
-	pool := x509.NewCertPool()
-	ok := pool.AppendCertsFromPEM(config.Ca)
-	if !ok {
-		return fmt.Errorf("fail to load ca content")
-	}
-	cert, err := tls.X509KeyPair(config.Cert, config.Key)
-	if err != nil {
-		return err
-	}
-	tlsConfig := tls.Config{
-		ClientCAs:    pool,
-		ClientAuth:   tls.RequestClientCert,
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
-	}
-
-	// init handler
-	ah := &AccessHandle{
-		EventHandle: &EventHandle{
-			KeepaliveInterval: config.KeepaliveInterval,
-			WriteTimeout:      config.WriteTimeout,
-			EventQueue:        eventq,
-		},
-		NodeLimit: config.NodeLimit,
-	}
-	EventHandler = ah.EventHandle
-
-	router := mux.NewRouter()
-	router.HandleFunc(PathEvent, ah.ServeEvent)
-
-	// start server
-	s := http.Server{
-		Addr:      fmt.Sprintf("%s:%d", config.Address, config.Port),
-		Handler:   router,
-		TLSConfig: &tlsConfig,
-		ErrorLog:  log.New(&FilterWriter{}, "", log.LstdFlags),
-	}
-	bhLog.LOGGER.Infof("Start cloud hub service")
-	go s.ListenAndServeTLS("", "")
-
-	return nil
 }


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:
set websocket as default protocal

if i am not set any config in conf/controller.yaml about `cloudhub.protocol*`
eg:(lack of `cloudhub.protocol_websocket` or `cloudhub.protocol_quic`)
```
controller:
  kube:
    master: http://localhost:8090
    namespace: ""
    content_type: "application/vnd.kubernetes.protobuf"
    qps: 5
    burst: 10
    node_update_frequency: 10
    kubeconfig: "/root/.kube/config"   #Enter path to kubeconfig file to enable https connection to k8s apiserver
cloudhub:
  address: 0.0.0.0
  port: 10000
  ca: /etc/kubeedge/ca/rootCA.crt
  cert: /etc/kubeedge/certs/edge.crt
  key: /etc/kubeedge/certs/edge.key
  keepalive-interval: 30
  write-timeout: 30
  node-limit: 10
```
edgecontroller can not start any web server. so edge can not register itself to k8s.
 
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

delete useless function `StartCloudHub` in `cloud/pkg/cloudhub/wsserver/server.go `.

This function  is not be called。