### PR TITLE
Change synccontroller configuration access method from Get() to global variable 'Config'

### DIFF
--- a/cloud/pkg/synccontroller/config/config.go
+++ b/cloud/pkg/synccontroller/config/config.go
@@ -7,7 +7,7 @@ import (
 	configv1alpha1 "github.com/kubeedge/kubeedge/pkg/apis/cloudcore/v1alpha1"
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -17,13 +17,9 @@ type Configure struct {
 
 func InitConfigure(sc *configv1alpha1.SyncController, kubeAPIConfig *v1alpha1.KubeAPIConfig) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			KubeAPIConfig:  kubeAPIConfig,
 			SyncController: sc,
 		}
 	})
-}
-
-func Get() *Configure {
-	return &c
 }

--- a/cloud/pkg/synccontroller/synccontroller.go
+++ b/cloud/pkg/synccontroller/synccontroller.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -244,13 +244,13 @@ func isFromEdgeNode(nodes []*v1.Node, nodeName string) bool {
 
 // build Config from flags
 func buildConfig() (conf *rest.Config, err error) {
-	kubeConfig, err := clientcmd.BuildConfigFromFlags(config.Get().KubeAPIConfig.Master,
-		config.Get().KubeAPIConfig.KubeConfig)
+	kubeConfig, err := clientcmd.BuildConfigFromFlags(config.Config.KubeAPIConfig.Master,
+		config.Config.KubeAPIConfig.KubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	kubeConfig.QPS = float32(config.Get().KubeAPIConfig.QPS)
-	kubeConfig.Burst = int(config.Get().KubeAPIConfig.Burst)
+	kubeConfig.QPS = float32(config.Config.KubeAPIConfig.QPS)
+	kubeConfig.Burst = int(config.Config.KubeAPIConfig.Burst)
 	kubeConfig.ContentType = "application/json"
 
 	return kubeConfig, nil


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

 /kind feature


**What this PR does / why we need it**:
Change synccontroller configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
