### PR TITLE
Remove event type from cloudhub

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -41,18 +41,18 @@ func (a *cloudHub) Start(c *beehiveContext.Context) {
 
 	initHubConfig()
 
-	eventq := channelq.NewChannelEventQueue(c)
+	messageq := channelq.NewChannelMessageQueue(c)
 
 	// start dispatch message from the cloud to edge node
-	go eventq.DispatchMessage(ctx)
+	go messageq.DispatchMessage(ctx)
 
 	// start the cloudhub server
 	if util.HubConfig.ProtocolWebsocket {
-		go servers.StartCloudHub(servers.ProtocolWebsocket, eventq, c)
+		go servers.StartCloudHub(servers.ProtocolWebsocket, messageq, c)
 	}
 
 	if util.HubConfig.ProtocolQuic {
-		go servers.StartCloudHub(servers.ProtocolQuic, eventq, c)
+		go servers.StartCloudHub(servers.ProtocolQuic, messageq, c)
 	}
 
 	if util.HubConfig.ProtocolUDS {

--- a/cloud/pkg/cloudhub/common/model/types.go
+++ b/cloud/pkg/cloudhub/common/model/types.go
@@ -61,48 +61,6 @@ type HubInfo struct {
 	NodeID    string
 }
 
-// UserGroupInfo struct
-type UserGroupInfo struct {
-	Resource  string `json:"resource"`
-	Operation string `json:"operation"`
-}
-
-// Event represents message communicated between cloud hub and edge hub
-type Event struct {
-	Group     string        `json:"msg_group"`
-	Source    string        `json:"source"`
-	UserGroup UserGroupInfo `json:"user_group"`
-	ID        string        `json:"msg_id"`
-	ParentID  string        `json:"parent_msg_id"`
-	Timestamp int64         `json:"timestamp"`
-	Content   interface{}   `json:"content"`
-}
-
-// EventToMessage converts an event to a model message
-func EventToMessage(event *Event) model.Message {
-	var msg model.Message
-	msg.BuildHeader(event.ID, event.ParentID, event.Timestamp)
-	msg.BuildRouter(event.Source, event.Group, event.UserGroup.Resource, event.UserGroup.Operation)
-	msg.FillBody(event.Content)
-	return msg
-}
-
-// MessageToEvent converts a model message to an event
-func MessageToEvent(msg *model.Message) Event {
-	var event Event
-	event.ID = msg.GetID()
-	event.ParentID = msg.GetParentID()
-	event.Timestamp = msg.GetTimestamp()
-	event.Source = msg.GetSource()
-	event.Group = msg.GetGroup()
-	event.Content = msg.GetContent()
-	event.UserGroup = UserGroupInfo{
-		Resource:  msg.GetResource(),
-		Operation: msg.GetOperation(),
-	}
-	return event
-}
-
 // NewResource constructs a resource field using resource type and ID
 func NewResource(resType, resID string, info *HubInfo) string {
 	var prefix string
@@ -116,20 +74,20 @@ func NewResource(resType, resID string, info *HubInfo) string {
 }
 
 // IsNodeStopped indicates if the node is stopped or running
-func (event *Event) IsNodeStopped() bool {
-	tokens := strings.Split(event.UserGroup.Resource, "/")
+func IsNodeStopped(msg *model.Message) bool {
+	tokens := strings.Split(msg.Router.Resource, "/")
 	if len(tokens) != 2 || tokens[0] != ResNode {
 		return false
 	}
-	if event.UserGroup.Operation == OpDelete {
+	if msg.Router.Operation == OpDelete {
 		return true
 	}
-	if event.UserGroup.Operation != OpUpdate || event.Content == nil {
+	if msg.Router.Operation != OpUpdate || msg.Content == nil {
 		return false
 	}
-	body, ok := event.Content.(map[string]interface{})
+	body, ok := msg.Content.(map[string]interface{})
 	if !ok {
-		klog.Errorf("fail to decode node update message: %s, type is %T", event.GetContent(), event.Content)
+		klog.Errorf("fail to decode node update message: %s, type is %T", msg.GetContent(), msg.Content)
 		// it can't be determined if the node has stopped
 		return false
 	}
@@ -142,16 +100,16 @@ func (event *Event) IsNodeStopped() bool {
 }
 
 // IsFromEdge judges if the event is sent from edge
-func (event *Event) IsFromEdge() bool {
+func IsFromEdge(msg *model.Message) bool {
 	return true
 }
 
 // IsToEdge judges if the vent should be sent to edge
-func (event *Event) IsToEdge() bool {
-	if event.Source != SrcManager {
+func IsToEdge(msg *model.Message) bool {
+	if msg.Router.Source != SrcManager {
 		return true
 	}
-	resource := event.UserGroup.Resource
+	resource := msg.Router.Resource
 	if strings.HasPrefix(resource, ResNode) {
 		tokens := strings.Split(resource, "/")
 		if len(tokens) >= 3 {
@@ -168,7 +126,7 @@ func (event *Event) IsToEdge() bool {
 	}
 	for res, ops := range resOpMap {
 		for _, op := range ops {
-			if event.UserGroup.Operation == op && strings.Contains(resource, res) {
+			if msg.Router.Operation == op && strings.Contains(resource, res) {
 				return false
 			}
 		}
@@ -177,6 +135,6 @@ func (event *Event) IsToEdge() bool {
 }
 
 // GetContent dumps the content to string
-func (event *Event) GetContent() string {
-	return fmt.Sprintf("%v", event.Content)
+func GetContent(msg *model.Message) string {
+	return fmt.Sprintf("%v", msg.Content)
 }

--- a/cloud/pkg/cloudhub/common/model/types_test.go
+++ b/cloud/pkg/cloudhub/common/model/types_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // modelMessage returns a new model.Message
-func modelMessage(ID string, PID string, Timestamp int64, Source string, Group string, Operation string, Resource string) model.Message {
+func modelMessage(ID string, PID string, Timestamp int64, Source string, Group string, Operation string, Resource string, Content interface{}) model.Message {
 	return model.Message{
 		Header: model.MessageHeader{
 			ID:        ID,
@@ -39,72 +39,7 @@ func modelMessage(ID string, PID string, Timestamp int64, Source string, Group s
 			Operation: Operation,
 			Resource:  Resource,
 		},
-	}
-}
-
-// modelEvent returns a new Event
-func modelEvent(ID string, PID string, Timestamp int64, Source string, Group string, Operation string, Resource string, Content interface{}) Event {
-	return Event{
-		Group:  Group,
-		Source: Source,
-		UserGroup: UserGroupInfo{
-			Resource:  Resource,
-			Operation: Operation,
-		},
-		ID:        ID,
-		ParentID:  PID,
-		Timestamp: Timestamp,
-		Content:   Content,
-	}
-}
-
-// TestEventToMessage is function to test EventToMessage
-func TestEventToMessage(t *testing.T) {
-	timestamp := time.Now().UnixNano() / 1e6
-	msg := modelMessage("ID1", "PID1", timestamp, "Source1", "Group1", "Operation1", "Resource1")
-	event := modelEvent("ID1", "PID1", timestamp, "Source1", "Group1", "Operation1", "Resource1", nil)
-	tests := []struct {
-		name  string
-		event *Event
-		msg   model.Message
-	}{
-		{
-			name:  "TestEventToMessage(): converts an event to a model message",
-			event: &event,
-			msg:   msg,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if msg := EventToMessage(test.event); !reflect.DeepEqual(msg, test.msg) {
-				t.Errorf("Model.TestEventToMessage() case failed: got = %v, Want = %v", msg, test.msg)
-			}
-		})
-	}
-}
-
-// TestMessageToEvent is function to test MessageToEvent
-func TestMessageToEvent(t *testing.T) {
-	timestamp := time.Now().UnixNano() / 1e6
-	msg := modelMessage("ID1", "PID1", timestamp, "Source1", "Group1", "Operation1", "Resource1")
-	event := modelEvent("ID1", "PID1", timestamp, "Source1", "Group1", "Operation1", "Resource1", nil)
-	tests := []struct {
-		name  string
-		msg   *model.Message
-		event Event
-	}{
-		{
-			name:  "TestMessageToEvent(): converts a model message to an event",
-			msg:   &msg,
-			event: event,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if event := MessageToEvent(test.msg); !reflect.DeepEqual(event, test.event) {
-				t.Errorf("Model.TestMessageToEvent() case failed: got = %v, Want = %v", event, test.event)
-			}
-		})
+		Content: Content,
 	}
 }
 
@@ -153,51 +88,51 @@ func TestIsNodeStopped(t *testing.T) {
 		"timestamp":  time.Now().Unix(),
 		"action":     "stop",
 	}
-	eventResource := modelEvent("", "", 0, "", "", "", "Resource1", nil)
-	eventOpDelete := modelEvent("", "", 0, "", "", OpDelete, "node/Node1", nil)
-	eventNoContent := modelEvent("", "", 0, "", "", "", "node/Node1", nil)
-	eventContent := modelEvent("", "", 0, "", "", OpUpdate, "node/Node1", content)
-	eventNoAction := modelEvent("", "", 0, "", "", OpUpdate, "node/Node1", body)
-	eventActionStop := modelEvent("", "", 0, "", "", OpUpdate, "node/Node1", bodyAction)
+	msgResource := modelMessage("", "", 0, "", "", "", "Resource1", nil)
+	msgOpDelete := modelMessage("", "", 0, "", "", OpDelete, "node/Node1", nil)
+	msgNoContent := modelMessage("", "", 0, "", "", "", "node/Node1", nil)
+	msgContent := modelMessage("", "", 0, "", "", OpUpdate, "node/Node1", content)
+	msgNoAction := modelMessage("", "", 0, "", "", OpUpdate, "node/Node1", body)
+	msgActionStop := modelMessage("", "", 0, "", "", OpUpdate, "node/Node1", bodyAction)
 	tests := []struct {
 		name      string
-		event     *Event
+		msg       *model.Message
 		errorWant bool
 	}{
 		{
 			name:      "TestIsNodeStopped(): Case 1: UserGroup.Resource!=ResNode",
-			event:     &eventResource,
+			msg:       &msgResource,
 			errorWant: false,
 		},
 		{
 			name:      "TestIsNodeStopped(): Case 2: UserGroup.Operation=OpDelete",
-			event:     &eventOpDelete,
+			msg:       &msgOpDelete,
 			errorWant: true,
 		},
 		{
-			name:      "TestIsNodeStopped(): Case 3: event.Content=nil",
-			event:     &eventNoContent,
+			name:      "TestIsNodeStopped(): Case 3: msg.Content=nil",
+			msg:       &msgNoContent,
 			errorWant: false,
 		},
 		{
-			name:      "TestIsNodeStopped(): Case 4: event.Content!=nil",
-			event:     &eventContent,
+			name:      "TestIsNodeStopped(): Case 4: msg.Content!=nil",
+			msg:       &msgContent,
 			errorWant: false,
 		},
 		{
-			name:      "TestIsNodeStopped(): Case 5: event.Content[action] is nil",
-			event:     &eventNoAction,
+			name:      "TestIsNodeStopped(): Case 5: msg.Content[action] is nil",
+			msg:       &msgNoAction,
 			errorWant: false,
 		},
 		{
-			name:      "TestIsNodeStopped(): Case 6: event.Content[action]=stop",
-			event:     &eventActionStop,
+			name:      "TestIsNodeStopped(): Case 6: msg.Content[action]=stop",
+			msg:       &msgActionStop,
 			errorWant: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if errorWant := test.event.IsNodeStopped(); !reflect.DeepEqual(errorWant, test.errorWant) {
+			if errorWant := IsNodeStopped(test.msg); !reflect.DeepEqual(errorWant, test.errorWant) {
 				t.Errorf("Model.TestIsNodeStopped() case failed: got = %v, Want = %v", errorWant, test.errorWant)
 			}
 		})
@@ -206,21 +141,21 @@ func TestIsNodeStopped(t *testing.T) {
 
 // TestIsFromEdge is function to test IsFromEdge
 func TestIsFromEdge(t *testing.T) {
-	event := modelEvent("", "", 0, "Source1", "", "", "", nil)
+	msg := modelMessage("", "", 0, "Source1", "", "", "", nil)
 	tests := []struct {
 		name      string
-		event     *Event
+		msg       *model.Message
 		errorWant bool
 	}{
 		{
-			name:      "TestIsFromEdge(): when the event is sent from edge",
-			event:     &event,
+			name:      "TestIsFromEdge(): when the msg is sent from edge",
+			msg:       &msg,
 			errorWant: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if errorWant := test.event.IsFromEdge(); !reflect.DeepEqual(errorWant, test.errorWant) {
+			if errorWant := IsFromEdge(test.msg); !reflect.DeepEqual(errorWant, test.errorWant) {
 				t.Errorf("Model.TestIsFromEdge() case failed: got = %v, Want = %v", errorWant, test.errorWant)
 			}
 		})
@@ -229,33 +164,33 @@ func TestIsFromEdge(t *testing.T) {
 
 // TestIsToEdge is function to test IsToEdge
 func TestIsToEdge(t *testing.T) {
-	eventSource := modelEvent("", "", 0, "Source1", "", "", "", nil)
-	eventResource := modelEvent("", "", 0, SrcManager, "", "", "node/Node1/node/res1", nil)
-	eventOperation := modelEvent("", "", 0, SrcManager, "", "get", "membership", nil)
+	msgSource := modelMessage("", "", 0, "Source1", "", "", "", nil)
+	msgResource := modelMessage("", "", 0, SrcManager, "", "", "node/Node1/node/res1", nil)
+	msgOperation := modelMessage("", "", 0, SrcManager, "", "get", "membership", nil)
 	tests := []struct {
 		name      string
-		event     *Event
+		msg       *model.Message
 		errorWant bool
 	}{
 		{
-			name:      "TestIsToEdge(): Case 1: when the event is sent from edge",
-			event:     &eventResource,
+			name:      "TestIsToEdge(): Case 1: when the msg is sent from edge",
+			msg:       &msgSource,
 			errorWant: true,
 		},
 		{
-			name:      "TestIsToEdge(): Case 2: event.Source!=SrcManager",
-			event:     &eventSource,
+			name:      "TestIsToEdge(): Case 2: msg.Source!=SrcManager",
+			msg:       &msgResource,
 			errorWant: true,
 		},
 		{
-			name:      "TestIsToEdge(): Case 3: when the event equals to resOpMap",
-			event:     &eventOperation,
+			name:      "TestIsToEdge(): Case 3: when the msg equals to resOpMap",
+			msg:       &msgOperation,
 			errorWant: false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if errorWant := test.event.IsToEdge(); !reflect.DeepEqual(errorWant, test.errorWant) {
+			if errorWant := IsToEdge(test.msg); !reflect.DeepEqual(errorWant, test.errorWant) {
 				t.Errorf("Model.TestIsToEdge() case failed: got = %v, Want = %v", errorWant, test.errorWant)
 			}
 		})

--- a/cloud/pkg/cloudhub/servers/factory.go
+++ b/cloud/pkg/cloudhub/servers/factory.go
@@ -15,7 +15,7 @@ const (
 	ProtocolQuic      = "quic"
 )
 
-func StartCloudHub(protocol string, eventq *channelq.ChannelEventQueue, c *context.Context) {
+func StartCloudHub(protocol string, eventq *channelq.ChannelMessageQueue, c *context.Context) {
 	switch protocol {
 	case ProtocolWebsocket:
 		wsserver.StartCloudHub(util.HubConfig, eventq, c)

--- a/cloud/pkg/cloudhub/servers/quicserver/server.go
+++ b/cloud/pkg/cloudhub/servers/quicserver/server.go
@@ -16,7 +16,7 @@ import (
 )
 
 // StartCloudHub starts the cloud hub service
-func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue, c *context.Context) {
+func StartCloudHub(config *util.Config, messageq *channelq.ChannelMessageQueue, c *context.Context) {
 	// init certificate
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(config.Ca)
@@ -35,7 +35,7 @@ func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue, c *c
 		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 	}
 
-	handler.InitHandler(config, eventq, c)
+	handler.InitHandler(config, messageq, c)
 
 	svc := server.Server{
 		Type:       api.ProtocolTypeQuic,

--- a/cloud/pkg/cloudhub/servers/wsserver/server.go
+++ b/cloud/pkg/cloudhub/servers/wsserver/server.go
@@ -22,7 +22,7 @@ var (
 )
 
 // StartCloudHub starts the cloud hub service
-func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue, c *context.Context) error {
+func StartCloudHub(config *util.Config, messageq *channelq.ChannelMessageQueue, c *context.Context) error {
 	// init certificate
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(config.Ca)
@@ -41,7 +41,7 @@ func StartCloudHub(config *util.Config, eventq *channelq.ChannelEventQueue, c *c
 		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
 	}
 
-	handler.InitHandler(config, eventq, c)
+	handler.InitHandler(config, messageq, c)
 
 	s := server.Server{
 		Type:       api.ProtocolTypeWS,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
Now we use `beehiveModel.Message` to send message between cloudhub and edgehub, this PR removed the `event type` from cloudhub. There's no need to change message to event and event to message again.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
