### PR TITLE
Automated cherry pick of #1467: Compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ KubeEdge is composed of the following components:
 
 ### Kubernetes compatibility
 
-|                     | Kubernetes 1.11 | Kubernetes 1.12 | Kubernetes 1.13 | Kubernetes 1.14 | Kubernetes 1.15 | Kubernetes 1.16 | Kubernetes 1.17 |
-|---------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-| KubeEdge 1.0        | ✓               | ✓              | ✓               | ✓              | ✓               | -               | -               |
-| KubeEdge 1.1        | ✓               | ✓               | ✓               | ✓               | ✓             | ✓               | ✓               |
-| KubeEdge HEAD       | ✓               | ✓               | ✓               | ✓               | ✓             | ✓               | ✓               |
+|                        | Kubernetes 1.11 | Kubernetes 1.12 | Kubernetes 1.13 | Kubernetes 1.14 | Kubernetes 1.15 | Kubernetes 1.16 | Kubernetes 1.17 |
+|------------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| KubeEdge 1.0           | ✓               | ✓               | ✓               | ✓              | ✓               | -               | -               |
+| KubeEdge 1.1           | ✓               | ✓               | ✓               | ✓               | ✓             | ✓               | ✓               |
+| KubeEdge 1.2           | ✓               | ✓               | ✓               | ✓               | ✓             | ✓               | ✓               |
+| KubeEdge HEAD (master) | ✓               | ✓               | ✓               | ✓               | ✓             | ✓               | ✓               |
 
 Key:
 * `✓` KubeEdge and the Kubernetes version are exactly compatible.
@@ -68,11 +69,12 @@ Key:
 
 ### Golang dependency
 
-|                     | Golang 1.10    | Golang 1.11     | Golang 1.12     | Golang 1.13     |
-|---------------------|----------------|-----------------|-----------------|-----------------|
-| KubeEdge 1.0        | ✓              | ✓              | ✓               | ✗               |
-| KubeEdge 1.1        | ✗              | ✗               | ✓               | ✗               |
-| KubeEdge HEAD       | ✗              | ✗               | ✓               | ✓               |
+|                         | Golang 1.10    | Golang 1.11     | Golang 1.12     | Golang 1.13     |
+|-------------------------|----------------|-----------------|-----------------|-----------------|
+| KubeEdge 1.0            | ✓              | ✓               | ✓               | ✗               |
+| KubeEdge 1.1            | ✗              | ✗               | ✓               | ✗               |
+| KubeEdge 1.2            | ✗              | ✗               | ✓               | ✓               |
+| KubeEdge HEAD (master)  | ✗              | ✗               | ✓               | ✓               |
 
 ## To start developing KubeEdge
 


### PR DESCRIPTION
Cherry pick of #1467 on release-1.2.

#1467: Compatibility matrix

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.