### PR TITLE
Changing AccessMode values to match API validation

### DIFF
--- a/build/crd-samples/devices/CC2650-device-model.yaml
+++ b/build/crd-samples/devices/CC2650-device-model.yaml
@@ -9,7 +9,7 @@ spec:
     description: temperature in degree celsius
     type:
      int:
-      accessMode: Read
+      accessMode: ReadOnly
       maximum: 100
       unit: degree celsius
   - name: temperature-enable

--- a/build/crd-samples/devices/led-light-device-model.yaml
+++ b/build/crd-samples/devices/led-light-device-model.yaml
@@ -16,5 +16,5 @@ spec:
     description: Indicates the GPIO pin to which LED is connected 
     type:
       int:
-        accessMode: Read
+        accessMode: ReadOnly
         defaultValue: 18   # Indicates the GPIO pin number to which the LED is connected, pls give the appropriate number according to the connection made

--- a/device/bluetooth_mapper/configuration/config.go
+++ b/device/bluetooth_mapper/configuration/config.go
@@ -44,7 +44,7 @@ var Config *BLEConfig
 const (
 	Protocol_Name string = "BLUETOOTH"
 	READWRITE     string = "ReadWrite"
-	READ          string = "Read"
+	READ          string = "ReadOnly"
 )
 
 //BLEConfig is the main structure that stores the configuration information read from both the config file as well as the config map


### PR DESCRIPTION
**What type of PR is this?**
  /kind cleanup

**What this PR does / why we need it**:
This PR corrects the access mode values from  "Read" to "ReadOnly". Currently validation is not enabled for all such fields , but once enabled , it won't allow creation of device models with incorrect access mode set.

**Which issue(s) this PR fixes**:

Fixes #675 


