### PR TITLE
remove useless errs variable

### DIFF
--- a/edge/pkg/common/config/config.go
+++ b/edge/pkg/common/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"sync"
 
 	"k8s.io/klog"
@@ -23,7 +22,6 @@ var once sync.Once
 
 func init() {
 	once.Do(func() {
-		var errs []error
 		driverName, err := config.CONFIG.GetValue("database.driver").ToString()
 		if err != nil {
 			// Guaranteed forward compatibility @kadisi
@@ -43,13 +41,6 @@ func init() {
 			klog.Infof("can not get database.source key, use default %v", dataSource)
 		}
 
-		if len(errs) != 0 {
-			for _, e := range errs {
-				klog.Errorf("%v", e)
-			}
-			klog.Error("init common config error")
-			os.Exit(1)
-		}
 		c = Configure{
 			DriverName: driverName,
 			DBName:     dbName,

--- a/edge/pkg/edged/config/config.go
+++ b/edge/pkg/edged/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"sync"
 	"time"
 
@@ -60,7 +59,6 @@ type Configure struct {
 
 func InitConfigure() {
 	once.Do(func() {
-		var errs []error
 		nodeStatusUpdateInterval := config.CONFIG.GetConfigurationByKey("edged.node-status-update-frequency").(int)
 		dockerAddress, ok := config.CONFIG.GetConfigurationByKey("edged.docker-address").(string)
 		if !ok {
@@ -123,13 +121,6 @@ func InitConfigure() {
 			runtimeRequestTimeout = 2
 		}
 
-		if len(errs) != 0 {
-			for _, e := range errs {
-				klog.Errorf("%v", e)
-			}
-			klog.Error("init edged config error")
-			os.Exit(1)
-		}
 		c = Configure{
 			NodeName:                  config.CONFIG.GetConfigurationByKey("edged.hostname-override").(string),
 			NodeNamespace:             config.CONFIG.GetConfigurationByKey("edged.register-node-namespace").(string),

--- a/edge/pkg/metamanager/config/config.go
+++ b/edge/pkg/metamanager/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"sync"
 
 	"k8s.io/klog"
@@ -31,8 +30,6 @@ type Configure struct {
 
 func InitConfigure() {
 	once.Do(func() {
-		var errs []error
-
 		groupName, err := config.CONFIG.GetValue("metamanager.context-send-group").ToString()
 		if err != nil || groupName == "" {
 			// Guaranteed forward compatibility @kadisi
@@ -59,13 +56,7 @@ func InitConfigure() {
 			syncInterval = defaultSyncInterval
 			klog.Infof("can not get meta.sync.podstatus.interval key, use default %v", syncInterval)
 		}
-		if len(errs) != 0 {
-			for _, e := range errs {
-				klog.Errorf("%v", e)
-			}
-			klog.Error("init common config error")
-			os.Exit(1)
-		}
+
 		c = Configure{
 			SendModuleGroupName: groupName,
 			SendModuleName:      moduleName,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind cleanup


**What this PR does / why we need it**:
The errs variable is useless, remove it.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
