### PR TITLE
Correcting nits in sample device model for bluetooth

### DIFF
--- a/build/crd-samples/devices/CC2650-device-model.yaml
+++ b/build/crd-samples/devices/CC2650-device-model.yaml
@@ -57,8 +57,8 @@ spec:
     bluetooth:
      characteristicUUID: f000aa0204514000b000000000000000
      dataWrite:
-      ON: [1]
-      OFF: [0]
+      "ON": [1]   #Here "ON" refers to the value of the property "temperature-enable" and [1] refers to the corresponding []byte value to be written into the device when the value of temperature-enable is "ON" 
+      "OFF": [0]
   - propertyName: io-config-initialize
     bluetooth:
      characteristicUUID: f000aa6604514000b000000000000000
@@ -72,10 +72,10 @@ spec:
     bluetooth:
      characteristicUUID: f000aa6504514000b000000000000000
      dataWrite:
-      Red: [1]
-      Green: [2]
-      RedGreen: [3]
-      Buzzer: [4]
-      BuzzerRed: [5]
-      BuzzerGreen: [6]
-      BuzzerRedGreen: [7]
+      "Red": [1]    #Here "Red" refers to the value of the property "io-data" and [1] refers to the corresponding []byte value to be written into the device when the value of io-data is "Red" 
+      "Green": [2]
+      "RedGreen": [3]
+      "Buzzer": [4]
+      "BuzzerRed": [5]
+      "BuzzerGreen": [6]
+      "BuzzerRedGreen": [7]


### PR DESCRIPTION
**What type of PR is this?**
 /kind documentation

**What this PR does / why we need it**:
This PR corrects the problem of not placing string keys of the map within quotes in the sample CRD device-model that has been given for bluetooth
