### PR TITLE
docs:[Fix:#608]: Open ports to cloud component for edge nodes in the …

### DIFF
--- a/keadm/README.md
+++ b/keadm/README.md
@@ -25,7 +25,8 @@ It also explains the functionality of the proposed commands.
 
 ## Installing KubeEdge Cloud component
 
-Referring to `KubeEdge Installer Doc`, the command to install KubeEdge cloud component (edge controller) and pre-requisites
+Referring to `KubeEdge Installer Doc`, the command to install KubeEdge cloud component (edge controller) and pre-requisites.
+Port 8080, 6443 and 10000 in your cloud component needs to be accessible for your edge nodes.
 
 - Execute `kubeedge init`
 


### PR DESCRIPTION
…installer(keadm) readme


**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
Extend the readme of kubeedge installer so that the right ports are opened of the cloud component for the edge nodes.
**Which issue(s) this PR fixes**:

Fixes #608 

**Special notes for your reviewer**:
