### PR TITLE
initialize OWNERS file for application deployment modules

### DIFF
--- a/cloud/pkg/controller/OWNERS
+++ b/cloud/pkg/controller/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - CindyXing
+  - kevin-wangzefeng
+  - sids-b
+reviewers:
+  - anyushun
+  - fisherxu
+  - kadisi

--- a/edge/pkg/edged/OWNERS
+++ b/edge/pkg/edged/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - kevin-wangzefeng
+  - m1093782566
+  - qizha
+  - rohitsardesai83
+reviewers:
+  - Baoqiang-Zhang
+  - fisherxu
+  - sids-b

--- a/edge/pkg/metamanager/OWNERS
+++ b/edge/pkg/metamanager/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+  - qizha
+  - rohitsardesai83
+  - sids-b
+reviewers:
+  - anyushun
+  - kadisi
+  - kevin-wangzefeng
+  - subpathdev


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR adds OWNERS file to application deployment modules.

**Which issue(s) this PR fixes**:
XREF #638 

