### PR TITLE
Get the stats of the image filesystem by cadvisor and imageService

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -385,7 +385,7 @@ func newEdged() (*edged, error) {
 		UID:       types.UID(ed.nodeName),
 		Namespace: "",
 	}
-	statsProvider := edgeimages.NewStatsProvider()
+
 	containerGCPolicy := kubecontainer.ContainerGCPolicy{
 		MinAge:             minAge,
 		MaxContainers:      -1,
@@ -509,6 +509,8 @@ func newEdged() (*edged, error) {
 	ed.containerRuntimeName = edgedconfig.RemoteContainerRuntime
 	ed.containerManager = containerManager
 	ed.runtimeService = runtimeService
+
+	statsProvider := edgeimages.NewStatsProvider(cadvisorInterface, imageService)
 	imageGCManager, err := images.NewImageGCManager(
 		ed.containerRuntime,
 		statsProvider,

--- a/edge/pkg/edged/images/image_gc_manager.go
+++ b/edge/pkg/edged/images/image_gc_manager.go
@@ -1,37 +1,86 @@
 package images
 
 import (
-	"syscall"
+	"fmt"
+	"time"
 
+	cadvisorfs "github.com/google/cadvisor/fs"
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	internalapi "k8s.io/cri-api/pkg/apis"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/klog"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/images"
-
-	"github.com/kubeedge/kubeedge/edge/pkg/edged/util"
 )
 
 type imageGCManager struct {
-	imageGCPath string
+	cadvisor     cadvisor.Interface
+	imageService internalapi.ImageManagerService
 }
 
+// getFsInfo returns the information of the filesystem with the specified
+// fsID. If any error occurs, this function logs the error and returns
+// nil.
+func (i *imageGCManager) getFsInfo(fsID *runtimeapi.FilesystemIdentifier) *cadvisorapiv2.FsInfo {
+	if fsID == nil {
+		klog.V(2).Infof("Failed to get filesystem info: fsID is nil.")
+		return nil
+	}
+	mountpoint := fsID.GetMountpoint()
+	fsInfo, err := i.cadvisor.GetDirFsInfo(mountpoint)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get the info of the filesystem with mountpoint %q: %v.", mountpoint, err)
+		if err == cadvisorfs.ErrNoSuchDevice {
+			klog.V(2).Info(msg)
+		} else {
+			klog.Error(msg)
+		}
+		return nil
+	}
+	return &fsInfo
+}
+
+// ImageFsStats returns the stats of the image filesystem.
 func (i *imageGCManager) ImageFsStats() (*statsapi.FsStats, error) {
-	fs := syscall.Statfs_t{}
-	err := syscall.Statfs(i.imageGCPath, &fs)
+	resp, err := i.imageService.ImageFsInfo()
 	if err != nil {
 		return nil, err
 	}
-	cap := fs.Blocks * uint64(fs.Bsize)
-	ava := fs.Bfree * uint64(fs.Bsize)
-	used := (fs.Blocks - fs.Bfree) * uint64(fs.Bsize)
-	return &statsapi.FsStats{
-		CapacityBytes:  &cap,
-		AvailableBytes: &ava,
-		UsedBytes:      &used,
-	}, nil
+
+	// CRI may return the stats of multiple image filesystems but we only
+	// return the first one.
+	if len(resp) == 0 {
+		return nil, fmt.Errorf("imageFs information is unavailable")
+	}
+	fs := resp[0]
+	s := &statsapi.FsStats{
+		Time:      metav1.NewTime(time.Unix(0, fs.Timestamp)),
+		UsedBytes: &fs.UsedBytes.Value,
+	}
+	if fs.InodesUsed != nil {
+		s.InodesUsed = &fs.InodesUsed.Value
+	}
+	imageFsInfo := i.getFsInfo(fs.GetFsId())
+	if imageFsInfo != nil {
+		// The image filesystem id is unknown to the local node or there's
+		// an error on retrieving the stats. In these cases, we omit those
+		// stats and return the best-effort partial result. See
+		// https://github.com/kubernetes/heapster/issues/1793.
+		s.AvailableBytes = &imageFsInfo.Available
+		s.CapacityBytes = &imageFsInfo.Capacity
+		s.InodesFree = imageFsInfo.InodesFree
+		s.Inodes = imageFsInfo.Inodes
+	}
+	return s, nil
 }
 
 //NewStatsProvider returns image status provider
-func NewStatsProvider() images.StatsProvider {
+func NewStatsProvider(cadvisorInterface cadvisor.Interface, imageService internalapi.ImageManagerService) images.StatsProvider {
 	return &imageGCManager{
-		util.GetCurPath(),
+		cadvisor:     cadvisorInterface,
+		imageService: imageService,
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,6 +107,7 @@ github.com/docker/docker/pkg/jsonmessage
 github.com/docker/docker/pkg/sysinfo
 github.com/docker/docker/api/types/blkiodev
 github.com/docker/docker/api/types/mount
+github.com/docker/docker/pkg/mount
 github.com/docker/docker/pkg/term/windows
 github.com/docker/docker/api/types/network
 github.com/docker/docker/api/types/registry
@@ -117,7 +118,6 @@ github.com/docker/docker/client
 github.com/docker/docker/pkg/stdcopy
 github.com/docker/docker/pkg/parsers
 github.com/docker/docker/daemon/logger/jsonfilelog/jsonlog
-github.com/docker/docker/pkg/mount
 github.com/docker/docker/errdefs
 github.com/docker/docker/api/types/swarm/runtime
 github.com/docker/docker/api
@@ -233,6 +233,7 @@ github.com/golang/protobuf/ptypes/duration
 github.com/google/cadvisor/info/v1
 github.com/google/cadvisor/events
 github.com/google/cadvisor/info/v2
+github.com/google/cadvisor/fs
 github.com/google/cadvisor/utils
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/container
@@ -240,20 +241,19 @@ github.com/google/cadvisor/container/containerd/install
 github.com/google/cadvisor/container/crio/install
 github.com/google/cadvisor/container/docker/install
 github.com/google/cadvisor/container/systemd/install
-github.com/google/cadvisor/fs
 github.com/google/cadvisor/manager
 github.com/google/cadvisor/utils/cloudinfo/aws
 github.com/google/cadvisor/utils/cloudinfo/azure
 github.com/google/cadvisor/utils/cloudinfo/gce
 github.com/google/cadvisor/utils/sysfs
+github.com/google/cadvisor/devicemapper
+github.com/google/cadvisor/utils/docker
 github.com/google/cadvisor/storage
 github.com/google/cadvisor/watcher
 github.com/google/cadvisor/container/containerd
 github.com/google/cadvisor/container/crio
 github.com/google/cadvisor/container/docker
 github.com/google/cadvisor/container/systemd
-github.com/google/cadvisor/devicemapper
-github.com/google/cadvisor/utils/docker
 github.com/google/cadvisor/accelerators
 github.com/google/cadvisor/collector
 github.com/google/cadvisor/container/raw


### PR DESCRIPTION
Currently edged gets the disk usage of image path by syscall, the
result is not right. Edged should invoke cadvisor and imageService.

> /kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Get the stats of the image filesystem by cadvisor and imageService.
```
