### PR TITLE
bugfix: Solve the problem of outputting a large amount of logs after cloudcore exits

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -1,13 +1,14 @@
 package channelq
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 
 	"k8s.io/klog"
 
-	"github.com/kubeedge/beehive/pkg/core/context"
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/model"
 )
 
@@ -50,12 +51,12 @@ func (s *ChannelEventSet) Get() (*model.Event, error) {
 
 // ChannelEventQueue is the channel implementation of EventQueue
 type ChannelEventQueue struct {
-	ctx         *context.Context
+	ctx         *beehiveContext.Context
 	channelPool sync.Map
 }
 
 // NewChannelEventQueue initializes a new ChannelEventQueue
-func NewChannelEventQueue(ctx *context.Context) *ChannelEventQueue {
+func NewChannelEventQueue(ctx *beehiveContext.Context) *ChannelEventQueue {
 	q := ChannelEventQueue{ctx: ctx}
 	return &q
 }
@@ -63,8 +64,14 @@ func NewChannelEventQueue(ctx *context.Context) *ChannelEventQueue {
 // DispatchMessage gets the message from the cloud, extracts the
 // node id from it, gets the channel associated with the node
 // and pushes the event on the channel
-func (q *ChannelEventQueue) DispatchMessage() {
+func (q *ChannelEventQueue) DispatchMessage(ctx context.Context) {
 	for {
+		select {
+		case <-ctx.Done():
+			klog.Warningf("Cloudhub channel eventqueue dispatch message loop stoped")
+			return
+		default:
+		}
 		msg, err := q.ctx.Receive(model.SrcCloudHub)
 		if err != nil {
 			klog.Info("receive not Message format message")


### PR DESCRIPTION
…em of outputting a large amount of logs after cloudcore exits

Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:

when cloudcore exist, it will output a large amount of logs.

The reason is that we didn't handle the logic of the stop channel very well. This change uses the golang context instead of the stop channel.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bugfix: Remove redundant logs when CloudCore exits
```
