### PR TITLE
dynamic create node version info

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -74,4 +74,6 @@ const (
 	CSIOperationTypeControllerPublishVolume   = "controllerpublishvolume"
 	CSIOperationTypeControllerUnpublishVolume = "controllerunpublishvolume"
 	CSISyncMsgRespTimeout                     = 1 * time.Minute
+
+	CurrentSupportK8sVersion = "v1.15.3"
 )

--- a/edge/conf/edge.yaml
+++ b/edge/conf/edge.yaml
@@ -40,7 +40,6 @@ edged:
     image-gc-low-threshold: 40 # percent
     maximum-dead-containers-per-container: 1
     docker-address: unix:///var/run/docker.sock
-    version: v1.15.0-kubeedge-v1.0.0
     runtime-type: docker
     remote-runtime-endpoint: unix:///var/run/dockershim.sock
     remote-image-endpoint: unix:///var/run/dockershim.sock

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -82,6 +82,7 @@ import (
 	"github.com/kubeedge/beehive/pkg/core"
 	"github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/edged/apis"
 	"github.com/kubeedge/kubeedge/edge/pkg/edged/cadvisor"
@@ -98,6 +99,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/edged/util/record"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
 const (
@@ -247,7 +249,6 @@ type Config struct {
 	imagePullProgressDeadline int
 	MaxPerPodContainerCount   int
 	DockerAddress             string
-	version                   string
 	runtimeType               string
 	remoteRuntimeEndpoint     string
 	remoteImageEndpoint       string
@@ -373,7 +374,6 @@ func getConfig() *Config {
 	conf.imageGCHighThreshold = config.CONFIG.GetConfigurationByKey("edged.image-gc-high-threshold").(int)
 	conf.imageGCLowThreshold = config.CONFIG.GetConfigurationByKey("edged.image-gc-low-threshold").(int)
 	conf.MaxPerPodContainerCount = config.CONFIG.GetConfigurationByKey("edged.maximum-dead-containers-per-container").(int)
-	conf.version = config.CONFIG.GetConfigurationByKey("edged.version").(string)
 	if conf.DockerAddress, ok = config.CONFIG.GetConfigurationByKey("edged.docker-address").(string); !ok {
 		conf.DockerAddress = DockerEndpoint
 	}
@@ -467,7 +467,7 @@ func newEdged() (*edged, error) {
 		nodeStatusUpdateFrequency: conf.nodeStatusUpdateInterval,
 		mounter:                   mount.New(""),
 		uid:                       types.UID("38796d14-1df3-11e8-8e5a-286ed488f209"),
-		version:                   conf.version,
+		version:                   fmt.Sprintf("%s-kubeedge-%s", constants.CurrentSupportK8sVersion, version.Get()),
 		rootDirectory:             DefaultRootDir,
 		secretStore:               cache.NewStore(cache.MetaNamespaceKeyFunc),
 		configMapStore:            cache.NewStore(cache.MetaNamespaceKeyFunc),

--- a/keadm/app/cmd/common/config.go
+++ b/keadm/app/cmd/common/config.go
@@ -152,7 +152,6 @@ func WriteEdgeYamlFile(path string, modifiedEdgeYaml *EdgeYamlSt) error {
 	iface := "eth0"
 	edgeID := "fb4ebb70-2783-42b8-b3ef-63e2fd6d242e"
 	url := fmt.Sprintf("wss://0.0.0.0:10000/%s/fb4ebb70-2783-42b8-b3ef-63e2fd6d242e/events", DefaultProjectID)
-	version := "2.0.0"
 	runtimeType := "docker"
 
 	if nil != modifiedEdgeYaml {
@@ -160,13 +159,9 @@ func WriteEdgeYamlFile(path string, modifiedEdgeYaml *EdgeYamlSt) error {
 			url = modifiedEdgeYaml.EdgeHub.WebSocket.URL
 			edgeID = strings.Split(modifiedEdgeYaml.EdgeHub.WebSocket.URL, "/")[4]
 		}
-		if "" != modifiedEdgeYaml.EdgeD.Version {
-			version = modifiedEdgeYaml.EdgeD.Version
-		}
 		if "" != modifiedEdgeYaml.EdgeD.RuntimeType {
 			runtimeType = modifiedEdgeYaml.EdgeD.RuntimeType
 		}
-
 		if "" != modifiedEdgeYaml.EdgeD.InterfaceName {
 			iface = modifiedEdgeYaml.EdgeD.InterfaceName
 		}
@@ -207,11 +202,11 @@ func WriteEdgeYamlFile(path string, modifiedEdgeYaml *EdgeYamlSt) error {
 			ImageGCLowThreshold:               40,
 			MaximumDeadContainersPerContainer: 1,
 			DockerAddress:                     "unix:///var/run/docker.sock",
-			Version:                           version, RuntimeType: runtimeType,
-			RuntimeEndpoint: "/var/run/containerd/containerd.sock",
-			ImageEndpoint:   "/var/run/containerd/containerd.sock",
-			RequestTimeout:  2,
-			PodSandboxImage: "k8s.gcr.io/pause",
+			RuntimeType:                       runtimeType,
+			RuntimeEndpoint:                   "/var/run/containerd/containerd.sock",
+			ImageEndpoint:                     "/var/run/containerd/containerd.sock",
+			RequestTimeout:                    2,
+			PodSandboxImage:                   "k8s.gcr.io/pause",
 		},
 		Mesh: Mesh{
 			LB: LoadBalance{

--- a/keadm/app/cmd/common/types.go
+++ b/keadm/app/cmd/common/types.go
@@ -236,7 +236,6 @@ type EdgeDSt struct {
 	ImageGCLowThreshold               uint16 `yaml:"image-gc-low-threshold"`
 	MaximumDeadContainersPerContainer uint16 `yaml:"maximum-dead-containers-per-container"`
 	DockerAddress                     string `yaml:"docker-address"`
-	Version                           string `yaml:"version"`
 	EdgedMemory                       uint16 `yaml:"edged-memory-capacity-bytes"`
 	RuntimeType                       string `yaml:"runtime-type"`
 	RuntimeEndpoint                   string `yaml:"remote-runtime-endpoint"`

--- a/keadm/app/cmd/util/edgecoreinstaller.go
+++ b/keadm/app/cmd/util/edgecoreinstaller.go
@@ -91,7 +91,7 @@ func (ku *KubeEdgeInstTool) createEdgeConfigFiles() error {
 
 	url := fmt.Sprintf("wss://%s:10000/%s/%s/events", serverIPAddr, types.DefaultProjectID, edgeID)
 	edgeYaml := &types.EdgeYamlSt{EdgeHub: types.EdgeHubSt{WebSocket: types.WebSocketSt{URL: url}},
-		EdgeD: types.EdgeDSt{Version: types.VendorK8sPrefix + ku.ToolVersion, RuntimeType: ku.RuntimeType, InterfaceName: ku.InterfaceName}}
+		EdgeD: types.EdgeDSt{RuntimeType: ku.RuntimeType, InterfaceName: ku.InterfaceName}}
 
 	if err = types.WriteEdgeYamlFile(KubeEdgeConfigEdgeYaml, edgeYaml); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind feature
**What this PR does / why we need it**:

now when we exec `kubectl get node`
```
kubectl get node
NAME                 STATUS     ROLES    AGE    VERSION
172.20.11.45-cloud   Ready      master   11d    v1.15.3
192.168.4.27-pi1     NotReady   edge     5d1h   v1.15.0-kubeedge-v1.0.0

```
the edgenode version is `v1.15.0-kubeedge-v1.0.0`, it is from the config of edge.yaml of edgecore

```
edged:
    register-node-namespace: default
    hostname-override: 192.168.4.27-pi1
    ...
    version: v1.15.0-kubeedge-v1.0.0
    runtime-type: docker
    remote-runtime-endpoint: unix:///var/run/dockershim.sock
    ...

```

it is hardcode.

this pr is dynamic get edge version and register it to k8s.

this is an example:
```
kubectl get node
NAME                 STATUS   ROLES    AGE    VERSION
172.20.11.45-cloud   Ready    master   11d    v1.15.3
192.168.4.27-pi1     Ready    edge     5d1h   v1.15.3-kubeedge-v1.0.0-344+2444224ba56784

```

because now we use k8s v1.15.3 library.  so we use v1.15.3 to stand for support k8s 1.15.3 version.



**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
