### PR TITLE
Automated cherry pick of #760: Changing Keadm Default version to 0.3.0

### DIFF
--- a/keadm/app/cmd/common/constant.go
+++ b/keadm/app/cmd/common/constant.go
@@ -45,7 +45,7 @@ const (
 	DefaultCertPath = "/etc/kubeedge/certs"
 
 	//DefaultKubeEdgeVersion is the current default version of KubeEdge
-	DefaultKubeEdgeVersion = "0.3.0-beta.0"
+	DefaultKubeEdgeVersion = "0.3.0"
 
 	//DefaultDockerVersion is the current default version of Docker
 	DefaultDockerVersion = "18.06.0"


### PR DESCRIPTION
Cherry pick of #760 on release-1.0.

#760: Changing Keadm Default version to 0.3.0