### PR TITLE
Correct broken links in testing user guide

### DIFF
--- a/docs/guides/unit_test_guide.md
+++ b/docs/guides/unit_test_guide.md
@@ -28,9 +28,9 @@ There is gomock package in kubeedge vendor directory without mockgen. Please use
  
  Read [godoc](https://godoc.org/github.com/onsi/ginkgo) for more information about ginkgo.
  
-See a [sample](https://github.com/kubeedge/kubeedge/blob/master/pkg/metamanager/dao/meta_test.go) in kubeedge where go builtin package testing and gomock is used for writing unit tests.
+See a [sample](https://github.com/kubeedge/kubeedge/blob/master/edge/pkg/metamanager/dao/meta_test.go) in kubeedge where go builtin package testing and gomock is used for writing unit tests.
 
-See a [sample](https://github.com/kubeedge/kubeedge/blob/master/pkg/devicetwin/dtmodule/dtmodule_test.go) in kubeedge where ginkgo is used for testing.
+See a [sample](https://github.com/kubeedge/kubeedge/blob/master/edge/pkg/devicetwin/dtmodule/dtmodule_test.go) in kubeedge where ginkgo is used for testing.
 
 ## Writing UT using GoMock  
 


### PR DESCRIPTION
Links to example tests are broken in the testing user guide
under "Ginkgo" heading.

This patch corrects those links.

Fixes #567

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #567

**Special notes for your reviewer**:
