### PR TITLE
Fix the UT failure and open the CI test on ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,10 @@ jobs:
       name: "unit test cloud"
 
     - stage: "unit tests on arm64"
-      script: make cloud_test
+      script: make edge_test
+      arch: arm64
+      name: "unit test edge"
+    - script: make cloud_test
       arch: arm64
       name: "unit test cloud"
 


### PR DESCRIPTION
1 millisecond is too small to get everything settle down, which might
cause the UT fail randomly on X86 and always fail on ARM64 with LXD.

The change extends the time to 10 milliseconds which makes the UT could be
stably pass on both X86 and ARM64.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**


/kind bug


```release-note
NONE
```
