### PR TITLE
keadm: Add constants for exectuable path

### DIFF
--- a/keadm/app/cmd/util/centosinstaller.go
+++ b/keadm/app/cmd/util/centosinstaller.go
@@ -166,7 +166,7 @@ func (c *CentOS) StartK8Scluster() error {
 
 //InstallKubeEdge downloads the provided version of KubeEdge.
 //Untar's in the specified location /etc/kubeedge/ and then copies
-//the binary to /usr/local/bin path.
+//the binary to excecutables' path (eg: /usr/local/bin)
 func (c *CentOS) InstallKubeEdge() error {
 	fmt.Println("InstallKubeEdge called")
 	return nil

--- a/keadm/app/cmd/util/cloudinstaller.go
+++ b/keadm/app/cmd/util/cloudinstaller.go
@@ -176,7 +176,7 @@ func linesFromReader(r io.Reader) ([]string, error) {
 //RunCloudCore starts cloudcore process
 func (cu *KubeCloudInstTool) RunCloudCore() error {
 
-	filetoCopy := fmt.Sprintf("cp %s/kubeedge/cloud/%s /usr/local/bin/.", KubeEdgePath, KubeCloudBinaryName)
+	filetoCopy := fmt.Sprintf("cp %s/kubeedge/cloud/%s %s/", KubeEdgePath, KubeCloudBinaryName, KubeEdgeUsrBinPath)
 	cmd := &Command{Cmd: exec.Command("sh", "-c", filetoCopy)}
 	err := cmd.ExecuteCmdShowOutput()
 	errout := cmd.GetStdErr()
@@ -185,7 +185,7 @@ func (cu *KubeCloudInstTool) RunCloudCore() error {
 		return fmt.Errorf("%s", errout)
 
 	}
-	binExec := fmt.Sprintf("chmod +x /usr/local/bin/%s && %s > %s/kubeedge/cloud/%s.log 2>&1 &", KubeCloudBinaryName, KubeCloudBinaryName, KubeEdgePath, KubeCloudBinaryName)
+	binExec := fmt.Sprintf("chmod +x %s/%s && %s > %s/kubeedge/cloud/%s.log 2>&1 &", KubeEdgeUsrBinPath, KubeCloudBinaryName, KubeCloudBinaryName, KubeEdgePath, KubeCloudBinaryName)
 	cmd = &Command{Cmd: exec.Command("sh", "-c", binExec)}
 	cmd.Cmd.Env = os.Environ()
 	env := fmt.Sprintf("GOARCHAIUS_CONFIG_PATH=%skubeedge/cloud", KubeEdgePath)

--- a/keadm/app/cmd/util/common.go
+++ b/keadm/app/cmd/util/common.go
@@ -43,6 +43,7 @@ const (
 
 	KubeEdgeDownloadURL       = "https://github.com/kubeedge/kubeedge/releases/download"
 	KubeEdgePath              = "/etc/kubeedge/"
+	KubeEdgeUsrBinPath        = "/usr/local/bin"
 	KubeEdgeConfPath          = KubeEdgePath + "kubeedge/edge/conf"
 	KubeEdgeBinaryName        = "edgecore"
 	KubeEdgeDefaultCertPath   = KubeEdgePath + "certs/"

--- a/keadm/app/cmd/util/ubuntuinstaller.go
+++ b/keadm/app/cmd/util/ubuntuinstaller.go
@@ -410,7 +410,7 @@ func (u *UbuntuOS) StartK8Scluster() error {
 
 //InstallKubeEdge downloads the provided version of KubeEdge.
 //Untar's in the specified location /etc/kubeedge/ and then copies
-//the binary to /usr/local/bin path.
+//the binary to excecutables' path (eg: /usr/local/bin)
 func (u *UbuntuOS) InstallKubeEdge() error {
 	var (
 		dwnldURL string
@@ -487,7 +487,7 @@ func (u *UbuntuOS) InstallKubeEdge() error {
 	}
 
 SKIPDOWNLOADAND:
-	untarFileAndMove := fmt.Sprintf("cd %s && tar -C %s -xvzf %s && cp %skubeedge/edge/%s /usr/local/bin/.", KubeEdgePath, KubeEdgePath, filename, KubeEdgePath, KubeEdgeBinaryName)
+	untarFileAndMove := fmt.Sprintf("cd %s && tar -C %s -xvzf %s && cp %skubeedge/edge/%s %s/.", KubeEdgePath, KubeEdgePath, filename, KubeEdgePath, KubeEdgeBinaryName, KubeEdgeUsrBinPath)
 	stdout, err := runCommandWithShell(untarFileAndMove)
 	if err != nil {
 		return err
@@ -500,7 +500,7 @@ SKIPDOWNLOADAND:
 //RunEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
 //and the starts edgecore with logs being captured
 func (u *UbuntuOS) RunEdgeCore() error {
-	binExec := fmt.Sprintf("chmod +x /usr/local/bin/%s && %s > %s/kubeedge/edge/%s.log 2>&1 &", KubeEdgeBinaryName, KubeEdgeBinaryName, KubeEdgePath, KubeEdgeBinaryName)
+	binExec := fmt.Sprintf("chmod +x %s/%s && %s > %s/kubeedge/edge/%s.log 2>&1 &", KubeEdgeUsrBinPath, KubeEdgeBinaryName, KubeEdgeBinaryName, KubeEdgePath, KubeEdgeBinaryName)
 	cmd := &Command{Cmd: exec.Command("sh", "-c", binExec)}
 	cmd.Cmd.Env = os.Environ()
 	env := fmt.Sprintf("GOARCHAIUS_CONFIG_PATH=%skubeedge/edge", KubeEdgePath)


### PR DESCRIPTION
Remove duplicated paths.

This variable could be eventually patched downstream
to "usr/bin" (for deeper integration in distros).

Forward: https://github.com/kubeedge/kubeedge/pull/
Relate-to: https://github.com/kubeedge/kubeedge/issues/1246
Change-Id: Ie93c1880bb258515a8c0a756510e505425d5246c
Signed-off-by: Philippe Coval <p.coval@samsung.com>

/kind cleanup
