### PR TITLE
Removing code to update device state from edge to cloud in bluetooth mapper

### DIFF
--- a/device/bluetooth_mapper/helper/helper.go
+++ b/device/bluetooth_mapper/helper/helper.go
@@ -134,22 +134,6 @@ func MqttConnect(mqttMode int, mqttInternalServer, mqttServer string) {
 	}
 }
 
-//ChangeDeviceState function is used to change the state of the device
-func ChangeDeviceState(state string, deviceID string) {
-	glog.Infof("Changing the state of the device: %s to %s", deviceID, state)
-	var deviceStateUpdateMessage DeviceStateUpdate
-	deviceStateUpdateMessage.State = state
-	stateUpdateBody, err := json.Marshal(deviceStateUpdateMessage)
-	if err != nil {
-		glog.Errorf("Error in marshalling: %s", err)
-	}
-	deviceStatusUpdate := DeviceETPrefix + deviceID + DeviceETStateUpdateSuffix
-	TokenClient = Client.Publish(deviceStatusUpdate, 0, false, stateUpdateBody)
-	if TokenClient.Wait() && TokenClient.Error() != nil {
-		glog.Errorf("client.publish() Error in device state update  is : %s", TokenClient.Error())
-	}
-}
-
 //ChangeTwinValue sends the updated twin value to the edge through the MQTT broker
 func ChangeTwinValue(updateMessage DeviceTwinUpdate, deviceID string) {
 	twinUpdateBody, err := json.Marshal(updateMessage)

--- a/device/bluetooth_mapper/watcher/watcher.go
+++ b/device/bluetooth_mapper/watcher/watcher.go
@@ -95,13 +95,11 @@ func onPeripheralDisconnected(p gatt.Peripheral, err error) {
 	DeviceConnected <- false
 	close(done)
 	p.Device().CancelConnection(p)
-	helper.ChangeDeviceState("offline", deviceID)
 }
 
 //onPeripheralConnected contains the operations to be performed as soon as the peripheral device is connected
 func (w *Watcher) onPeripheralConnected(p gatt.Peripheral, err error) {
 	actionmanager.GattPeripheral = p
-	helper.ChangeDeviceState("online", deviceID)
 	ss, err := p.DiscoverServices(nil)
 	if err != nil {
 		glog.Errorf("Failed to discover services, err: %s\n", err)


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
This PR cleans up unused code from bluetooth mapper 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #909
