### PR TITLE
keadm support to add runtimetype flag as remote

### DIFF
--- a/keadm/app/cmd/common/types.go
+++ b/keadm/app/cmd/common/types.go
@@ -67,6 +67,7 @@ type ToolsInstaller interface {
 
 //OSTypeInstaller interface for methods to be executed over a specified OS distribution type
 type OSTypeInstaller interface {
+	InstallContainerd() error
 	IsToolVerInRepo(string, string) (bool, error)
 	IsDockerInstalled(string) (InstallState, error)
 	InstallDocker() error

--- a/keadm/app/cmd/edge/join.go
+++ b/keadm/app/cmd/edge/join.go
@@ -134,7 +134,7 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 	} else {
 		dockerVer = joinOptions.DockerVersion
 	}
-	toolList["Docker"] = &util.DockerInstTool{Common: util.Common{ToolVersion: dockerVer}, DefaultToolVer: flgData.DefVal.(string)}
+	toolList["Docker"] = &util.DockerInstTool{Common: util.Common{ToolVersion: dockerVer, Runtime: joinOptions.RuntimeType}, DefaultToolVer: flgData.DefVal.(string)}
 	toolList["MQTT"] = &util.MQTTInstTool{}
 }
 
@@ -143,6 +143,7 @@ func Execute(toolList map[string]types.ToolsInstaller) {
 
 	//Install all the required pre-requisite tools
 	for name, tool := range toolList {
+
 		if name != "KubeEdge" {
 			err := tool.InstallTools()
 			if err != nil {

--- a/keadm/app/cmd/util/centosinstaller.go
+++ b/keadm/app/cmd/util/centosinstaller.go
@@ -76,6 +76,22 @@ func (c *CentOS) InstallDocker() error {
 	return nil
 }
 
+func (c *CentOS) InstallContainerd() error {
+	fmt.Println("InstallContainerd called")
+	// yum install -y yum-utils
+	// yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+	// yum makecache
+	// yum list --showduplicates 'docker-ce' | grep '17.06.0' | head -1 | awk '{print $2}'
+	// yum install -y docker-ce-17.06.0.ce-1.el7.centos
+	// [root@localhost ~]# systemctl start docker
+	// [root@localhost ~]# ---> Always restart  systemctl restart docker
+	// [root@localhost ~]#
+	// IF downgrade yum downgrade -y docker-ce-17.06.0.ce-1.el7.centos
+	// Check always for version, if it is a downgrade or upgrade
+
+	return nil
+}
+
 //IsToolVerInRepo checks if the tool mentioned in available in OS repo or not
 func (c *CentOS) IsToolVerInRepo(toolName, version string) (bool, error) {
 	//yum --cacheonly list | grep openssl

--- a/keadm/app/cmd/util/common.go
+++ b/keadm/app/cmd/util/common.go
@@ -90,6 +90,7 @@ type Common struct {
 	OSVersion   string
 	ToolVersion string
 	KubeConfig  string
+	Runtime     string
 }
 
 //SetOSInterface defines a method to set the implemtation of the OS interface

--- a/keadm/app/cmd/util/dockerinstaller.go
+++ b/keadm/app/cmd/util/dockerinstaller.go
@@ -33,29 +33,35 @@ type DockerInstTool struct {
 //If required then install the said version.
 func (d *DockerInstTool) InstallTools() error {
 	d.SetOSInterface(GetOSInterface())
-	d.SetDockerVersion(d.ToolVersion)
-
-	action, err := d.IsDockerInstalled(d.DefaultToolVer)
-	if err != nil {
-		return err
-	}
-	switch action {
-	case types.VersionNAInRepo:
-		return fmt.Errorf("Expected Docker version is not available in OS repo")
-	case types.AlreadySameVersionExist:
-		return fmt.Errorf("Same version of docker already installed in this host")
-	case types.DefVerInstallRequired:
-		d.SetDockerVersion(d.DefaultToolVer)
-		fallthrough
-	case types.NewInstallRequired:
-		err := d.InstallDocker()
+	if d.Runtime == "remote" {
+		err := d.InstallContainerd()
 		if err != nil {
 			return err
 		}
-	default:
-		return fmt.Errorf("Error in getting the docker version from host")
-	}
+	} else {
+		d.SetDockerVersion(d.ToolVersion)
 
+		action, err := d.IsDockerInstalled(d.DefaultToolVer)
+		if err != nil {
+			return err
+		}
+		switch action {
+		case types.VersionNAInRepo:
+			return fmt.Errorf("Expected Docker version is not available in OS repo")
+		case types.AlreadySameVersionExist:
+			return fmt.Errorf("Same version of docker already installed in this host")
+		case types.DefVerInstallRequired:
+			d.SetDockerVersion(d.DefaultToolVer)
+			fallthrough
+		case types.NewInstallRequired:
+			err := d.InstallDocker()
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("Error in getting the docker version from host")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
keadm support to add runtimetype flag as remote(installs containerd if the runtimetype =remote)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
![remote](https://user-images.githubusercontent.com/39593583/60168451-8047a600-9822-11e9-9546-29b69637d31b.png)
 /kind bug
