### PR TITLE
Change cloudhub configuration access method from Get() to global variable 'Config'

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -65,10 +65,10 @@ func (a *cloudHub) Start() {
 
 	servers.StartCloudHub(messageq)
 
-	if hubconfig.Get().UnixSocket.Enable {
+	if hubconfig.Config.UnixSocket.Enable {
 		// The uds server is only used to communicate with csi driver from kubeedge on cloud.
 		// It is not used to communicate between cloud and edge.
-		go udsserver.StartServer(hubconfig.Get().UnixSocket.Address)
+		go udsserver.StartServer(hubconfig.Config.UnixSocket.Address)
 	}
 }
 
@@ -106,13 +106,13 @@ func newObjectSyncController() *hubconfig.ObjectSyncController {
 
 // build Config from flags
 func buildConfig() (conf *rest.Config, err error) {
-	kubeConfig, err := clientcmd.BuildConfigFromFlags(hubconfig.Get().KubeAPIConfig.Master,
-		hubconfig.Get().KubeAPIConfig.KubeConfig)
+	kubeConfig, err := clientcmd.BuildConfigFromFlags(hubconfig.Config.KubeAPIConfig.Master,
+		hubconfig.Config.KubeAPIConfig.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	kubeConfig.QPS = float32(hubconfig.Get().KubeAPIConfig.QPS)
-	kubeConfig.Burst = int(hubconfig.Get().KubeAPIConfig.Burst)
+	kubeConfig.QPS = float32(hubconfig.Config.KubeAPIConfig.QPS)
+	kubeConfig.Burst = int(hubconfig.Config.KubeAPIConfig.Burst)
 	kubeConfig.ContentType = "application/json"
 
 	return kubeConfig, nil

--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/cloudcore/v1alpha1"
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -38,7 +38,7 @@ func InitConfigure(hub *v1alpha1.CloudHub, kubeAPIConfig *v1alpha1.KubeAPIConfig
 		if err != nil {
 			klog.Fatalf("read key file %v error %v", hub.TLSPrivateKeyFile, err)
 		}
-		c = Configure{
+		Config = Configure{
 			CloudHub:      *hub,
 			KubeAPIConfig: kubeAPIConfig,
 			Ca:            ca,
@@ -46,10 +46,6 @@ func InitConfigure(hub *v1alpha1.CloudHub, kubeAPIConfig *v1alpha1.KubeAPIConfig
 			Key:           key,
 		}
 	})
-}
-
-func Get() *Configure {
-	return &c
 }
 
 // ObjectSyncController use beehive context message layer

--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -74,10 +74,10 @@ var CloudhubHandler *MessageHandle
 func InitHandler(eventq *channelq.ChannelMessageQueue) {
 	once.Do(func() {
 		CloudhubHandler = &MessageHandle{
-			KeepaliveInterval: int(hubconfig.Get().KeepaliveInterval),
-			WriteTimeout:      int(hubconfig.Get().WriteTimeout),
+			KeepaliveInterval: int(hubconfig.Config.KeepaliveInterval),
+			WriteTimeout:      int(hubconfig.Config.WriteTimeout),
 			MessageQueue:      eventq,
-			NodeLimit:         int(hubconfig.Get().NodeLimit),
+			NodeLimit:         int(hubconfig.Config.NodeLimit),
 		}
 
 		CloudhubHandler.KeepaliveChannel = make(map[string]chan struct{})

--- a/cloud/pkg/cloudhub/servers/server.go
+++ b/cloud/pkg/cloudhub/servers/server.go
@@ -18,11 +18,11 @@ import (
 func StartCloudHub(messageq *channelq.ChannelMessageQueue) {
 	handler.InitHandler(messageq)
 	// start websocket server
-	if hubconfig.Get().WebSocket.Enable {
+	if hubconfig.Config.WebSocket.Enable {
 		go startWebsocketServer()
 	}
 	// start quic server
-	if hubconfig.Get().Quic.Enable {
+	if hubconfig.Config.Quic.Enable {
 		go startQuicServer()
 	}
 }
@@ -48,13 +48,13 @@ func createTLSConfig(ca, cert, key []byte) tls.Config {
 }
 
 func startWebsocketServer() {
-	tlsConfig := createTLSConfig(hubconfig.Get().Ca, hubconfig.Get().Cert, hubconfig.Get().Key)
+	tlsConfig := createTLSConfig(hubconfig.Config.Ca, hubconfig.Config.Cert, hubconfig.Config.Key)
 	svc := server.Server{
 		Type:       api.ProtocolTypeWS,
 		TLSConfig:  &tlsConfig,
 		AutoRoute:  true,
 		ConnNotify: handler.CloudhubHandler.OnRegister,
-		Addr:       fmt.Sprintf("%s:%d", hubconfig.Get().WebSocket.Address, hubconfig.Get().WebSocket.Port),
+		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.WebSocket.Address, hubconfig.Config.WebSocket.Port),
 		ExOpts:     api.WSServerOption{Path: "/"},
 	}
 	klog.Infof("Startting cloudhub %s server", api.ProtocolTypeWS)
@@ -62,14 +62,14 @@ func startWebsocketServer() {
 }
 
 func startQuicServer() {
-	tlsConfig := createTLSConfig(hubconfig.Get().Ca, hubconfig.Get().Cert, hubconfig.Get().Key)
+	tlsConfig := createTLSConfig(hubconfig.Config.Ca, hubconfig.Config.Cert, hubconfig.Config.Key)
 	svc := server.Server{
 		Type:       api.ProtocolTypeQuic,
 		TLSConfig:  &tlsConfig,
 		AutoRoute:  true,
 		ConnNotify: handler.CloudhubHandler.OnRegister,
-		Addr:       fmt.Sprintf("%s:%d", hubconfig.Get().Quic.Address, hubconfig.Get().Quic.Port),
-		ExOpts:     api.QuicServerOption{MaxIncomingStreams: int(hubconfig.Get().Quic.MaxIncomingStreams)},
+		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.Quic.Address, hubconfig.Config.Quic.Port),
+		ExOpts:     api.QuicServerOption{MaxIncomingStreams: int(hubconfig.Config.Quic.MaxIncomingStreams)},
 	}
 
 	klog.Infof("Startting cloudhub %s server", api.ProtocolTypeQuic)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature


**What this PR does / why we need it**:
Change cloudhub configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
