### PR TITLE
Handle the error of initialNode and use configured nodeIP for getIP() first

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -560,8 +560,14 @@ func newEdged(enable bool) (*edged, error) {
 }
 
 func (e *edged) initializeModules() error {
-	node, _ := e.initialNode()
-	if err := e.containerManager.Start(node, e.GetActivePods, edgedutil.NewSourcesReady(), e.statusManager, e.runtimeService); err != nil {
+	node, err := e.initialNode()
+	if err != nil {
+		klog.Errorf("Failed to initialNode %v", err)
+		return err
+	}
+
+	err = e.containerManager.Start(node, e.GetActivePods, edgedutil.NewSourcesReady(), e.statusManager, e.runtimeService)
+	if err != nil {
 		klog.Errorf("Failed to start device plugin manager %v", err)
 		return err
 	}

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -299,6 +299,9 @@ func (e *edged) setGPUInfo(nodeStatus *edgeapi.NodeStatusRequest) error {
 }
 
 func (e *edged) getIP() (string, error) {
+	if nodeIP := config.Get().NodeIP; nodeIP != "" {
+		return nodeIP, nil
+	}
 	hostName, _ := os.Hostname()
 	if hostName == "" {
 		hostName = e.nodeName


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug
**What this PR does / why we need it**:
initialNode returns an error, it is not handled. And when there is no default route, it is better to use configured nodeIP.
**Which issue(s) this PR fixes**:
Fixes #1466
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
None
```
