### PR TITLE
docker: Build everything in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+#!/bin/echo docker build . -f
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
+
+FROM golang:1.12-buster
+LABEL maintainer "Philippe Coval (rzr@users.sf.net)"
+
+ENV project kubeedge
+ENV project_dir /usr/local/opt/${project}
+ENV src_dir ${project_dir}/src/${project}
+
+WORKDIR ${src_dir}
+COPY . ${src_dir}/
+RUN echo "# log: ${project}: Building sources" \
+  && set -x \
+  && go version \
+  && make \
+  && sync


### PR DESCRIPTION
As the date of today this trivial dockerfile
only serve for development purposes
(on controled reference environement).

On benefit of using a top level Dockerfile,
is that the project can be built from URL
without manually cloning source:

```sh
docker build https://github.com/tizenteam/kubeedge.git
```

Official golang image in debian-10 flavour
is currenly used as base which is closer to what developer might use.

For deployment, consider to use per applications smaller images.
(./build/*/Dockerfile).

This docker file will be improved,
once my other pending packaging patches are merged.

Change-Id: Id7e6045aa049bd531e08c0c3ad3e137974751e9c
Relate-to: https://github.com/kubeedge/kubeedge/issues/1246
Signed-off-by: Philippe Coval <rzr@users.sf.net>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
