### PR TITLE
Enable devicecontroller in 05-configmap.yaml

### DIFF
--- a/build/cloud/05-configmap.yaml
+++ b/build/cloud/05-configmap.yaml
@@ -33,4 +33,4 @@ data:
     writers: [stdout]
   modules.yaml: |
     modules:
-      enabled: [controller, cloudhub]
+      enabled: [devicecontroller, controller, cloudhub]


### PR DESCRIPTION
devicecontroller should be enabled when the kubeedge edgecontroller is deployed in k8s cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

> /kind bug


**What this PR does / why we need it**:
devicecontroller should be enabled when the kubeedge edgecontroller is deployed in k8s cluster.
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
