### PR TITLE
Use the same golang base image to build images 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # make all builds both cloud and edge binaries
-.PHONY: all  
+.PHONY: all
 ifeq ($(WHAT),)
 all:
 	cd cloud && $(MAKE)
@@ -117,10 +117,10 @@ csidriverimage:
 edgeimage:
 	mkdir -p ./build/edge/tmp
 	rm -rf ./build/edge/tmp/*
-	curl -L -o ./build/edge/tmp/qemu-${QEMU_ARCH}-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/v3.0.0/qemu-${QEMU_ARCH}-static.tar.gz 
-	tar -xzf ./build/edge/tmp/qemu-${QEMU_ARCH}-static.tar.gz -C ./build/edge/tmp 
+	curl -L -o ./build/edge/tmp/qemu-${QEMU_ARCH}-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/v3.0.0/qemu-${QEMU_ARCH}-static.tar.gz
+	tar -xzf ./build/edge/tmp/qemu-${QEMU_ARCH}-static.tar.gz -C ./build/edge/tmp
 	docker build -t kubeedge/edgecore:${IMAGE_TAG} \
-	--build-arg BUILD_FROM=${ARCH}/golang:1.12-alpine3.9 \
+	--build-arg BUILD_FROM=${ARCH}/golang:1.12-alpine3.10 \
 	--build-arg RUN_FROM=${ARCH}/docker:dind \
 	-f build/edge/Dockerfile .
 
@@ -131,7 +131,7 @@ edgesiteimage:
 	curl -L -o ./build/edgesite/tmp/qemu-${QEMU_ARCH}-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/v3.0.0/qemu-${QEMU_ARCH}-static.tar.gz
 	tar -xzf ./build/edgesite/tmp/qemu-${QEMU_ARCH}-static.tar.gz -C ./build/edgesite/tmp
 	docker build -t kubeedge/edgesite:${IMAGE_TAG} \
-	--build-arg BUILD_FROM=${ARCH}/golang:1.12-alpine3.9 \
+	--build-arg BUILD_FROM=${ARCH}/golang:1.12-alpine3.10 \
 	--build-arg RUN_FROM=${ARCH}/docker:dind \
 	-f build/edgesite/Dockerfile .
 

--- a/build/admission/Dockerfile
+++ b/build/admission/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-alpine3.9 AS builder
+FROM golang:1.12-alpine3.10 AS builder
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 

--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           EOF
       containers:
       - name: cloudcore
-        image: kubeedge/cloudcore:v1.0.0
+        image: kubeedge/cloudcore:v1.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 10000

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine3.9 AS builder
+FROM golang:1.12-alpine3.10 AS builder
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/cloudcore -ldflags="-w -s" \
 github.com/kubeedge/kubeedge/cloud/cmd/cloudcore
 
 
-FROM gcr.io/distroless/static
+FROM alpine:3.9
 
 ENV GOARCHAIUS_CONFIG_PATH /etc/kubeedge/cloud
 

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-alpine3.9 AS builder
+FROM golang:1.12-alpine3.9 AS builder
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/cloudcore -ldflags="-w -s" \
 github.com/kubeedge/kubeedge/cloud/cmd/cloudcore
 
 
-FROM alpine:3.9
+FROM gcr.io/distroless/static
 
 ENV GOARCHAIUS_CONFIG_PATH /etc/kubeedge/cloud
 

--- a/build/csidriver/Dockerfile
+++ b/build/csidriver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine3.9 AS builder
+FROM golang:1.12-alpine3.10 AS builder
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 

--- a/build/csidriver/Dockerfile
+++ b/build/csidriver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.1-alpine3.9 AS builder
+FROM golang:1.12-alpine3.9 AS builder
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 

--- a/build/edge/Dockerfile
+++ b/build/edge/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=golang:1.12-alpine3.9
+ARG BUILD_FROM=golang:1.12-alpine3.10
 ARG RUN_FROM=docker:dind
 
 FROM ${BUILD_FROM} AS builder

--- a/build/edge/docker-compose.yaml
+++ b/build/edge/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
   dind:
     image: ${ARCH}/docker:dind
     restart: always
-    privileged: true 
+    privileged: true
     networks:
       - kubeedge-bridge
   emqx:
@@ -19,28 +19,28 @@ services:
 
   edgecore:
     image: ${EDGECOREIMAGE}
-    build: 
+    build:
        context: ../..
        dockerfile: ./build/edge/Dockerfile
-       args: 
-        - BUILD_FROM=${ARCH}/golang:1.12-alpine3.9
-        - RUN_FROM=${ARCH}/docker:dind 
+       args:
+        - BUILD_FROM=${ARCH}/golang:1.12-alpine3.10
+        - RUN_FROM=${ARCH}/docker:dind
         - QEMU_ARCH=${QEMU_ARCH}
     depends_on:
       - emqx
       - dind
     environment:
       mqtt.server: tcp://emqx:1883
-      edgehub.websocket.url: wss://${CLOUDHUB}/e632aba927ea4ac2b575ec1603d56f10/${EDGENAME}/events 
+      edgehub.websocket.url: wss://${CLOUDHUB}/e632aba927ea4ac2b575ec1603d56f10/${EDGENAME}/events
       edged.hostname-override: ${EDGENAME}
       edgehub.controller.node-id: ${EDGENAME}
-      edgehub.websocket.certfile: ${CERTFILE} 
+      edgehub.websocket.certfile: ${CERTFILE}
       edgehub.websocket.keyfile: ${KEYFILE}
       edged.docker-address: tcp://dind:2375
       DOCKER_HOST: tcp://dind:2375
     volumes:
       - ${CERTPATH}:/etc/kubeedge/certs:ro
-      - /var/lib/edged:/var/lib/edged 
+      - /var/lib/edged:/var/lib/edged
       - /var/lib/kubeedge:/var/lib/kubeedge
     privileged: true
     deploy:

--- a/build/edgesite/Dockerfile
+++ b/build/edgesite/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=golang:1.12-alpine3.9
+ARG BUILD_FROM=golang:1.12-alpine3.10
 ARG RUN_FROM=docker:dind
 
 FROM ${BUILD_FROM} AS builder


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
Use the same golang base image to build images  and update cloudcore version in deployment manifest to latest tag. This makes the builds more consistent since they use the same golang version (if triggered at the same time and no push of a newer golang version happens). Also I updated the deployment manifest to use the latest (git) tag `1.1.0` instead of 1.0.0 which doesn't exits on docker hub.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
