### PR TITLE
Bugfix: modify the default kube qps value for edgecontroller

### DIFF
--- a/cloud/pkg/edgecontroller/config/config.go
+++ b/cloud/pkg/edgecontroller/config/config.go
@@ -62,9 +62,9 @@ type Configure struct {
 	KubeConfig string
 	// KubeContentType is the content type communicate with edge master(default is "application/vnd.kubernetes.protobuf")
 	KubeContentType string
-	// KubeQPS is the QPS communicate with edge master(default is 1024)
+	// KubeQPS is the QPS communicate with edge master(default is 100)
 	KubeQPS float32
-	// KubeBurst default is 10
+	// KubeBurst default is 200
 	KubeBurst int
 	// KubeUpdateNodeFrequency is the time duration for update node status(default is 20s)
 	KubeUpdateNodeFrequency time.Duration

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -11,7 +11,7 @@ const (
 	DefaultKubeContentType         = "application/vnd.kubernetes.protobuf"
 	DefaultKubeNamespace           = v1.NamespaceAll
 	DefaultKubeQPS                 = 100.0
-	DefaultKubeBurst               = 10
+	DefaultKubeBurst               = 200
 	DefaultKubeUpdateNodeFrequency = 20
 
 	DefaultUpdatePodStatusWorkers            = 1


### PR DESCRIPTION
Signed-off-by: Su Xiaolin <linxxnil@126.com>

/kind bug

**What this PR does / why we need it**:
Set the default burst to 200, which is twice the value of default kube QPS(100)
‘’‘The rate limiter allows bursts of up to 'burst' to exceed the QPS, while still maintaining a smoothed qps rate of 'qps'.‘’‘
When the request suddenly becomes larger than the QPS，set the burst largger than QPS，the rate limiter will allow request exceed the QPS which can reduced request latency