### PR TITLE
bugfix:edgecore panic on GetConfigurationByKey() when run on raspberrypi 4

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -238,7 +238,7 @@ type Config struct {
 	nodeName                  string
 	nodeNamespace             string
 	interfaceName             string
-	memoryCapacity            int
+	memoryCapacity            int64
 	nodeStatusUpdateInterval  time.Duration
 	devicePluginEnabled       bool
 	gpuPluginEnabled          bool
@@ -389,7 +389,16 @@ func getConfig() *Config {
 		conf.clusterDomain = ""
 	}
 
-	conf.memoryCapacity = config.CONFIG.GetConfigurationByKey("edged.edged-memory-capacity-bytes").(int)
+	//Deal with 32-bit and 64-bit compatibility issues: issue #1070
+	switch v := config.CONFIG.GetConfigurationByKey("edged.edged-memory-capacity-bytes").(type) {
+	case int:
+		conf.memoryCapacity = int64(v)
+	case int64:
+		conf.memoryCapacity = v
+	default:
+		panic("Invalid type for edged.edged-memory-capacity-bytes, valid types are one of [int,int64].")
+	}
+
 	if conf.memoryCapacity == 0 {
 		conf.memoryCapacity = MinimumEdgedMemoryCapacity
 	}

--- a/edge/test/integration/scripts/execute.sh
+++ b/edge/test/integration/scripts/execute.sh
@@ -38,7 +38,8 @@ if pgrep edgecore >/dev/null
 then
     echo "edgecore process is Running"
 else
-    echo "edgecore process is not started"
+    echo "edgecore process is not started, log info:"
+    cat edgecore.log
     exit 1
 fi
 PWD=${curpath}/test/integration


### PR DESCRIPTION

Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1070 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
