### PR TITLE
Mismatch in access mode names

### DIFF
--- a/device/bluetooth_mapper/configuration/config.go
+++ b/device/bluetooth_mapper/configuration/config.go
@@ -43,6 +43,8 @@ var Config *BLEConfig
 //Blutooth protocol name
 const (
 	Protocol_Name string = "BLUETOOTH"
+	READWRITE     string = "ReadWrite"
+	READ          string = "Read"
 )
 
 //BLEConfig is the main structure that stores the configuration information read from both the config file as well as the config map
@@ -182,7 +184,7 @@ func (b *BLEConfig) Load() error {
 			if strings.ToUpper(deviceModel.Name) == strings.ToUpper(b.Device.Name) {
 				for _, property := range deviceModel.Properties {
 					if strings.ToUpper(property.Name) == strings.ToUpper(actionConfig.PropertyName) {
-						if strings.ToUpper(property.AccessMode) == "RW" {
+						if strings.ToUpper(property.AccessMode) == strings.ToUpper(READWRITE){
 							action.Operation.Action = "Write"
 							if strings.ToUpper(property.DataType) == "INT" {
 								value := string(int(property.DefaultValue.(float64)))
@@ -200,7 +202,7 @@ func (b *BLEConfig) Load() error {
 									}
 								}
 							}
-						} else if strings.ToUpper(property.AccessMode) == "R" {
+						} else if strings.ToUpper(property.AccessMode) == strings.ToUpper(READ) {
 							action.Operation.Action = "Read"
 						}
 					}

--- a/device/bluetooth_mapper/configuration/config.go
+++ b/device/bluetooth_mapper/configuration/config.go
@@ -184,7 +184,7 @@ func (b *BLEConfig) Load() error {
 			if strings.ToUpper(deviceModel.Name) == strings.ToUpper(b.Device.Name) {
 				for _, property := range deviceModel.Properties {
 					if strings.ToUpper(property.Name) == strings.ToUpper(actionConfig.PropertyName) {
-						if strings.ToUpper(property.AccessMode) == strings.ToUpper(READWRITE){
+						if property.AccessMode == READWRITE{
 							action.Operation.Action = "Write"
 							if strings.ToUpper(property.DataType) == "INT" {
 								value := string(int(property.DefaultValue.(float64)))
@@ -202,7 +202,7 @@ func (b *BLEConfig) Load() error {
 									}
 								}
 							}
-						} else if strings.ToUpper(property.AccessMode) == strings.ToUpper(READ) {
+						} else if property.AccessMode == READ {
 							action.Operation.Action = "Read"
 						}
 					}

--- a/device/bluetooth_mapper/configuration/config.yaml
+++ b/device/bluetooth_mapper/configuration/config.yaml
@@ -2,7 +2,7 @@ mqtt:
   mode: 0       # 0 -internal mqtt broker  1 - external mqtt broker
   server: tcp://127.0.0.1:1883 # external mqtt broker url.
   internal-server: tcp://127.0.0.1:1884 # internal mqtt broker url.
-device-model-name: CC2650 SensorTag
+device-model-name: cc2650-sensortag
 action-manager:
   actions:
     - name: IRTemperatureConfiguration


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR fixes a mismatch in the Access mode names due to which the action manager is not performing as expected in the bluetooth mapper

**Which issue(s) this PR fixes**:
Fixes #545 
