### PR TITLE
controller check error

### DIFF
--- a/edge/pkg/devicetwin/dtcontroller.go
+++ b/edge/pkg/devicetwin/dtcontroller.go
@@ -123,7 +123,9 @@ func (dtc *DTController) distributeMsg(m interface{}) error {
 	if message.Msg.GetParentID() != "" {
 		log.LOGGER.Infof("Send msg to the %s module in twin", dtcommon.CommModule)
 		confirmMsg := dttype.DTMessage{Msg: model.NewMessage(message.Msg.GetParentID()), Action: dtcommon.Confirm}
-		dtc.DTContexts.CommTo(dtcommon.CommModule, &confirmMsg)
+		if err := dtc.DTContexts.CommTo(dtcommon.CommModule, &confirmMsg); err != nil {
+			return err
+		}
 	}
 	if !classifyMsg(&message) {
 		return errors.New("Not found action")
@@ -135,7 +137,9 @@ func (dtc *DTController) distributeMsg(m interface{}) error {
 	if moduleName, exist := ActionModuleMap[message.Action]; exist {
 		//how to deal write channel error
 		log.LOGGER.Infof("Send msg to the %s module in twin", moduleName)
-		dtc.DTContexts.CommTo(moduleName, &message)
+		if err := dtc.DTContexts.CommTo(moduleName, &message); err != nil {
+			return err
+		}
 	} else {
 		log.LOGGER.Info("Not found deal module for msg")
 		return errors.New("Not found deal module for msg")

--- a/edge/pkg/devicetwin/dtcontroller_test.go
+++ b/edge/pkg/devicetwin/dtcontroller_test.go
@@ -317,10 +317,10 @@ func TestDTController_distributeMsg(t *testing.T) {
 			wantErr: errors.New("Not found action"),
 		},
 		{
-			//Success Case
-			name:    "distributeMsgTest-ActualMessage",
+			//Failure Case
+			name:    "distributeMsgTest-ActualMessage-NoChanel",
 			message: *msg,
-			wantErr: nil,
+			wantErr: errors.New("Not found chan to communicate"),
 		},
 	}
 	for _, tt := range tests {
@@ -330,6 +330,24 @@ func TestDTController_distributeMsg(t *testing.T) {
 			}
 		})
 	}
+
+	//Successful Case
+	dh := make(chan interface{}, 1)
+	ch := make(chan interface{}, 1)
+	mh := make(chan interface{}, 1)
+	deh := make(chan interface{}, 1)
+	th := make(chan interface{}, 1)
+	dtc.DTContexts.CommChan["DeviceStateUpdate"] = dh
+	dtc.DTContexts.CommChan["CommModule"] = ch
+	dtc.DTContexts.CommChan["MemModule"] = mh
+	dtc.DTContexts.CommChan["DeviceModule"] = deh
+	dtc.DTContexts.CommChan["TwinModule"] = th
+	name := "distributeMsgTest-ActualMessage-Success"
+	t.Run(name, func(t *testing.T) {
+		if err := dtc.distributeMsg(*msg); !reflect.DeepEqual(err, nil) {
+			t.Errorf("DTController.distributeMsg() error = %v, wantError %v", err, nil)
+		}
+	})
 }
 
 //TestSyncSqlite is function to test SyncSqlite().


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In this line we can see, that the CommTo return nil or an error. https://github.com/kubeedge/kubeedge/blob/master/edge/pkg/devicetwin/dtcontext/dtcontext.go#L71

In this PR I take this error and create an error in function distributeMsg (https://github.com/kubeedge/kubeedge/blob/98c27623689af5d6d70d3f0f4af9c7f6ff3278ba/edge/pkg/devicetwin/dtcontroller.go#L116). This will be catched here: (https://github.com/kubeedge/kubeedge/blob/98c27623689af5d6d70d3f0f4af9c7f6ff3278ba/edge/pkg/devicetwin/dtcontroller.go#L79)

In my opinion we should check if an error occur or not when it is possible. This will also increase the possibility to debug the program.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
