### PR TITLE
Add --image-repository  && --pod-network-cidr for keadm init.

### DIFF
--- a/keadm/app/cmd/common/constant.go
+++ b/keadm/app/cmd/common/constant.go
@@ -20,6 +20,12 @@ const (
 	//KubeEdgeVersion sets the version of KubeEdge to be used
 	KubeEdgeVersion = "kubeedge-version"
 
+	// K8SImageRepository sets the image repository of Kubernetes
+	K8SImageRepository = "image-repository"
+	
+	//K8SPodNetworkCidr sets pod network cidr of Kubernetes
+	K8SPodNetworkCidr = "pod-network-cidr"	
+
 	//DockerVersion sets the version of Docker to be used
 	DockerVersion = "docker-version"
 
@@ -55,6 +61,12 @@ const (
 
 	// DefaultProjectID is default project id
 	DefaultProjectID = "e632aba927ea4ac2b575ec1603d56f10"
+
+	//DefaultImageRepository is the default k8s image repository
+	DefaultK8SImageRepository = "k8s.gcr.io"
+
+	//DefaultPodNetworkCidr is the default k8s pod network cidr
+	DefaultK8SPodNetworkCidr = "100.64.0.0/10"
 
 	VendorK8sPrefix = "v1.10.9-kubeedge-"
 

--- a/keadm/app/cmd/common/types.go
+++ b/keadm/app/cmd/common/types.go
@@ -26,6 +26,8 @@ type InitOptions struct {
 	KubernetesVersion string
 	DockerVersion     string
 	KubeConfig        string
+	K8SImageRepository   string
+	K8SPodNetworkCidr    string
 }
 
 //JoinOptions has the kubeedge cloud init information filled by CLI
@@ -77,6 +79,7 @@ type OSTypeInstaller interface {
 	InstallKubeEdge() error
 	SetDockerVersion(string)
 	SetK8SVersionAndIsNodeFlag(version string, flag bool)
+	SetK8SImageRepoAndPodNetworkCidr(string, string)
 	SetKubeEdgeVersion(string)
 	RunEdgeCore() error
 	KillKubeEdgeBinary(string) error

--- a/keadm/app/cmd/util/centosinstaller.go
+++ b/keadm/app/cmd/util/centosinstaller.go
@@ -31,6 +31,8 @@ type CentOS struct {
 	KubernetesVersion string
 	KubeEdgeVersion   string
 	IsEdgeNode        bool //True - Edgenode False - Cloudnode
+	K8SImageRepository string
+	K8SPodNetworkCidr  string
 }
 
 //SetDockerVersion sets the Docker version for the objects instance
@@ -43,6 +45,13 @@ func (c *CentOS) SetDockerVersion(version string) {
 func (c *CentOS) SetK8SVersionAndIsNodeFlag(version string, flag bool) {
 	c.KubernetesVersion = version
 	c.IsEdgeNode = flag
+}
+
+//SetK8SImageRepoAndPodNetworkCidr sets the K8S image Repository and pod network
+// cidr.
+func (c *CentOS) SetK8SImageRepoAndPodNetworkCidr(repo, cidr string) {
+	c.K8SImageRepository = repo
+	c.K8SPodNetworkCidr = cidr
 }
 
 //SetKubeEdgeVersion sets the KubeEdge version for the objects instance

--- a/keadm/app/cmd/util/cloudinstaller.go
+++ b/keadm/app/cmd/util/cloudinstaller.go
@@ -18,6 +18,8 @@ import (
 //It implements ToolsInstaller interface
 type KubeCloudInstTool struct {
 	Common
+	K8SImageRepository string
+	K8SPodNetworkCidr  string
 }
 
 //InstallTools downloads KubeEdge for the specified version
@@ -25,6 +27,7 @@ type KubeCloudInstTool struct {
 func (cu *KubeCloudInstTool) InstallTools() error {
 	cu.SetOSInterface(GetOSInterface())
 	cu.SetKubeEdgeVersion(cu.ToolVersion)
+	cu.SetK8SImageRepoAndPodNetworkCidr(cu.K8SImageRepository, cu.K8SPodNetworkCidr)
 
 	err := cu.InstallKubeEdge()
 	if err != nil {

--- a/keadm/app/cmd/util/ubuntuinstaller.go
+++ b/keadm/app/cmd/util/ubuntuinstaller.go
@@ -41,6 +41,8 @@ type UbuntuOS struct {
 	KubernetesVersion string
 	KubeEdgeVersion   string
 	IsEdgeNode        bool //True - Edgenode False - Cloudnode
+	K8SImageRepository string
+	K8SPodNetworkCidr  string
 }
 
 //SetDockerVersion sets the Docker version for the objects instance
@@ -53,6 +55,13 @@ func (u *UbuntuOS) SetDockerVersion(version string) {
 func (u *UbuntuOS) SetK8SVersionAndIsNodeFlag(version string, flag bool) {
 	u.KubernetesVersion = version
 	u.IsEdgeNode = flag
+}
+
+//SetK8SImageRepoAndPodNetworkCidr sets the K8S image Repository and pod network
+// cidr.
+func (u *UbuntuOS) SetK8SImageRepoAndPodNetworkCidr(repo, cidr string) {
+	u.K8SImageRepository = repo
+	u.K8SPodNetworkCidr = cidr
 }
 
 //SetKubeEdgeVersion sets the KubeEdge version for the objects instance
@@ -380,7 +389,8 @@ func (u *UbuntuOS) StartK8Scluster() error {
 		install = false
 	}
 	if install == true {
-		stdout, err := runCommandWithShell("swapoff -a && kubeadm init")
+		k8sInit := fmt.Sprintf("swapoff -a && kubeadm init --image-repository  \"%s\" --pod-network-cidr=%s", u.K8SImageRepository, u.K8SPodNetworkCidr)
+		stdout, err := runCommandWithShell(k8sInit)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION

**What type of PR is this?**
> /kind feature


**What this PR does / why we need it**:
 It should be add when kubeadmin init to select the image-repository  and pod-network-cidr. We pass them to kubeadm by keadm

**Which issue(s) this PR fixes**:
Fixes #  Fix the request: from https://github.com/kubeedge/kubeedge/pull/957

**Special notes for your reviewer**:
