### PR TITLE
Automated cherry pick of #1465: update v1.2 and v1.1 changelog, add download links

### DIFF
--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -9,6 +9,27 @@
          * [Known Issues](#known-issues)
          * [Other notable changes](#other-notable-changes)
 
+# v1.1.0
+
+## Downloads for v1.1.0
+
+### KubeEdge Binaries
+| filename | Size | sha512 hash |
+| -------- | ---- | ----------- |
+| [kubeedge-v1.1.0-linux-amd64.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.1.0/kubeedge-v1.1.0-linux-amd64.tar.gz) | 76.3 MB | `f28aebb6ac26e859f8f2510987dd727e018a3c6cd3bdbb66464228cd2f32387cc4d216275cd3cba9c78216f143a611ad3b3c7e2bfc70648da6f73f46d6f85084` |
+| [kubeedge-v1.1.0-linux-arm.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.1.0/kubeedge-v1.1.0-linux-arm.tar.gz) | 70.9 MB | `4fafd8447dca3466a42d145f3e229f186d8725b53ec6a51681b9f79cdda4b955bef7494c7b7a68513eccb9393383a50c850b76e3b678ae1da1b198b891d9e09e` |
+
+### Installer Binaries
+| filename | Size | sha512 hash |
+| -------- | ---- | ----------- |
+| [keadm-v1.1.0-linux-amd64.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.1.0/keadm-v1.1.0-linux-amd64.tar.gz) | 8.27 MB | `0f17124675adcb2396771b5ac872cf60b09b32e5d18ab5909c243c7a97adb56acd428e21df3073ec5df701ce08ae8dead98f7cd4b38e323cc9aed60c97c0df41` |
+
+### EdgeSite Binaries
+| filename | Size | sha512 hash |
+| -------- | ---- | ----------- |
+| [edgesite-v1.1.0-linux-amd64.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.1.0/edgesite-v1.1.0-linux-amd64.tar.gz) | 27.4 MB | `a16d7f5e2f45ecb0f500f794c4f07ea74b2663bcac8008711a44b3cdea34d1f104f38c1c147ca90f3ab1ff7cf529d4445c1da34c3eff3386fc9b98f45ee173be` |
+| [edgesite-v1.1.0-linux-arm.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.1.0/edgesite-v1.1.0-linux-arm.tar.gz) | 25.1 MB | `facef575c67759d234568fef16cf7d8e2797874520f845817b56372a45413448aa55a9014d33de5535dd7a73b4d521ad5ebdedaff9f147e838a7f8d2887f4bf4` |
+
 # KubeEdge v1.1 Release Notes
 
 ## 1.1 What's New
@@ -19,7 +40,7 @@ This feature enables running applications with persistant data store at edge and
 
 **Dynamic Admission Control Webhook**
 
-Admission control webhook is an effective way of validating/mutating the object configuration for KubeEdge API objects like devicemodels, devices. 
+Admission control webhook is an effective way of validating/mutating the object configuration for KubeEdge API objects like devicemodels, devices.
 
 **Kubernetes Upgrade**
 

--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -9,6 +9,27 @@
          * [Known Issues](#known-issues)
          * [Other notable changes](#other-notable-changes)
 
+# v1.2.0
+
+## Downloads for v1.2.0
+
+### KubeEdge Binaries
+| filename | Size | sha512 hash |
+| -------- | ---- | ----------- |
+| [kubeedge-v1.2.0-linux-amd64.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.2.0/kubeedge-v1.2.0-linux-amd64.tar.gz) | 77.3 MB | `d258171bca85adac2bdf604d4e2789e61ece17e40d3320ad93545b42a28ba48c581f7a468b5fb1ef4063e3ac3e2dcb8fde1f3b032697dcd8f429cb22111b7dc4` |
+| [kubeedge-v1.2.0-linux-arm.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.2.0/kubeedge-v1.2.0-linux-arm.tar.gz) | 71.8 MB MB | `a7c865b30b2850597c860a878d9aaf43face0f7dad5b362d06af9a72dcf36523faa60a316b7bd3a7b9596db8636a63a34ef706f2289671eac0335bae381658e4` |
+
+### Installer Binaries
+| filename | Size | sha512 hash |
+| -------- | ---- | ----------- |
+| [keadm-v1.2.0-linux-amd64.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.2.0/keadm-v1.2.0-linux-amd64.tar.gz) | 8.41 MB | `7ddc59fe800c81d7f3f128a87bbe2fff71efc212cc5d252e492cafeafd14855c2f254cbc4db7a472b1ffecb7e09ad70d97448b3bd4f9bc2b5f8fd9144bda86a7` |
+
+### EdgeSite Binaries
+| filename | Size | sha512 hash |
+| -------- | ---- | ----------- |
+| [edgesite-v1.2.0-linux-amd64.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.2.0/edgesite-v1.2.0-linux-amd64.tar.gz) | 27.8 MB | `e655c00791b01eb27d57b276d1ba666b482729761fc795776bbb17a86b728c41f84918bc1ec002b8cabd45222334229ea1cb9f38c42e9eda1c69ee0ef3480b72` |
+| [edgesite-v1.2.0-linux-arm.tar.gz](https://github.com/kubeedge/kubeedge/releases/download/v1.2.0/edgesite-v1.2.0-linux-arm.tar.gz) | 25.4 MB | `d07d05a28614ae96cde6ec2706ebe9d03f6cb93042261c3ae9158508eac291a47131c73f706f828798e2ce7781700aaa148b0cf4cac88ca58a0f72df50acd669` |
+
 # KubeEdge v1.2 Release Notes
 
 ## 1.2 What's New
@@ -16,19 +37,19 @@
 **Reliable message delivery from cloud to edge**
 
 This feature improved the reliable message delivery mechanism from cloud to edge. If cloudcore or edgecore
-being restarted or offline for a while, it can ensure that the messages sent to the edge are not lost, and 
+being restarted or offline for a while, it can ensure that the messages sent to the edge are not lost, and
 avoid inconsistency between cloud and edge.
 ([#1343](https://github.com/kubeedge/kubeedge/pull/1343), [@kevin-wangzefeng](https://github.com/kevin-wangzefeng), [@fisherxu](https://github.com/fisherxu), [@SpaghettiAndSalmon](https://github.com/SpaghettiAndSalmon))
 
 **KubeEdge Component Config**
 
-The configuration information of all KubeEdge components is integrated into the unified API, 
+The configuration information of all KubeEdge components is integrated into the unified API,
 and users can view all configuration information and their default values through the API.
 ([#1172](https://github.com/kubeedge/kubeedge/pull/1172), [@kadisi](https://github.com/kadisi))
 
 **Kubernetes dependencies Upgrade**
 
-Upgrade the venderod kubernetes version to v1.17.1, so users can use the feature of new version 
+Upgrade the venderod kubernetes version to v1.17.1, so users can use the feature of new version
 on the cloud and on the edge side.
 ([#1349](https://github.com/kubeedge/kubeedge/pull/1349), [@fisherxu](https://github.com/fisherxu))
 


### PR DESCRIPTION
Cherry pick of #1465 on release-1.2.

#1465: update v1.2 and v1.1 changelog, add download links

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.