### PR TITLE
set minimum go version

### DIFF
--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -18,6 +18,8 @@
     - --insecure-bind-address=0.0.0.0
     ```
 
++ **Go** The minimum required go version is 1.11. You can install this version by using [this website.](https://golang.org/dl/) 
+
 + (**Optional**)KubeEdge also supports https connection to Kubernetes apiserver. Follow the steps in [Kubernetes Documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) to create the kubeconfig file.
 
   Enter the path to kubeconfig file in controller.yaml


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
set a minimum go version to avoid frustrating users

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
I set the go version to 1.11 because our travis is using this version. On my own machine I am using 1.12 and it works fine.