### PR TITLE
Bugfix: fix the error of configs validation

### DIFF
--- a/pkg/apis/cloudcore/v1alpha1/validation/validation.go
+++ b/pkg/apis/cloudcore/v1alpha1/validation/validation.go
@@ -49,37 +49,34 @@ func ValidateModuleCloudHub(c cloudconfig.CloudHub) field.ErrorList {
 	validQPort := utilvalidation.IsValidPortNum(int(c.Quic.Port))
 	validQAddress := utilvalidation.IsValidIP(c.Quic.Address)
 
-	switch {
-	case len(validWPort) > 0:
+	if len(validWPort) > 0 {
 		for _, m := range validWPort {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("port"), c.WebSocket.Port, m))
 		}
-		fallthrough
-	case len(validAddress) > 0:
+	}
+	if len(validAddress) > 0 {
 		for _, m := range validAddress {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.WebSocket.Address, m))
 		}
-		fallthrough
-	case len(validQPort) > 0:
+	}
+	if len(validQPort) > 0 {
 		for _, m := range validQPort {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("port"), c.Quic.Port, m))
 		}
-		fallthrough
-	case len(validQAddress) > 0:
+	}
+	if len(validQAddress) > 0 {
 		for _, m := range validQAddress {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.Quic.Address, m))
 		}
-		fallthrough
-	case !utilvalidation.FileIsExist(c.TLSPrivateKeyFile):
+	}
+	if !utilvalidation.FileIsExist(c.TLSPrivateKeyFile) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSPrivateKeyFile"), c.TLSPrivateKeyFile, "TLSPrivateKeyFile not exist"))
-		fallthrough
-	case !utilvalidation.FileIsExist(c.TLSCertFile):
+	}
+	if !utilvalidation.FileIsExist(c.TLSCertFile) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSCertFile"), c.TLSCertFile, "TLSCertFile not exist"))
-		fallthrough
-	case !utilvalidation.FileIsExist(c.TLSCAFile):
+	}
+	if !utilvalidation.FileIsExist(c.TLSCAFile) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSCAFile"), c.TLSCAFile, "TLSCAFile not exist"))
-		fallthrough
-	default:
 	}
 	if !strings.HasPrefix(strings.ToLower(c.UnixSocket.Address), "unix://") {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("address"),
@@ -100,11 +97,8 @@ func ValidateModuleEdgeController(e cloudconfig.EdgeController) field.ErrorList 
 		return field.ErrorList{}
 	}
 	allErrs := field.ErrorList{}
-	switch {
-	case e.NodeUpdateFrequency <= 0:
+	if e.NodeUpdateFrequency <= 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("NodeUpdateFrequency"), e.NodeUpdateFrequency, "NodeUpdateFrequency need > 0"))
-		fallthrough
-	default:
 	}
 	return allErrs
 }
@@ -122,15 +116,11 @@ func ValidateModuleDeviceController(d cloudconfig.DeviceController) field.ErrorL
 // ValidateKubeAPIConfig validates `k` and returns an errorList if it is invalid
 func ValidateKubeAPIConfig(k cloudconfig.KubeAPIConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
-	switch {
-	case k.KubeConfig != "" && !path.IsAbs(k.KubeConfig):
+	if k.KubeConfig != "" && !path.IsAbs(k.KubeConfig) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("kubeconfig"), k.KubeConfig, "kubeconfig need abs path"))
-		fallthrough
-	case k.KubeConfig != "" && !utilvalidation.FileIsExist(k.KubeConfig):
+	}
+	if k.KubeConfig != "" && !utilvalidation.FileIsExist(k.KubeConfig) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("kubeconfig"), k.KubeConfig, "kubeconfig not exist"))
-		fallthrough
-	default:
-
 	}
 	return allErrs
 }

--- a/pkg/apis/edgecore/v1alpha1/validation/validation.go
+++ b/pkg/apis/edgecore/v1alpha1/validation/validation.go
@@ -80,24 +80,21 @@ func ValidateModuleEdgeHub(h edgecoreconfig.EdgeHub) field.ErrorList {
 		return field.ErrorList{}
 	}
 	allErrs := field.ErrorList{}
-	switch {
-	case !utilvalidation.FileIsExist(h.TLSPrivateKeyFile):
+	if !utilvalidation.FileIsExist(h.TLSPrivateKeyFile) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSPrivateKeyFile"),
 			h.TLSPrivateKeyFile, "TLSPrivateKeyFile not exist"))
-		fallthrough
-	case !utilvalidation.FileIsExist(h.TLSCertFile):
+	}
+	if !utilvalidation.FileIsExist(h.TLSCertFile) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSCertFile"),
 			h.TLSCertFile, "TLSCertFile not exist"))
-		fallthrough
-	case !utilvalidation.FileIsExist(h.TLSCAFile):
+	}
+	if !utilvalidation.FileIsExist(h.TLSCAFile) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSCAFile"),
 			h.TLSCAFile, "TLSCAFile not exist"))
-		fallthrough
-	case h.WebSocket.Enable == h.Quic.Enable:
+	}
+	if h.WebSocket.Enable == h.Quic.Enable {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("enable"),
 			h.Quic.Enable, "websocket.enable and quic.enable cannot be true and false at the same time"))
-		fallthrough
-	default:
 	}
 
 	return allErrs
@@ -109,14 +106,10 @@ func ValidateModuleEventBus(m edgecoreconfig.EventBus) field.ErrorList {
 		return field.ErrorList{}
 	}
 	allErrs := field.ErrorList{}
-	switch {
-	case m.MqttMode > edgecoreconfig.MqttModeExternal || m.MqttMode < edgecoreconfig.MqttModeInternal:
+	if m.MqttMode > edgecoreconfig.MqttModeExternal || m.MqttMode < edgecoreconfig.MqttModeInternal {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("Mode"), m.MqttMode,
 			fmt.Sprintf("Mode need in [%v,%v] range", edgecoreconfig.MqttModeInternal,
 				edgecoreconfig.MqttModeExternal)))
-		fallthrough
-	default:
-
 	}
 	return allErrs
 }


### PR DESCRIPTION
Signed-off-by: kuramal <linxxnil@126.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

 /kind bug

**What this PR does / why we need it**:
Now, the config validation use method likes:
```
    switch {
    case !utilvalidation.FileIsExist(h.TLSPrivateKeyFile):
        allErrs = append(allErrs, field.Invalid(field.NewPath("TLSPrivateKeyFile"),
            h.TLSPrivateKeyFile, "TLSPrivateKeyFile not exist"))
        fallthrough
    case !utilvalidation.FileIsExist(h.TLSCertFile):
        allErrs = append(allErrs, field.Invalid(field.NewPath("TLSCertFile"),
            h.TLSCertFile, "TLSCertFile not exist"))
        fallthrough
    case !utilvalidation.FileIsExist(h.TLSCAFile):
        allErrs = append(allErrs, field.Invalid(field.NewPath("TLSCAFile"),
            h.TLSCAFile, "TLSCAFile not exist"))
        fallthrough
    case h.WebSocket.Enable == h.Quic.Enable:
        allErrs = append(allErrs, field.Invalid(field.NewPath("enable"),
            h.Quic.Enable, "websocket.enable and quic.enable cannot be true and false at the same time"))
        fallthrough
    default:
    }
```
there is problem, When fallthrough is encountered, the next case is entered (even if the expression does not match)

So, I changed switch to if.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1423

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
