### PR TITLE
Ensure installed docker version is not uninstalled by keadm if the version is equal to or greater than 17.03.1 docker version

### DIFF
--- a/keadm/app/cmd/util/common.go
+++ b/keadm/app/cmd/util/common.go
@@ -38,6 +38,16 @@ const (
 	DefaultDownloadURL = "https://download.docker.com"
 	DockerPreqReqList  = "apt-transport-https ca-certificates curl gnupg-agent software-properties-common"
 
+	//-- nsriam start
+	// Among the qualified docker versions mentioned (please refer to below
+	// mentioned reference link), docker version 1.13.1 is not
+	// shown in the output 'apt-cache madison 'docker-ce'' next mentioned &
+	// available docker version is 17.03.1 is treated as the minimum docker version
+	// Reference - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#external-dependencies
+
+	DockerMinimumVersionNumber = "17.03.1"
+	//-- nsriam end
+
 	KubernetesDownloadURL = "https://apt.kubernetes.io/"
 	KubernetesGPGURL      = "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 

--- a/keadm/app/cmd/util/common.go
+++ b/keadm/app/cmd/util/common.go
@@ -38,7 +38,6 @@ const (
 	DefaultDownloadURL = "https://download.docker.com"
 	DockerPreqReqList  = "apt-transport-https ca-certificates curl gnupg-agent software-properties-common"
 
-	//-- nsriam start
 	// Among the qualified docker versions mentioned (please refer to below
 	// mentioned reference link), docker version 1.13.1 is not
 	// shown in the output 'apt-cache madison 'docker-ce'' next mentioned &
@@ -46,7 +45,6 @@ const (
 	// Reference - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#external-dependencies
 
 	DockerMinimumVersionNumber = "17.03.1"
-	//-- nsriam end
 
 	KubernetesDownloadURL = "https://apt.kubernetes.io/"
 	KubernetesGPGURL      = "https://packages.cloud.google.com/apt/doc/apt-key.gpg"

--- a/keadm/app/cmd/util/dockerinstaller.go
+++ b/keadm/app/cmd/util/dockerinstaller.go
@@ -43,7 +43,9 @@ func (d *DockerInstTool) InstallTools() error {
 	case types.VersionNAInRepo:
 		return fmt.Errorf("Expected Docker version is not available in OS repo")
 	case types.AlreadySameVersionExist:
-		fmt.Println("Same version of docker already installed in this host")
+		//--nsriram start
+		//fmt.Println("Same version of docker already installed in this host")
+		//--nsriram end
 		return nil
 	case types.DefVerInstallRequired:
 		d.SetDockerVersion(d.DefaultToolVer)

--- a/keadm/app/cmd/util/dockerinstaller.go
+++ b/keadm/app/cmd/util/dockerinstaller.go
@@ -43,9 +43,6 @@ func (d *DockerInstTool) InstallTools() error {
 	case types.VersionNAInRepo:
 		return fmt.Errorf("Expected Docker version is not available in OS repo")
 	case types.AlreadySameVersionExist:
-		//--nsriram start
-		//fmt.Println("Same version of docker already installed in this host")
-		//--nsriram end
 		return nil
 	case types.DefVerInstallRequired:
 		d.SetDockerVersion(d.DefaultToolVer)

--- a/keadm/app/cmd/util/ubuntuinstaller.go
+++ b/keadm/app/cmd/util/ubuntuinstaller.go
@@ -151,12 +151,6 @@ func (u *UbuntuOS) IsDockerInstalled(defVersion string) (types.InstallState, err
 		fmt.Println("Docker Version installed is = ", str)
 	}
 
-	//--nsriram start
-
-	//if strings.Count(str, ".") == 2 {
-	//	fmt.Println("Docker version", str, "already installed in this host")
-	//	return types.AlreadySameVersionExist, nil
-	//}
 	// Docker version format MM.mm.PP
 	// Split version number into three parts M = Major number, m = minor number, P = patch number
 	sliceOfDockerMinimumVersionNumber := strings.SplitN(DockerMinimumVersionNumber, ".", 3)
@@ -201,8 +195,6 @@ func (u *UbuntuOS) IsDockerInstalled(defVersion string) (types.InstallState, err
 	if strings.Contains(str, u.DockerVersion) {
 		return types.AlreadySameVersionExist, nil
 	}
-
-	//--nsriram end
 
 	if err := u.addDockerRepositoryAndUpdate(); err != nil {
 		return types.VersionNAInRepo, err
@@ -541,7 +533,7 @@ func (u *UbuntuOS) InstallKubeEdge() error {
 	}
 
 SKIPDOWNLOADAND:
-	untarFileAndMove := fmt.Sprintf("cd %s && tar -C %s -xvzf %s && cp %s/kubeedge/edge/%s /usr/local/bin/.", KubeEdgePath, KubeEdgePath, filename, KubeEdgePath, KubeEdgeBinaryName)
+	untarFileAndMove := fmt.Sprintf("cd %s && tar -C %s -xvzf %s && cp %skubeedge/edge/%s /usr/local/bin/.", KubeEdgePath, KubeEdgePath, filename, KubeEdgePath, KubeEdgeBinaryName)
 	stdout, err := runCommandWithShell(untarFileAndMove)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
 /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
Though latest version of docker was installed in the system such as 18.09.2 keadm earlier used to uninstall that version and install 18.06.0 version. 
This fix validates against the installed docker version is greater than or equal to 17.03.1 and only in case of lower than 17.03.1 version keadm installs docker version.

 
**Which issue(s) this PR fixes**:
No specific issue is created prior on this.

**Special notes for your reviewer**:

Among the qualified docker versions mentioned (please refer to below mentioned reference link), docker version 1.13.1 is not shown in the output 'apt-cache madison 'docker-ce'' next mentioned & available docker version is 17.03.1 treated as the minimum docker version 
Reference - https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#external-dependencies

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
