### PR TITLE
Change metamanager configuration access method from Get() to global variable 'Config'

### DIFF
--- a/edge/pkg/metamanager/config/config.go
+++ b/edge/pkg/metamanager/config/config.go
@@ -10,7 +10,7 @@ const (
 	defaultSyncInterval = 60
 )
 
-var c Configure
+var Config Configure
 var once sync.Once
 
 // Connected stands for whether it is connected
@@ -23,12 +23,8 @@ type Configure struct {
 
 func InitConfigure(m *v1alpha1.MetaManager) {
 	once.Do(func() {
-		c = Configure{
+		Config = Configure{
 			MetaManager: *m,
 		}
 	})
-}
-
-func Get() *Configure {
-	return &c
 }

--- a/edge/pkg/metamanager/metamanager.go
+++ b/edge/pkg/metamanager/metamanager.go
@@ -80,5 +80,5 @@ func (m *metaManager) Start() {
 }
 
 func getSyncInterval() time.Duration {
-	return time.Duration(metamanagerconfig.Get().PodStatusSyncInterval) * time.Second
+	return time.Duration(metamanagerconfig.Config.PodStatusSyncInterval) * time.Second
 }

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
 	"github.com/kubeedge/beehive/pkg/common/util"
@@ -66,7 +66,7 @@ func sendToEdgeMesh(message *model.Message, sync bool) {
 }
 
 func sendToCloud(message *model.Message) {
-	beehiveContext.SendToGroup(string(metaManagerConfig.Get().ContextSendGroup), *message)
+	beehiveContext.SendToGroup(string(metaManagerConfig.Config.ContextSendGroup), *message)
 }
 
 // Resource format: <namespace>/<restype>[/resid]
@@ -400,7 +400,7 @@ func (m *metaManager) processRemoteQuery(message model.Message) {
 		originalID := message.GetID()
 		message.UpdateID()
 		resp, err := beehiveContext.SendSync(
-			string(metaManagerConfig.Get().ContextSendModule),
+			string(metaManagerConfig.Config.ContextSendModule),
 			message,
 			60*time.Second) // TODO: configurable
 		klog.Infof("########## process get: req[%+v], resp[%+v], err[%+v]", message, resp, err)


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

 /kind feature


**What this PR does / why we need it**:
Change metamanager configuration access method from Get() to global variable 'Config'

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
