### PR TITLE
refer to PR1141, update the download path of the kubeedge checksum file

### DIFF
--- a/keadm/app/cmd/util/ubuntuinstaller.go
+++ b/keadm/app/cmd/util/ubuntuinstaller.go
@@ -437,7 +437,7 @@ func (u *UbuntuOS) InstallKubeEdge() error {
 	//Currently it is missing and once checksum is in place, checksum check required
 	//to be added here.
 	filename := fmt.Sprintf("kubeedge-v%s-linux-%s.tar.gz", u.KubeEdgeVersion, arch)
-	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.txt", u.KubeEdgeVersion, arch)
+	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.tar.gz.txt", u.KubeEdgeVersion, arch)
 	filePath := fmt.Sprintf("%s%s", KubeEdgePath, filename)
 	fileStat, err := os.Stat(filePath)
 	if err == nil && fileStat.Name() != "" {


### PR DESCRIPTION
> /kind bug

**What this PR does / why we need it**:
refer to #1141, update the download path of the checksum file.
The #1141 commit has changed two files, one of files does not pass by CI which has no influence on the bug. 

**Which issue(s) this PR fixes**:
Fixes #1133

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note

```
