### PR TITLE
PR:bug fix in the bluetooth_mapper controller

### DIFF
--- a/mappers/bluetooth_mapper/controller/controller.go
+++ b/mappers/bluetooth_mapper/controller/controller.go
@@ -86,7 +86,8 @@ func (c *Config) Start() {
 
 	for _, schedule := range c.Scheduler.Schedules {
 		helper.ControllerWg.Add(1)
-		go schedule.ExecuteSchedule(c.ActionManager.Actions, c.Converter.DataRead, c.Device.ID)
+		newSchedule := schedule
+		go newSchedule.ExecuteSchedule(c.ActionManager.Actions, c.Converter.DataRead, c.Device.ID)
 	}
 	helper.ControllerWg.Wait()
 }


### PR DESCRIPTION
Only the last schedule would be called when using the bluetooth_mapper, if there were multiple schedules defined in the conf.yaml.
It is a code bug in the start function in controller pacakge. When using the goroutines on the loop iterator, the goroutines(schedule.ExecuteSchedule()) will only start until after the loop.

<why this change was made>
To declare a new variable inside the loop to fix it.

markWangC, 5128470@qq.com

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
#1330 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
