### PR TITLE
fix wrong dockerfile of bluetooth_mapper

### DIFF
--- a/build/edge/Dockerfile
+++ b/build/edge/Dockerfile
@@ -27,6 +27,4 @@ VOLUME ["/etc/kubeedge/certs", "/var/lib/edged", "/var/lib/kubeedge", "/var/run/
 COPY --from=builder /usr/local/bin/edgecore /usr/local/bin/edgecore
 COPY --from=builder /go/src/github.com/kubeedge/kubeedge/edge/conf /etc/kubeedge/edge/conf
 
-EXPOSE 1884
-
 ENTRYPOINT ["edgecore"]

--- a/build/edge/Dockerfile
+++ b/build/edge/Dockerfile
@@ -27,4 +27,6 @@ VOLUME ["/etc/kubeedge/certs", "/var/lib/edged", "/var/lib/kubeedge", "/var/run/
 COPY --from=builder /usr/local/bin/edgecore /usr/local/bin/edgecore
 COPY --from=builder /go/src/github.com/kubeedge/kubeedge/edge/conf /etc/kubeedge/edge/conf
 
+EXPOSE 1884
+
 ENTRYPOINT ["edgecore"]

--- a/mappers/bluetooth_mapper/Dockerfile
+++ b/mappers/bluetooth_mapper/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
 
-CMD mkdir -p kubeedge
+RUN mkdir -p kubeedge
 
 COPY . kubeedge/
 
 WORKDIR kubeedge
 
-ENTRYPOINT ["/kubeedge/main","-logtostderr=true"]
+ENTRYPOINT ["/kubeedge/main","--logtostderr=true"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
Fix the wrong dockerfile codes of bluetooth_mapper. 

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix wrong dockerfile codes of bluetooth_mapper.
```
