### PR TITLE
add self-defined kubeclient

### DIFF
--- a/edge/pkg/edged/fake/fake_clientset.go
+++ b/edge/pkg/edged/fake/fake_clientset.go
@@ -1,0 +1,35 @@
+package fake
+
+import (
+	clientset "k8s.io/client-go/kubernetes"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
+	fakestoragev1 "k8s.io/client-go/kubernetes/typed/storage/v1/fake"
+
+	kecorev1 "github.com/kubeedge/kubeedge/edge/pkg/edged/fake/typed/core/v1"
+	kestoragev1 "github.com/kubeedge/kubeedge/edge/pkg/edged/fake/typed/storage/v1"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+)
+
+// NewSimpleClientset is new interface
+func NewSimpleClientset(metaClient client.CoreInterface) clientset.Interface {
+	return &Clientset{*fakekube.NewSimpleClientset(), metaClient}
+}
+
+// Clientset extends Clientset
+type Clientset struct {
+	fakekube.Clientset
+	MetaClient client.CoreInterface
+}
+
+// CoreV1 retrieves the CoreV1Client
+func (c *Clientset) CoreV1() corev1.CoreV1Interface {
+	return &kecorev1.FakeCoreV1{FakeCoreV1: fakecorev1.FakeCoreV1{Fake: &c.Fake}, MetaClient: c.MetaClient}
+}
+
+// StorageV1 retrieves the StorageV1Client
+func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
+	return &kestoragev1.FakeStorageV1{FakeStorageV1: fakestoragev1.FakeStorageV1{Fake: &c.Fake}, MetaClient: c.MetaClient}
+}

--- a/edge/pkg/edged/fake/typed/core/v1/fake_core_client.go
+++ b/edge/pkg/edged/fake/typed/core/v1/fake_core_client.go
@@ -1,0 +1,25 @@
+package v1
+
+import (
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+)
+
+type FakeCoreV1 struct {
+	fakecorev1.FakeCoreV1
+	MetaClient client.CoreInterface
+}
+
+func (c *FakeCoreV1) Nodes() corev1.NodeInterface {
+	return &FakeNodes{fakecorev1.FakeNodes{Fake: &c.FakeCoreV1}, c.MetaClient}
+}
+
+func (c *FakeCoreV1) PersistentVolumes() corev1.PersistentVolumeInterface {
+	return &FakePersistentVolumes{fakecorev1.FakePersistentVolumes{Fake: &c.FakeCoreV1}, c.MetaClient}
+}
+
+func (c *FakeCoreV1) PersistentVolumeClaims(namespace string) corev1.PersistentVolumeClaimInterface {
+	return &FakePersistentVolumeClaims{fakecorev1.FakePersistentVolumeClaims{Fake: &c.FakeCoreV1}, namespace, c.MetaClient}
+}

--- a/edge/pkg/edged/fake/typed/core/v1/fake_node.go
+++ b/edge/pkg/edged/fake/typed/core/v1/fake_node.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+)
+
+// FakeNodes implements NodeInterface
+type FakeNodes struct {
+	fakecorev1.FakeNodes
+	MetaClient client.CoreInterface
+}
+
+// Get takes name of the node, and returns the corresponding node object
+func (c *FakeNodes) Get(name string, options metav1.GetOptions) (result *corev1.Node, err error) {
+	return c.MetaClient.Nodes(metav1.NamespaceDefault).Get(name)
+}
+
+// Update takes the representation of a node and updates it
+func (c *FakeNodes) Update(node *corev1.Node) (result *corev1.Node, err error) {
+	err = c.MetaClient.Nodes(metav1.NamespaceDefault).Update(node)
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
+}

--- a/edge/pkg/edged/fake/typed/core/v1/fake_persistentvolume.go
+++ b/edge/pkg/edged/fake/typed/core/v1/fake_persistentvolume.go
@@ -1,0 +1,19 @@
+package v1
+
+import (
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+)
+
+// FakePersistentVolumes implements PersistentVolumeInterface
+type FakePersistentVolumes struct {
+	fakecorev1.FakePersistentVolumes
+	MetaClient client.CoreInterface
+}
+
+// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
+func (c *FakePersistentVolumes) Get(name string, options metav1.GetOptions) (result *corev1.PersistentVolume, err error) {
+	return c.MetaClient.PersistentVolumes(metav1.NamespaceDefault).Get(name, options)
+}

--- a/edge/pkg/edged/fake/typed/core/v1/fake_persistentvolumeclaim.go
+++ b/edge/pkg/edged/fake/typed/core/v1/fake_persistentvolumeclaim.go
@@ -1,0 +1,20 @@
+package v1
+
+import (
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+)
+
+// FakePersistentVolumeClaims implements PersistentVolumeClaimInterface
+type FakePersistentVolumeClaims struct {
+	fakecorev1.FakePersistentVolumeClaims
+	ns         string
+	MetaClient client.CoreInterface
+}
+
+// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object
+func (c *FakePersistentVolumeClaims) Get(name string, options metav1.GetOptions) (result *corev1.PersistentVolumeClaim, err error) {
+	return c.MetaClient.PersistentVolumeClaims(c.ns).Get(name, options)
+}

