### PR TITLE
Change edged configuration access method from Get() to global variable 'Config'

### DIFF
--- a/edge/pkg/edged/config/config.go
+++ b/edge/pkg/edged/config/config.go
@@ -26,7 +26,7 @@ const (
 	ImagePullProgressDeadlineDefault = 60
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -35,11 +35,8 @@ type Configure struct {
 
 func InitConfigure(e *v1alpha1.Edged) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			Edged: *e,
 		}
 	})
-}
-func Get() *Configure {
-	return &c
 }

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -350,8 +350,8 @@ func newEdged(enable bool) (*edged, error) {
 
 	podManager := podmanager.NewPodManager()
 	policy := images.ImageGCPolicy{
-		HighThresholdPercent: int(edgedconfig.Get().ImageGCHighThreshold),
-		LowThresholdPercent:  int(edgedconfig.Get().ImageGCLowThreshold),
+		HighThresholdPercent: int(edgedconfig.Config.ImageGCHighThreshold),
+		LowThresholdPercent:  int(edgedconfig.Config.ImageGCLowThreshold),
 		MinAge:               minAge,
 	}
 	// build new object to match interface
@@ -360,11 +360,11 @@ func newEdged(enable bool) (*edged, error) {
 	metaClient := client.New()
 
 	ed := &edged{
-		nodeName:                  edgedconfig.Get().HostnameOverride,
-		interfaceName:             edgedconfig.Get().InterfaceName,
-		namespace:                 edgedconfig.Get().RegisterNodeNamespace,
-		gpuPluginEnabled:          edgedconfig.Get().GPUPluginEnabled,
-		cgroupDriver:              edgedconfig.Get().CGroupDriver,
+		nodeName:                  edgedconfig.Config.HostnameOverride,
+		interfaceName:             edgedconfig.Config.InterfaceName,
+		namespace:                 edgedconfig.Config.RegisterNodeNamespace,
+		gpuPluginEnabled:          edgedconfig.Config.GPUPluginEnabled,
+		cgroupDriver:              edgedconfig.Config.CGroupDriver,
 		podManager:                podManager,
 		podAdditionQueue:          workqueue.New(),
 		podCache:                  kubecontainer.NewCache(),
@@ -373,7 +373,7 @@ func newEdged(enable bool) (*edged, error) {
 		podDeletionBackoff:        backoff,
 		metaClient:                metaClient,
 		kubeClient:                fakekube.NewSimpleClientset(metaClient),
-		nodeStatusUpdateFrequency: time.Duration(edgedconfig.Get().NodeStatusUpdateFrequency) * time.Second,
+		nodeStatusUpdateFrequency: time.Duration(edgedconfig.Config.NodeStatusUpdateFrequency) * time.Second,
 		mounter:                   mount.New(""),
 		uid:                       types.UID("38796d14-1df3-11e8-8e5a-286ed488f209"),
 		version:                   fmt.Sprintf("%s-kubeedge-%s", constants.CurrentSupportK8sVersion, version.Get()),
@@ -381,7 +381,7 @@ func newEdged(enable bool) (*edged, error) {
 		secretStore:               cache.NewStore(cache.MetaNamespaceKeyFunc),
 		configMapStore:            cache.NewStore(cache.MetaNamespaceKeyFunc),
 		workQueue:                 queue.NewBasicWorkQueue(clock.RealClock{}),
-		nodeIP:                    net.ParseIP(edgedconfig.Get().NodeIP),
+		nodeIP:                    net.ParseIP(edgedconfig.Config.NodeIP),
 		recorder:                  recorder,
 		enable:                    enable,
 	}
@@ -405,16 +405,16 @@ func newEdged(enable bool) (*edged, error) {
 	containerGCPolicy := kubecontainer.ContainerGCPolicy{
 		MinAge:             minAge,
 		MaxContainers:      -1,
-		MaxPerPodContainer: int(edgedconfig.Get().MaximumDeadContainersPerPod),
+		MaxPerPodContainer: int(edgedconfig.Config.MaximumDeadContainersPerPod),
 	}
 
 	//create and start the docker shim running as a grpc server
-	if edgedconfig.Get().RemoteRuntimeEndpoint == DockerShimEndpoint ||
-		edgedconfig.Get().RemoteRuntimeEndpoint == DockerShimEndpointDeprecated {
+	if edgedconfig.Config.RemoteRuntimeEndpoint == DockerShimEndpoint ||
+		edgedconfig.Config.RemoteRuntimeEndpoint == DockerShimEndpointDeprecated {
 		streamingConfig := &streaming.Config{}
 		DockerClientConfig := &dockershim.ClientConfig{
-			DockerEndpoint:            edgedconfig.Get().DockerAddress,
-			ImagePullProgressDeadline: time.Duration(edgedconfig.Get().ImagePullProgressDeadline) * time.Second,
+			DockerEndpoint:            edgedconfig.Config.DockerAddress,
+			ImagePullProgressDeadline: time.Duration(edgedconfig.Config.ImagePullProgressDeadline) * time.Second,
 			EnableSleep:               true,
 			WithTraceDisabled:         true,
 		}
@@ -432,7 +432,7 @@ func newEdged(enable bool) (*edged, error) {
 		cgroupDriver := ed.cgroupDriver
 
 		ds, err := dockershim.NewDockerService(DockerClientConfig,
-			edgedconfig.Get().PodSandboxImage,
+			edgedconfig.Config.PodSandboxImage,
 			streamingConfig,
 			&pluginConfigs,
 			cgroupName,
@@ -445,30 +445,30 @@ func newEdged(enable bool) (*edged, error) {
 		}
 
 		klog.Infof("RemoteRuntimeEndpoint: %q, remoteImageEndpoint: %q",
-			edgedconfig.Get().RemoteRuntimeEndpoint, edgedconfig.Get().RemoteRuntimeEndpoint)
+			edgedconfig.Config.RemoteRuntimeEndpoint, edgedconfig.Config.RemoteRuntimeEndpoint)
 
 		klog.Info("Starting the GRPC server for the docker CRI shim.")
-		server := dockerremote.NewDockerServer(edgedconfig.Get().RemoteRuntimeEndpoint, ds)
+		server := dockerremote.NewDockerServer(edgedconfig.Config.RemoteRuntimeEndpoint, ds)
 		if err := server.Start(); err != nil {
 			return nil, err
 		}
 
 	}
-	ed.clusterDNS = convertStrToIP(edgedconfig.Get().ClusterDNS)
+	ed.clusterDNS = convertStrToIP(edgedconfig.Config.ClusterDNS)
 	ed.dnsConfigurer = kubedns.NewConfigurer(recorder,
 		nodeRef,
 		ed.nodeIP,
 		ed.clusterDNS,
-		edgedconfig.Get().ClusterDomain,
+		edgedconfig.Config.ClusterDomain,
 		ResolvConfDefault)
 
 	containerRefManager := kubecontainer.NewRefManager()
 	httpClient := &http.Client{}
 	runtimeService, imageService, err := getRuntimeAndImageServices(
-		edgedconfig.Get().RemoteRuntimeEndpoint,
-		edgedconfig.Get().RemoteRuntimeEndpoint,
+		edgedconfig.Config.RemoteRuntimeEndpoint,
+		edgedconfig.Config.RemoteRuntimeEndpoint,
 		metav1.Duration{
-			Duration: time.Duration(edgedconfig.Get().RuntimeRequestTimeout) * time.Minute,
+			Duration: time.Duration(edgedconfig.Config.RuntimeRequestTimeout) * time.Minute,
 		})
 	if err != nil {
 		return nil, err
@@ -480,7 +480,7 @@ func newEdged(enable bool) (*edged, error) {
 	ed.clcm, err = clcm.NewContainerLifecycleManager(DefaultRootDir)
 
 	var machineInfo cadvisorapi.MachineInfo
-	machineInfo.MemoryCapacity = uint64(edgedconfig.Get().EdgedMemoryCapacity)
+	machineInfo.MemoryCapacity = uint64(edgedconfig.Config.EdgedMemoryCapacity)
 	containerRuntime, err := kuberuntime.NewKubeGenericRuntimeManager(
 		recorder,
 		ed.livenessManager,
@@ -512,15 +512,15 @@ func newEdged(enable bool) (*edged, error) {
 	containerManager, err := cm.NewContainerManager(mount.New(""),
 		cadvisorInterface,
 		cm.NodeConfig{
-			CgroupDriver:                 edgedconfig.Get().CGroupDriver,
-			SystemCgroupsName:            edgedconfig.Get().CGroupDriver,
-			KubeletCgroupsName:           edgedconfig.Get().CGroupDriver,
-			ContainerRuntime:             edgedconfig.Get().RuntimeType,
+			CgroupDriver:                 edgedconfig.Config.CGroupDriver,
+			SystemCgroupsName:            edgedconfig.Config.CGroupDriver,
+			KubeletCgroupsName:           edgedconfig.Config.CGroupDriver,
+			ContainerRuntime:             edgedconfig.Config.RuntimeType,
 			KubeletRootDir:               DefaultRootDir,
 			ExperimentalCPUManagerPolicy: string(cpumanager.PolicyNone),
 		},
 		false,
-		edgedconfig.Get().DevicePluginEnabled,
+		edgedconfig.Config.DevicePluginEnabled,
 		recorder)
 	if err != nil {
 		return nil, fmt.Errorf("init container manager failed with error: %v", err)
@@ -535,7 +535,7 @@ func newEdged(enable bool) (*edged, error) {
 		recorder,
 		nodeRef,
 		policy,
-		edgedconfig.Get().PodSandboxImage,
+		edgedconfig.Config.PodSandboxImage,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize image manager: %v", err)

--- a/edge/pkg/edged/edged_pods.go
+++ b/edge/pkg/edged/edged_pods.go
@@ -547,8 +547,8 @@ func (e *edged) removeOrphanedPodStatuses(pods []*v1.Pod) {
 // GetPodCgroupParent gets pod cgroup parent from container manager.
 func (e *edged) GetPodCgroupParent(pod *v1.Pod) string {
 	ret := e.cgroupDriver
-	if edgedconfig.Get().RemoteRuntimeEndpoint == DockerShimEndpoint ||
-		edgedconfig.Get().RemoteRuntimeEndpoint == DockerShimEndpointDeprecated {
+	if edgedconfig.Config.RemoteRuntimeEndpoint == DockerShimEndpoint ||
+		edgedconfig.Config.RemoteRuntimeEndpoint == DockerShimEndpointDeprecated {
 		//always have a ".slice" suffix
 		ret = ret + systemdSuffix
 	}

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -355,7 +355,7 @@ func (e *edged) registerNode() error {
 
 	e.setInitNode(node)
 
-	if config.Get().RegisterNode == false {
+	if config.Config.RegisterNode == false {
 		//when register-node set to false, do not auto register node
 		klog.Infof("register-node is set to false")
 		e.registrationCompleted = true


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

 /kind feature


**What this PR does / why we need it**:
Change edged configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
