### PR TITLE
delete useless sync group module

### DIFF
--- a/edge/pkg/edgehub/controller.go
+++ b/edge/pkg/edgehub/controller.go
@@ -25,7 +25,6 @@ const (
 var groupMap = map[string]string{
 	"resource": modules.MetaGroup,
 	"twin":     modules.TwinGroup,
-	"app":      "sync",
 	"func":     modules.MetaGroup,
 	"user":     modules.BusGroup,
 }


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:

when run edgecore , it will output:
```
...

I0925 10:26:01.060077    1976 websocket.go:79] Websocket connect to cloud access successful
2019-09-25 10:26:01.060 +08:00 WARN context/context_channel.go:341 failed to get type channel, type(sync)
2019-09-25 10:26:01.060 +08:00 WARN context/context_channel.go:186 bad module type (sync), do nothing
...

```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
