### PR TITLE
Upload device state and lastOnline(device table's data) to cloud, and can be seen from command "kubectl describe device ..."

### DIFF
--- a/cloud/pkg/devicecontroller/apis/devices/v1alpha1/device_instance_types.go
+++ b/cloud/pkg/devicecontroller/apis/devices/v1alpha1/device_instance_types.go
@@ -136,6 +136,15 @@ type Twin struct {
 	Reported TwinProperty `json:"reported,omitempty"`
 }
 
+type DeviceState struct {
+	Reported DeviceOnOffline `json:"state,omitempty"`
+}
+
+type DeviceOnOffline struct {
+	LightState string `json:"light_state, omitempty"`
+	LastOnline string `json:"last_online, omitempty"`
+}
+
 // TwinProperty represents the device property for which an Expected/Actual state can be defined.
 type TwinProperty struct {
 	// Required: The value for this property.
@@ -156,6 +165,7 @@ type Device struct {
 
 	Spec   DeviceSpec   `json:"spec,omitempty"`
 	Status DeviceStatus `json:"status,omitempty"`
+	State  DeviceState  `json:"state,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/cloud/pkg/devicecontroller/constants/service.go
+++ b/cloud/pkg/devicecontroller/constants/service.go
@@ -14,6 +14,7 @@ const (
 	ResourceNode                = "node"
 	ResourceDevice              = "device"
 	ResourceTypeTwinEdgeUpdated = "twin/edge_updated"
+	ResourceDeviceStateUpdate   = "led-light-instance-01"
 
 	// Group
 	GroupTwin = "twin"

--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -63,6 +63,7 @@ type CacheDevice struct {
 	metav1.ObjectMeta
 	Spec   v1alpha1.DeviceSpec
 	Status v1alpha1.DeviceStatus
+	State  v1alpha1.DeviceState
 }
 
 // CacheDeviceModel is the struct save DeviceModel data for check DeviceModel is really changed
@@ -353,7 +354,7 @@ func addDeviceInstanceAndProtocol(device *v1alpha1.Device, deviceProfile *types.
 
 // deviceAdded creates a device, adds in deviceManagers map, send a message to edge node if node selector is present.
 func (dc *DownstreamController) deviceAdded(device *v1alpha1.Device) {
-	dc.deviceManager.Device.Store(device.Name, &CacheDevice{ObjectMeta: device.ObjectMeta, Spec: device.Spec, Status: device.Status})
+	dc.deviceManager.Device.Store(device.Name, &CacheDevice{ObjectMeta: device.ObjectMeta, Spec: device.Spec, Status: device.Status, State: device.State})
 	if len(device.Spec.NodeSelector.NodeSelectorTerms) != 0 && len(device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions) != 0 && len(device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values) != 0 {
 		dc.addToConfigMap(device)
 		edgeDevice := createDevice(device)
@@ -538,7 +539,7 @@ func (dc *DownstreamController) updateProtocolInConfigMap(device *v1alpha1.Devic
 // If twin is updated, send twin update message to edge
 func (dc *DownstreamController) deviceUpdated(device *v1alpha1.Device) {
 	value, ok := dc.deviceManager.Device.Load(device.Name)
-	dc.deviceManager.Device.Store(device.Name, &CacheDevice{ObjectMeta: device.ObjectMeta, Spec: device.Spec, Status: device.Status})
+	dc.deviceManager.Device.Store(device.Name, &CacheDevice{ObjectMeta: device.ObjectMeta, Spec: device.Spec, Status: device.Status, State: device.State})
 	if ok {
 		cachedDevice := value.(*CacheDevice)
 		if isDeviceUpdated(cachedDevice, device) {

--- a/cloud/pkg/devicecontroller/controller/upstream.go
+++ b/cloud/pkg/devicecontroller/controller/upstream.go
@@ -214,13 +214,8 @@ func (uc *UpstreamController) UpdateDeviceState(stop chan struct{}) {
 				continue
 			}
 			deviceState := &DeviceState{State: cacheDeviceState.State}
-			//deviceState := cacheDeviceState.State
 			deviceState.State.Reported.LightState = msgDevice.State
 			deviceState.State.Reported.LastOnline = msgDevice.LastOnline
-			//reported := v1alpha1.DeviceOnOffline{}
-			//reported.LightState = msgDevice.State
-			//reported.LastOnline = msgDevice.LastOnline
-			//deviceState = reported
 			cacheDeviceState.State = deviceState.State
 			uc.dc.deviceManager.Device.Store(deviceID, cacheDeviceState)
 			body, err := json.Marshal(deviceState)

--- a/cloud/pkg/devicecontroller/types/device.go
+++ b/cloud/pkg/devicecontroller/types/device.go
@@ -106,3 +106,14 @@ type DeviceTwinUpdate struct {
 	BaseMessage
 	Twin map[string]*MsgTwin `json:"twin"`
 }
+
+type DeviceStateUpdate struct {
+	BaseMessage
+	DDevice `json:"device"`
+}
+
+type DDevice struct {
+	Name       string `json:"name,omitempty"`
+	State      string `json:"state,omitempty"`
+	LastOnline string `json:"last_online,omitempty"`
+}

--- a/edge/pkg/devicetwin/dtmanager/device.go
+++ b/edge/pkg/devicetwin/dtmanager/device.go
@@ -105,17 +105,17 @@ func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg in
 	if err != nil {
 
 	}
-	topic := dtcommon.DeviceETPrefix + device.ID + dtcommon.DeviceETStateUpdateSuffix + "/result"
-	context.Send(device.ID,
-		dtcommon.SendToEdge,
-		dtcommon.CommModule,
-		context.BuildModelMessage(modules.BusGroup, "", topic, "publish", payload))
+	//topic := dtcommon.DeviceETPrefix + device.ID + dtcommon.DeviceETStateUpdateSuffix + "/result"
+	//context.Send(device.ID,
+	//	dtcommon.SendToEdge,
+	//	dtcommon.CommModule,
+	//	context.BuildModelMessage(modules.BusGroup, "", topic, "publish", payload))
 
 	msgResource := "device/" + device.ID + "/state"
 	context.Send(deviceID,
 		dtcommon.SendToCloud,
 		dtcommon.CommModule,
-		context.BuildModelMessage("resource", "", msgResource, "update", string(payload)))
+		context.BuildModelMessage("resource", "", msgResource, "update", payload))
 	return nil, nil
 }
 

--- a/edge/pkg/devicetwin/dttype/types_helper.go
+++ b/edge/pkg/devicetwin/dttype/types_helper.go
@@ -156,18 +156,18 @@ type DeviceMsg struct {
 }
 
 //BuildDeviceState build the msg
-func BuildDeviceState(baseMessage BaseMessage, device Device) ([]byte, error) {
+func BuildDeviceState(baseMessage BaseMessage, device Device) (DeviceMsg, error) {
 	result := DeviceMsg{
 		BaseMessage: baseMessage,
 		Device: Device{
 			Name:       device.Name,
 			State:      device.State,
 			LastOnline: device.LastOnline}}
-	payload, err := json.Marshal(result)
-	if err != nil {
-		return []byte(""), err
-	}
-	return payload, nil
+	//payload, err := json.Marshal(result)
+	//if err != nil {
+	//	return []byte(""), err
+	//}
+	return result, nil
 }
 
 //DeviceAttrUpdate the struct of device attr update msg


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
cloud part can see the device state at any time
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
