### PR TITLE
Added nil pointer handling in watcher,go

### DIFF
--- a/device/bluetooth_mapper/controller/controller.go
+++ b/device/bluetooth_mapper/controller/controller.go
@@ -79,7 +79,7 @@ func (c *ControllerConfig) Start() {
 
 	<-watcher.DeviceConnected
 	for _, action := range c.ActionManager.Actions {
-		if action.PerformImmediately{
+		if action.PerformImmediately {
 			action.PerformOperation()
 		}
 	}

--- a/device/bluetooth_mapper/watcher/watcher.go
+++ b/device/bluetooth_mapper/watcher/watcher.go
@@ -103,8 +103,8 @@ func (w *Watcher) onPeripheralConnected(p gatt.Peripheral, err error) {
 	DeviceConnected <- true
 	helper.ChangeDeviceState("online", deviceID)
 	for {
-		newWatcher:=&Watcher{}
-		if !reflect.DeepEqual(w,newWatcher) {
+		newWatcher := &Watcher{}
+		if !reflect.DeepEqual(w, newWatcher) {
 			err := w.EquateTwinValue(deviceID)
 			if err != nil {
 				glog.Errorf("Error in watcher functionality: %s", err)
@@ -123,9 +123,9 @@ func (w *Watcher) EquateTwinValue(deviceID string) error {
 	helper.GetTwin(updateMessage, deviceID)
 	helper.Wg.Wait()
 	twinUpdated := false
-	for _, twinAttribute := range w.DeviceTwinAttributes  {
+	for _, twinAttribute := range w.DeviceTwinAttributes {
 		if helper.TwinResult.Twin[twinAttribute.Name] != nil {
-			if (helper.TwinResult.Twin[twinAttribute.Name].Actual == nil) || (*helper.TwinResult.Twin[twinAttribute.Name].Expected.Value != *helper.TwinResult.Twin[twinAttribute.Name].Actual.Value) {
+			if helper.TwinResult.Twin[twinAttribute.Name].Expected != nil && ((helper.TwinResult.Twin[twinAttribute.Name].Actual == nil) && helper.TwinResult.Twin[twinAttribute.Name].Expected != nil || (*helper.TwinResult.Twin[twinAttribute.Name].Expected.Value != *helper.TwinResult.Twin[twinAttribute.Name].Actual.Value)) {
 				glog.Infof("%s Expected Value : %s", twinAttribute.Name, *helper.TwinResult.Twin[twinAttribute.Name].Expected.Value)
 				if helper.TwinResult.Twin[twinAttribute.Name].Actual == nil {
 					glog.Infof("%s  Actual Value: %s", twinAttribute.Name, helper.TwinResult.Twin[twinAttribute.Name].Actual)


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR fixes the issue of bluetooth mapper panicing when watcher is started without creating desired state for the device

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #560 

**Special notes for your reviewer**:
