### PR TITLE
K8S: Fix edgecontroller ClusterRole definition

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -15,6 +15,8 @@ rules:
   - pods
   - pods/status
   - secrets
+  - endpoints
+  - services
   verbs:
   - get
   - list

--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           EOF
       containers:
       - name: edgecontroller
-        image: kubeedge/edgecontroller:v0.2
+        image: kubeedge/edgecontroller:v1.0.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 10000


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes K8S ClusterRole definition to allow `edgecontroller` POD access `endpoints` and `services` resources. This PR also bumps edgecontroller to v1.0.0 in k8s manifest examples shipped in build/cloud 

**Which issue(s) this PR fixes**:
Fixes #976

**Special notes for your reviewer**:
You should add a v1.0.0 tag as currently (as of 2019.07.29) latest tag is v0.3.0-beta; the version referenced in build/cloud is v0.2 (I submit a fix to use v1.0.0 instead in this PR). 
This default is set in Makefile:70 "cloudimage" target
```
$ git describe --tags
v0.3.0-beta.0-449-g630eaf95
```
