### PR TITLE
add scripts for syncing standalone subprojects code into tree

### DIFF
--- a/hack/sync-subproject-code.sh
+++ b/hack/sync-subproject-code.sh
@@ -49,7 +49,8 @@ fi
 function check-and-add-upstream() {
   local upstream=$1
   local upstream_url=$2
-  git remote -v | grep -qE "^${upstream}\b.*${upstream_url}" || rc="$?"
+  # git remote -v | grep -qE "^${upstream}\b.*${upstream_url}" || rc="$?"
+  git remote get-url ${upstream} | grep -qE "${upstream_url}" || rc="$?"
   if [[ "${rc}" -ne "0" ]]; then
     printf "[INFO] git remote not found, adding: %s\t%s\n" ${upstream} ${upstream_url}
     git remote add ${upstream} ${upstream_url}

--- a/hack/sync-subproject-code.sh
+++ b/hack/sync-subproject-code.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# set USE_HTTPS to false if you are using git@github.com/xxx/xx.git as remote
+USE_HTTPS=${USE_HTTPS:-true}
+
+# set CHECK_GIT_REMOTE false if you already set remote correctly
+CHECK_GIT_REMOTE=${CHECK_GIT_REMOTE:-true}
+
+# Useful Defaults
+## Target github organization name
+TARGET_ORG=${TARGET_ORG:-"kubeedge"}
+## main repo uptream configs
+UPSTREAM=${UPSTREAM:-"upstream"}
+UPSTREAM_HEAD=${UPSTREAM_HEAD:-"master"}
+UPSTREAM_REPO_NAME=${UPSTREAM_REPO_NAME:-"kubeedge"}
+## out of tree upstream configs
+OOT_UPSTREAM=${OOT_UPSTREAM:-"beehive-upstream"}
+OOT_UPSTREAM_HEAD=${OOT_UPSTREAM_HEAD:-"master"}
+OOT_UPSTREAM_REPO_NAME=${OOT_UPSTREAM_REPO_NAME:-"beehive"}
+# sub-directory to sync from upstream project
+PATH_TO_SYNC=${PATH_TO_SYNC:-"staging/src/github.com/kubeedge/beehive"}
+# branch name for working changes
+WORKING_BRANCH_NAME=${WORKING_BRANCH_NAME:-"sync-beehive-code"}
+
+
+PROTO_HEAD="git@"
+SPLITER=":"
+if [[ ${USE_HTTPS} ]]; then
+  PROTO_HEAD="https://"
+  SPLITER="/"
+fi
+
+function check-and-add-upstream() {
+  local upstream=$1
+  local upstream_url=$2
+  git remote -v | grep -qE "^${upstream}\b.*${upstream_url}" || rc="$?"
+  if [[ "${rc}" -ne "0" ]]; then
+    printf "[INFO] git remote not found, adding: %s\t%s\n" ${upstream} ${upstream_url}
+    git remote add ${upstream} ${upstream_url}
+  fi
+}
+
+if [[ ${CHECK_GIT_REMOTE} ]]; then
+  UPSTREAM_URL="${PROTO_HEAD}github.com${SPLITER}${TARGET_ORG}/${UPSTREAM_REPO_NAME}.git"
+  OOT_UPSTREAM_URL="${PROTO_HEAD}github.com${SPLITER}${TARGET_ORG}/${OOT_UPSTREAM_REPO_NAME}.git"
+  check-and-add-upstream ${UPSTREAM} ${UPSTREAM_URL}
+  check-and-add-upstream ${OOT_UPSTREAM} ${OOT_UPSTREAM_URL}
+fi
+
+printf "[INFO] updating remote %s, %s.\n" ${UPSTREAM} ${OOT_UPSTREAM}
+git remote update --prune ${UPSTREAM} ${OOT_UPSTREAM}
+
+printf "[INFO] creating branch %s based on %s.\n" ${WORKING_BRANCH_NAME} "${UPSTREAM}/${UPSTREAM_HEAD}"
+git checkout -b ${WORKING_BRANCH_NAME} --track "${UPSTREAM}/${UPSTREAM_HEAD}"
+
+
+function sync-code(){
+  local PTS=$1
+  local target_head=$(git log -1 --pretty=format:"%H" ${OOT_UPSTREAM}/${OOT_UPSTREAM_HEAD})
+
+  # printf "[INFO] checking in %s code with history from %s.\n" ${PTS} ${OOT_UPSTREAM}
+  if [ -d ${PTS} ]; then
+    #### need test
+    local base=$(git log -1 --pretty=format:"%H" ${PTS})
+    printf "[INFO] %-20s already exists, updating code to %s.\n" ${PTS} "${OOT_UPSTREAM}/${OOT_UPSTREAM_HEAD}"
+    git read-tree --prefix=${PTS} -u ${base}:${PTS} ${target_head}
+  else
+    printf "[INFO] %-20s not exist, checking in code with history from %s.\n" ${PTS} ${OOT_UPSTREAM}
+    mkdir -p ${PTS}
+    git read-tree --prefix=${PTS} -u ${target_head}
+    git checkout -- ${PTS}
+  fi
+  printf "[INFO] folders (%s) are now up to date with %s.\n" "${PATHS[*]}" "${target_head}"
+}
+
+# Check in code with history from upstream repo
+sync-code "${PATH_TO_SYNC}"
+
+
+NEW_COMMIT=$(git write-tree)
+PARENT_A=$(git rev-parse ${WORKING_BRANCH_NAME})
+PARENT_B=$(git rev-parse ${OOT_UPSTREAM}/${OOT_UPSTREAM_HEAD})
+
+printf "[INFO] generating merge commit %s with parents:\n" ${NEW_COMMIT}
+printf "\t%-20s\t%s\n" ${UPSTREAM} ${PARENT_A}
+printf "\t%-20s\t%s\n" ${OOT_UPSTREAM} ${PARENT_B}
+
+
+# commit subtree updates
+FINAL_COMMIT=$(echo "update in-tree ${OOT_UPSTREAM} code" |\
+ git commit-tree ${NEW_COMMIT} -p ${PARENT_A} -p ${PARENT_B})
+
+git reset ${FINAL_COMMIT}
+
+printf "[INFO] done.\n"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: part of https://github.com/kubeedge/kubeedge/issues/1082

**Special notes for your reviewer**:
Script for syncing beehive code into tree, might be only useful the first time if we only update beehive code from in-tree staging directory afterwards.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
