### PR TITLE
Change eventbus configuration access method from Get() to global variable 'Config'

### DIFF
--- a/edge/pkg/eventbus/config/config.go
+++ b/edge/pkg/eventbus/config/config.go
@@ -20,7 +20,7 @@ const (
 	ExternalMqttMode        // 2: launch an external mqtt broker.
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 type Configure struct {
@@ -30,12 +30,9 @@ type Configure struct {
 
 func InitConfigure(eventbus *v1alpha1.EventBus, nodeName string) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			EventBus: *eventbus,
 			NodeName: nodeName,
 		}
 	})
-}
-func Get() *Configure {
-	return &c
 }


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature


**What this PR does / why we need it**:
Change eventbus configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
