### PR TITLE
Changing Keadm Default version to 0.3.0

### DIFF
--- a/keadm/app/cmd/common/constant.go
+++ b/keadm/app/cmd/common/constant.go
@@ -45,7 +45,7 @@ const (
 	DefaultCertPath = "/etc/kubeedge/certs"
 
 	//DefaultKubeEdgeVersion is the current default version of KubeEdge
-	DefaultKubeEdgeVersion = "0.3.0-beta.0"
+	DefaultKubeEdgeVersion = "0.3.0"
 
 	//DefaultDockerVersion is the current default version of Docker
 	DefaultDockerVersion = "18.06.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Keadm default version is changed to 0.3.0
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Version is changed as shown in below attachment
![0 3 0](https://user-images.githubusercontent.com/39593583/59976772-88b39d00-95e6-11e9-9672-5379551176e6.png)

