### PR TITLE
Automated cherry pick of #555: Fix edge_core crashs when SecurityContext.Privileged pointer

### DIFF
--- a/edge/pkg/edged/containers/helpers.go
+++ b/edge/pkg/edged/containers/helpers.go
@@ -62,7 +62,7 @@ func GenerateEnvList(envs []v1.EnvVar) (result []string) {
 
 //EnableHostUserNamespace checks security to enable host user namespace
 func EnableHostUserNamespace(pod *v1.Pod) bool {
-	if pod.Spec.Containers[0].SecurityContext != nil && *pod.Spec.Containers[0].SecurityContext.Privileged {
+	if pod.Spec.Containers[0].SecurityContext != nil && pod.Spec.Containers[0].SecurityContext.Privileged != nil && *pod.Spec.Containers[0].SecurityContext.Privileged {
 		return true
 	}
 	return false


### PR DESCRIPTION
Cherry pick of #555 on release-0.3.

#555: Fix edge_core crashs when SecurityContext.Privileged pointer