### PR TITLE
Fixed unmarshal error in device controller upstream

### DIFF
--- a/cloud/pkg/devicecontroller/controller/upstream.go
+++ b/cloud/pkg/devicecontroller/controller/upstream.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"encoding/json"
+	"errors"
 	"strconv"
 
 	"github.com/kubeedge/beehive/pkg/common/log"
@@ -179,11 +180,11 @@ func (uc *UpstreamController) updateDeviceStatus(stop chan struct{}) {
 func (uc *UpstreamController) unmarshalDeviceStatusMessage(msg model.Message) (*types.DeviceTwinUpdate, error) {
 	content := msg.GetContent()
 	twinUpdate := &types.DeviceTwinUpdate{}
-	bytes, err := json.Marshal(content)
-	if err != nil {
-		return nil, err
+	bytes, ok := content.([]byte)
+	if !ok {
+		return nil, errors.New("Unable to convert incoming message to []bytes")
 	}
-	err = json.Unmarshal(bytes, twinUpdate)
+	err := json.Unmarshal(bytes, twinUpdate)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This fixes the unmarshal error that occurs in device controller upstream while updating device twin 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #908 
