### PR TITLE
docs: setup required kubernetes version 1.15+

### DIFF
--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -20,7 +20,7 @@
 
 + **Go** The minimum required go version is 1.12. You can install this version by using [this website.](https://golang.org/dl/) 
 
-+ (**Optional**)KubeEdge also supports https connection to Kubernetes apiserver. Follow the steps in [Kubernetes Documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) to create the kubeconfig file.
++ (**Optional**)KubeEdge also supports https connection to Kubernetes (required version is 1.15+) apiserver. Follow the steps in [Kubernetes Documentation](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) to create the kubeconfig file.
 
   Enter the path to kubeconfig file in controller.yaml
   ```yaml


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind documentation

**What this PR does / why we need it**:

when i use kubernetes 1.12, and run cloudcore, it output:
```
E0821 18:45:30.912626    7443 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager/devicemodel.go:40: Failed to list *v1alpha1.DeviceModel: the server could not find the requested resource (get devicemodels.devices.kubeedge.io)
E0821 18:45:30.913397    7443 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager/device.go:40: Failed to list *v1alpha1.Device: the server could not find the requested resource (get devices.devices.kubeedge.io)
E0821 18:45:30.914801    7443 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/manager/configmap.go:31: Failed to list *v1.ConfigMap: the server could not find the requested resource (get configmaps)
E0821 18:45:30.915285    7443 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/manager/pod.go:100: Failed to list *v1.Pod: the server could not find the requested resource (get pods)
W0821 18:45:30.916048    7443 controller.go:51] new downstream controller failed with error: the server could not find the requested resource (get nodes)

```

and now  kubernetes dependencies in vendor to v1.15
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
