### PR TITLE
initialize OWNERS file for device management

### DIFF
--- a/cloud/pkg/devicecontroller/OWNERS
+++ b/cloud/pkg/devicecontroller/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - kevin-wangzefeng
+  - rohitsardesai83
+  - sids-b
+reviewers:
+  - chendave
+  - subpathdev

--- a/edge/pkg/devicetwin/OWNERS
+++ b/edge/pkg/devicetwin/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - kevin-wangzefeng
+  - qizha
+  - rohitsardesai83
+reviewers:
+  - sids-b
+  - subpathdev


### PR DESCRIPTION

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR adds OWNERS file for main device management modules at cloud(deviceController) and edge(deviceTwin)

**Which issue(s) this PR fixes**:
XREF #638 
