### PR TITLE
add GetLatency func

### DIFF
--- a/tests/performance/assets/02-edgeconfigmap.yaml
+++ b/tests/performance/assets/02-edgeconfigmap.yaml
@@ -53,6 +53,7 @@ data:
         maximum-dead-containers-per-container: 1
         docker-address: tcp://localhost:2375
         version: 2.0.0
+        runtime-type: docker
   logging.yaml: |
     loggerLevel: "DEBUG"
     enableRsyslog: false

--- a/tests/performance/scripts/runperf.sh
+++ b/tests/performance/scripts/runperf.sh
@@ -35,8 +35,8 @@ cat >config.json<<END
         "node_num": 500,
         "imagerepo": "kubeedge",
         "k8smasterforprovisionedgenodes": "$K8SMasterForProvisionEdgeNodes",
-        "cloudimageurl": "pavan187/cloudcore:v2.2",
-        "edgeimageurl": "pavan187/edgecore:v2.2",
+        "cloudimageurl": "kubeedge/edgecontroller-test:v1.0.0",
+        "edgeimageurl": "kubeedge/edgecore-test:v1.0.0",
         "namespace":"default",
         "controllerstubport": 54321,
         "protocol": "websocket"


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
The `GetLatency` is deleted in v1.0, we need to keep it for calculating the latency metrics.
* add GetLatency func
* quic support in hubtest
* bump image version
