### PR TITLE
change kubeconfig to absolute path

### DIFF
--- a/cloud/conf/controller.yaml
+++ b/cloud/conf/controller.yaml
@@ -5,7 +5,7 @@ controller:
     qps: 5
     burst: 10
     node_update_frequency: 10
-    kubeconfig: "~/.kube/config"   #Enter path to kubeconfig file to enable https connection to k8s apiserver, if master and kubeconfig are both set, master will override any value in kubeconfig.
+    kubeconfig: "/root/.kube/config"   #Enter absolute path to kubeconfig file to enable https connection to k8s apiserver, if master and kubeconfig are both set, master will override any value in kubeconfig.
 cloudhub:
   protocol_websocket: true # enable websocket protocol
   port: 10000 # open port for websocket server
@@ -27,4 +27,4 @@ devicecontroller:
     content_type: "application/vnd.kubernetes.protobuf"
     qps: 5
     burst: 10
-    kubeconfig: "~/.kube/config" #Enter path to kubeconfig file to enable https connection to k8s apiserver,if master and kubeconfig are both set, master will override any value in kubeconfig.
+    kubeconfig: "/root/.kube/config" #Enter absolute path to kubeconfig file to enable https connection to k8s apiserver,if master and kubeconfig are both set, master will override any value in kubeconfig.

--- a/docs/setup/setup.md
+++ b/docs/setup/setup.md
@@ -93,7 +93,7 @@ The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/cert
         qps: 5
         burst: 10
         node_update_frequency: 10
-        kubeconfig: "~/.kube/config"   #Enter path to kubeconfig file to enable https connection to k8s apiserver, if master and kubeconfig are both set, master will override any value in kubeconfig.
+        kubeconfig: "/root/.kube/config"   #Enter absolute path to kubeconfig file to enable https connection to k8s apiserver, if master and kubeconfig are both set, master will override any value in kubeconfig.
     cloudhub:
       protocol_websocket: true # enable websocket protocol
       port: 10000 # open port for websocket server
@@ -116,7 +116,7 @@ The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/cert
         content_type: "application/vnd.kubernetes.protobuf"
         qps: 5
         burst: 10
-        kubeconfig: "~/.kube/config" #Enter path to kubeconfig file to enable https connection to k8s apiserver,if master and kubeconfig are both set, master will override any value in kubeconfig.
+        kubeconfig: "/root/.kube/config" #Enter absolute path to kubeconfig file to enable https connection to k8s apiserver,if master and kubeconfig are both set, master will override any value in kubeconfig.
     ```
     cloudcore default supports https connection to Kubernetes apiserver, so you need to check whether the path for `controller.kube.kubeconfig` and `devicecontroller.kube.kubeconfig` exist, but if `master` and `kubeconfig` are both set, `master` will override any value in kubeconfig.
     Check whether the cert files for `cloudhub.ca`, `cloudhub.cert`,`cloudhub.key` exist.

--- a/keadm/app/cmd/cloud/init.go
+++ b/keadm/app/cmd/cloud/init.go
@@ -38,13 +38,13 @@ keadm init
 
 - This command will download and install the default version of pre-requisites and KubeEdge
 
-keadm init --kubeedge-version=0.2.1 --kubernetes-version=1.14.1 --docker-version=18.06.3 --kube-config=~/.kube/config
+keadm init --kubeedge-version=0.2.1 --kubernetes-version=1.14.1 --docker-version=18.06.3 --kube-config=/root/.kube/config
 
   - In case, any flag is used in a format like "--docker-version" or "--docker-version=" (without a value)
     then default versions shown in help will be chosen. 
     The versions for "--docker-version", "--kubernetes-version" and "--kubeedge-version" flags should be in the
     format "18.06.3", "1.14.0" and "0.2.1" respectively
-  - kube-config is the path of kubeconfig which used to secure connectivity between cloudcore and kube-apiserver
+  - kube-config is the absolute path of kubeconfig which used to secure connectivity between cloudcore and kube-apiserver
 `
 )
 


### PR DESCRIPTION
**What type of PR is this?**

add support '~' for kubeconfig path,now will return error with "no such file or directory".
golang default can not recognized ~ path

/kind bug
