### PR TITLE
Fix cleanup scripts

### DIFF
--- a/tests/e2e/scripts/cleanup.sh
+++ b/tests/e2e/scripts/cleanup.sh
@@ -17,42 +17,44 @@
 setuptype=$1
 
 kill_edgecore() {
-   sudo pkill edgecore
-    #kill the edgecore process if it exists.
-    sleep 5s
     if pgrep edgecore >/dev/null
     then
-        echo "Failed to kill edgecore process !!"
-        exit 1
-    else
-        echo "edgecore is successfully killed !!"
+        # edgecore process is found, kill the process.
+        sudo pkill edgecore
+        if [[ "$?" == "0" ]]; then
+            echo "edgecore is successfully killed !!"
+        else
+            echo "Failed to kill edgecore process !!"
+            exit 1
+        fi
     fi
 }
 
 kill_cloudcore() {
-    sudo pkill cloudcore
-    #kill the cloudcore process if it exists.
-    sleep 5s
     if pgrep cloudcore >/dev/null
     then
-        echo "Failed to kill the cloudcore !!"
-        exit 1
-    else
-        echo "cloudcore is successfully killed !!"
+        # cloudcore process is found, kill the process.
+        sudo pkill cloudcore
+        if [[ "$?" == "0" ]]; then
+            echo "cloudcore is successfully killed !!"
+        else
+            echo "Failed to kill cloudcore process !!"
+            exit 1
+        fi
     fi
 }
 
 kill_edgesite() {
-    exit 0
-    sudo pkill edgesite
-    #kill the edgecore process if it exists.
-    sleep 5s
     if pgrep edgesite >/dev/null
     then
-        echo "Failed to kill edgesite process !!"
-        exit 1
-    else
-        echo "edgesite is successfully killed !!"
+        # edgesite process is found, kill the process.
+        sudo pkill edgesite
+        if [[ "$?" == "0" ]]; then
+            echo "edgesite is successfully killed !!"
+        else
+            echo "Failed to kill edgesite process !!"
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
- kill process and print info only when they exist
- edgesite was never killed cause it exit directly
- fix the incorrect comments or messages

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
