### PR TITLE
fix message lost

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -713,7 +713,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2c1f62bde7baabd852485b201e3e188cec0e8214935c3cf820558e09717247d3"
+  digest = "1:0fa0d86b0f5f8b8c9335982ba21a44c7fe17d9d36db7e848b0b0590cf03f15da"
   name = "github.com/kubeedge/beehive"
   packages = [
     "pkg/common/config",
@@ -724,7 +724,7 @@
     "pkg/core/model",
   ]
   pruneopts = "UT"
-  revision = "aec6adb4c27903ea748a901126a976ef7f821077"
+  revision = "50be051df747ac7b509aadca5daba5b205e2ba81"
 
 [[projects]]
   digest = "1:1abad3afc8a8a736bbb7d643f8817c8da182b4c3b9bf2be59b47a0bcbedc52d5"

--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -92,7 +92,6 @@ func (q *ChannelEventQueue) dispatchMessage() {
 		event := model.MessageToEvent(&msg)
 		select {
 		case rChannel <- event:
-		default:
 		}
 	}
 }

--- a/vendor/github.com/kubeedge/beehive/pkg/common/config/config.go
+++ b/vendor/github.com/kubeedge/beehive/pkg/common/config/config.go
@@ -96,6 +96,6 @@ func (e EventListener) Event(event *core.Event) {
 	configValue := CONFIG.GetConfigurationByKey(event.Key)
 	for _, c := range ConfigChangeCallbacks {
 		c.Callback(event.Key, configValue)
-		fmt.Printf("config value %v", event.Key, " | ", configValue)
+		fmt.Printf("config value %v | %v", event.Key, configValue)
 	}
 }

--- a/vendor/github.com/kubeedge/beehive/pkg/core/context/context_channel.go
+++ b/vendor/github.com/kubeedge/beehive/pkg/core/context/context_channel.go
@@ -171,7 +171,10 @@ func (ctx *ChannelContext) Send2Group(moduleType string, message model.Message) 
 		select {
 		case ch <- message:
 		default:
-			log.LOGGER.Warnf("the message channel is full, just drop this message:%+v", message)
+			log.LOGGER.Warnf("the message channel is full, message: %+v", message)
+			select {
+			case ch <- message:
+			}
 		}
 	}
 	if channelList := ctx.getTypeChannel(moduleType); channelList != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the Send2Group function will lost message when the channel is full.
Actually we need to wait for the idle channel so that we will not lose messages.
Sync some modification from beehive and remove the 'default' in cloudhub

Related with https://github.com/kubeedge/beehive/pull/8