### PR TITLE
set load balance strategy from edge.yaml and tcp server listens on ip of interface docker0

### DIFF
--- a/edgemesh/pkg/resolver/resolver.go
+++ b/edgemesh/pkg/resolver/resolver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	mconfig "github.com/kubeedge/beehive/pkg/common/config"
 	"github.com/go-chassis/go-chassis/core/invocation"
 	"github.com/kubeedge/beehive/pkg/common/log"
 )
@@ -58,7 +59,7 @@ func (resolver *MyResolver) Resolve(data chan []byte, stop chan interface{}, inv
 				i.SourceServiceID = ""
 				i.Protocol = "rest"
 				i.Args = req
-				i.Strategy = "Random"
+				i.Strategy = mconfig.CONFIG.GetConfigurationByKey("mesh.loadbalance.strategy-name").(string)
 				i.Reply = &http.Response{}
 				invCallback("http", *i)
 			}

--- a/edgemesh/pkg/server/dns.go
+++ b/edgemesh/pkg/server/dns.go
@@ -18,7 +18,6 @@ import (
 )
 
 var (
-	inter       = "docker0"
 	dnsQr       = uint16(0x8000)
 	oneByteSize = uint16(1)
 	twoByteSize = uint16(2)
@@ -74,37 +73,13 @@ func DnsStart() {
 	startDnsServer()
 }
 
-// getDnsServer returns the specific interface ip of version 4
-func getDnsServer() (net.IP, error) {
-	for {
-		ifaces, err := net.InterfaceByName(inter)
-		if err != nil {
-			log.LOGGER.Warnf("get interface error : %s", err)
-			time.Sleep(time.Second * 3)
-			continue
-		}
-
-		addrs, _ := ifaces.Addrs()
-
-		for _, addr := range addrs {
-			if ip, inet, _ := net.ParseCIDR(addr.String()); len(inet.Mask) == 4 {
-				return ip, nil
-			}
-		}
-
-		log.LOGGER.Warnf("the interface " + inter + " has not config ip of version 4")
-		time.Sleep(time.Second * 3)
-	}
-
-}
-
 // startDnsServer start the DNS Server
 func startDnsServer() {
 	// init meta client
 	c := context.GetContext(context.MsgCtxTypeChannel)
 	metaClient = client.New(c)
 	//get DNS server name
-	lip, err := getDnsServer()
+	lip, err := getIP()
 	if err != nil {
 		log.LOGGER.Errorf("Dns server Start error : %s", err)
 		return

--- a/edgemesh/pkg/server/ip.go
+++ b/edgemesh/pkg/server/ip.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"net"
+	"time"
+
+	"github.com/kubeedge/beehive/pkg/common/log"
+)
+const inter = "docker0"
+// getIP returns the specific interface ip of version 4
+func getIP() (net.IP, error) {
+	for {
+		ifaces, err := net.InterfaceByName(inter)
+		if err != nil {
+			return nil, err
+		}
+		addrs, _ := ifaces.Addrs()
+		for _, addr := range addrs {
+			if ip, inet, _ := net.ParseCIDR(addr.String()); len(inet.Mask) == 4 {
+				return ip, nil
+			}
+		}
+		log.LOGGER.Warnf("the interface %s have not config ip of version 4",inter)
+		time.Sleep(time.Second * 3)
+	}
+}

--- a/edgemesh/pkg/server/server.go
+++ b/edgemesh/pkg/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chassis/go-chassis/core/registry"
 	_ "github.com/kubeedge/kubeedge/edgemesh/pkg/panel"
 	edgeregistry "github.com/kubeedge/kubeedge/edgemesh/pkg/registry"
+	mconfig "github.com/kubeedge/beehive/pkg/common/config"
 	"github.com/kubeedge/kubeedge/edgemesh/pkg/resolver"
 )
 
@@ -35,8 +36,15 @@ func Start() {
 	control.Init(opts)
 	opt := registry.Options{}
 	registry.DefaultServiceDiscoveryService = edgeregistry.NewServiceDiscovery(opt)
-	loadbalancer.InstallStrategy(loadbalancer.StrategyRandom, func() loadbalancer.Strategy {
-		return &loadbalancer.RandomStrategy{}
+	myStrategy := mconfig.CONFIG.GetConfigurationByKey("mesh.loadbalance.strategy-name").(string)
+	loadbalancer.InstallStrategy(myStrategy, func() loadbalancer.Strategy {
+		switch myStrategy{
+		case "RoundRobin":
+			return &loadbalancer.RoundRobinStrategy{}
+		case "Random":
+			return &loadbalancer.RandomStrategy{}
+		default: return &loadbalancer.RoundRobinStrategy{}
+		}
 	})
 	//Start dns server
 	go DnsStart()

--- a/edgemesh/pkg/server/tcp.go
+++ b/edgemesh/pkg/server/tcp.go
@@ -15,12 +15,16 @@ import (
 )
 
 func StartTCP() {
-	server := config.GetString("server", "0.0.0.0")
+	server, err:= getIP()
+	if err != nil {
+		log.LOGGER.Errorf("TCP server start error : %s", err)
+		return
+	}
+
+	serverIP := server.String()
 	port := config.GetString("port", "8080")
-
-	log.LOGGER.Infof("start listening at %s:%s", server, port)
-
-	listener, err := net.Listen("tcp", server+":"+port)
+	log.LOGGER.Infof("start listening at %s:%s", serverIP, port)
+	listener, err := net.Listen("tcp", serverIP+":"+port)
 	if err != nil {
 		log.LOGGER.Errorf("failed to start TCP server with error:%v\n", err)
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind  bug

**What this PR does / why we need it**:
1.  The tcp server listens on ip of interface ```docker0```
2. The load balance strategy can be set from ```edge.yaml```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #986

**Special notes for your reviewer**:
