### PR TITLE
Correct broken links in usage_zh guide

### DIFF
--- a/docs/getting-started/usage_zh.md
+++ b/docs/getting-started/usage_zh.md
@@ -99,7 +99,7 @@ KubeEdge 在云和边缘之间基于证书进行身份验证/授权。证书可�
   ```
 
   KubeEdge 可以跨平台编译，运行在基于ARM的处理器上。
-  请点击 [Cross Compilation](../docs/setup/cross-compilation.md) 获得相关说明。
+  请点击 [Cross Compilation](../setup/cross-compilation.md) 获得相关说明。
 
 + 修改`$GOPATH/src/github.com/kubeedge/kubeedge/edge/conf/edge.yaml`配置文件
   + 将 `edgehub.websocket.certfile` 和 `edgehub.websocket.keyfile` 替换为自己的证书路径


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind documentation


**What this PR does / why we need it**:
Link to cross-compilation.md are broken in the docs/getting-started/usage_zh.md guide.
This patch correct that link.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
