### PR TITLE
bug fix: cpumanager state file not written error

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -251,6 +251,14 @@ type Config struct {
 }
 
 func init() {
+	_, err := os.Stat(DefaultRootDir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(DefaultRootDir, 0755)
+		if err != nil {
+			panic(fmt.Errorf("Create %v dir error: %v", DefaultRootDir, err))
+		}
+	}
+
 	edged, err := newEdged()
 	if err != nil {
 		log.LOGGER.Errorf("init new edged error, %v", err)
@@ -526,7 +534,9 @@ func newEdged() (*edged, error) {
 	if ed.os == nil {
 		ed.os = kubecontainer.RealOS{}
 	}
+
 	ed.clcm, err = clcm.NewContainerLifecycleManager(DefaultRootDir)
+
 	var machineInfo cadvisorapi.MachineInfo
 	machineInfo.MemoryCapacity = uint64(conf.memoryCapacity)
 	containerRuntime, err := kuberuntime.NewKubeGenericRuntimeManager(


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

 /kind bug



**What this PR does / why we need it**:

edge_core will panic when dir (`DefaultRootDir                   = "/var/lib/edged"`) not exist.

edge_core will report:

```
panic: [cpumanager] state file not written

goroutine 1 [running]:
github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state.(*stateFile).storeState(0xc4201cf360)
	/go/src/github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state/state_file.go:145 +0x2ba
github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state.(*stateFile).tryRestoreState(0xc4201cf360, 0x0, 0x0)
	/go/src/github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state/state_file.go:81 +0x140
github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state.NewFileState(0xc420184fe0, 0x20, 0x29dc80e, 0x4, 0x20, 0xc4202644c0)
	/go/src/github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state/state_file.go:52 +0xe3
github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager.NewManager(0x29dc80e, 0x4, 0x3b9aca00, 0x0, 0xc420277830, 0x29e9bd9, 0xe, 0xc420040630, 0x2a, 0x1bf08eb000, ...)
	/go/src/github.com/kubeedge/kubeedge/vendor/k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/cpu_manager.go:140 +0x222
github.com/kubeedge/kubeedge/edge/pkg/edged/clcm.NewContainerLifecycleManager(0x29e9bd9, 0xe, 0xc420040630, 0x2a, 0x1bf08eb000, 0x2c42900)
	/go/src/github.com/kubeedge/kubeedge/edge/pkg/edged/clcm/clcm_policy_none.go:48 +0x9c
github.com/kubeedge/kubeedge/edge/pkg/edged.newEdged(0x8, 0x6400000, 0x0)
	/go/src/github.com/kubeedge/kubeedge/edge/pkg/edged/edged.go:533 +0xf07
github.com/kubeedge/kubeedge/edge/pkg/edged.init.0()
	/go/src/github.com/kubeedge/kubeedge/edge/pkg/edged/edged.go:257 +0x26

```


how to fix:

if `DefaultRootDir` not exist, create this dir when edge package imported.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
