### PR TITLE
edge: fix data race in initTwinActionCallBack()

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubeedge/beehive/pkg/common/log"
@@ -33,7 +34,8 @@ const (
 
 var (
 	//twinActionCallBack map for action to callback
-	twinActionCallBack map[string]CallBack
+	twinActionCallBack         map[string]CallBack
+	initTwinActionCallBackOnce sync.Once
 )
 
 //TwinWorker deal twin event
@@ -74,10 +76,12 @@ func (tw TwinWorker) Start() {
 }
 
 func initTwinActionCallBack() {
-	twinActionCallBack = make(map[string]CallBack)
-	twinActionCallBack[dtcommon.TwinUpdate] = dealTwinUpdate
-	twinActionCallBack[dtcommon.TwinGet] = dealTwinGet
-	twinActionCallBack[dtcommon.TwinCloudSync] = dealTwinSync
+	initTwinActionCallBackOnce.Do(func() {
+		twinActionCallBack = make(map[string]CallBack)
+		twinActionCallBack[dtcommon.TwinUpdate] = dealTwinUpdate
+		twinActionCallBack[dtcommon.TwinGet] = dealTwinGet
+		twinActionCallBack[dtcommon.TwinCloudSync] = dealTwinSync
+	})
 }
 
 func dealTwinSync(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind failing-test

**What this PR does / why we need it**:
This PR add `sync.Once` to guard initialization on `twinActionCallBack` map.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1010 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```