### PR TITLE
Restructure KubeEdge Documentation on Installation/ Configuration/ Ex…

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,9 @@ make
 ```
 
 ## Usage
-
-* [One click KubeEdge Installer to install both Cloud and Edge nodes](./docs/setup/installer_setup.md)
-* [Run KubeEdge from release package](./docs/getting-started/release_package.md)
-* [Run KubeEdge from source](./docs/setup/setup.md)
-* [Deploy Application](./docs/setup/setup.md#deploy-application-on-cloud-side)
-* [Run Tests](./docs/setup/setup.md#run-tests)
+* [Install KubeEdge](./docs/setup/kubeedge_install.md)
+* [Configure KubeEdge](./docs/setup/kubeedge_configure.md)
+* [Deploy Application and Run Tests](./docs/setup/kubeedge_precheck.md)
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -136,5 +136,5 @@ details on submitting patches and the contribution workflow.
 
 KubeEdge is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.
 
-[set up]: docs/setup/setup.md
+[set up]: docs/setup/kubeedge_install.md
 [Go environment]: https://golang.org/doc/install

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,19 @@ application orchestration capabilities to hosts at Edge.
 
 .. toctree::
    :maxdepth: 2
+   :caption: Setup
+
+   setup/requirements
+   setup/setup
+   setup/kubeedge_install
+   setup/kubeedge_configure
+   setup/kubeedge_precheck
+   setup/kubeedge_run
+   setup/memfootprint-test-setup
+   Integrate with HuaweiCloud [Intelligent EdgeFabric (IEF)] <guides/try_kubeedge_with_ief>
+
+.. toctree::
+   :maxdepth: 2
    :caption: General Concepts
 
    modules/kubeedge.md
@@ -66,20 +79,6 @@ application orchestration capabilities to hosts at Edge.
 
    mappers/bluetooth_mapper
    mappers/modbus_mapper
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Setup
-
-   setup/requirements
-   setup/setup
-   setup/kubeedge_install
-   setup/kubeedge_configure
-   setup/kubeedge_precheck
-   setup/kubeedge_run
-   setup/memfootprint-test-setup
-   Integrate with HuaweiCloud [Intelligent EdgeFabric (IEF)] <guides/try_kubeedge_with_ief>
-
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,6 @@ application orchestration capabilities to hosts at Edge.
    getting-started/roadmap.md
    getting-started/support.md
    getting-started/community-membership
-   getting-started/release_package
    getting-started/reporting_bugs
 
 .. toctree::
@@ -74,8 +73,10 @@ application orchestration capabilities to hosts at Edge.
 
    setup/requirements
    setup/setup
-   One Click Installer <setup/installer_setup>
-   setup/cross-compilation
+   setup/kubeedge_install
+   setup/kubeedge_configure
+   setup/kubeedge_precheck
+   setup/kubeedge_run
    setup/memfootprint-test-setup
    Integrate with HuaweiCloud [Intelligent EdgeFabric (IEF)] <guides/try_kubeedge_with_ief>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,9 @@ application orchestration capabilities to hosts at Edge.
    setup/kubeedge_precheck
    setup/kubeedge_run
    setup/memfootprint-test-setup
+   setup/cross-compilation
    Integrate with HuaweiCloud [Intelligent EdgeFabric (IEF)] <guides/try_kubeedge_with_ief>
+
 
 .. toctree::
    :maxdepth: 2

--- a/docs/setup/cross-compilation.md
+++ b/docs/setup/cross-compilation.md
@@ -1,6 +1,6 @@
-# Cross Compiling KubeEdge
+# Cross Compiling KubeEdge 
 
-## For ARM Architecture from x86 Architecture
+## For ARM Architecture from x86 Architecture 
 
 Clone KubeEdge
 

--- a/docs/setup/cross-compilation.md
+++ b/docs/setup/cross-compilation.md
@@ -1,6 +1,6 @@
-# Cross Compiling KubeEdge 
+# Cross Compiling KubeEdge
 
-## For ARM Architecture from x86 Architecture 
+## For ARM Architecture from x86 Architecture
 
 Clone KubeEdge
 

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -7,7 +7,7 @@ KubeEdge requires configuration on both [Cloud side (KubeEdge Master)](#configur
 Setting up cloud side requires two steps
 
 1. [Modification of the configuration files](#modification-of-the-configuration-file)
-2. [Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master)](#adding-the-edge-nodes-kubeedge-worker-node-on-the-cloud-side-kubeedge-master). Node Registration can be completed by a automatic or manual method.
+2. Edge node will be auto registered by default. [Users can still choose to register manually](#adding-the-edge-nodes-kubeedge-worker-node-on-the-cloud-side-kubeedge-master).
 
 ### Modification of the configuration file
 

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -6,8 +6,8 @@ KubeEdge requires configuration on both [Cloud side (KubeEdge Master)](#configur
 
 Setting up cloud side requires two steps
 
-1. Modification of the configuration files
-2. Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master). Node Registration can be completed by a automatic or manual method.
+1. [Modification of the configuration files](#modification-of-the-configuration-file)
+2. [Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master)](#adding-the-edge-nodes-kubeedge-worker-node-on-the-cloud-side-kubeedge-master). Node Registration can be completed by a automatic or manual method.
 
 ### Modification of the configuration file
 
@@ -151,10 +151,10 @@ In the cloudcore.yaml, modify the below settings.
 
 Node registration can be completed in two ways:
 
-1. Automatic Registration
-2. Manual Registration
+1. Node - Automatic Registration
+2. Node - Manual Registration
 
-#### Node Auto Registration
+#### Node - Automatic Registration
 
 Edge node can be registered automatically if the `modules.edged.registerNode` is true.
 
@@ -164,7 +164,7 @@ modules:
     registerNode: true
 ```
 
-#### Node Manual Registration
+#### Node - Manual Registration
 
 We have provided a sample node.json to add a node in kubernetes. Please make sure edge-node is added in kubernetes. Run below steps to add edge-node.
 

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -7,7 +7,7 @@ KubeEdge requires configuration on both [Cloud side (KubeEdge Master)](#configur
 Setting up cloud side requires two steps
 
 1. Modification of the configuration files
-2. Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master).
+2. Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master). Node Registration can be completed by a automatic or manual method.
 
 ### Modification of the configuration file
 
@@ -149,6 +149,23 @@ In the cloudcore.yaml, modify the below settings.
 
 ### Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master)
 
+Node registration can be completed in two ways:
+
+1. Automatic Registration
+2. Manual Registration
+
+#### Node Auto Registration
+
+Edge node can be registered automatically if the `modules.edged.registerNode` is true.
+
+```yaml
+modules:
+  edged:
+    registerNode: true
+```
+
+#### Node Manual Registration
+
 We have provided a sample node.json to add a node in kubernetes. Please make sure edge-node is added in kubernetes. Run below steps to add edge-node.
 
 + Copy the `$GOPATH/src/github.com/kubeedge/kubeedge/build/node.json` file and change `metadata.name` to the name of the edge node
@@ -195,7 +212,7 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
  }
  ```
 
-#### Modification in node.json
+##### Modification in node.json
 
 1. metadata.name : This is the name of your edge node device. (Referring the edge node configuration would make it more clear).
 
@@ -214,7 +231,7 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
         kubectl get nodes --show-labels
         ```
 
-#### Deploy edge node (Run on cloud side)
+##### Deploy edge node (Run on cloud side)
 
 ```shell
 kubectl apply -f ~/cmd/yaml/node.json

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -18,28 +18,28 @@ Create and set cloudcore config file
 Create the `/etc/kubeedge/config` folder
 
 ```shell
-    # the default configuration file path is '/etc/kubeedge/config/cloudcore.yaml'
-    # also you can specify it anywhere with '--config'
-    mkdir -p /etc/kubeedge/config/
+# the default configuration file path is '/etc/kubeedge/config/cloudcore.yaml'
+# also you can specify it anywhere with '--config'
+mkdir -p /etc/kubeedge/config/
 ```
 
 Either create a minimal configuration with command `~/cmd/cloudcore --minconfig`
 
 ```shell
 
-    ~/cmd/cloudcore --minconfig > /etc/kubeedge/config/cloudcore.yaml
+~/cmd/cloudcore --minconfig > /etc/kubeedge/config/cloudcore.yaml
 ```
 
 or a full configuration with command `~/cmd/cloudcore --defaultconfig`
 
 ```shell
-    ~/cmd/cloudcore --defaultconfig > /etc/kubeedge/config/cloudcore.yaml
+~/cmd/cloudcore --defaultconfig > /etc/kubeedge/config/cloudcore.yaml
 ```
 
 Edit the configuration file
 
 ```shell
-    vim /etc/kubeedge/config/cloudcore.yaml
+vim /etc/kubeedge/config/cloudcore.yaml
 ```
 
 Verify the configurations before running `cloudcore`
@@ -154,8 +154,8 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
 + Copy the `$GOPATH/src/github.com/kubeedge/kubeedge/build/node.json` file and change `metadata.name` to the name of the edge node
 
     ```shell
-        mkdir -p ~/cmd/yaml
-        cp $GOPATH/src/github.com/kubeedge/kubeedge/build/node.json ~/cmd/yaml
+    mkdir -p ~/cmd/yaml
+    cp $GOPATH/src/github.com/kubeedge/kubeedge/build/node.json ~/cmd/yaml
     ```
 
     Node.json
@@ -217,7 +217,7 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
 #### Deploy edge node (Run on cloud side)
 
 ```shell
-    kubectl apply -f ~/cmd/yaml/node.json
+kubectl apply -f ~/cmd/yaml/node.json
 ```
 
 #### Check if the certificates are created (Run on cloud side)

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -15,21 +15,24 @@ Cloudcore requires changes in `cloudcore.yaml` configuration file.
 
 Create and set cloudcore config file
 
+Create the `/etc/kubeedge/config` folder
+
 ```shell
-    # the default configration file path is '/etc/kubeedge/config/cloudcore.yaml'
+    # the default configuration file path is '/etc/kubeedge/config/cloudcore.yaml'
     # also you can specify it anywhere with '--config'
     mkdir -p /etc/kubeedge/config/
 ```
 
+Either create a minimal configuration with command `~/cmd/cloudcore --minconfig`
+
 ```shell
-    # create a minimal configuration with command `~/cmd/cloudcore --minconfig`
+
     ~/cmd/cloudcore --minconfig > /etc/kubeedge/config/cloudcore.yaml
 ```
 
-or
+or a full configuration with command `~/cmd/cloudcore --defaultconfig`
 
 ```shell
