### PR TITLE
Change devicetwin configuration access method from Get() to global variable 'Config'

### DIFF
--- a/edge/pkg/devicetwin/config/config.go
+++ b/edge/pkg/devicetwin/config/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/edgecore/v1alpha1"
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -16,7 +16,7 @@ type Configure struct {
 
 func InitConfigure(deviceTwin *v1alpha1.DeviceTwin, nodeName string) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			DeviceTwin: *deviceTwin,
 			NodeName:   nodeName,
 		}
@@ -24,5 +24,5 @@ func InitConfigure(deviceTwin *v1alpha1.DeviceTwin, nodeName string) {
 }
 
 func Get() *Configure {
-	return &c
+	return &Config
 }

--- a/edge/pkg/devicetwin/dtcontext/dtcontext.go
+++ b/edge/pkg/devicetwin/dtcontext/dtcontext.go
@@ -41,7 +41,7 @@ type DTContext struct {
 func InitDTContext() (*DTContext, error) {
 	return &DTContext{
 		GroupID:       "",
-		NodeName:      deviceconfig.Get().NodeName,
+		NodeName:      deviceconfig.Config.NodeName,
 		CommChan:      make(map[string]chan interface{}),
 		ConfirmChan:   make(chan interface{}, 1000),
 		ConfirmMap:    &sync.Map{},


### PR DESCRIPTION
*What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

 /kind feature


**What this PR does / why we need it**:

Change devicetwin configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
