### PR TITLE
dtcommon: fix column name error

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/common.go
+++ b/edge/pkg/devicetwin/dtcommon/common.go
@@ -123,11 +123,6 @@ var (
 	//OperaMembershipResult get memebership
 	OperaMembershipResult = "membership_result"
 
-	// InsertDocument insert document
-	InsertDocument = "INSERT INTO document(deviceid, deviceName, expected, actual, metadata,attributes, lastsate,versionset) values(?,?,?,?,?,?,?,?)"
-	// DeleteDocument delete document
-	DeleteDocument = "DELETE FROM document where deviceid = ?"
-
 	//DealExpectedUpdateType deal expected update
 	DealExpectedUpdateType = "expected"
 	//DealActualUpdateType deal actual update


### PR DESCRIPTION
Signed-off-by: Guangming Wang <guangming.wang@daocloud.io>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
i beleive this column name "lastsate" is wrong,  ref from [here](https://github.com/kubeedge/kubeedge/blob/45fb42520b3022ad53132f5140c803f03f8a8122/edge/pkg/devicetwin/dtclient/sqlite.go#L21)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