-    # or a full configuration with command `~/cmd/cloudcore --defaultconfig`
     ~/cmd/cloudcore --defaultconfig > /etc/kubeedge/config/cloudcore.yaml
 ```
 

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -1,0 +1,306 @@
+# KubeEdge Configuration
+
+KubeEdge requires configuration on both [Cloud side (KubeEdge Master Node)](#Configuration-Cloud-side-(KubeEdge-Master-Node)) and [Edge side (KubeEdge Worker Node)](#Configuration-Edge-side-(KubeEdge-Worker-Node))
+
+## Configuration Cloud side (KubeEdge Master Node)
+
+Setting up cloud side requires two steps 
+
+1. Modification of the configuration files
+2. Adding the edge nodes (KubeEdge Worker Node) on the Cloud side KubeEdge Master Node).
+
+### Modification of the configuration files
+
+Cloudcore requires three configuration file as of now. However this might change in future as per the [Issue 1171](https://github.com/kubeedge/kubeedge/issues/1171)
+
+1. controller.yaml
+2. logging.yaml
+3. modules.yaml
+
+
+Set cloudcore config file
+
+```shell
+    cd ~/cmd/conf
+    vim controller.yaml
+```
+
+Verify the configurations before running `cloudcore`
+    
+```
+controller:
+    kube:
+        master:     # kube-apiserver address (such as:http://localhost:8080)
+        namespace: ""
+        content_type: "application/vnd.kubernetes.protobuf"
+        qps: 5
+        burst: 10
+        node_update_frequency: 10
+        kubeconfig: "/root/.kube/config"   #Enter absolute path to kubeconfig file to enable https connection to k8s apiserver, if master and kubeconfig are both set, master will override any value in kubeconfig.
+    cloudhub:
+      protocol_websocket: true # enable websocket protocol
+      port: 10000 # open port for websocket server
+      protocol_quic: true # enable quic protocol
+      quic_port: 10001 # open prot for quic server
+      max_incomingstreams: 10000 # the max incoming stream for quic server
+      enable_uds: true # enable unix domain socket protocol
+      uds_address: unix:///var/lib/kubeedge/kubeedge.sock # unix domain socket address
+      address: 0.0.0.0
+      ca: /etc/kubeedge/ca/rootCA.crt
+      cert: /etc/kubeedge/certs/edge.crt
+      key: /etc/kubeedge/certs/edge.key
+      keepalive-interval: 30
+      write-timeout: 30
+      node-limit: 10
+    devicecontroller:
+      kube:
+        master:        # kube-apiserver address (such as:http://localhost:8080)
+        namespace: ""
+        content_type: "application/vnd.kubernetes.protobuf"
+        qps: 5
+        burst: 10
+        kubeconfig: "/root/.kube/config" #Enter absolute path to kubeconfig file to enable https connection to k8s apiserver,if master and kubeconfig are both set, master will override any value in kubeconfig.
+```
+
+cloudcore default supports https connection to Kubernetes apiserver, so you need to check whether the path for `controller.kube.kubeconfig` and `devicecontroller.kube.kubeconfig` exist, but if `master` and `kubeconfig` are both set, `master` will override any value in kubeconfig.
+
+Check whether the cert files for `cloudhub.ca`, `cloudhub.cert`,`cloudhub.key` exist.
+
+#### Modification in controller.yaml
+
+In the controller.yaml, the below settings needs to be modified:
+
+1. `controller.kube.master` : This would be kube-apiserver address. It might be 
+
+    ```
+    https://your_hostname:6443 or http://your_hostname:8080
+    ```
+    based on your kubernetes configuration.
+
+2. `controller.kube.kubeconfig` and `devicecontroller.kube.kubeconfig` : This would be the path to your kubeconfig file. It might be either
+
+    ```
+    /root/.kube/config or /home/your_username/.kube/config
+    ```
+    depending on where you have setup your kubernetes by performing the below step:
+
+    ```
+    To start using your cluster, you need to run the following as a regular user:
+
+    mkdir -p $HOME/.kube
+    sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+    sudo chown $(id -u):$(id -g) $HOME/.kube/config
+    ```
+
+### Adding the edge nodes (KubeEdge Worker Node) on the Cloud side KubeEdge Master Node)
+
+We have provided a sample node.json to add a node in kubernetes. Please make sure edge-node is added in kubernetes. Run below steps to add edge-node.
+
++ Copy the `$GOPATH/src/github.com/kubeedge/kubeedge/build/node.json` file and change `metadata.name` to the name of the edge node
+
+    ```shell
+        mkdir -p ~/cmd/yaml
+        cp $GOPATH/src/github.com/kubeedge/kubeedge/build/node.json ~/cmd/yaml
+    ```
+
+    Node.json
+    ```script
+    {
+      "kind": "Node",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "edge-node",
+        "labels": {
+          "name": "edge-node",
+          "node-role.kubernetes.io/edge": ""
+        }
+      }
+    }
+    ```
+
+#### Modification in node.json
+
+1. metadata.name : This is the name of your edge node device. (Referring the edge node configuration would make it more clear). 
+ 
+    **Note: you need to remember `metadata.name` , because edgecore need it**.
+
+2. metadata.labels: Labels are the name by which you can remember a set of nodes.
+
+    + Make sure role is set to edge for the node. For this a key of the form `"node-role.kubernetes.io/edge"` must be present in `labels` tag of `metadata`.
+    + Please ensure to add the label `node-role.kubernetes.io/edge` to the `build/node.json` file.
+    
+    + If role is not set for the node, the pods, configmaps and secrets created/updated in the cloud cannot be synced with the node they are targeted for.
+
+    + This can be checked by running the below command on Cloud side
+
+        ```
+        kubectl get nodes --show-labels
+        ```
+
+#### Deploy edge node (**you must run on cloud side**)
+
+    ```shell
+    kubectl apply -f ~/cmd/yaml/node.json
+    ```
+#### Transfer certificate file from the cloud side to edge side
+
+Transfer certificate files to the edge node, because `edgecore` use these certificate files to connection `cloudcore` 
+
+This can be done by utilising scp
+
+```
+cd /etc/kubeedge/
+scp -r certs.tgz username@ipaddress_Edge_Node:/etc/kubeedge
+```
+Here, we are copying the certs.tgz from the cloud side to the edge node in the /etc/kubeedge directory. You may copy in any directory and then move the certs to /etc/kubeedge folder.
+
+## Configuration Edge side (KubeEdge Worker Node)
+
+### Set edgecore config file
+
+
+```shell
+  mkdir ~/cmd/conf
+  cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/conf/* ~/cmd/conf
+  vim ~/cmd/conf/edge.yaml
+```
+
+**Note:** `~/cmd/` dir is also an example as well as `cloudcore`, `conf/` should be in the same directory as edgecore binary,
+
+Verify the configurations before running `edgecore`
+
+```
+    mqtt:
+        server: tcp://127.0.0.1:1883 # external mqtt broker url.
+        internal-server: tcp://127.0.0.1:1884 # internal mqtt broker url.
+        mode: 0 # 0: internal mqtt broker enable only. 1: internal and external mqtt broker enable. 2: external mqtt broker
+    enable only.
+        qos: 0 # 0: QOSAtMostOnce, 1: QOSAtLeastOnce, 2: QOSExactlyOnce.
+        retain: false # if the flag set true, server will store the message and can be delivered to future subscribers.
+        session-queue-size: 100 # A size of how many sessions will be handled. default to 100.
+    
+    edgehub:
+        websocket:
+            url: wss://0.0.0.0:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events 
+            certfile: /etc/kubeedge/certs/edge.crt
+            keyfile: /etc/kubeedge/certs/edge.key
+            handshake-timeout: 30 #second
+            write-deadline: 15 # second
+            read-deadline: 15 # second
+        quic:
+            url: 127.0.0.1:10001
+            cafile: /etc/kubeedge/ca/rootCA.crt
+            certfile: /etc/kubeedge/certs/edge.crt
+            keyfile: /etc/kubeedge/certs/edge.key
+            handshake-timeout: 30 #second
+            write-deadline: 15 # second
+            read-deadline: 15 # second
+        controller:
+            protocol: websocket # websocket, quic
+            heartbeat: 15  # second
+            project-id: e632aba927ea4ac2b575ec1603d56f10
+            node-id: edge-node
+    
+    edged:
+        register-node-namespace: default
+        hostname-override: edge-node
+        interface-name: eth0
+        edged-memory-capacity-bytes: 7852396000
+        node-status-update-frequency: 10 # second
+        device-plugin-enabled: false
+        gpu-plugin-enabled: false
+        image-gc-high-threshold: 80 # percent
+        image-gc-low-threshold: 40 # percent
+        maximum-dead-containers-per-container: 1
+        docker-address: unix:///var/run/docker.sock
+        runtime-type: docker
+        remote-runtime-endpoint: unix:///var/run/dockershim.sock
+        remote-image-endpoint: unix:///var/run/dockershim.sock
+        runtime-request-timeout: 2
+        podsandbox-image: kubeedge/pause:3.1 # kubeedge/pause:3.1 for x86 arch , kubeedge/pause-arm:3.1 for arm arch, kubeedge/pause-arm64 for arm64 arch
+        image-pull-progress-deadline: 60 # second
+        cgroup-driver: cgroupfs
+        node-ip: ""
+        cluster-dns: ""
+        cluster-domain: ""
+        
+        mesh:
+            loadbalance:
+                strategy-name: RoundRobin
+```
+
+#### Modification in edge.yaml
+
+1. Update the IP address of the master in the `edgehub.websocket.url` field. You need set cloudcore ip address.
+
+    ```
+    url: wss://0.0.0.0:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events
+    ```
+    to 
+
+    ```
+    url: wss://X.X.X.X:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events
+    ```
+    where X.X.X.X is your cloudcore IP Address.
+
+2. Update the IP address of the master in the `edgehub.quic.url` field. You need set cloudcore ip address.
+
+    ```
+    quic:
+        url: 127.0.0.1:10001
+    ```
+    to 
+    ```
+    quic:
+        url: X.X.X.X:10001
+    ```
+3. Check `edged.podsandbox-image` : This is very important and must be set correct. If you are wondering what's your architecture either 32-bit or 64-bit run 
+    ```
+    getconf LONG_BIT
+    ```
+    + `kubeedge/pause-arm:3.1` for arm arch
+    + `kubeedge/pause-arm64:3.1` for arm64 arch
+    + `kubeedge/pause:3.1` for x86 arch
+4. Check whether the cert files for `edgehub.websocket.certfile` and `edgehub.websocket.keyfile`  exist.
+    
+5. Check whether the cert files for `edgehub.quic.certfile` ,`edgehub.quic.keyfile` and `edgehub.quic.cafile` exist. If those files not exist, you need to copy them from the cloud side. 
+   
+6. Most importantly, Replace `edge-node` with edge node name in edge.yaml for the below fields :
+    + `websocket:URL`
+
+        ```
+        url: wss://0.0.0.0:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events 
+        ```
+    + `controller:node-id`
+        ```
+        controller:
+        node-id: edge-node
+        ```
+    + `edged:hostname-override`
+        ```
+        edged:
+        register-node-namespace: default
+        hostname-override: edge-node
+        ```
+7.  Configure the desired container runtime to be used as either docker or remote (for all CRI based runtimes including containerd). If this parameter is not specified docker runtime will be used by default
+    ```
+    runtime-type:docker or runtime-type:remote
+    ```
+8. If your runtime-type is remote, specify the following parameters for remote/CRI based runtimes
+    ```
+    remote-runtime-endpoint:/var/run/containerd/containerd.sock`
+    remote-image-endpoint:/var/run/containerd/containerd.sock`
+    runtime-request-timeout: 2`
+    podsandbox-image: k8s.gcr.io/pause`
+    kubelet-root-dir: /var/run/kubelet/`
+    ```
+
+#### Configuring MQTT mode
+The Edge part of KubeEdge uses MQTT for communication between deviceTwin and devices. KubeEdge supports 3 MQTT modes:
+
+internalMqttMode: internal mqtt broker is enabled.
+bothMqttMode: internal as well as external broker are enabled.
+externalMqttMode: only external broker is enabled.
+Use mode field in edge.yaml to select the desired mode.
+
+To use KubeEdge in double mqtt or external mode, you need to make sure that mosquitto or emqx edge is installed on the edge node as an MQTT Broker.

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -1,6 +1,6 @@
 # KubeEdge Configuration
 
-KubeEdge requires configuration on both [Cloud side (KubeEdge Master Node)](#configuration-cloud-side-(kubeedge-master-node)) and [Edge side (KubeEdge Worker Node)](#configuration-edge-side-(kubeedge-worker-node))
+KubeEdge requires configuration on both [Cloud side (KubeEdge Master Node)](#configuration-cloud-side-kubeedge-master-node) and [Edge side (KubeEdge Worker Node)](#configuration-edge-side-kubeedge-worker-node)
 
 ## Configuration Cloud side (KubeEdge Master Node)
 

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -27,7 +27,7 @@ Set cloudcore config file
 
 Verify the configurations before running `cloudcore`
     
-```
+```yaml
 controller:
     kube:
         master:     # kube-apiserver address (such as:http://localhost:8080)
@@ -68,19 +68,27 @@ Check whether the cert files for `cloudhub.ca`, `cloudhub.cert`,`cloudhub.key` e
 
 #### Modification in controller.yaml
 
-In the controller.yaml, the below settings needs to be modified:
+In the controller.yaml, modify the below settings.
 
 1. `controller.kube.master` : This would be kube-apiserver address. It might be 
 
     ```
-    https://your_hostname:6443 or http://your_hostname:8080
+    https://<your_hostname>:6443
     ```
-    based on your kubernetes configuration.
+    or
+    ```
+    http://<your_hostname>:8080
+    ```
+    based on your kubernetes configuration. `your_hostname` should be replaced with the IP Address of your hostname.
 
 2. `controller.kube.kubeconfig` and `devicecontroller.kube.kubeconfig` : This would be the path to your kubeconfig file. It might be either
 
     ```
-    /root/.kube/config or /home/your_username/.kube/config
+    /root/.kube/config
+    ```
+    or
+    ```
+    /home/<your_username>/.kube/config
     ```
     depending on where you have setup your kubernetes by performing the below step:
 
@@ -92,7 +100,7 @@ In the controller.yaml, the below settings needs to be modified:
     sudo chown $(id -u):$(id -g) $HOME/.kube/config
     ```
 
-### Adding the edge nodes (KubeEdge Worker Node) on the Cloud side KubeEdge Master Node)
+### Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master Node)
 
 We have provided a sample node.json to add a node in kubernetes. Please make sure edge-node is added in kubernetes. Run below steps to add edge-node.
 
@@ -122,11 +130,11 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
 
 1. metadata.name : This is the name of your edge node device. (Referring the edge node configuration would make it more clear). 
  
-    **Note: you need to remember `metadata.name` , because edgecore need it**.
+    **Note: you need to remember `metadata.name` , because edgecore needs it**.
 
 2. metadata.labels: Labels are the name by which you can remember a set of nodes.
 
-    + Make sure role is set to edge for the node. For this a key of the form `"node-role.kubernetes.io/edge"` must be present in `labels` tag of `metadata`.
+    + Make sure role is set to `edge` for the node. For this a key of the form `"node-role.kubernetes.io/edge"` must be present in `labels` tag of `metadata`.
     + Please ensure to add the label `node-role.kubernetes.io/edge` to the `build/node.json` file.
     
     + If role is not set for the node, the pods, configmaps and secrets created/updated in the cloud cannot be synced with the node they are targeted for.
@@ -137,20 +145,21 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
         kubectl get nodes --show-labels
         ```
 
-#### Deploy edge node (**you must run on cloud side**)
+#### Deploy edge node (Run on cloud side)
 
-    ```shell
+```shell
     kubectl apply -f ~/cmd/yaml/node.json
-    ```
+```
+
 #### Transfer certificate file from the cloud side to edge side
 
-Transfer certificate files to the edge node, because `edgecore` use these certificate files to connection `cloudcore` 
+Transfer certificate files to the edge node, because `edgecore` uses these certificate files to connect to `cloudcore`
 
 This can be done by utilising scp
 
 ```
 cd /etc/kubeedge/
-scp -r certs.tgz username@ipaddress_Edge_Node:/etc/kubeedge
+scp -r certs.tgz username@destination:/etc/kubeedge
 ```
 Here, we are copying the certs.tgz from the cloud side to the edge node in the /etc/kubeedge directory. You may copy in any directory and then move the certs to /etc/kubeedge folder.
 
@@ -169,7 +178,7 @@ Here, we are copying the certs.tgz from the cloud side to the edge node in the /
 
 Verify the configurations before running `edgecore`
 
-```
+```yaml
     mqtt:
         server: tcp://127.0.0.1:1883 # external mqtt broker url.
         internal-server: tcp://127.0.0.1:1884 # internal mqtt broker url.
@@ -233,63 +242,71 @@ Verify the configurations before running `edgecore`
 
 1. Update the IP address of the master in the `edgehub.websocket.url` field. You need set cloudcore ip address.
 
-    ```
+    ```yaml
     url: wss://0.0.0.0:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events
     ```
     to 
 
-    ```
-    url: wss://X.X.X.X:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events
+    ```yaml
+    url: wss://<X.X.X.X>:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events
     ```
     where X.X.X.X is your cloudcore IP Address.
 
 2. Update the IP address of the master in the `edgehub.quic.url` field. You need set cloudcore ip address.
 
-    ```
+    ```yaml
     quic:
         url: 127.0.0.1:10001
     ```
     to 
-    ```
+    ```yaml
     quic:
-        url: X.X.X.X:10001
+        url:<X.X.X.X>:10001
     ```
-3. Check `edged.podsandbox-image` : This is very important and must be set correct. If you are wondering what's your architecture either 32-bit or 64-bit run 
+3. Check `edged.podsandbox-image` : This is very important and must be set correctly.
+
+   To check the architecture of your machine run the following
+
     ```
     getconf LONG_BIT
     ```
+
     + `kubeedge/pause-arm:3.1` for arm arch
     + `kubeedge/pause-arm64:3.1` for arm64 arch
     + `kubeedge/pause:3.1` for x86 arch
 4. Check whether the cert files for `edgehub.websocket.certfile` and `edgehub.websocket.keyfile`  exist.
     
-5. Check whether the cert files for `edgehub.quic.certfile` ,`edgehub.quic.keyfile` and `edgehub.quic.cafile` exist. If those files not exist, you need to copy them from the cloud side. 
+5. Check whether the cert files for `edgehub.quic.certfile` ,`edgehub.quic.keyfile` and `edgehub.quic.cafile` exist. If those files do not exist, you need to copy them from the cloud side.
    
 6. Most importantly, Replace `edge-node` with edge node name in edge.yaml for the below fields :
     + `websocket:URL`
 
-        ```
+        ```yaml
         url: wss://0.0.0.0:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events 
         ```
     + `controller:node-id`
-        ```
+        ```yaml
         controller:
         node-id: edge-node
         ```
     + `edged:hostname-override`
-        ```
+        ```yaml
         edged:
         register-node-namespace: default
         hostname-override: edge-node
         ```
 7.  Configure the desired container runtime to be used as either docker or remote (for all CRI based runtimes including containerd). If this parameter is not specified docker runtime will be used by default
+    ```yaml
+    runtime-type: docker
     ```
-    runtime-type:docker or runtime-type:remote
+    or
+    ```yaml
+    runtime-type: remote
     ```
 8. If your runtime-type is remote, specify the following parameters for remote/CRI based runtimes
-    ```
-    remote-runtime-endpoint:/var/run/containerd/containerd.sock`
-    remote-image-endpoint:/var/run/containerd/containerd.sock`
+    ```yaml
+    remote-runtime-endpoint: /var/run/containerd/containerd.sock`
+    remote-image-endpoint: /var/run/containerd/containerd.sock`
     runtime-request-timeout: 2`
     podsandbox-image: k8s.gcr.io/pause`
     kubelet-root-dir: /var/run/kubelet/`

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -9,11 +9,9 @@ Setting up cloud side requires two steps
 1. Modification of the configuration files
 2. Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master).
 
-### Modification of the configuration files
+### Modification of the configuration file
 
-Cloudcore requires one configuration file.
-
-1. cloudcore.yaml
+Cloudcore requires changes in `cloudcore.yaml` configuration file.
 
 Create and set cloudcore config file
 
@@ -21,15 +19,23 @@ Create and set cloudcore config file
     # the default configration file path is '/etc/kubeedge/config/cloudcore.yaml'
     # also you can specify it anywhere with '--config'
     mkdir -p /etc/kubeedge/config/
-  
+```
+
+```shell
     # create a minimal configuration with command `~/cmd/cloudcore --minconfig`
     ~/cmd/cloudcore --minconfig > /etc/kubeedge/config/cloudcore.yaml
+```
 
-    or
+or
 
+```shell
     # or a full configuration with command `~/cmd/cloudcore --defaultconfig`
     ~/cmd/cloudcore --defaultconfig > /etc/kubeedge/config/cloudcore.yaml
+```
 
+Edit the configuration file
+
+```shell
     vim /etc/kubeedge/config/cloudcore.yaml
 ```
 
@@ -138,7 +144,7 @@ In the cloudcore.yaml, modify the below settings.
 
 2. Check whether the cert files for `modules.cloudhub.tlsCAFile`, `modules.cloudhub.tlsCertFile`,`modules.cloudhub.tlsPrivateKeyFile` exists.
 
-### Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master Node)
+### Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master)
 
 We have provided a sample node.json to add a node in kubernetes. Please make sure edge-node is added in kubernetes. Run below steps to add edge-node.
 
@@ -165,10 +171,10 @@ We have provided a sample node.json to add a node in kubernetes. Please make sur
     }
     ```
 
-If you want to add an edge node to an existing kubernetes cluster you should a taint to this node. An example is given in this Node.yaml file:
+ If you want to add an edge node to an existing kubernetes cluster you should a taint to this node. An example is given in this Node.yaml file:
 
-```yaml
-{
+ ```yaml
+ {
     kind: Node
     apiVersion: v1
     metadata: {
@@ -183,8 +189,8 @@ If you want to add an edge node to an existing kubernetes cluster you should a t
         key: node.kubeedge.io
         value: edge
     }
-}
-```
+ }
+ ```
 
 #### Modification in node.json
 
@@ -274,17 +280,32 @@ tar -xvzf certs.tgz
 
 ### Create and set edgecore config file
 
+Create the `/etc/kubeedge/config` folder
+
 ```shell
 
     # the default configration file path is '/etc/kubeedge/config/edgecore.yaml'
     # also you can specify it anywhere with '--config'
     mkdir -p /etc/kubeedge/config/
+```
 
-    # create a minimal configuration with command `~/cmd/edgecore --minconfig`
-    # or a full configuration with command `~/cmd/edgecore --defaultconfig`
+Either create a minimal configuration with command `~/cmd/edgecore --minconfig`
+
+```shell
     ~/cmd/edgecore --minconfig > /etc/kubeedge/config/edgecore.yaml
+```
+
+or a full configuration with command `~/cmd/edgecore --defaultconfig`
+
+```shell
+~/cmd/edgecore --defaultconfig > /etc/kubeedge/config/edgecore.yaml
+```
+
+Edit the configuration file
+
+```shell
     vim /etc/kubeedge/config/edgecore.yaml
-    ```
+```
 
 Verify the configurations before running `edgecore`
 
@@ -389,13 +410,13 @@ modules:
 4. Configure the desired container runtime to be used as either docker or remote (for all CRI based runtimes including containerd). If this parameter is not specified docker runtime will be used by default
 
     ```yaml
-    runtime-type: docker
+    runtimeType: docker
     ```
 
     or
 
     ```yaml
-    runtime-type: remote
+    runtimeType: remote
     ```
 
 5. If your runtime-type is remote, specify the following parameters for remote/CRI based runtimes

--- a/docs/setup/kubeedge_install.md
+++ b/docs/setup/kubeedge_install.md
@@ -1,0 +1,74 @@
+# Install KubeEdge
+
+In this section, we would cover the below topics
+
+1. [Abstract](#Abstract)
+2. [Pre-requisties](#Prerequisties)
+3. [Setup KubeEdge](#Setup-KubeEdge)
+4. [Configure KubeEdge](#Configure-KubeEdge)
+5. [Run KubeEdge](#Run-KubeEdge)
+6. [KubeEdge Pre-Check](#KubeEdge-Pre-Check)
+## Abstract
+KubeEdge is composed of cloud and edge parts. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup kubeedge, we need to setup kubernetes cluster, cloud side and edge side.
+
++ on cloud side, we need to install docker, kubernetes cluster and cloudcore.
++ on edge side, we need to install docker, mqtt and edgecore.
+
+## Prerequisites
+
++ **Go dependency** and **Kubernetes compatibility** please refer to [compatibility-matrix](https://github.com/kubeedge/kubeedge#compatibility-matrix). Please refer this to understand what version of Docker, Kubernetes, Golang can be installed.
+
+### Cloud side (KubeEdge Master Node)
+
++ [Install golang](https://golang.org/dl/)
+
++ [Install docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
+
++ [Install kubeadm/kubectl](https://kubernetes.io/docs/setup/independent/install-kubeadm/)
+
++ [Creating kubernetes cluster with kubeadm](<https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>)
+
+If you are creating Kubernetes cluster for just testing KubeEdge, maybe start with Flannel.
+
+Check Kubernetes Master Status: It should be ready.
+
+```
+$ kubectl get nodes
+NAME               STATUS   ROLES    AGE    VERSION
+kubeedge-master   Ready    master   4d3h   v1.16.1
+```
+
+**Note:** If you choose to decide installing KubeEdge using KubeEdge Installer keadm, do pass the flag 
+```
+--pod-network-cidr
+```
+### Edge side (KubeEdge Worker Node)
+
++ [Install golang](https://golang.org/dl/)
+
++ [Install docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
+
++ [Install mosquitto](https://mosquitto.org/download/)
+
+**Note:** Do not install **kubelet** and **kube-proxy** on edge side
+
+## Setup KubeEdge
+
+Currently there are two different ways of installing KubeEdge
+
+1. From [Source](kubeedge_install_source.md)
+2. From [KubeEdge Installer keadm](kubeedge_install_keadm.md)
+
+## Configure KubeEdge
+
+At this point, we assume that you have completed the installation of KubeEdge and want to configure either Cloudcore or Edgecore
+
+Refer [KubeEdge Configuration](kubeedge_configure.md)
+
+## Run KubeEdge
+
+Refer [KubeEdge Run](kubeedge_run.md)
+
+## KubeEdge Pre-Check
+
+Refer [KubeEdge Pre-Check](kubeedge_precheck.md)

--- a/docs/setup/kubeedge_install.md
+++ b/docs/setup/kubeedge_install.md
@@ -11,7 +11,7 @@ In this section, we would cover the below topics
 
 ## Abstract
 
-KubeEdge is composed of cloud and edge sides. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup KubeEdge, we need to setup Kubernetes cluster, cloud side and edge side.
+KubeEdge is composed of cloud and edge sides. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup KubeEdge, we need to setup Kubernetes cluster (exisiting cluster can be used), cloud side and edge side.
 
 + on `cloud side`, we need to install Docker, Kubernetes cluster and cloudcore.
 + on `edge side`, we need to install Docker, MQTT (We can also use internal MQTT broker) and edgecore.
@@ -53,7 +53,7 @@ keadm init --pod-network-cidr
 
 + [Install Docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
 
-+ [Install mosquitto](https://mosquitto.org/download/)
++ [Install mosquitto](https://mosquitto.org/download/) : If you are just trying KubeEdge, this step can be skipped.
 
 **Note:** Do not install **kubelet** and **kube-proxy** on edge side
 

--- a/docs/setup/kubeedge_install.md
+++ b/docs/setup/kubeedge_install.md
@@ -9,10 +9,10 @@ In this section, we would cover the below topics
 5. [Run KubeEdge](#Run-KubeEdge)
 6. [KubeEdge Pre-Check](#KubeEdge-Pre-Check)
 ## Abstract
-KubeEdge is composed of cloud and edge parts. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup kubeedge, we need to setup kubernetes cluster, cloud side and edge side.
+KubeEdge is composed of cloud and edge parts. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup KubeEdge, we need to setup Kubernetes cluster, cloud side and edge side.
 
-+ on cloud side, we need to install docker, kubernetes cluster and cloudcore.
-+ on edge side, we need to install docker, mqtt and edgecore.
++ on `cloud side`, we need to install Docker, Kubernetes cluster and cloudcore.
++ on `edge side`, we need to install Docker, mqtt and edgecore.
 
 ## Prerequisites
 
@@ -22,18 +22,18 @@ KubeEdge is composed of cloud and edge parts. It is built upon Kubernetes and pr
 
 + [Install golang](https://golang.org/dl/)
 
-+ [Install docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
++ [Install Docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
 
 + [Install kubeadm/kubectl](https://kubernetes.io/docs/setup/independent/install-kubeadm/)
 
-+ [Creating kubernetes cluster with kubeadm](<https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>)
++ [Creating Kubernetes cluster with kubeadm](<https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>)
 
 If you are creating Kubernetes cluster for just testing KubeEdge, maybe start with Flannel.
 
 Check Kubernetes Master Status: It should be ready.
 
 ```
-$ kubectl get nodes
+kubectl get nodes
 NAME               STATUS   ROLES    AGE    VERSION
 kubeedge-master   Ready    master   4d3h   v1.16.1
 ```
@@ -46,7 +46,7 @@ kubeedge-master   Ready    master   4d3h   v1.16.1
 
 + [Install golang](https://golang.org/dl/)
 
-+ [Install docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
++ [Install Docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
 
 + [Install mosquitto](https://mosquitto.org/download/)
 

--- a/docs/setup/kubeedge_install.md
+++ b/docs/setup/kubeedge_install.md
@@ -3,11 +3,11 @@
 In this section, we would cover the below topics
 
 1. [Abstract](#Abstract)
-2. [Pre-requisties](#Prerequisties)
-3. [Setup KubeEdge](#Setup-KubeEdge)
-4. [Configure KubeEdge](#Configure-KubeEdge)
-5. [Run KubeEdge](#Run-KubeEdge)
-6. [KubeEdge Pre-Check](#KubeEdge-Pre-Check)
+2. [Pre-requisties](#prerequisties)
+3. [Setup KubeEdge](#setup-kubeEdge)
+4. [Configure KubeEdge](#configure-kubeEdge)
+5. [Run KubeEdge](#run-kubeedge)
+6. [KubeEdge Pre-Check](#kubeedge-pre-check)
 ## Abstract
 KubeEdge is composed of cloud and edge parts. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup KubeEdge, we need to setup Kubernetes cluster, cloud side and edge side.
 

--- a/docs/setup/kubeedge_install.md
+++ b/docs/setup/kubeedge_install.md
@@ -3,7 +3,7 @@
 In this section, we would cover the below topics
 
 1. [Abstract](#Abstract)
-2. [Pre-Requisite](#prerequisite)
+2. [Pre-Requisite](#pre-requisite)
 3. [Setup KubeEdge](#setup-kubeEdge)
 4. [Configure KubeEdge](#configure-kubeEdge)
 5. [Run KubeEdge](#run-kubeedge)

--- a/docs/setup/kubeedge_install.md
+++ b/docs/setup/kubeedge_install.md
@@ -3,20 +3,20 @@
 In this section, we would cover the below topics
 
 1. [Abstract](#Abstract)
-2. [Pre-requisties](#prerequisties)
+2. [Pre-Requisite](#prerequisite)
 3. [Setup KubeEdge](#setup-kubeEdge)
 4. [Configure KubeEdge](#configure-kubeEdge)
 5. [Run KubeEdge](#run-kubeedge)
 6. [KubeEdge Pre-Check](#kubeedge-pre-check)
 ## Abstract
-KubeEdge is composed of cloud and edge parts. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup KubeEdge, we need to setup Kubernetes cluster, cloud side and edge side.
+KubeEdge is composed of cloud and edge sides. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup KubeEdge, we need to setup Kubernetes cluster, cloud side and edge side.
 
 + on `cloud side`, we need to install Docker, Kubernetes cluster and cloudcore.
-+ on `edge side`, we need to install Docker, mqtt and edgecore.
++ on `edge side`, we need to install Docker, MQTT and edgecore.
 
-## Prerequisites
+## Pre-Requisite
 
-+ **Go dependency** and **Kubernetes compatibility** please refer to [compatibility-matrix](https://github.com/kubeedge/kubeedge#compatibility-matrix). Please refer this to understand what version of Docker, Kubernetes, Golang can be installed.
++ Please refer [compatibility-matrix](https://github.com/kubeedge/kubeedge#compatibility-matrix) to understand **Go dependency** and **Kubernetes compatibility** and determine what version of Docker, Kubernetes, Golang can be installed.
 
 ### Cloud side (KubeEdge Master Node)
 
@@ -24,23 +24,25 @@ KubeEdge is composed of cloud and edge parts. It is built upon Kubernetes and pr
 
 + [Install Docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
 
-+ [Install kubeadm/kubectl](https://kubernetes.io/docs/setup/independent/install-kubeadm/)
++ [Install kubeadm/ kubectl](https://kubernetes.io/docs/setup/independent/install-kubeadm/)
 
 + [Creating Kubernetes cluster with kubeadm](<https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>)
 
 If you are creating Kubernetes cluster for just testing KubeEdge, maybe start with Flannel.
 
-Check Kubernetes Master Status: It should be ready.
+Check Kubernetes Master Status: It should be `ready`.
 
 ```
 kubectl get nodes
+
 NAME               STATUS   ROLES    AGE    VERSION
 kubeedge-master   Ready    master   4d3h   v1.16.1
 ```
 
 **Note:** If you choose to decide installing KubeEdge using KubeEdge Installer keadm, do pass the flag 
+
 ```
---pod-network-cidr
+keadm init --pod-network-cidr
 ```
 ### Edge side (KubeEdge Worker Node)
 

--- a/docs/setup/kubeedge_install.md
+++ b/docs/setup/kubeedge_install.md
@@ -8,19 +8,21 @@ In this section, we would cover the below topics
 4. [Configure KubeEdge](#configure-kubeEdge)
 5. [Run KubeEdge](#run-kubeedge)
 6. [KubeEdge Pre-Check](#kubeedge-pre-check)
+
 ## Abstract
+
 KubeEdge is composed of cloud and edge sides. It is built upon Kubernetes and provides core infrastructure support for networking, application deployment and metadata synchronization between cloud and edge. So if we want to setup KubeEdge, we need to setup Kubernetes cluster, cloud side and edge side.
 
 + on `cloud side`, we need to install Docker, Kubernetes cluster and cloudcore.
-+ on `edge side`, we need to install Docker, MQTT and edgecore.
++ on `edge side`, we need to install Docker, MQTT (We can also use internal MQTT broker) and edgecore.
 
 ## Pre-Requisite
 
 + Please refer [compatibility-matrix](https://github.com/kubeedge/kubeedge#compatibility-matrix) to understand **Go dependency** and **Kubernetes compatibility** and determine what version of Docker, Kubernetes, Golang can be installed.
 
-### Cloud side (KubeEdge Master Node)
+### Cloud side (KubeEdge Master)
 
-+ [Install golang](https://golang.org/dl/)
++ [Install golang](https://golang.org/dl/) (If you want to compile KubeEdge)
 
 + [Install Docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
 
@@ -32,21 +34,22 @@ If you are creating Kubernetes cluster for just testing KubeEdge, maybe start wi
 
 Check Kubernetes Master Status: It should be `ready`.
 
-```
+```shell
 kubectl get nodes
 
 NAME               STATUS   ROLES    AGE    VERSION
 kubeedge-master   Ready    master   4d3h   v1.16.1
 ```
 
-**Note:** If you choose to decide installing KubeEdge using KubeEdge Installer keadm, do pass the flag 
+**Note:** If you choose to decide installing KubeEdge using KubeEdge Installer keadm, do pass the flag
 
-```
+```shell
 keadm init --pod-network-cidr
 ```
+
 ### Edge side (KubeEdge Worker Node)
 
-+ [Install golang](https://golang.org/dl/)
++ [Install golang](https://golang.org/dl/) (If you want to compile KubeEdge)
 
 + [Install Docker](https://docs.docker.com/install/), or other runtime, such as [containerd](https://github.com/containerd/containerd)
 
@@ -56,10 +59,12 @@ keadm init --pod-network-cidr
 
 ## Setup KubeEdge
 
-Currently there are two different ways of installing KubeEdge
+Currently there are four different ways of installing KubeEdge
 
 1. From [Source](kubeedge_install_source.md)
 2. From [KubeEdge Installer keadm](kubeedge_install_keadm.md)
+3. From Binary
+4. From Container
 
 ## Configure KubeEdge
 

--- a/docs/setup/kubeedge_install_keadm.md
+++ b/docs/setup/kubeedge_install_keadm.md
@@ -224,7 +224,15 @@ Flags:
 
     or
 
-  ```shell
-  kubectl create -f https://raw.githubusercontent.com/kubeedge/kubeedge/<kubeEdge Version>/build/crds/devices/devices_v1alpha1_device.yaml
-  kubectl create -f https://raw.githubusercontent.com/kubeedge/kubeedge/<kubeEdge Version>/build/crds/devices/devices_v1alpha1_devicemodel.yaml
-```
+    ```shell
+     kubectl create -f https://raw.githubusercontent.com/kubeedge/kubeedge/<kubeEdge Version>/build/crds/devices/devices_v1alpha1_device.yaml
+     kubectl create -f https://raw.githubusercontent.com/kubeedge/kubeedge/<kubeEdge Version>/build/crds/devices/devices_v1alpha1_devicemodel.yaml
+    ```
+
+  Also, create ClusterObjectSync and ObjectSync CRDs which are used in reliable message delivery.
+
+    ```shell
+     cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/reliablesyncs
+     kubectl create -f cluster_objectsync_v1alpha1.yaml
+     kubectl create -f objectsync_v1alpha1.yaml
+    ```

--- a/docs/setup/kubeedge_install_keadm.md
+++ b/docs/setup/kubeedge_install_keadm.md
@@ -192,8 +192,7 @@ Flags:
 
 ## Errata
 
-1. If GPG key for docker repo fail to fetch from key server.
-Please refer [Docker GPG error fix](<https://forums.docker.com/t/gpg-key-for-docker-repo-fail-to-fetch-from-key-server/24253>)
+1. If GPG key for docker repo fail to fetch from key server. Please refer [Docker GPG error fix](<https://forums.docker.com/t/gpg-key-for-docker-repo-fail-to-fetch-from-key-server/24253>)
 
 2. After kubeadm init, if you face any errors regarding swap memory and preflight checks please refer  [Kubernetes preflight error fix](<https://github.com/kubernetes/kubeadm/issues/610>)
 

--- a/docs/setup/kubeedge_install_keadm.md
+++ b/docs/setup/kubeedge_install_keadm.md
@@ -1,0 +1,220 @@
+# Setup from KubeEdge Installer
+
+Please refer to KubeEdge Installer proposal document for details on the motivation of having KubeEdge Installer.
+It also explains the functionality of the proposed commands.
+[KubeEdge Installer Doc](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/keadm-scope.md/)
+
+## Limitation
+
+- Currently support of `KubeEdge installer` is available only for Ubuntu OS. CentOS support is in-progress.
+
+## Getting KubeEdge Installer
+
+There are currently two ways to get keadm
+
++ Download from [KubeEdge Release](<https://github.com/kubeedge/kubeedge/releases>)
+
+  1. Go to [KubeEdge Release](<https://github.com/kubeedge/kubeedge/releases>) page and download `keadm-$VERSION-$OS-$ARCH.tar.gz.`.
+  2. Untar it at desired location, by executing `tar -xvzf keadm-$VERSION-$OS-$ARCH.tar.gz`.
+  3. kubeedge folder is created after execution the command.
+
++ Building from source
+
+  1. Download the source code
+
+  ```
+    git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/keadm
+    make
+  ```
+  2. Binary `keadm` is available in current path
+
+
+## Setup Cloud Side (KubeEdge Master Node)
+
+Referring to `KubeEdge Installer Doc`, the command to install KubeEdge cloud component (edge controller) and pre-requisites.
+Port 8080, 6443 and 10000 in your cloud component needs to be accessible for your edge nodes.
+
+keadm by default can install Docker, Kubernetes and KubeEdge. It also provide flag by which specific versions can be set.
+
+1. Execute `keadm init`
+
+    Command flags
+    The optional flags with this command are mentioned below
+
+    ```
+    $ keadm init --help
+
+    keadm init command bootstraps KubeEdge's cloud component. It checks if the pre-requisites are installed already, If not installed, this command will help in download, install and execute on the host.
+
+    Usage:
+      keadm init [flags]
+
+    Examples:
+
+    keadm init
+
+    Flags:
+        -h, --help                                       help for init
+        --docker-version string[="18.06.0"]          Use this key to download and use the required Docker version (default "18.06.0")
+        --kubeedge-version string[="0.3.0-beta.0"]   Use this key to download and use the required KubeEdge version (default "0.3.0-beta.0")
+        --kubernetes-version string[="1.14.1"]       Use this key to download and use the required Kubernetes version (default "1.14.1"). It will install `kubeadm`, `kubectl` and `kubelet` in this host.
+        --pod-network-cidr string[="100.64.0.0/10"]   Use this key to set the Kubernetes pod Network cidr  (default "100.64.0.0/10")
+        --kube-config string                          Use this key to set kube-config path, eg: $HOME/.kube/config
+    ```
+
+    Command format is
+
+    ```
+    keadm init --docker-version=<expected version> --kubernetes-version=<expected version>  --kubeedge-version=<expected version>
+    ```
+
+  **NOTE:**
+  Version mentioned as defaults for Docker and K8S are being tested with.
+
+  **NOTE:**
+On the console output, observe the below line
+
+```
+kubeadm join **192.168.20.134**:6443 --token 2lze16.l06eeqzgdz8sfcvh \
+         --discovery-token-ca-cert-hash sha256:1e5c808e1022937474ba264bb54fea42b05eddb9fde2d35c9cad5b83cf5ef9ac  
+```
+
+After Kubeedge init ,please note the **cloudIP** as highlighted above generated from console output and port is **8080**.
+
+
+## Setup Edge Side (KubeEdge Worker Node)
+
+Referring to `KubeEdge Installer Doc`, the command to install KubeEdge Edge component (edge core) and pre-requisites
+
+Execute `keadm join <flags>`
+
+ Command flags
+
+  The optional flags with this command are shown in below shell
+
+  ```
+  $ keadm join --help
+ 
+  "keadm join" command bootstraps KubeEdge's edge component. It checks if the pre-requisites are installed already, If not installed, this command will help in download, to install the prerequisites. It will help the edge node to connect to the cloud.
+  
+  Usage:
+  keadm join [flags]
+
+  Flags:
+      --docker-version string[="18.06.0"]          Use this key to download and use the required Docker version (default "18.06.0")
+  -e, --cloudcoreip string                         IP address of KubeEdge cloudcore
+  -i, --edgenodeid string                          KubeEdge Node unique identification string, If flag not used then the command will generate a unique id on its own
+  -h, --help                                       help for join
+  -k, --k8sserverip string                         IP:Port address of K8S API-Server
+      --kubeedge-version string[="0.3.0-beta.0"]   Use this key to download and use the required KubeEdge version (default "0.3.0-beta.0")
+
+For this command --cloudcoreip flag is a Mandatory flag
+  ```
+
+ Examples:
+
+  ```
+    keadm join --cloudcoreip=<ip address> --edgenodeid=<unique string as edge identifier>
+  ```
+
+ ```
+  keadm join --cloudcoreip=10.20.30.40 --edgenodeid=testing123 --kubeedge-version=0.2.1 --k8sserverip=50.60.70.80:8080
+ ```
+
+ In case, any option is used in a format like as shown for "--docker-version" or "--docker-version=", without a value then default values will be used. Also options like "--docker-version", and "--kubeedge-version", version should be in format like "18.06.3" and "0.2.1".
+
+
+**IMPORTANT NOTE:** The KubeEdge version used in cloud and edge side should be same.
+
+Sample execution output:
+```
+# ./keadm join --cloudcoreip=192.168.20.50 --edgenodeid=testing123 --k8sserverip=192.168.20.50:8080
+Same version of docker already installed in this host
+Host has mosquit+ already installed and running. Hence skipping the installation steps !!!
+Expected or Default KubeEdge version 0.3.0-beta.0 is already downloaded
+kubeedge/
+kubeedge/edge/
+kubeedge/edge/conf/
+kubeedge/edge/conf/modules.yaml
+kubeedge/edge/conf/logging.yaml
+kubeedge/edge/conf/edge.yaml
+kubeedge/edge/edgecore
+kubeedge/cloud/
+kubeedge/cloud/cloudcore
+kubeedge/cloud/conf/
+kubeedge/cloud/conf/controller.yaml
+kubeedge/cloud/conf/modules.yaml
+kubeedge/cloud/conf/logging.yaml
+kubeedge/version
+
+KubeEdge Edge Node: testing123 successfully add to kube-apiserver, with operation status: 201 Created
+Content {"kind":"Node","apiVersion":"v1","metadata":{"name":"testing123","selfLink":"/api/v1/nodes/testing123","uid":"87d8d7a3-7acd-11e9-b86b-286ed488c645","resourceVersion":"3864","creationTimestamp":"2019-05-20T07:04:37Z","labels":{"name":"edge-node"}},"spec":{"taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}
+
+KubeEdge edge core is running, For logs visit /etc/kubeedge/kubeedge/edge/
+```
+
+**Note**:Cloud IP refers to IP generated ,from the step 1 as highlighted
+
+
+## Reset KubeEdge Master and Worker nodes
+
+Referring to `KubeEdge Installer Doc`, the command to stop KubeEdge cloud (edge controller). It doesn't uninstall/remove any of the pre-requisites.
+
+Execute `keadm reset`
+
+Command flags
+
+```
+keadm reset --help
+
+keadm reset command can be executed in both cloud and edge node
+In master node it shuts down the cloud processes of KubeEdge
+In worker node it shuts down the edge processes of KubeEdge
+
+Usage:
+  keadm reset [flags]
+
+Examples:
+
+For master node:
+keadm reset
+
+For worker node:
+keadm reset --k8sserverip 10.20.30.40:8080
+
+
+Flags:
+  -h, --help                 help for reset
+  -k, --k8sserverip string   IP:Port address of cloud components host/VM
+
+```
+
+## Errata
+
+1. If GPG key for docker repo fail to fetch from key server.
+Please refer [Docker GPG error fix](<https://forums.docker.com/t/gpg-key-for-docker-repo-fail-to-fetch-from-key-server/24253>)
+
+2. After kubeadm init, if you face any errors regarding swap memory and preflight checks please refer  [Kubernetes preflight error fix](<https://github.com/kubernetes/kubeadm/issues/610>)
+
+3. Error in CloudCore
+
+    If you are getting the below error in Cloudcore.log
+
+    ```
+    E1231 04:37:27.397431   19607 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager/device.go:40: Failed to list *v1alpha1.Device: the server could not find the requested resource (get devices.devices.kubeedge.io)
+    E1231 04:37:27.398273   19607 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager/devicemodel.go:40: Failed to list *v1alpha1.DeviceModel: the server could not find the requested resource (get devicemodels.devices.kubeedge.io)
+    ```
+ 
+    browse to the 
+
+    ```
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
+    ```
+
+    and apply the below
+
+    ```
+      kubectl create -f devices_v1alpha1_devicemodel.yaml
+      kubectl create -f devices_v1alpha1_device.yaml
+    ```

--- a/docs/setup/kubeedge_install_keadm.md
+++ b/docs/setup/kubeedge_install_keadm.md
@@ -20,14 +20,14 @@ There are currently two ways to get keadm
 
 + Building from source
 
-  1. Download the source code
-
-  ```
-    git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
-    cd $GOPATH/src/github.com/kubeedge/kubeedge/keadm
-    make
-  ```
-  2. Binary `keadm` is available in current path
+  1. Download the source code.
+  
+      ```
+      git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/ kubeedge/kubeedge
+      cd $GOPATH/src/github.com/kubeedge/kubeedge/keadm
+      make
+      ```
+  2. Binary `keadm` is available in current path.
 
 
 ## Setup Cloud Side (KubeEdge Master Node)
@@ -43,7 +43,7 @@ keadm by default can install Docker, Kubernetes and KubeEdge. It also provide fl
     The optional flags with this command are mentioned below
 
     ```
-    $ keadm init --help
+    keadm init --help
 
     keadm init command bootstraps KubeEdge's cloud component. It checks if the pre-requisites are installed already, If not installed, this command will help in download, install and execute on the host.
 
@@ -128,7 +128,7 @@ For this command --cloudcoreip flag is a Mandatory flag
 **IMPORTANT NOTE:** The KubeEdge version used in cloud and edge side should be same.
 
 Sample execution output:
-```
+```shell
 # ./keadm join --cloudcoreip=192.168.20.50 --edgenodeid=testing123 --k8sserverip=192.168.20.50:8080
 Same version of docker already installed in this host
 Host has mosquit+ already installed and running. Hence skipping the installation steps !!!
@@ -208,13 +208,13 @@ Please refer [Docker GPG error fix](<https://forums.docker.com/t/gpg-key-for-doc
  
     browse to the 
 
-    ```
+    ```shell
     cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
     ```
 
     and apply the below
 
-    ```
+    ```shell
       kubectl create -f devices_v1alpha1_devicemodel.yaml
       kubectl create -f devices_v1alpha1_device.yaml
     ```

--- a/docs/setup/kubeedge_install_keadm.md
+++ b/docs/setup/kubeedge_install_keadm.md
@@ -12,23 +12,29 @@ It also explains the functionality of the proposed commands.
 
 There are currently two ways to get keadm
 
-+ Download from [KubeEdge Release](<https://github.com/kubeedge/kubeedge/releases>)
+- Download from [KubeEdge Release](<https://github.com/kubeedge/kubeedge/releases>)
 
   1. Go to [KubeEdge Release](<https://github.com/kubeedge/kubeedge/releases>) page and download `keadm-$VERSION-$OS-$ARCH.tar.gz.`.
   2. Untar it at desired location, by executing `tar -xvzf keadm-$VERSION-$OS-$ARCH.tar.gz`.
   3. kubeedge folder is created after execution the command.
 
-+ Building from source
+- Building from source
 
   1. Download the source code.
   
-      ```
+      ```shell
       git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/ kubeedge/kubeedge
       cd $GOPATH/src/github.com/kubeedge/kubeedge/keadm
       make
       ```
-  2. Binary `keadm` is available in current path.
 
+      or
+
+      ```shell
+      go get github.com/kubeedge/kubeedge/keadm/cmd/keadm
+      ```
+
+  2. Binary `keadm` is available in current path. If you are using `go` get the binary is available in `$GOPATH/bin/`
 
 ## Setup Cloud Side (KubeEdge Master Node)
 
@@ -37,15 +43,15 @@ Port 8080, 6443 and 10000 in your cloud component needs to be accessible for you
 
 keadm by default can install Docker, Kubernetes and KubeEdge. It also provide flag by which specific versions can be set.
 
-1. Execute `keadm init`
+1. Execute `keadm init` : keadm needs super user rights (or root rights) to run successfully.
 
     Command flags
     The optional flags with this command are mentioned below
 
-    ```
+    ```shell
     keadm init --help
 
-    keadm init command bootstraps KubeEdge's cloud component. It checks if the pre-requisites are installed already, If not installed, this command will help in download, install and execute on the host.
+    keadm init command bootstraps KubeEdge cloud component. It checks if the pre-requisites are installed already, If not installed, this command will help in download, install and execute on the host.
 
     Usage:
       keadm init [flags]
@@ -65,7 +71,7 @@ keadm by default can install Docker, Kubernetes and KubeEdge. It also provide fl
 
     Command format is
 
-    ```
+    ```shell
     keadm init --docker-version=<expected version> --kubernetes-version=<expected version>  --kubeedge-version=<expected version>
     ```
 
@@ -75,13 +81,12 @@ keadm by default can install Docker, Kubernetes and KubeEdge. It also provide fl
   **NOTE:**
 On the console output, observe the below line
 
-```
+```shell
 kubeadm join **192.168.20.134**:6443 --token 2lze16.l06eeqzgdz8sfcvh \
          --discovery-token-ca-cert-hash sha256:1e5c808e1022937474ba264bb54fea42b05eddb9fde2d35c9cad5b83cf5ef9ac  
 ```
 
-After Kubeedge init ,please note the **cloudIP** as highlighted above generated from console output and port is **8080**.
-
+After Kubeedge init, please note the **cloudIP** as highlighted above generated from console output and port is **8080**.
 
 ## Setup Edge Side (KubeEdge Worker Node)
 
@@ -93,9 +98,9 @@ Execute `keadm join <flags>`
 
   The optional flags with this command are shown in below shell
 
-  ```
+  ```shell
   $ keadm join --help
- 
+
   "keadm join" command bootstraps KubeEdge's edge component. It checks if the pre-requisites are installed already, If not installed, this command will help in download, to install the prerequisites. It will help the edge node to connect to the cloud.
   
   Usage:
@@ -114,20 +119,20 @@ For this command --cloudcoreip flag is a Mandatory flag
 
  Examples:
 
-  ```
+  ```shell
     keadm join --cloudcoreip=<ip address> --edgenodeid=<unique string as edge identifier>
   ```
 
- ```
-  keadm join --cloudcoreip=10.20.30.40 --edgenodeid=testing123 --kubeedge-version=0.2.1 --k8sserverip=50.60.70.80:8080
+ ```shell
+  keadm join --cloudcoreip=10.20.30.40 --edgenodeid=testing123 --kubeedge-version=1.1.1 --k8sserverip=50.60.70.80:8080
  ```
 
  In case, any option is used in a format like as shown for "--docker-version" or "--docker-version=", without a value then default values will be used. Also options like "--docker-version", and "--kubeedge-version", version should be in format like "18.06.3" and "0.2.1".
 
-
 **IMPORTANT NOTE:** The KubeEdge version used in cloud and edge side should be same.
 
 Sample execution output:
+
 ```shell
 # ./keadm join --cloudcoreip=192.168.20.50 --edgenodeid=testing123 --k8sserverip=192.168.20.50:8080
 Same version of docker already installed in this host
@@ -156,7 +161,6 @@ KubeEdge edge core is running, For logs visit /etc/kubeedge/kubeedge/edge/
 
 **Note**:Cloud IP refers to IP generated ,from the step 1 as highlighted
 
-
 ## Reset KubeEdge Master and Worker nodes
 
 Referring to `KubeEdge Installer Doc`, the command to stop KubeEdge cloud (edge controller). It doesn't uninstall/remove any of the pre-requisites.
@@ -165,7 +169,7 @@ Execute `keadm reset`
 
 Command flags
 
-```
+```shell
 keadm reset --help
 
 keadm reset command can be executed in both cloud and edge node
@@ -200,12 +204,12 @@ Flags:
 
     If you are getting the below error in Cloudcore.log
 
-    ```
+    ```shell
     E1231 04:37:27.397431   19607 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager/device.go:40: Failed to list *v1alpha1.Device: the server could not find the requested resource (get devices.devices.kubeedge.io)
     E1231 04:37:27.398273   19607 reflector.go:125] github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager/devicemodel.go:40: Failed to list *v1alpha1.DeviceModel: the server could not find the requested resource (get devicemodels.devices.kubeedge.io)
     ```
- 
-    browse to the 
+
+    browse to the
 
     ```shell
     cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
@@ -217,3 +221,10 @@ Flags:
       kubectl create -f devices_v1alpha1_devicemodel.yaml
       kubectl create -f devices_v1alpha1_device.yaml
     ```
+
+    or
+
+  ```shell
+  kubectl create -f https://raw.githubusercontent.com/kubeedge/kubeedge/<kubeEdge Version>/build/crds/devices/devices_v1alpha1_device.yaml
+  kubectl create -f https://raw.githubusercontent.com/kubeedge/kubeedge/<kubeEdge Version>/build/crds/devices/devices_v1alpha1_devicemodel.yaml
+```

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -2,7 +2,7 @@
 
 This guide provide steps which can be utilised to install KubeEdge Cloud and Edge side. At this point, we assume that you would have installed the [Pre-Requisite](kubeedge_install.md#prerequisite) for Cloud and Edge.
 
-## Setup Cloud Side (KubeEdge Master Node)
+## Setup Cloud Side (KubeEdge Master)
 
 1. Clone KubeEdge
 
@@ -25,14 +25,13 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
 
 3. Compile Cloudcore
 
-
-   + Firstly, make sure `gcc` is already installed on your host. You can verify it via:
+   + Make sure a C compiler is installed on your host. The installation is tested with `gcc` and `clang`.
 
      ```shell
      gcc --version
      ```
 
-   + Build cloudcore 
+   + Build cloudcore
 
      ```shell
      cd $GOPATH/src/github.com/kubeedge/kubeedge/
@@ -41,11 +40,11 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
 
     **Note:** If you don't want to compile, you may perform the below step
 
-    + Download KubeEdge (latest or stable version) from [Releases](https://github.com/kubeedge/kubeedge/releases)   
-    
-      Download `kubeedge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Cloudcore and the configuration files.
+    + Download KubeEdge (latest or stable version) from [Releases](https://github.com/kubeedge/kubeedge/releases)
 
-4. Create device model and device CRDs.
+      Download `kubeedge-$VERSION-$OS-$ARCH.tar.gz` from above link. It contains Cloudcore and the configuration files.
+
+4. Create DeviceModel and Device CRDs.
 
     ```shell
     cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
@@ -53,7 +52,16 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
     kubectl create -f devices_v1alpha1_devicemodel.yaml
     kubectl create -f devices_v1alpha1_device.yaml
     ```
-5. Copy cloudcore binary/ Setup as a systemctl
+
+5. Create ClusterObjectSync and ObjectSync CRDs which used in reliable message delivery.
+
+    ```shell
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/reliablesyncs
+    kubectl create -f cluster_objectsync_v1alpha1.yaml
+    kubectl create -f objectsync_v1alpha1.yaml
+    ```
+
+6. Copy cloudcore binary/ Setup as a systemctl
 
     At this point, cloudcore can be copied to a new directory or can be setup as a systemctl service. Edit the configuration files to setup how cloudcore would run.
 
@@ -63,11 +71,11 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
 
         ```shell
         sudo ln build/tools/cloudcore.service /etc/systemd/system/cloudcore.service
-        
+
         sudo systemctl daemon-reload
         sudo systemctl start cloudcore
         ```
-    
+
         **Note:** Please fix __ExecStart__ path in cloudcore.service. Do __NOT__ use relative path, use absoulte path instead.
 
         If you also want also an autostart, you have to execute this, too:
@@ -76,7 +84,7 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
         sudo systemctl enable cloudcore
         ```
 
-   + Copy cloudcore binary and config file 
+   + Copy cloudcore binary and config file
 
      ```shell
      cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud
@@ -87,7 +95,7 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
      cp cloudcore ~/cmd/
      cp -rf conf/* ~/cmd/conf/
      ```
-    
+
         **Note:**  `~/cmd/` dir is an example, in the following examples we continue to  use `~/cmd/` as the binary startup directory. You can move `cloudcore` or  `edgecore` binary to anywhere, but you need to create `conf` dir in the same  directory as binary.
 
 + (**Optional**) Run `admission`, this feature is still being evaluated.
@@ -133,21 +141,22 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
 
     **Note:** If you don't want to compile, you may perform the next step
 
-    + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)   
-    
+    + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)
+
         Download `kubeedge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Edgecore and the configuration files.
 
 3. Copy edgecore binary/ Setup as a systemctl
 
- + Run edgecore with systemd
++ Run edgecore with systemd
 
-    It is also possible to start the edgecore with systemd. If you want, you could use the example systemd-unit-file. 
+    It is also possible to start the edgecore with systemd. If you want, you could use the example systemd-unit-file.
 
     ```shell
     sudo ln build/tools/edgecore.service /etc/systemd/system/edgecore.service
     sudo systemctl daemon-reload
     sudo systemctl start edgecore
     ```
+
     **Note:** Please fix __ExecStart__ path in edgecore.service. Do __NOT__ use relative path, use absoulte path instead.
 
     If you also want also an autostart, you have to execute this, too:
@@ -156,10 +165,9 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
     sudo systemctl enable edgecore
     ```
 
- + Copy edgecore file and sample config in a new directory
++ Copy edgecore file and sample config in a new directory
 
-    ```
+    ```shell
     cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/
     cd ~/cmd
     ```
-

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -53,7 +53,7 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
     kubectl create -f devices_v1alpha1_device.yaml
     ```
 
-5. Create ClusterObjectSync and ObjectSync CRDs which used in reliable message delivery.
+5. Create ClusterObjectSync and ObjectSync CRDs which are used in reliable message delivery.
 
     ```shell
     cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/reliablesyncs

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -43,7 +43,7 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
 
     + Download KubeEdge (latest or stable version) from [Releases](https://github.com/kubeedge/kubeedge/releases)   
     
-      Download `KubeEdge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Cloudcore and the configuration files.
+      Download `kubeedge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Cloudcore and the configuration files.
 
 4. Create device model and device CRDs.
 
@@ -135,7 +135,7 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
 
     + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)   
     
-        Download `KubeEdge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Edgecore and the configuration files.
+        Download `kubeedge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Edgecore and the configuration files.
 
 3. Copy edgecore binary/ Setup as a systemctl
 

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -1,12 +1,12 @@
 # Setup from Source Code
 
-This guide would provide steps which can be utilised to install KubeEdge Cloud and Edge side. At this point, we assume that you would have installed the Pre-Requisites for Cloud and Edge.
+This guide provide steps which can be utilised to install KubeEdge Cloud and Edge side. At this point, we assume that you would have installed the [Pre-Requisite](kubeedge_install.md#prerequisite) for Cloud and Edge.
 
 ## Setup Cloud Side (KubeEdge Master Node)
 
 1. Clone KubeEdge
 
-    + Before this it might be a good idea to setup [$GOPATH ](https://github.com/golang/go/wiki/SettingGOPATH)
+    + Setup [$GOPATH ](https://github.com/golang/go/wiki/SettingGOPATH) to clone the KubeEdge repository in the `$GOPATH`.
 
         ```shell
         git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
@@ -15,18 +15,18 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
 
 2. Generate Certificates
 
-   RootCA certificate and a cert/key pair is required to have a setup for KubeEdge. Same cert/key pair can be used in both cloud and edge.
+   RootCA certificate and a cert/ key pair is required to have a setup for KubeEdge. Same cert/ key pair can be used in both cloud and edge.
 
     ```bash
     $GOPATH/src/github.com/kubeedge/kubeedge/build/tools/certgen.sh genCertAndKey edge
     ```
 
-    The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/certs` respectively, so this command should be run with root or users who have access to those directories. We need to copy these files to the corresponding edge side server directory.
+    The cert/ key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/certs` respectively, so this command should be run with root or users who have access to those directories. Copy these files to the corresponding edge side server directory.
 
 3. Compile Cloudcore
 
 
-   + Firstly, make sure gcc is already installed on your host. You can verify it via:
+   + Firstly, make sure `gcc` is already installed on your host. You can verify it via:
 
      ```shell
      gcc --version
@@ -41,7 +41,7 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
 
     **Note:** If you don't want to compile, you may perform the below step
 
-    + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)   
+    + Download KubeEdge (latest or stable version) from [Releases](https://github.com/kubeedge/kubeedge/releases)   
     
       Download `KubeEdge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Cloudcore and the configuration files.
 
@@ -49,12 +49,13 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
 
     ```shell
     cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
+
     kubectl create -f devices_v1alpha1_devicemodel.yaml
     kubectl create -f devices_v1alpha1_device.yaml
     ```
 5. Copy cloudcore binary/ Setup as a systemctl
 
-    At this point, cloudcore can be copied to a new directory or can be setup as a systemctl service. We also need to edit the configuration files to setup how cloudcore would run.
+    At this point, cloudcore can be copied to a new directory or can be setup as a systemctl service. Edit the configuration files to setup how cloudcore would run.
 
    + Run cloudcore with systemd
 
@@ -62,6 +63,7 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
 
         ```shell
         sudo ln build/tools/cloudcore.service /etc/systemd/system/cloudcore.service
+        
         sudo systemctl daemon-reload
         sudo systemctl start cloudcore
         ```
@@ -95,7 +97,7 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
 
 1. Clone KubeEdge
 
-    + Before this it might be a good idea to setup [$GOPATH ](https://github.com/golang/go/wiki/SettingGOPATH)
+    + Setup [$GOPATH ](https://github.com/golang/go/wiki/SettingGOPATH) to clone the KubeEdge repository in the `$GOPATH`.
 
         ```shell
         git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
@@ -133,7 +135,7 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
 
     + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)   
     
-        Download KubeEdge-version-linux-$platform.tar.gz from above link. It would contain Edgecore and the configuration files.
+        Download `KubeEdge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Edgecore and the configuration files.
 
 3. Copy edgecore binary/ Setup as a systemctl
 

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -1,0 +1,163 @@
+# Setup from Source Code
+
+This guide would provide steps which can be utilised to install KubeEdge Cloud and Edge side. At this point, we assume that you would have installed the Pre-Requisites for Cloud and Edge.
+
+## Setup Cloud Side (KubeEdge Master Node)
+
+1. Clone KubeEdge
+
+    + Before this it might be a good idea to setup [$GOPATH ](https://github.com/golang/go/wiki/SettingGOPATH)
+
+        ```shell
+        git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
+        cd $GOPATH/src/github.com/kubeedge/kubeedge
+        ```
+
+2. Generate Certificates
+
+   RootCA certificate and a cert/key pair is required to have a setup for KubeEdge. Same cert/key pair can be used in both cloud and edge.
+
+    ```bash
+    $GOPATH/src/github.com/kubeedge/kubeedge/build/tools/certgen.sh genCertAndKey edge
+    ```
+
+    The cert/key will be generated in the `/etc/kubeedge/ca` and `/etc/kubeedge/certs` respectively, so this command should be run with root or users who have access to those directories. We need to copy these files to the corresponding edge side server directory.
+
+3. Compile Cloudcore
+
+
+   + Firstly, make sure gcc is already installed on your host. You can verify it via:
+
+     ```shell
+        gcc --version
+        ```
+
+   + Build cloudcore 
+
+        ```shell
+        cd $GOPATH/src/github.com/kubeedge/kubeedge/
+        make all WHAT=cloudcore
+        ```
+
+    **Note:** If you don't want to compile, you may perform the below step
+
+    + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)   
+    
+        Download KubeEdge-$VERSION-$OS-$ARCH.tar.gz. from above link. It would contain Cloudcore and the configuration files.
+
+4. Create device model and device CRDs.
+
+    ```shell
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/build/crds/devices
+    kubectl create -f devices_v1alpha1_devicemodel.yaml
+    kubectl create -f devices_v1alpha1_device.yaml
+    ```
+5. Copy cloudcore binary/ Setup as a systemctl
+
+    At this point, cloudcore can be copied to a new directory or can be setup as a systemctl service. We also need to edit the configuration files to setup how cloudcore would run.
+
+   + Run cloudcore with systemd
+
+        It is also possible to start the cloudcore with systemd. If you want, you could use the example systemd-unit-file. The following command will show you how to setup this:
+
+        ```shell
+        sudo ln build/tools/cloudcore.service /etc/systemd/system/cloudcore.service
+        sudo systemctl daemon-reload
+        sudo systemctl start cloudcore
+        ```
+    
+        **Note:** Please fix __ExecStart__ path in cloudcore.service. Do __NOT__ use relative path, use absoulte path instead.
+
+        If you also want also an autostart, you have to execute this, too:
+
+        ```shell
+        sudo systemctl enable cloudcore
+        ```
+
+   + Copy cloudcore binary and config file 
+
+        ```shell
+        cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud
+        # run cloudcore controller
+        # `conf/` should be in the same directory as the cloned KubeEdge repository
+        # verify the configurations before running cloud(cloudcore)
+        mkdir -p ~/cmd/conf
+        cp cloudcore ~/cmd/
+        cp -rf conf/* ~/cmd/conf/
+        ```
+    
+        **Note** `~/cmd/` dir is an example, in the following examples we continue to use `~/cmd/` as the binary startup directory. You can move `cloudcore` or `edgecore` binary to anywhere, but you need to create `conf` dir in the same directory as binary.
+
++ (**Optional**) Run `admission`, this feature is still being evaluated.
+    please read the docs in [install the admission webhook](../../build/admission/README.md)
+
+## Setup Edge Node (KubeEdge Worker Node)
+
+1. Clone KubeEdge
+
+    + Before this it might be a good idea to setup [$GOPATH ](https://github.com/golang/go/wiki/SettingGOPATH)
+
+        ```shell
+        git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
+        cd $GOPATH/src/github.com/kubeedge/kubeedge
+        ```
+
+2. Compile Edgecore
+
+    ```shell
+    cd $GOPATH/src/github.com/kubeedge/kubeedge
+    make all WHAT=edgecore
+    ```
+
+    KubeEdge can also be cross compiled to run on ARM based processors.
+    Please follow the instructions given below or click [Cross Compilation](cross-compilation.md) for detailed instructions.
+
+    ```shell
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
+    make cross_build
+    ```
+
+    KubeEdge can also be compiled with a small binary size. Please follow the below steps to build a binary of lesser size:
+
+    ```shell
+    apt-get install upx-ucl
+    cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
+    make edge_small_build
+    ```
+
+    **Note:** If you are using the smaller version of the binary, it is compressed using upx, therefore the possible side effects of using upx compressed binaries like more RAM usage,
+    lower performance, whole code of program being loaded instead of it being on-demand, not allowing sharing of memory which may cause the code to be loaded to memory
+    more than once etc. are applicable here as well.
+
+    **Note:** If you don't want to compile, you may perform the next step
+
+    + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)   
+    
+        Download KubeEdge-version-linux-$platform.tar.gz from above link. It would contain Edgecore and the configuration files.
+
+3. Copy edgecore binary/ Setup as a systemctl
+
+ + Run edgecore with systemd
+
+    It is also possible to start the edgecore with systemd. If you want, you could use the example systemd-unit-file. 
+
+    ```shell
+    sudo ln build/tools/edgecore.service /etc/systemd/system/edgecore.service
+    sudo systemctl daemon-reload
+    sudo systemctl start edgecore
+    ```
+    **Note:** Please fix __ExecStart__ path in edgecore.service. Do __NOT__ use relative path, use absoulte path instead.
+
+    If you also want also an autostart, you have to execute this, too:
+
+    ```shell
+    sudo systemctl enable edgecore
+    ```
+
+ + Copy edgecore file and sample config in a new directory
+
+    ```
+    cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/
+    cd ~/cmd
+    ```
+

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -89,14 +89,12 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
      ```shell
      cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud
      # run cloudcore controller
-     # `conf/` should be in the same directory as the cloned KubeEdge repository
      # verify the configurations before running cloud(cloudcore)
-     mkdir -p ~/cmd/conf
+     mkdir ~/cmd/
      cp cloudcore ~/cmd/
-     cp -rf conf/* ~/cmd/conf/
      ```
 
-        **Note:**  `~/cmd/` dir is an example, in the following examples we continue to  use `~/cmd/` as the binary startup directory. You can move `cloudcore` or  `edgecore` binary to anywhere, but you need to create `conf` dir in the same  directory as binary.
+        **Note:**  `~/cmd/` dir is an example, in the following examples we continue to  use `~/cmd/` as the binary startup directory. You can move `cloudcore` or  `edgecore` binary to anywhere.
 
 + (**Optional**) Run `admission`, this feature is still being evaluated.
     please read the docs in [install the admission webhook](../../build/admission/README.md)
@@ -109,7 +107,6 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
 
         ```shell
         git clone https://github.com/kubeedge/kubeedge.git $GOPATH/src/github.com/kubeedge/kubeedge
-        cd $GOPATH/src/github.com/kubeedge/kubeedge
         ```
 
 2. Compile Edgecore
@@ -165,7 +162,7 @@ This guide provide steps which can be utilised to install KubeEdge Cloud and Edg
     sudo systemctl enable edgecore
     ```
 
-+ Copy edgecore file and sample config in a new directory
++ Copy edgecore file in a new directory
 
     ```shell
     cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -29,21 +29,21 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
    + Firstly, make sure gcc is already installed on your host. You can verify it via:
 
      ```shell
-        gcc --version
-        ```
+     gcc --version
+     ```
 
    + Build cloudcore 
 
-        ```shell
-        cd $GOPATH/src/github.com/kubeedge/kubeedge/
-        make all WHAT=cloudcore
-        ```
+     ```shell
+     cd $GOPATH/src/github.com/kubeedge/kubeedge/
+     make all WHAT=cloudcore
+     ```
 
     **Note:** If you don't want to compile, you may perform the below step
 
     + Download KubeEdge from [Releases](https://github.com/kubeedge/kubeedge/releases)   
     
-        Download KubeEdge-$VERSION-$OS-$ARCH.tar.gz. from above link. It would contain Cloudcore and the configuration files.
+      Download `KubeEdge-$VERSION-$OS-$ARCH.tar.gz` from above link. It would contain Cloudcore and the configuration files.
 
 4. Create device model and device CRDs.
 
@@ -76,17 +76,17 @@ This guide would provide steps which can be utilised to install KubeEdge Cloud a
 
    + Copy cloudcore binary and config file 
 
-        ```shell
-        cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud
-        # run cloudcore controller
-        # `conf/` should be in the same directory as the cloned KubeEdge repository
-        # verify the configurations before running cloud(cloudcore)
-        mkdir -p ~/cmd/conf
-        cp cloudcore ~/cmd/
-        cp -rf conf/* ~/cmd/conf/
-        ```
+     ```shell
+     cd $GOPATH/src/github.com/kubeedge/kubeedge/cloud
+     # run cloudcore controller
+     # `conf/` should be in the same directory as the cloned KubeEdge repository
+     # verify the configurations before running cloud(cloudcore)
+     mkdir -p ~/cmd/conf
+     cp cloudcore ~/cmd/
+     cp -rf conf/* ~/cmd/conf/
+     ```
     
-        **Note** `~/cmd/` dir is an example, in the following examples we continue to use `~/cmd/` as the binary startup directory. You can move `cloudcore` or `edgecore` binary to anywhere, but you need to create `conf` dir in the same directory as binary.
+        **Note:**  `~/cmd/` dir is an example, in the following examples we continue to  use `~/cmd/` as the binary startup directory. You can move `cloudcore` or  `edgecore` binary to anywhere, but you need to create `conf` dir in the same  directory as binary.
 
 + (**Optional**) Run `admission`, this feature is still being evaluated.
     please read the docs in [install the admission webhook](../../build/admission/README.md)

--- a/docs/setup/kubeedge_precheck.md
+++ b/docs/setup/kubeedge_precheck.md
@@ -13,7 +13,7 @@ NAME         STATUS     ROLES    AGE     VERSION
 testing123   Ready      <none>   6s      0.3.0-beta.0
 ```
 
-Please make sure the status of edge node you created is **ready**.
+Please make sure the `status` of edge node you created is **ready**.
 
 ## Deploy Application on cloud side
 
@@ -36,7 +36,8 @@ NAME                               READY   STATUS    RESTARTS   AGE
 nginx-deployment-d86dfb797-scfzz   1/1     Running   0          44s
 ```
 
-Check the deployment is up and is running state
+Check the deployment is up and is in `running` state
+
 ```
 kubectl get deployments
 

--- a/docs/setup/kubeedge_precheck.md
+++ b/docs/setup/kubeedge_precheck.md
@@ -14,10 +14,6 @@ or
 
 ```shell
 kubectl get nodes -l node-role.kubernetes.io/edge=
-
-
-NAME         STATUS     ROLES    AGE     VERSION
-testing123   Ready      none   6s      0.3.0-beta.0
 ```
 
 Please make sure the `status` of edge node you created is **ready**.

--- a/docs/setup/kubeedge_precheck.md
+++ b/docs/setup/kubeedge_precheck.md
@@ -6,11 +6,18 @@ After the Cloud and Edge parts have started, you can use below command to check 
 
 On cloud host run,
 
-```
+```shell
 kubectl get nodes
+````
+
+or
+
+```shell
+kubectl get nodes -l node-role.kubernetes.io/edge=
+
 
 NAME         STATUS     ROLES    AGE     VERSION
-testing123   Ready      <none>   6s      0.3.0-beta.0
+testing123   Ready      none   6s      0.3.0-beta.0
 ```
 
 Please make sure the `status` of edge node you created is **ready**.
@@ -30,7 +37,7 @@ Then you can use below command to check if the application is normally running.
 
 Check the pod is up and is `running` state
 
-```
+```shell
 kubectl get pods
 NAME                               READY   STATUS    RESTARTS   AGE
 nginx-deployment-d86dfb797-scfzz   1/1     Running   0          44s
@@ -38,7 +45,7 @@ nginx-deployment-d86dfb797-scfzz   1/1     Running   0          44s
 
 Check the deployment is up and is in `running` state
 
-```
+```shell
 kubectl get deployments
 
 NAME               READY   UP-TO-DATE   AVAILABLE   AGE
@@ -49,7 +56,7 @@ nginx-deployment   1/1     1            1           63s
 
 If the container runtime configured to manage containers is containerd , then the following commands can be used to inspect container status and list images.
 
-```
+```shell
 sudo ctr --namespace k8s.io containers ls
 sudo ctr --namespace k8s.io images ls
 sudo crictl exec -ti <containerid> /bin/bash

--- a/docs/setup/kubeedge_precheck.md
+++ b/docs/setup/kubeedge_precheck.md
@@ -1,0 +1,81 @@
+# KubeEdge Pre-Check
+
+## Status Check
+
+After the Cloud and Edge parts have started, you can use below command to check the edge node status.
+
+On cloud host run,
+
+```
+kubectl get nodes
+
+NAME         STATUS     ROLES    AGE     VERSION
+testing123   Ready      <none>   6s      0.3.0-beta.0
+```
+
+Please make sure the status of edge node you created is **ready**.
+
+## Deploy Application on cloud side
+
+Try out a sample application deployment by following below steps.
+
+```shell
+kubectl apply -f $GOPATH/src/github.com/kubeedge/kubeedge/build/deployment.yaml
+deployment.apps/nginx-deployment created
+```
+
+**Note:** Currently, for applications running on edge nodes, we don't support `kubectl logs` and `kubectl exec` commands(will support in future release), support pod to pod communication running on **edge nodes in same subnet** using edgemesh.
+
+Then you can use below command to check if the application is normally running.
+
+Check the pod is up and is running state
+
+```
+kubectl get pods
+NAME                               READY   STATUS    RESTARTS   AGE
+nginx-deployment-d86dfb797-scfzz   1/1     Running   0          44s
+```
+
+Check the deployment is up and is running state
+```
+kubectl get deployments
+
+NAME               READY   UP-TO-DATE   AVAILABLE   AGE
+nginx-deployment   1/1     1            1           63s
+```
+
+### Monitoring containers status
+
+If the container runtime configured to manage containers is containerd , then the following commands can be used to inspect container status and list images.
+
+```
+sudo ctr --namespace k8s.io containers ls
+sudo ctr --namespace k8s.io images ls
+sudo crictl exec -ti <containerid> /bin/bash
+```
+
+## Run Tests
+
+### Run Edge Unit Tests
+
+ ```shell
+ make edge_test
+ ```
+
+ To run unit tests of a package individually.
+
+ ```shell
+ export GOARCHAIUS_CONFIG_PATH=$GOPATH/src/github.com/kubeedge/kubeedge/edge
+ cd <path to package to be tested>
+ go test -v
+ ```
+
+### Run Edge Integration Tests
+
+```shell
+make edge_integration_test
+```
+
+### Details and use cases of integration test framework
+
+Please find the [link](https://github.com/kubeedge/kubeedge/tree/master/edge/test/integration) to use cases of intergration test framework for KubeEdge.

--- a/docs/setup/kubeedge_precheck.md
+++ b/docs/setup/kubeedge_precheck.md
@@ -28,7 +28,7 @@ deployment.apps/nginx-deployment created
 
 Then you can use below command to check if the application is normally running.
 
-Check the pod is up and is running state
+Check the pod is up and is `running` state
 
 ```
 kubectl get pods

--- a/docs/setup/kubeedge_precheck.md
+++ b/docs/setup/kubeedge_precheck.md
@@ -77,7 +77,7 @@ sudo crictl exec -ti <containerid> /bin/bash
 ### Run Edge Integration Tests
 
 ```shell
-make edge_integration_test
+make integrationtest
 ```
 
 ### Details and use cases of integration test framework

--- a/docs/setup/kubeedge_run.md
+++ b/docs/setup/kubeedge_run.md
@@ -1,0 +1,35 @@
+# Run KubeEdge
+
+## Cloudcore on Cloud side
+
+    If you have copied the cloudcore binary in a folder and the configuration (conf) are stored in the same folder 
+
+    ```
+    cd ~/folder/
+    nohup ./cloudcore &
+    ```
+
+    or 
+
+    If you have setup using the systemctl
+
+    ```
+    sudo systemctl start cloudcore
+    ```
+
+## Run Edgecore on Edge side
+
+    ```
+    cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/
+    cd ~/cmd
+    ./edgecore
+     or
+    nohup ./edgecore > edgecore.log 2>&1 &
+    ```
+
+    If you have setup using the systemctl
+    ```
+    sudo systemctl start edgecore
+    ```
+
+    **Note:** Please run edgecore using the users who have root permission.

--- a/docs/setup/kubeedge_run.md
+++ b/docs/setup/kubeedge_run.md
@@ -2,34 +2,38 @@
 
 ## Cloudcore on Cloud side
 
-    If you have copied the cloudcore binary in a folder and the configuration (conf) are stored in the same folder 
+If you have copied the cloudcore binary in a folder and the configuration (conf) are stored in the same folder
 
-    ```
-    cd ~/folder/
-    nohup ./cloudcore &
-    ```
+```shell
+ cd ~/folder/
+ nohup ./cloudcore &
+```
 
-    or 
+or
 
-    If you have setup using the systemctl
+If you have setup using the systemctl
 
-    ```
-    sudo systemctl start cloudcore
-    ```
+```shell
+ sudo systemctl start cloudcore
+```
 
 ## Run Edgecore on Edge side
 
-    ```
-    cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/
-    cd ~/cmd
-    ./edgecore
-     or
-    nohup ./edgecore > edgecore.log 2>&1 &
-    ```
+```shell
+ cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/
+ cd ~/cmd
+ ./edgecore
+ ```
+ or
 
-    If you have setup using the systemctl
-    ```
-    sudo systemctl start edgecore
-    ```
+ ```shell
+ nohup ./edgecore > edgecore.log 2>&1 &
+ ```
 
-    **Note:** Please run edgecore using the users who have root permission.
+ If you have setup using the systemctl
+
+```
+ sudo systemctl start edgecore
+```
+
+**Note:** Please run edgecore using the users who have root permission.

--- a/docs/setup/kubeedge_run.md
+++ b/docs/setup/kubeedge_run.md
@@ -24,6 +24,7 @@ If you have setup using the systemctl
  cd ~/cmd
  ./edgecore
  ```
+
  or
 
  ```shell
@@ -32,7 +33,7 @@ If you have setup using the systemctl
 
  If you have setup using the systemctl
 
-```
+```shell
  sudo systemctl start edgecore
 ```
 

--- a/docs/setup/kubeedge_run.md
+++ b/docs/setup/kubeedge_run.md
@@ -5,8 +5,8 @@
 If you have copied the cloudcore binary in a folder and the configuration (conf) are stored in the same folder
 
 ```shell
- cd ~/folder/
- nohup ./cloudcore &
+cd ~/folder/
+nohup ./cloudcore &
 ```
 
 or
@@ -14,27 +14,27 @@ or
 If you have setup using the systemctl
 
 ```shell
- sudo systemctl start cloudcore
+sudo systemctl start cloudcore
 ```
 
 ## Run Edgecore on Edge side
 
 ```shell
- cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/
- cd ~/cmd
- ./edgecore
+cp $GOPATH/src/github.com/kubeedge/kubeedge/edge/edgecore ~/cmd/
+cd ~/cmd
+./edgecore
  ```
 
  or
 
  ```shell
- nohup ./edgecore > edgecore.log 2>&1 &
+nohup ./edgecore > edgecore.log 2>&1 &
  ```
 
  If you have setup using the systemctl
 
 ```shell
- sudo systemctl start edgecore
+sudo systemctl start edgecore
 ```
 
 **Note:** Please run edgecore using the users who have root permission.

--- a/docs/setup/kubeedge_run.md
+++ b/docs/setup/kubeedge_run.md
@@ -1,5 +1,8 @@
 # Run KubeEdge
 
+**Note:** This step is only required if KubeEdge is installed using Source. If KubeEdge is installed using `keadm` ignore this step.
+***
+
 ## Cloudcore on Cloud side
 
 If you have copied the cloudcore binary in a folder and the configuration (conf) are stored in the same folder


### PR DESCRIPTION
**What type of PR is this?**
> /kind documentation

**What this PR does / why we need it**:

- Documentation has been structured into Installation/ Configuration/ Pre-Check/ Execution.
- Information from multiple files below was referred and gathered into a structured document.
 -- docs/setup/setup.md
 -- docs/setup/installer_setup.md
 -- docs/getting-started/release_package.md

**Special notes for your reviewer**:
Start by reviewing kubeedge_install.md

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
