### PR TITLE
Change edgecontroller configuration access method from Get() to global variable 'Config'

### DIFF
--- a/cloud/pkg/edgecontroller/config/config.go
+++ b/cloud/pkg/edgecontroller/config/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/cloudcore/v1alpha1"
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -18,14 +18,11 @@ type Configure struct {
 
 func InitConfigure(ec *v1alpha1.EdgeController, kubeAPIConfig *v1alpha1.KubeAPIConfig, nodeName string, edgesite bool) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			EdgeController: *ec,
 			KubeAPIConfig:  *kubeAPIConfig,
 			NodeName:       nodeName,
 			EdgeSiteEnable: edgesite,
 		}
 	})
-}
-func Get() *Configure {
-	return &c
 }

--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -473,10 +473,10 @@ func (dc *DownstreamController) initLocating() error {
 		dc.lc.UpdateEdgeNode(node.ObjectMeta.Name, status)
 	}
 
-	if !config.Get().EdgeSiteEnable {
+	if !config.Config.EdgeSiteEnable {
 		pods, err = dc.kubeClient.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{})
 	} else {
-		selector := fields.OneTermEqualSelector("spec.nodeName", config.Get().NodeName).String()
+		selector := fields.OneTermEqualSelector("spec.nodeName", config.Config.NodeName).String()
 		pods, err = dc.kubeClient.CoreV1().Pods(v1.NamespaceAll).List(metav1.ListOptions{FieldSelector: selector})
 	}
 	if err != nil {
@@ -502,11 +502,11 @@ func NewDownstreamController() (*DownstreamController, error) {
 	}
 
 	var nodeName = ""
-	if config.Get().EdgeSiteEnable {
-		if config.Get().NodeName == "" {
+	if config.Config.EdgeSiteEnable {
+		if config.Config.NodeName == "" {
 			return nil, fmt.Errorf("kubeEdge node name is not provided in edgesite controller configuration")
 		}
-		nodeName = config.Get().NodeName
+		nodeName = config.Config.NodeName
 	}
 
 	podManager, err := manager.NewPodManager(cli, v1.NamespaceAll, nodeName)

--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -94,51 +94,51 @@ type UpstreamController struct {
 func (uc *UpstreamController) Start() error {
 	klog.Info("start upstream controller")
 
-	uc.nodeStatusChan = make(chan model.Message, config.Get().Buffer.UpdateNodeStatus)
-	uc.podStatusChan = make(chan model.Message, config.Get().Buffer.UpdatePodStatus)
-	uc.configMapChan = make(chan model.Message, config.Get().Buffer.QueryConfigmap)
-	uc.secretChan = make(chan model.Message, config.Get().Buffer.QuerySecret)
-	uc.serviceChan = make(chan model.Message, config.Get().Buffer.QueryService)
-	uc.endpointsChan = make(chan model.Message, config.Get().Buffer.QueryEndpoints)
-	uc.persistentVolumeChan = make(chan model.Message, config.Get().Buffer.QueryPersistentVolume)
-	uc.persistentVolumeClaimChan = make(chan model.Message, config.Get().Buffer.QueryPersistentVolumeClaim)
-	uc.volumeAttachmentChan = make(chan model.Message, config.Get().Buffer.QueryVolumeAttachment)
-	uc.queryNodeChan = make(chan model.Message, config.Get().Buffer.QueryNode)
-	uc.updateNodeChan = make(chan model.Message, config.Get().Buffer.UpdateNode)
+	uc.nodeStatusChan = make(chan model.Message, config.Config.Buffer.UpdateNodeStatus)
+	uc.podStatusChan = make(chan model.Message, config.Config.Buffer.UpdatePodStatus)
+	uc.configMapChan = make(chan model.Message, config.Config.Buffer.QueryConfigmap)
+	uc.secretChan = make(chan model.Message, config.Config.Buffer.QuerySecret)
+	uc.serviceChan = make(chan model.Message, config.Config.Buffer.QueryService)
+	uc.endpointsChan = make(chan model.Message, config.Config.Buffer.QueryEndpoints)
+	uc.persistentVolumeChan = make(chan model.Message, config.Config.Buffer.QueryPersistentVolume)
+	uc.persistentVolumeClaimChan = make(chan model.Message, config.Config.Buffer.QueryPersistentVolumeClaim)
+	uc.volumeAttachmentChan = make(chan model.Message, config.Config.Buffer.QueryVolumeAttachment)
+	uc.queryNodeChan = make(chan model.Message, config.Config.Buffer.QueryNode)
+	uc.updateNodeChan = make(chan model.Message, config.Config.Buffer.UpdateNode)
 
 	go uc.dispatchMessage()
 
-	for i := 0; i < int(config.Get().Load.UpdateNodeStatusWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.UpdateNodeStatusWorkers); i++ {
 		go uc.updateNodeStatus()
 	}
-	for i := 0; i < int(config.Get().Load.UpdatePodStatusWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.UpdatePodStatusWorkers); i++ {
 		go uc.updatePodStatus()
 	}
-	for i := 0; i < int(config.Get().Load.QueryConfigmapWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QueryConfigmapWorkers); i++ {
 		go uc.queryConfigMap()
 	}
-	for i := 0; i < int(config.Get().Load.QuerySecretWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QuerySecretWorkers); i++ {
 		go uc.querySecret()
 	}
-	for i := 0; i < int(config.Get().Load.QueryServiceWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QueryServiceWorkers); i++ {
 		go uc.queryService()
 	}
-	for i := 0; i < int(config.Get().Load.QueryEndpointsWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QueryEndpointsWorkers); i++ {
 		go uc.queryEndpoints()
 	}
-	for i := 0; i < int(config.Get().Load.QueryPersistentVolumeWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QueryPersistentVolumeWorkers); i++ {
 		go uc.queryPersistentVolume()
 	}
-	for i := 0; i < int(config.Get().Load.QueryPersistentVolumeClaimWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QueryPersistentVolumeClaimWorkers); i++ {
 		go uc.queryPersistentVolumeClaim()
 	}
-	for i := 0; i < int(config.Get().Load.QueryVolumeAttachmentWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QueryVolumeAttachmentWorkers); i++ {
 		go uc.queryVolumeAttachment()
 	}
-	for i := 0; i < int(config.Get().Load.QueryNodeWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.QueryNodeWorkers); i++ {
 		go uc.queryNode()
 	}
-	for i := 0; i < int(config.Get().Load.UpdateNodeWorkers); i++ {
+	for i := 0; i < int(config.Config.Load.UpdateNodeWorkers); i++ {
 		go uc.updateNode()
 	}
 	return nil
@@ -407,13 +407,13 @@ func (uc *UpstreamController) updateNodeStatus() {
 
 				// TODO: comment below for test failure. Needs to decide whether to keep post troubleshoot
 				// In case the status stored at metadata service is outdated, update the heartbeat automatically
-				if !config.Get().EdgeSiteEnable {
+				if !config.Config.EdgeSiteEnable {
 					for i := range nodeStatusRequest.Status.Conditions {
-						if time.Now().Sub(nodeStatusRequest.Status.Conditions[i].LastHeartbeatTime.Time) > time.Duration(config.Get().NodeUpdateFrequency)*time.Second {
+						if time.Now().Sub(nodeStatusRequest.Status.Conditions[i].LastHeartbeatTime.Time) > time.Duration(config.Config.NodeUpdateFrequency)*time.Second {
 							nodeStatusRequest.Status.Conditions[i].LastHeartbeatTime = metaV1.NewTime(time.Now())
 						}
 
-						if time.Now().Sub(nodeStatusRequest.Status.Conditions[i].LastTransitionTime.Time) > time.Duration(config.Get().NodeUpdateFrequency)*time.Second {
+						if time.Now().Sub(nodeStatusRequest.Status.Conditions[i].LastTransitionTime.Time) > time.Duration(config.Config.NodeUpdateFrequency)*time.Second {
 							nodeStatusRequest.Status.Conditions[i].LastTransitionTime = metaV1.NewTime(time.Now())
 						}
 					}

--- a/cloud/pkg/edgecontroller/manager/configmap.go
+++ b/cloud/pkg/edgecontroller/manager/configmap.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -23,7 +23,7 @@ func (cmm *ConfigMapManager) Events() chan watch.Event {
 // NewConfigMapManager create ConfigMapManager by kube clientset and namespace
 func NewConfigMapManager(kubeClient *kubernetes.Clientset, namespace string) (*ConfigMapManager, error) {
 	lw := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "configmaps", namespace, fields.Everything())
-	events := make(chan watch.Event, config.Get().Buffer.ConfigmapEvent)
+	events := make(chan watch.Event, config.Config.Buffer.ConfigmapEvent)
 	rh := NewCommonResourceEventHandler(events)
 	si := cache.NewSharedInformer(lw, &v1.ConfigMap{}, 0)
 	si.AddEventHandler(rh)

--- a/cloud/pkg/edgecontroller/manager/endpoint.go
+++ b/cloud/pkg/edgecontroller/manager/endpoint.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -23,7 +23,7 @@ func (sm *EndpointsManager) Events() chan watch.Event {
 // NewEndpointsManager create EndpointsManager by kube clientset and namespace
 func NewEndpointsManager(kubeClient *kubernetes.Clientset, namespace string) (*EndpointsManager, error) {
 	lw := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "endpoints", namespace, fields.Everything())
-	events := make(chan watch.Event, config.Get().Buffer.EndpointsEvent)
+	events := make(chan watch.Event, config.Config.Buffer.EndpointsEvent)
 	rh := NewCommonResourceEventHandler(events)
 	si := cache.NewSharedInformer(lw, &v1.Endpoints{}, 0)
 	si.AddEventHandler(rh)

--- a/cloud/pkg/edgecontroller/manager/pod.go
+++ b/cloud/pkg/edgecontroller/manager/pod.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
@@ -88,8 +88,8 @@ func NewPodManager(kubeClient *kubernetes.Clientset, namespace, nodeName string)
 		selector := fields.OneTermEqualSelector("spec.nodeName", nodeName)
 		lw = cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", namespace, selector)
 	}
-	realEvents := make(chan watch.Event, config.Get().Buffer.PodEvent)
-	mergedEvents := make(chan watch.Event, config.Get().Buffer.PodEvent)
+	realEvents := make(chan watch.Event, config.Config.Buffer.PodEvent)
+	mergedEvents := make(chan watch.Event, config.Config.Buffer.PodEvent)
 	rh := NewCommonResourceEventHandler(realEvents)
 	si := cache.NewSharedInformer(lw, &v1.Pod{}, 0)
 	si.AddEventHandler(rh)

--- a/cloud/pkg/edgecontroller/manager/secret.go
+++ b/cloud/pkg/edgecontroller/manager/secret.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -23,7 +23,7 @@ func (sm *SecretManager) Events() chan watch.Event {
 // NewSecretManager create SecretManager by kube clientset and namespace
 func NewSecretManager(kubeClient *kubernetes.Clientset, namespace string) (*SecretManager, error) {
 	lw := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "secrets", namespace, fields.Everything())
-	events := make(chan watch.Event, config.Get().Buffer.SecretEvent)
+	events := make(chan watch.Event, config.Config.Buffer.SecretEvent)
 	rh := NewCommonResourceEventHandler(events)
 	si := cache.NewSharedInformer(lw, &v1.Secret{}, 0)
 	si.AddEventHandler(rh)

--- a/cloud/pkg/edgecontroller/manager/service.go
+++ b/cloud/pkg/edgecontroller/manager/service.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -23,7 +23,7 @@ func (sm *ServiceManager) Events() chan watch.Event {
 // NewServiceManager create ServiceManager by kube clientset and namespace
 func NewServiceManager(kubeClient *kubernetes.Clientset, namespace string) (*ServiceManager, error) {
 	lw := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "services", namespace, fields.Everything())
-	events := make(chan watch.Event, config.Get().Buffer.ServiceEvent)
+	events := make(chan watch.Event, config.Config.Buffer.ServiceEvent)
 	rh := NewCommonResourceEventHandler(events)
 	si := cache.NewSharedInformer(lw, &v1.Service{}, 0)
 	si.AddEventHandler(rh)

--- a/cloud/pkg/edgecontroller/messagelayer/context.go
+++ b/cloud/pkg/edgecontroller/messagelayer/context.go
@@ -33,7 +33,7 @@ func (cml *ContextMessageLayer) Receive() (model.Message, error) {
 
 // Response message
 func (cml *ContextMessageLayer) Response(message model.Message) error {
-	if !config.Get().EdgeSiteEnable {
+	if !config.Config.EdgeSiteEnable {
 		beehiveContext.Send(cml.ResponseModuleName, message)
 	} else {
 		beehiveContext.SendResp(message)
@@ -44,8 +44,8 @@ func (cml *ContextMessageLayer) Response(message model.Message) error {
 // NewContextMessageLayer create a ContextMessageLayer
 func NewContextMessageLayer() MessageLayer {
 	return &ContextMessageLayer{
-		SendModuleName:     string(config.Get().Context.SendModule),
-		ReceiveModuleName:  string(config.Get().Context.ReceiveModule),
-		ResponseModuleName: string(config.Get().Context.ResponseModule),
+		SendModuleName:     string(config.Config.Context.SendModule),
+		ReceiveModuleName:  string(config.Config.Context.ReceiveModule),
+		ResponseModuleName: string(config.Config.Context.ResponseModule),
 	}
 }

--- a/cloud/pkg/edgecontroller/messagelayer/util.go
+++ b/cloud/pkg/edgecontroller/messagelayer/util.go
@@ -15,7 +15,7 @@ import (
 // BuildResource return a string as "beehive/pkg/core/model".Message.Router.Resource
 func BuildResource(nodeID, namespace, resourceType, resourceID string) (resource string, err error) {
 	if namespace == "" || resourceType == "" {
-		if !config.Get().EdgeSiteEnable && nodeID == "" {
+		if !config.Config.EdgeSiteEnable && nodeID == "" {
 			err = fmt.Errorf("required parameter are not set (node id, namespace or resource type)")
 		} else {
 			err = fmt.Errorf("required parameter are not set (namespace or resource type)")
@@ -24,7 +24,7 @@ func BuildResource(nodeID, namespace, resourceType, resourceID string) (resource
 	}
 
 	resource = fmt.Sprintf("%s%s%s%s%s%s%s", controller.ResourceNode, constants.ResourceSep, nodeID, constants.ResourceSep, namespace, constants.ResourceSep, resourceType)
-	if config.Get().EdgeSiteEnable {
+	if config.Config.EdgeSiteEnable {
 		resource = fmt.Sprintf("%s%s%s", namespace, constants.ResourceSep, resourceType)
 	}
 	if resourceID != "" {
@@ -46,7 +46,7 @@ func GetNodeID(msg model.Message) (string, error) {
 func GetNamespace(msg model.Message) (string, error) {
 	sli := strings.Split(msg.GetResource(), constants.ResourceSep)
 	length := controller.ResourceNamespaceIndex
-	if config.Get().EdgeSiteEnable {
+	if config.Config.EdgeSiteEnable {
 		length = controller.EdgeSiteResourceNamespaceIndex
 	}
 	if len(sli) <= length {
@@ -54,7 +54,7 @@ func GetNamespace(msg model.Message) (string, error) {
 	}
 	var res string
 	var index uint8
-	if config.Get().EdgeSiteEnable {
+	if config.Config.EdgeSiteEnable {
 		res = sli[controller.EdgeSiteResourceNamespaceIndex]
 		index = controller.EdgeSiteResourceNamespaceIndex
 	} else {
@@ -69,7 +69,7 @@ func GetNamespace(msg model.Message) (string, error) {
 func GetResourceType(msg model.Message) (string, error) {
 	sli := strings.Split(msg.GetResource(), constants.ResourceSep)
 	length := controller.ResourceResourceTypeIndex
-	if config.Get().EdgeSiteEnable {
+	if config.Config.EdgeSiteEnable {
 		length = controller.EdgeSiteResourceResourceTypeIndex
 	}
 	if len(sli) <= length {
@@ -78,7 +78,7 @@ func GetResourceType(msg model.Message) (string, error) {
 
 	var res string
 	var index uint8
-	if config.Get().EdgeSiteEnable {
+	if config.Config.EdgeSiteEnable {
 		res = sli[controller.EdgeSiteResourceResourceTypeIndex]
 		index = controller.EdgeSiteResourceResourceTypeIndex
 	} else {
@@ -94,7 +94,7 @@ func GetResourceType(msg model.Message) (string, error) {
 func GetResourceName(msg model.Message) (string, error) {
 	sli := strings.Split(msg.GetResource(), constants.ResourceSep)
 	length := controller.ResourceResourceNameIndex
-	if config.Get().EdgeSiteEnable {
+	if config.Config.EdgeSiteEnable {
 		length = controller.EdgeSiteResourceResourceNameIndex
 	}
 	if len(sli) <= length {
@@ -103,7 +103,7 @@ func GetResourceName(msg model.Message) (string, error) {
 
 	var res string
 	var index uint8
-	if config.Get().EdgeSiteEnable {
+	if config.Config.EdgeSiteEnable {
 		res = sli[controller.EdgeSiteResourceResourceNameIndex]
 		index = controller.EdgeSiteResourceResourceNameIndex
 	} else {

--- a/cloud/pkg/edgecontroller/utils/kubeconfig.go
+++ b/cloud/pkg/edgecontroller/utils/kubeconfig.go
@@ -9,14 +9,14 @@ import (
 
 // KubeConfig from flags
 func KubeConfig() (conf *rest.Config, err error) {
-	kubeConfig, err := clientcmd.BuildConfigFromFlags(config.Get().KubeAPIConfig.Master,
-		config.Get().KubeAPIConfig.KubeConfig)
+	kubeConfig, err := clientcmd.BuildConfigFromFlags(config.Config.KubeAPIConfig.Master,
+		config.Config.KubeAPIConfig.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	kubeConfig.QPS = float32(config.Get().KubeAPIConfig.QPS)
-	kubeConfig.Burst = int(config.Get().KubeAPIConfig.Burst)
-	kubeConfig.ContentType = config.Get().KubeAPIConfig.ContentType
+	kubeConfig.QPS = float32(config.Config.KubeAPIConfig.QPS)
+	kubeConfig.Burst = int(config.Config.KubeAPIConfig.Burst)
+	kubeConfig.ContentType = config.Config.KubeAPIConfig.ContentType
 
 	return kubeConfig, nil
 }


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature


**What this PR does / why we need it**:
Change edgecontroller configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