--- a/edge/pkg/edged/fake/typed/storage/v1/fake_storage_client.go
+++ b/edge/pkg/edged/fake/typed/storage/v1/fake_storage_client.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
+	fakestoragev1 "k8s.io/client-go/kubernetes/typed/storage/v1/fake"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+)
+
+type FakeStorageV1 struct {
+	fakestoragev1.FakeStorageV1
+	MetaClient client.CoreInterface
+}
+
+func (c *FakeStorageV1) VolumeAttachments() storagev1.VolumeAttachmentInterface {
+	return &FakeVolumeAttachments{fakestoragev1.FakeVolumeAttachments{Fake: &c.FakeStorageV1}, c.MetaClient}
+}

--- a/edge/pkg/edged/fake/typed/storage/v1/fake_volumeattachment.go
+++ b/edge/pkg/edged/fake/typed/storage/v1/fake_volumeattachment.go
@@ -1,0 +1,19 @@
+package v1
+
+import (
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakestoragev1 "k8s.io/client-go/kubernetes/typed/storage/v1/fake"
+)
+
+// FakeVolumeAttachments implements PersistentVolumeInterface
+type FakeVolumeAttachments struct {
+	fakestoragev1.FakeVolumeAttachments
+	MetaClient client.CoreInterface
+}
+
+// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object
+func (c *FakeVolumeAttachments) Get(name string, options metav1.GetOptions) (result *storagev1.VolumeAttachment, err error) {
+	return c.MetaClient.VolumeAttachments(metav1.NamespaceDefault).Get(name, options)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -717,10 +717,14 @@ k8s.io/client-go/util/cert
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/rest
 k8s.io/client-go/tools/cache
-k8s.io/client-go/kubernetes/fake
 k8s.io/client-go/tools/record
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/workqueue
+k8s.io/client-go/kubernetes/fake
+k8s.io/client-go/kubernetes/typed/core/v1
+k8s.io/client-go/kubernetes/typed/core/v1/fake
+k8s.io/client-go/kubernetes/typed/storage/v1
+k8s.io/client-go/kubernetes/typed/storage/v1/fake
 k8s.io/client-go/discovery
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
 k8s.io/client-go/kubernetes/typed/apps/v1
@@ -740,7 +744,6 @@ k8s.io/client-go/kubernetes/typed/batch/v2alpha1
 k8s.io/client-go/kubernetes/typed/certificates/v1beta1
 k8s.io/client-go/kubernetes/typed/coordination/v1
 k8s.io/client-go/kubernetes/typed/coordination/v1beta1
-k8s.io/client-go/kubernetes/typed/core/v1
 k8s.io/client-go/kubernetes/typed/events/v1beta1
 k8s.io/client-go/kubernetes/typed/extensions/v1beta1
 k8s.io/client-go/kubernetes/typed/networking/v1
@@ -755,7 +758,6 @@ k8s.io/client-go/kubernetes/typed/scheduling/v1
 k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1
 k8s.io/client-go/kubernetes/typed/scheduling/v1beta1
 k8s.io/client-go/kubernetes/typed/settings/v1alpha1
-k8s.io/client-go/kubernetes/typed/storage/v1
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1beta1
 k8s.io/client-go/tools/auth
@@ -769,6 +771,11 @@ k8s.io/client-go/tools/metrics
 k8s.io/client-go/transport
 k8s.io/client-go/tools/pager
 k8s.io/client-go/util/retry
+k8s.io/client-go/tools/record/util
+k8s.io/client-go/tools/reference
+k8s.io/client-go/informers
+k8s.io/client-go/tools/remotecommand
+k8s.io/client-go/listers/storage/v1beta1
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/apps/v1/fake
@@ -788,7 +795,6 @@ k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake
 k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/coordination/v1/fake
 k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake
-k8s.io/client-go/kubernetes/typed/core/v1/fake
 k8s.io/client-go/kubernetes/typed/events/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/networking/v1/fake
@@ -803,15 +809,9 @@ k8s.io/client-go/kubernetes/typed/scheduling/v1/fake
 k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake
-k8s.io/client-go/kubernetes/typed/storage/v1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake
 k8s.io/client-go/testing
-k8s.io/client-go/tools/record/util
-k8s.io/client-go/tools/reference
-k8s.io/client-go/informers
-k8s.io/client-go/tools/remotecommand
-k8s.io/client-go/listers/storage/v1beta1
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/tools/clientcmd/api/v1
 k8s.io/client-go/pkg/apis/clientauthentication


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
add self-defined kubeclient which will issue metaclient.
Mainly implements the following resources:
* PersistentVolume
* PersistentVolumeClaim
* VolumeAttachment
* Node

This pr depends on the pr #1046
It will be rebased once the #1046 is merged

**Which issue(s) this PR fixes**:
XREF #272