### PR TITLE
fix travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ go:
 
 before_install:
   - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|(.png)|(.pdf)|(.html)|^(LICENSE)|^(docs)'
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.png)|(\.pdf)|(\.html)|^(LICENSE)|^(docs)'
       then
         echo "Only doc files were updated, skip running the CI."
         exit


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix travis skip stages.
the problem was: we didn't escape the "." so cmd in the path are matched with ".md". This problem occurs on pr #844

**Which issue(s) this PR fixes**:
Fixes #846 

**Special notes for your reviewer**:
