### PR TITLE
make image error

### DIFF
--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-alpine3.9 AS builder
+FROM golang:1.12.1-alpine3.9
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Self build cloud side images error.
```
cd $GOPATH/src/github.com/kubeedge/kubeedge
[root@localhost kubeedge]# make cloudimage
docker build -t kubeedge/edgecontroller:v0.3.0-beta.0-148-gf7664c0 -f build/cloud/Dockerfile .
Sending build context to Docker daemon 112.5 MB
Step 1 : FROM golang:1.12.1-alpine3.9 AS builder
Error parsing reference: "golang:1.12.1-alpine3.9 AS builder" is not a valid repository/tag
make: *** [cloudimage] Error 1
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #617 

**Special notes for your reviewer**:
N/A