### PR TITLE
Update common.go

### DIFF
--- a/keadm/app/cmd/util/common.go
+++ b/keadm/app/cmd/util/common.go
@@ -184,6 +184,7 @@ func GetOSInterface() types.OSTypeInstaller {
 	case CentOSType:
 		return &CentOS{}
 	default:
+		panic("unsupport os-release")
 	}
 	return nil
 }


### PR DESCRIPTION
When exec "keadm init" on support systems like debian, the keadm should exit immediately.
Now the keadm crash because of a null pointer err.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Without this PR, keadm crash because of a null pointer error when execute "keadm init" on unsupport systems(like debian and so on).
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #901 

**Special notes for your reviewer**:
