### PR TITLE
Update ubuntuinstaller.go

### DIFF
--- a/keadm/app/cmd/util/ubuntuinstaller.go
+++ b/keadm/app/cmd/util/ubuntuinstaller.go
@@ -437,7 +437,7 @@ func (u *UbuntuOS) InstallKubeEdge() error {
 	//Currently it is missing and once checksum is in place, checksum check required
 	//to be added here.
 	filename := fmt.Sprintf("kubeedge-v%s-linux-%s.tar.gz", u.KubeEdgeVersion, arch)
-	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.txt", u.KubeEdgeVersion, arch)
+	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.tar.gz.txt", u.KubeEdgeVersion, arch)
 	filePath := fmt.Sprintf("%s%s", KubeEdgePath, filename)
 	fileStat, err := os.Stat(filePath)
 	if err == nil && fileStat.Name() != "" {

--- a/vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go
@@ -60,7 +60,7 @@ var (
 	preferredPathLock sync.Mutex
 	preferredPath     = ""
 	workingDirPath    = ""
-	homeDirPath, _    = os.UserHomeDir()
+	homeDirPath, _    = os.Getenv("HOME")
 	rootDirPath       = "/"
 	homeJsonDirPath   = filepath.Join(homeDirPath, ".docker")
 	rootJsonDirPath   = filepath.Join(rootDirPath, ".docker")


### PR DESCRIPTION
scripts: update the download path of the checksum file. the release version of the checksum file is *.tar.gz.txt just like this:https://github.com/kubeedge/kubeedge/releases/download/v1.1.0/checksum_kubeedge-v1.1.0-linux-amd64.tar.gz.txt

this can fix the wrong kubeedge checksum file download path 

Fixes #1133


