### PR TITLE
edgecore exist when edged init error

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -239,6 +239,7 @@ func Register() {
 	edged, err := newEdged()
 	if err != nil {
 		klog.Errorf("init new edged error, %v", err)
+		os.Exit(1)
 		return
 	}
 	core.Register(edged)


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


/kind bug

**What this PR does / why we need it**:
The edged module is the most important module in edgecore. If it fails to start, it will directly cause node not ready, and users often cannot locate problems. For example, cgroupdriver and docker's cgroupdriver are inconsistent, causing node not ready. So this module fails to start, we should let the program exit directly

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1138 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
edgecore exits if edged failed to initialize
```
