### PR TITLE
bump golangci-lint from 1.16 to 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
       fi
 
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint sh -s -- -d -b $(go env GOPATH)/bin v1.16.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=golangci-lint sh -s -- -d -b $(go env GOPATH)/bin v1.20.0
   - mkdir -p $HOME/gopath/src/github.com/kubeedge/kubeedge
   - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/kubeedge/kubeedge/
   - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/kubeedge/kubeedgee


### PR DESCRIPTION
golangci-lint 1.16 is not available for arm

Signed-off-by: Dave Chen <dave.chen@arm.com>

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Related #1185

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
