### PR TITLE
Handled case in bluetooth mapper with no converter information while reading

### DIFF
--- a/device/bluetooth_mapper/configuration/config.go
+++ b/device/bluetooth_mapper/configuration/config.go
@@ -147,7 +147,8 @@ func (b *BLEConfig) Load() error {
 					return errors.New("Error in unmarshalling data property visitor configuration: " + err.Error())
 				}
 				action.Operation.CharacteristicUUID = bluetoothPropertyVisitor.CharacteristicUUID
-				if !reflect.DeepEqual(bluetoothPropertyVisitor.BluetoothDataConverter, nil) {
+				newBluetoothVisitorConfig := VisitorConfigBluetooth{}
+				if !reflect.DeepEqual(bluetoothPropertyVisitor.BluetoothDataConverter, newBluetoothVisitorConfig.BluetoothDataConverter) {
 					readAction := dataconverter.ReadAction{}
 					readAction.ActionName = actionConfig.Name
 					readAction.ConversionOperation.StartIndex = bluetoothPropertyVisitor.BluetoothDataConverter.StartIndex


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
This PR handles case in bluetooth mapper when no data converter is given while reading

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #734 
