### PR TITLE
fix random unit tests exception

### DIFF
--- a/cloud/pkg/cloudhub/common/model/types_test.go
+++ b/cloud/pkg/cloudhub/common/model/types_test.go
@@ -60,8 +60,9 @@ func modelEvent(ID string, PID string, Timestamp int64, Source string, Group str
 
 // TestEventToMessage is function to test EventToMessage
 func TestEventToMessage(t *testing.T) {
-	msg := modelMessage("ID1", "PID1", time.Now().UnixNano()/1e6, "Source1", "Group1", "Operation1", "Resource1")
-	event := modelEvent("ID1", "PID1", time.Now().UnixNano()/1e6, "Source1", "Group1", "Operation1", "Resource1", nil)
+	ts := time.Now().UnixNano() / 1e6
+	msg := modelMessage("ID1", "PID1", ts, "Source1", "Group1", "Operation1", "Resource1")
+	event := modelEvent("ID1", "PID1", ts, "Source1", "Group1", "Operation1", "Resource1", nil)
 	tests := []struct {
 		name  string
 		event *Event
@@ -84,8 +85,9 @@ func TestEventToMessage(t *testing.T) {
 
 // TestMessageToEvent is function to test MessageToEvent
 func TestMessageToEvent(t *testing.T) {
-	msg := modelMessage("ID1", "PID1", time.Now().UnixNano()/1e6, "Source1", "Group1", "Operation1", "Resource1")
-	event := modelEvent("ID1", "PID1", time.Now().UnixNano()/1e6, "Source1", "Group1", "Operation1", "Resource1", nil)
+	ts := time.Now().UnixNano() / 1e6
+	msg := modelMessage("ID1", "PID1", ts, "Source1", "Group1", "Operation1", "Resource1")
+	event := modelEvent("ID1", "PID1", ts, "Source1", "Group1", "Operation1", "Resource1", nil)
 	tests := []struct {
 		name  string
 		msg   *model.Message


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When running `make cloud_test`, it appears that the unit tests exception like below:
```
  got = {{ID1 PID1 1563431396481 false} {Source1 Group1 Operation1 Resource1} <nil>}, 
 want = {{ID1 PID1 1563431396480 false} {Source1 Group1 Operation1 Resource1} <nil>}
```
That is caused by the actual timestamp and expect timestamp.