### PR TITLE
Automated cherry pick of #761: update edge_core version to reflect the vendor k8s and kubeedge version

### DIFF
--- a/edge/conf/edge.yaml
+++ b/edge/conf/edge.yaml
@@ -44,7 +44,7 @@ edged:
     image-gc-low-threshold: 40 # percent
     maximum-dead-containers-per-container: 1
     docker-address: unix:///var/run/docker.sock
-    version: 2.0.0
+    version: v1.10.9-kubeedge-v1.0.0
     runtime-type: docker
     remote-runtime-endpoint: /var/run/containerd/containerd.sock
     remote-image-endpoint: /var/run/containerd/containerd.sock


### PR DESCRIPTION
Cherry pick of #761 on release-1.0.

#761: update edge_core version to reflect the vendor k8s and kubeedge version