### PR TITLE
Fix doc error about cross compiling for ARM

### DIFF
--- a/docs/setup/cross-compilation.md
+++ b/docs/setup/cross-compilation.md
@@ -17,7 +17,7 @@ export GOOS="linux"
 export GOARM=6 #Pls give the appropriate arm version of your device 
 export CGO_ENABLED=1
 export CC=arm-linux-gnueabi-gcc
-make all WHAT=edge
+make edgecore
 ```
 
 If you are compiling KubeEdge edgecore for Raspberry Pi and check the [Makefile](https://github.com/kubeedge/kubeedge/blob/master/edge/Makefile) for the edge.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
There is an error in the cross-compiled documentation. There is no “all” target in file “edge / Makefile”, but the original document uses "make all". This results in the following error "make: *** No rule to make target` all '. Stop. "
This commit fixes this error.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
