### PR TITLE
Change edgehub configuration access method from Get() to global variable 'Config'

### DIFF
--- a/edge/pkg/edgehub/clients/factory.go
+++ b/edge/pkg/edgehub/clients/factory.go
@@ -17,7 +17,7 @@ const (
 
 //GetClient returns an Adapter object with new web socket
 func GetClient() (Adapter, error) {
-	config := config.Get()
+	config := config.Config
 	switch {
 	case config.WebSocket.Enable:
 		websocketConf := wsclient.WebSocketConfig{

--- a/edge/pkg/edgehub/config/config.go
+++ b/edge/pkg/edgehub/config/config.go
@@ -19,7 +19,7 @@ const (
 	protocolQuic      = "quic"
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -30,14 +30,10 @@ type Configure struct {
 
 func InitConfigure(eh *v1alpha1.EdgeHub, nodeName string) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			EdgeHub:      *eh,
 			WebSocketURL: strings.Join([]string{"wss:/", eh.WebSocket.Server, eh.ProjectID, nodeName, "events"}, "/"),
 			NodeName:     nodeName,
 		}
 	})
-}
-
-func Get() *Configure {
-	return &c
 }

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -95,7 +95,7 @@ func (eh *EdgeHub) Start() {
 		eh.pubConnectInfo(false)
 
 		// sleep one period of heartbeat, then try to connect cloud hub again
-		time.Sleep(time.Duration(config.Get().Heartbeat) * time.Second * 2)
+		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second * 2)
 
 		// clean channel
 	clean:

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -133,7 +133,7 @@ func (eh *EdgeHub) sendToCloud(message model.Message) error {
 
 	syncKeep := func(message model.Message) {
 		tempChannel := eh.addKeepChannel(message.GetID())
-		sendTimer := time.NewTimer(time.Duration(config.Get().Heartbeat) * time.Second)
+		sendTimer := time.NewTimer(time.Duration(config.Config.Heartbeat) * time.Second)
 		select {
 		case response := <-tempChannel:
 			sendTimer.Stop()
@@ -198,7 +198,7 @@ func (eh *EdgeHub) keepalive() {
 			return
 		}
 
-		time.Sleep(time.Duration(config.Get().Heartbeat) * time.Second)
+		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second)
 	}
 }
 

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -333,7 +333,7 @@ func TestSendToCloud(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAdapter.EXPECT().Send(gomock.Any()).Return(tt.mockError).Times(1)
-			config.Get().Heartbeat = tt.HeartbeatPeriod
+			config.Config.Heartbeat = tt.HeartbeatPeriod
 			if !tt.waitError && tt.expectedError == nil {
 				go tt.hub.sendToCloud(tt.message)
 				time.Sleep(1 * time.Second)
@@ -412,7 +412,7 @@ func TestKeepalive(t *testing.T) {
 			},
 		},
 	}
-	edgeHubConfig := config.Get()
+	edgeHubConfig := config.Config
 	edgeHubConfig.TLSCertFile = CertFile
 	edgeHubConfig.TLSPrivateKeyFile = KeyFile
 


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature


**What this PR does / why we need it**:
Change edgehub configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
