### PR TITLE
Adding wait group for schedules created at runtime

### DIFF
--- a/device/bluetooth_mapper/controller/controller.go
+++ b/device/bluetooth_mapper/controller/controller.go
@@ -139,6 +139,7 @@ func (c *Config) handleScheduleCreateMessage(client MQTT.Client, message MQTT.Me
 			glog.Infof("New Schedule: %v", newSchedule)
 		}
 		configuration.Config.Scheduler = c.Scheduler
+		helper.ControllerWg.Add(1)
 		newSchedule.ExecuteSchedule(c.ActionManager.Actions, c.Converter.DataRead, c.Device.ID)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR contains change to fix the issue of bluetooth maper exiting before completion of all schedules created at runtime

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #934 

**Special notes for your reviewer**:
