### PR TITLE
adjust the reference of udsserver

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/util"
 	chconfig "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/config"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers"
+	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers/udsserver"
 )
 
 type cloudHub struct {
@@ -53,7 +54,9 @@ func (a *cloudHub) Start(c *context.Context) {
 	}
 
 	if util.HubConfig.ProtocolUDS {
-		go servers.StartCloudHub(servers.ProtocolUDS, eventq, c)
+		// The uds server is only used to communicate with csi driver from kubeedge on cloud.
+		// It is not used to communicate between cloud and edge.
+		go udsserver.StartServer(util.HubConfig, c)
 	}
 
 	<-a.stopChan

--- a/cloud/pkg/cloudhub/servers/factory.go
+++ b/cloud/pkg/cloudhub/servers/factory.go
@@ -7,14 +7,12 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/channelq"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/util"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers/quicserver"
-	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers/udsserver"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers/wsserver"
 )
 
 const (
 	ProtocolWebsocket = "websocket"
 	ProtocolQuic      = "quic"
-	ProtocolUDS       = "uds"
 )
 
 func StartCloudHub(protocol string, eventq *channelq.ChannelEventQueue, c *context.Context) {
@@ -23,8 +21,6 @@ func StartCloudHub(protocol string, eventq *channelq.ChannelEventQueue, c *conte
 		wsserver.StartCloudHub(util.HubConfig, eventq, c)
 	case ProtocolQuic:
 		quicserver.StartCloudHub(util.HubConfig, eventq, c)
-	case ProtocolUDS:
-		udsserver.StartServer(util.HubConfig, c)
 	default:
 		panic(fmt.Errorf("invalid protocol, should be websocket or quic or uds"))
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adjust the reference of uds server since the uds server is only used to communicate on cloud.
and websocket server & quic server are used to communicate between cloud and edge.
