### PR TITLE
Cloud k8s: ClusterRole and ConfigMap fixes

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -23,6 +23,14 @@ rules:
   - watch
   - update
 - apiGroups:
+  - "devices.kubeedge.io"
+  resources:
+  - devices
+  - devicemodels
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/build/cloud/05-configmap.yaml
+++ b/build/cloud/05-configmap.yaml
@@ -33,4 +33,4 @@ data:
     writers: [stdout]
   modules.yaml: |
     modules:
-      enabled: [devicecontroller, controller, cloudhub]
+      enabled: [devicecontroller, edgecontroller, cloudhub]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Missing resources in k8s ClusterRole definition, fix cloudcore ConfigMap module typo
- Fixes missing roles cloudcore require to update k8s objects. 
- Fixes module name in cloudcore (after it was renamed by 17fd9125e83f932c70de7adc4268aec1214f4520)

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This PR fixes edge node status to be properly handled by the k8s cloud part. Error example:
```
2019-08-23 13:48:07.773 +00:00 WARN context/context_channel.go:341 failed to get type channel, type(edgecontroller)
2019-08-23 13:48:07.773 +00:00 WARN context/context_channel.go:186 bad module type (edgecontroller), do nothing
I0823 13:48:17.807222       1 eventhandler.go:189] event received for node edge-1 id: fb795d77-fcaa-49d6-9308-21656e7c2473, parent_id: , group: meta, source: edged, resource: node/edge-1/default/nodestatus/edge-1, operation: update, content: {"UID":"38796d14-1df3-11e8-8e5a-286ed488f209","Status":{"capacity":{"cpu":"1","memory":"991Mi","pods":"110"},"allocatable":{"cpu":"1","memory":"891Mi","pods":"110"},"phase":"Running","conditions":[{"type":"Ready","status":"True","lastHeartbeatTime":"2019-08-23T13:48:17Z","lastTransitionTime":"2019-08-23T13:48:17Z","reason":"EdgeReady","message":"edge is posting ready status"}],"addresses":[{"type":"InternalIP","address":"172.17.0.2"},{"type":"Hostname","address":"4ac9ec57b5cd"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"3.10.0-862.14.4.el7.x86_64","osImage":"Alpine Linux v3.10","containerRuntimeVersion":"remote://19.3.1","kubeletVersion":"v1.15.0-kubeedge-v1.0.0","kubeProxyVersion":"","operatingSystem":"linux","architecture":"amd64"}},"ExtendResources":null}
2019-08-23 13:48:17.807 +00:00 WARN context/context_channel.go:341 failed to get type channel, type(edgecontroller)
2019-08-23 13:48:17.807 +00:00 WARN context/context_channel.go:186 bad module type (edgecontroller), do nothing
I0823 13:48:18.288392       1 eventhandler.go:92] Keepalive message received from node: edge-1
I0823 13:48:18.288761       1 eventhandler.go:123] Node edge-1 is still alive


``` 

**Does this PR introduce a user-facing change?**:
NONE