### PR TITLE
Fix cannot set edgecore_image bug

### DIFF
--- a/build/edge/run_daemon.sh
+++ b/build/edge/run_daemon.sh
@@ -88,7 +88,7 @@ docker_set(){
     #
     # Example
     # 
-    #  ./build.sh set \
+    #  ./run_daemon.sh set \
     #    cloudhub=0.0.0.0:10000 \
     #    edgename=edge-node \
     #    edgecore_image="kubeedge/edgecore:latest" \
@@ -108,7 +108,7 @@ docker_set(){
 
     [[ ! -z $cloudhub ]] &&  sed -i "/CLOUDHUB=/c\CLOUDHUB=${cloudhub}" .env && echo "set cloudhub success"
     [[ ! -z $edgename ]] &&  sed -i "/EDGENAME=/c\EDGENAME=${edgename}" .env && echo "set edgename success"
-    [[ ! -z $edge_code_image_tag ]] &&  sed -i "/EDGECOREIMAGE=/c\EDGECOREIMAGE=kubeedge/edgecore:${edgecore_image}" .env && echo "set edgecore_image success"
+    [[ ! -z $edgecore_image ]] &&  sed -i "/EDGECOREIMAGE=/c\EDGECOREIMAGE=${edgecore_image}" .env && echo "set edgecore_image success"
     [[ ! -z $arch ]] &&  sed -i "/\<ARCH\>/c\ARCH=${arch}" .env && echo "set arch success"
     [[ ! -z $qemu_arch ]] &&  sed -i "/QEMU_ARCH=/c\QEMU_ARCH=${qemu_arch}" .env && echo "set qemu_arch success"
     [[ ! -z $certpath ]] &&  sed -i "/CERTPATH=/c\CERTPATH=${certpath}" .env && echo "set certpath success"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug

**What this PR does / why we need it**:
When executing `./run_daemon.sh set edgecore_image="kubeedge/edgecore:v1.1.0"`, EDGECOREIMAGE variable in [.env](https://github.com/kubeedge/kubeedge/blob/master/build/edge/.env) file is not changed. This PR fix the bug, and we don't need to change the usage shown in docs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1290 

**Special notes for your reviewer**:
Another method to fix the bug is using the `$edge_code_image_tag` variable to set the image tag only, but we should change the usage shown in docs.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix cannot set edgecore_image bug
```
