### PR TITLE
Fix the gating issue with ubuntu distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
 
 sudo: required
 
-dist: xenial
+dist: cosmic
 
 services:
   - docker
@@ -33,14 +33,16 @@ jobs:
       script:
         - make verify
         - make lint
-        
+
     - stage: "Test on amd64"
       name: "build, smallbuild, crossbuild"
       arch: amd64
-      dist: trusty
       before_script:
         - sudo apt-get install upx-ucl -y
+        - sudo apt-get install gcc-aarch64-linux-gnu -y
+        - sudo apt-get install libc6-dev-arm64-cross -y
         - sudo apt-get install gcc-arm-linux-gnueabi -y
+        - sudo apt-get install libc6-dev-armel-cross -y
         - export GOFLAGS=-mod=vendor
       script:
         - make
@@ -85,7 +87,6 @@ jobs:
     - stage: "Test on arm64"
       name: "build, smallbuild"
       arch: arm64
-      dist: trusty
       before_script:
         - export GOFLAGS=-mod=vendor
         - sudo apt-get install upx-ucl -y

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -37,11 +37,10 @@ clean:
 
 .PHONY: cross_build
 cross_build: verify
-	export GOARCH=arm \
+	export GOARCH=arm64 \
         export GOOS="linux" \
-        export GOARM=6 \
         export CGO_ENABLED=1 \
-        export CC=arm-linux-gnueabi-gcc; \
+        export CC=aarch64-linux-gnu-gcc; \
         go build cmd/edgecore/edgecore.go
 
 .PHONY: armv7

--- a/edgesite/Makefile
+++ b/edgesite/Makefile
@@ -11,11 +11,10 @@ verify:
 
 .PHONY: cross_build
 cross_build: verify
-	export GOARCH=arm \
+	export GOARCH=arm64 \
         export GOOS="linux" \
-        export GOARM=6 \
         export CGO_ENABLED=1 \
-        export CC=arm-linux-gnueabi-gcc; \
+        export CC=aarch64-linux-gnu-gcc; \
         go build cmd/edgesite/edgesite.go
 
 .PHONY: armv7


### PR DESCRIPTION
- upgrade ubuntu distro from `xenial` to `cosmic` and make
it a default config

- fix the cross-building issue by adding the mandatory packages.

- make `cross_build` target build arm64 instead of arm32 since
arm64 is used more widely.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind bug


**What this PR does / why we need it**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`make cross_build` now target on building arm64 instead of arm32, users can use `make edge_cross_build_v7` to build arm32 binaries.
```
