### PR TITLE
Set PluginBinDirString instead of PluginBinDirs directly

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -422,12 +422,12 @@ func newEdged(enable bool) (*edged, error) {
 		}
 
 		pluginConfigs := dockershim.NetworkPluginSettings{
-			HairpinMode:       kubeletinternalconfig.HairpinMode(HairpinMode),
-			NonMasqueradeCIDR: NonMasqueradeCIDR,
-			PluginName:        pluginName,
-			PluginBinDirs:     []string{pluginBinDir},
-			PluginConfDir:     pluginConfDir,
-			MTU:               mtu,
+			HairpinMode:        kubeletinternalconfig.HairpinMode(HairpinMode),
+			NonMasqueradeCIDR:  NonMasqueradeCIDR,
+			PluginName:         pluginName,
+			PluginBinDirString: pluginBinDir,
+			PluginConfDir:      pluginConfDir,
+			MTU:                mtu,
 		}
 
 		redirectContainerStream := redirectContainerStream


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

 /kind bug

**What this PR does / why we need it**:
Now edged set PluginBinDirs of NetworkPluginSettings directly, which will be overwritten by empty strings in [`NewDockerService()`](https://github.com/kubernetes/kubernetes/blob/2e5d5ebf593c551cdba2e4eff76ddb37e72d9b50/pkg/kubelet/dockershim/docker_service.go#L241) .Set PluginBinDirString instead of PluginBinDirs, just like [kubelet](https://github.com/kubernetes/kubernetes/blob/2e5d5ebf593c551cdba2e4eff76ddb37e72d9b50/pkg/kubelet/kubelet.go#L350).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
