### PR TITLE
change the way to get the HomeDir

### DIFF
--- a/keadm/app/cmd/util/ubuntuinstaller.go
+++ b/keadm/app/cmd/util/ubuntuinstaller.go
@@ -437,7 +437,7 @@ func (u *UbuntuOS) InstallKubeEdge() error {
 	//Currently it is missing and once checksum is in place, checksum check required
 	//to be added here.
 	filename := fmt.Sprintf("kubeedge-v%s-linux-%s.tar.gz", u.KubeEdgeVersion, arch)
-	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.txt", u.KubeEdgeVersion, arch)
+	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.tar.gz.txt", u.KubeEdgeVersion, arch)
 	filePath := fmt.Sprintf("%s%s", KubeEdgePath, filename)
 	fileStat, err := os.Stat(filePath)
 	if err == nil && fileStat.Name() != "" {

--- a/vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go
+++ b/vendor/k8s.io/kubernetes/pkg/credentialprovider/config.go
@@ -60,7 +60,7 @@ var (
 	preferredPathLock sync.Mutex
 	preferredPath     = ""
 	workingDirPath    = ""
-	homeDirPath, _    = os.UserHomeDir()
+	homeDirPath, _    = os.Getenv("HOME")
 	rootDirPath       = "/"
 	homeJsonDirPath   = filepath.Join(homeDirPath, ".docker")
 	rootJsonDirPath   = filepath.Join(rootDirPath, ".docker")


### PR DESCRIPTION


**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:

change the way to get the HomeDir.
if the go version is lower than 1.12, using UserHomeDir() may cause compilation errors

