### PR TITLE
Added initial OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - CindyXing
+  - kevin-wangzefeng
+  - m1093782566
+  - qizha
+  - rohitsardesai83
+  - sids-b
+  - skdwriting


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
Added initial owners file at root level. Made all maintainers as approvers.

PROW is not able to find any OWNERS file so created this one to not block any PR
