### PR TITLE
go version check, now need go 1.12 version

### DIFF
--- a/hack/verify-golang.sh
+++ b/hack/verify-golang.sh
@@ -37,7 +37,7 @@ if [ $X -lt 1 ] ; then
 	exit 1
 fi
 
-if [ $Y -lt 12 ] ; then  
-	echo "go minor version must >= 12, now is $Y"
+if [ $Y -ne 12 ] ; then  
+	echo "go minor version must == 12, now is $Y"
 	exit 1
 fi


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

 /kind bug
**What this PR does / why we need it**:

now kubeedge compiled error in go 1.13 , and we have not check in go 1.13 version.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1288 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
go version check, now  only support go 1.12 version
```
