### PR TITLE
Change devicecontroller configuration access method from Get() to global variable 'Config'

### DIFF
--- a/cloud/pkg/devicecontroller/config/config.go
+++ b/cloud/pkg/devicecontroller/config/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/cloudcore/v1alpha1"
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -16,13 +16,9 @@ type Configure struct {
 
 func InitConfigure(dc *v1alpha1.DeviceController, kubeAPIConfig *v1alpha1.KubeAPIConfig) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			DeviceController: *dc,
 			KubeAPIConfig:    *kubeAPIConfig,
 		}
 	})
-}
-
-func Get() *Configure {
-	return &c
 }

--- a/cloud/pkg/devicecontroller/controller/upstream.go
+++ b/cloud/pkg/devicecontroller/controller/upstream.go
@@ -60,10 +60,10 @@ type UpstreamController struct {
 func (uc *UpstreamController) Start() error {
 	klog.Info("Start upstream devicecontroller")
 
-	uc.deviceStatusChan = make(chan model.Message, config.Get().Buffer.UpdateDeviceStatus)
+	uc.deviceStatusChan = make(chan model.Message, config.Config.Buffer.UpdateDeviceStatus)
 	go uc.dispatchMessage()
 
-	for i := 0; i < int(config.Get().Buffer.UpdateDeviceStatus); i++ {
+	for i := 0; i < int(config.Config.Buffer.UpdateDeviceStatus); i++ {
 		go uc.updateDeviceStatus()
 	}
 	return nil

--- a/cloud/pkg/devicecontroller/manager/device.go
+++ b/cloud/pkg/devicecontroller/manager/device.go
@@ -29,7 +29,7 @@ func (dmm *DeviceManager) Events() chan watch.Event {
 // NewDeviceManager create DeviceManager from config
 func NewDeviceManager(crdClient *rest.RESTClient, namespace string) (*DeviceManager, error) {
 	lw := cache.NewListWatchFromClient(crdClient, "devices", namespace, fields.Everything())
-	events := make(chan watch.Event, config.Get().Buffer.DeviceEvent)
+	events := make(chan watch.Event, config.Config.Buffer.DeviceEvent)
 	rh := NewCommonResourceEventHandler(events)
 	si := cache.NewSharedInformer(lw, &v1alpha1.Device{}, 0)
 	si.AddEventHandler(rh)

--- a/cloud/pkg/devicecontroller/manager/devicemodel.go
+++ b/cloud/pkg/devicecontroller/manager/devicemodel.go
@@ -29,7 +29,7 @@ func (dmm *DeviceModelManager) Events() chan watch.Event {
 // NewDeviceModelManager create DeviceModelManager from config
 func NewDeviceModelManager(crdClient *rest.RESTClient, namespace string) (*DeviceModelManager, error) {
 	lw := cache.NewListWatchFromClient(crdClient, "devicemodels", namespace, fields.Everything())
-	events := make(chan watch.Event, config.Get().Buffer.DeviceModelEvent)
+	events := make(chan watch.Event, config.Config.Buffer.DeviceModelEvent)
 	rh := NewCommonResourceEventHandler(events)
 	si := cache.NewSharedInformer(lw, &v1alpha1.DeviceModel{}, 0)
 	si.AddEventHandler(rh)

--- a/cloud/pkg/devicecontroller/messagelayer/context.go
+++ b/cloud/pkg/devicecontroller/messagelayer/context.go
@@ -40,8 +40,8 @@ func (cml *ContextMessageLayer) Response(message model.Message) error {
 // NewContextMessageLayer create a ContextMessageLayer
 func NewContextMessageLayer() MessageLayer {
 	return &ContextMessageLayer{
-		SendModuleName:     string(config.Get().Context.SendModule),
-		ReceiveModuleName:  string(config.Get().Context.ReceiveModule),
-		ResponseModuleName: string(config.Get().Context.ResponseModule),
+		SendModuleName:     string(config.Config.Context.SendModule),
+		ReceiveModuleName:  string(config.Config.Context.ReceiveModule),
+		ResponseModuleName: string(config.Config.Context.ResponseModule),
 	}
 }

--- a/cloud/pkg/devicecontroller/utils/kubeclient.go
+++ b/cloud/pkg/devicecontroller/utils/kubeclient.go
@@ -21,13 +21,13 @@ func KubeClient() (*kubernetes.Clientset, error) {
 
 // KubeConfig from flags
 func KubeConfig() (conf *rest.Config, err error) {
-	kubeConfig, err := clientcmd.BuildConfigFromFlags(config.Get().KubeAPIConfig.Master, config.Get().KubeAPIConfig.KubeConfig)
+	kubeConfig, err := clientcmd.BuildConfigFromFlags(config.Config.KubeAPIConfig.Master, config.Config.KubeAPIConfig.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	kubeConfig.QPS = float32(config.Get().KubeAPIConfig.QPS)
-	kubeConfig.Burst = int(config.Get().KubeAPIConfig.Burst)
-	kubeConfig.ContentType = config.Get().KubeAPIConfig.ContentType
+	kubeConfig.QPS = float32(config.Config.KubeAPIConfig.QPS)
+	kubeConfig.Burst = int(config.Config.KubeAPIConfig.Burst)
+	kubeConfig.ContentType = config.Config.KubeAPIConfig.ContentType
 
 	return kubeConfig, err
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

 /kind feature


**What this PR does / why we need it**:
Change devicecontroller configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
