### PR TITLE
Create socket address directory if not exist

### DIFF
--- a/cloud/pkg/cloudhub/servers/udsserver/uds.go
+++ b/cloud/pkg/cloudhub/servers/udsserver/uds.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/klog"
@@ -59,6 +60,16 @@ func (us *UnixDomainSocket) StartServer() error {
 		if err := os.Remove(addr); err != nil && !os.IsNotExist(err) { //nolint: vetshadow
 			klog.Errorf("failed to remove addr: %v", err)
 			return err
+		}
+	}
+
+	dir, err := filepath.Abs(filepath.Dir(addr))
+	if err != nil {
+		klog.Errorf("invalid dir of addr found: %v", err)
+	}
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.Mkdir(dir, 0755); err != nil {
+			klog.Errorf("failed to create addr dir: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Hit below issue if the directory does not exist
`failed to listen addr: listen unix //var/lib/kubeedge/kubeedge.sock: bind:
no such file or directory`

Signed-off-by: Dave Chen <dave.chen@arm.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
