### PR TITLE
Print message content as string instead of uint8 array

### DIFF
--- a/edge/pkg/edgehub/controller.go
+++ b/edge/pkg/edgehub/controller.go
@@ -196,7 +196,7 @@ func (ehc *Controller) routeToEdge() {
 			return
 		}
 
-		log.LOGGER.Infof("received msg from cloud-hub:%#v", message)
+		log.LOGGER.Infof("received msg from cloud-hub:%+v", message)
 		err = ehc.dispatch(message)
 		if err != nil {
 			log.LOGGER.Errorf("failed to dispatch message, discard: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Print message content as string instead of uint8 array

**Which issue(s) this PR fixes**:
Fixes #547

**Special notes for your reviewer**:
