### PR TITLE
Fix a crash error of keadm

### DIFF
--- a/keadm/app/cmd/util/common.go
+++ b/keadm/app/cmd/util/common.go
@@ -184,7 +184,7 @@ func GetOSInterface() types.OSTypeInstaller {
 	case CentOSType:
 		return &CentOS{}
 	default:
-		panic("unsupport os-release")
+		panic("This OS version is currently un-supported by keadm")
 	}
 }
 

--- a/keadm/app/cmd/util/common.go
+++ b/keadm/app/cmd/util/common.go
@@ -184,8 +184,8 @@ func GetOSInterface() types.OSTypeInstaller {
 	case CentOSType:
 		return &CentOS{}
 	default:
+		panic("unsupport os-release")
 	}
-	return nil
 }
 
 //IsKubeEdgeController identifies if the node is having edge controller and k8s api-server already running.


### PR DESCRIPTION
Keadm crash because of a null pointer error when execute "keadm init" on unsupport systems(like debian and so on).
This change is to fix this error.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Without this PR, keadm crash because of a null pointer error when execute "keadm init" on unsupport systems(like debian and so on).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #901 

**Special notes for your reviewer**:
