### PR TITLE
Remove coreutils in alpine

### DIFF
--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -25,16 +25,12 @@ spec:
           mountPath: /etc/kubeedge/cloud
           subPath: kubeconfig.yaml
         command:
-        - /bin/sh
-        - -c
-        - |
-          cat | tee /etc/kubeedge/cloud/kubeconfig.yaml <<EOF
           apiVersion: v1
           kind: Config
           clusters:
           - name: kubeedge
             cluster:
-              certificate-authority-data: $(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 | awk '{printf $0}')
+              certificate-authority: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           users:
           - name: kubeedge
             user:
@@ -48,7 +44,7 @@ spec:
           EOF
       containers:
       - name: cloudcore
-        image: kubeedge/cloudcore:v1.0.0
+        image: kubeedge/cloudcore:v1.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 10000

--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -25,6 +25,10 @@ spec:
           mountPath: /etc/kubeedge/cloud
           subPath: kubeconfig.yaml
         command:
+        - /bin/sh
+        - -c
+        - |
+          cat | tee /etc/kubeedge/cloud/kubeconfig.yaml <<EOF
           apiVersion: v1
           kind: Config
           clusters:

--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -28,13 +28,13 @@ spec:
         - /bin/sh
         - -c
         - |
-          apk --no-cache add coreutils && cat | tee /etc/kubeedge/cloud/kubeconfig.yaml <<EOF
+          cat | tee /etc/kubeedge/cloud/kubeconfig.yaml <<EOF
           apiVersion: v1
           kind: Config
           clusters:
           - name: kubeedge
             cluster:
-              certificate-authority-data: $(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 -w 0)
+              certificate-authority-data: $(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 | awk '{printf $0}')
           users:
           - name: kubeedge
             user:


### PR DESCRIPTION
"apk --no-cache add coreutils" may failed when node can't access to Internet.
Using awk '{printf $0}' instead of base64 -w 0.


**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
Speedup the installation of deploy cloud part into a k8s cluster.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
