### PR TITLE
remove vendor/ in staging repo after update-vendor.sh execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ cloud/admission
 edge/edgecore
 edgesite/edgesite
 keadm/keadm
-staging/**/vendor
 _output

--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -43,6 +43,10 @@ for repo in $(kubeedge::util::list_staging_repos); do
   # We would have to always execute go mod vendor after go mod tidy to ensure correctness.
   echo "running 'go mod vendor' for ${repo}"
   go mod vendor
+
+  # vendor/ is not supposed to exist in staging repos, remove it.
+  rm -rf vendor/
+
   popd
 done
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**Why we need it**:
If developer executed `hack/update-vendor.sh` and then set `GO11MODULE=off`, it would result in build failure like this:
```shell
go build -ldflags '-X github.com/kubeedge/kubeedge/pkg/version.buildDate=2019-10-18T03:42:22Z -X github.com/kubeedge/kubeedge/pkg/version.gitCommit=52945c93c538a823c93f71bacfc8720c96d0dbb7 -X github.com/kubeedge/kubeedge/pkg/version.gitTreeState=dirty -X github.com/kubeedge/kubeedge/pkg/version.gitVersion=v1.1.0-beta.0.147+52945c93c538a8-dirty -X github.com/kubeedge/kubeedge/pkg/version.gitMajor=1 -X github.com/kubeedge/kubeedge/pkg/version.gitMinor=1+' cmd/cloudcore/cloudcore.go
# github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/io
pkg/cloudhub/common/io/hubio.go:37:39: cannot use d.(*"github.com/kubeedge/kubeedge/vendor/github.com/kubeedge/beehive/pkg/core/model".Message) (type *"github.com/kubeedge/kubeedge/vendor/github.com/kubeedge/beehive/pkg/core/model".Message) as type *"github.com/kubeedge/kubeedge/vendor/github.com/kubeedge/viaduct/vendor/github.com/kubeedge/beehive/pkg/core/model".Message in argument to io.Connection.ReadMessage
pkg/cloudhub/common/io/hubio.go:46:40: cannot use msg (type *"github.com/kubeedge/kubeedge/vendor/github.com/kubeedge/beehive/pkg/core/model".Message) as type *"github.com/kubeedge/kubeedge/vendor/github.com/kubeedge/viaduct/vendor/github.com/kubeedge/beehive/pkg/core/model".Message in argument to io.Connection.WriteMessageAsync
make: *** [cloudcore] Error 2
```
Though it doesn't seem to be a real-world/common case, we can still improve the scripts.
See also https://github.com/kubeedge/kubeedge/issues/1210.

**What this PR does:**
- remove the vendor/ after every time script executed.
- removed `staging/**/vendor` from `.gitignore` to make it visible to developer if vendor/ exists in any staging repos.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/1210

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
