### PR TITLE
expose concurrentConsumers as variable

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -33,6 +33,7 @@ const (
 	DefaultCNIBinDir                   = "/opt/cni/bin"
 	DefaultCNICacheDir                 = "/var/lib/cni/cache"
 	DefaultNetworkPluginMTU            = 1500
+	DefaultConcurrentConsumers         = 5
 )
 const (
 	DefaultPodStatusSyncInterval = 60

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -351,6 +351,7 @@ modules:
     cgroupDriver: cgroupfs
     clusterDNS: ""
     clusterDomain: ""
+    concurrentConsumers: 5
     devicePluginEnabled: false
     dockerAddress: unix:///var/run/docker.sock
     edgedMemoryCapacity: 7852396000

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -113,7 +113,6 @@ import (
 const (
 	plegChannelCapacity = 1000
 	plegRelistPeriod    = time.Second * 1
-	concurrentConsumers = 5
 	backOffPeriod       = 10 * time.Second
 	// MaxContainerBackOff is the max backoff period, exported for the e2e test
 	MaxContainerBackOff = 300 * time.Second
@@ -177,6 +176,7 @@ type edged struct {
 	registrationCompleted     bool
 	containerManager          cm.ContainerManager
 	containerRuntimeName      string
+	concurrentConsumers       int
 	// container runtime
 	containerRuntime   kubecontainer.Runtime
 	podCache           kubecontainer.Cache
@@ -285,8 +285,8 @@ func (e *edged) Start() {
 	e.statusManager.Start()
 	e.pleg.Start()
 
-	e.podAddWorkerRun(concurrentConsumers)
-	e.podRemoveWorkerRun(concurrentConsumers)
+	e.podAddWorkerRun(e.concurrentConsumers)
+	e.podRemoveWorkerRun(e.concurrentConsumers)
 
 	housekeepingTicker := time.NewTicker(housekeepingPeriod)
 	syncWorkQueueCh := time.NewTicker(syncWorkQueuePeriod)
@@ -359,6 +359,7 @@ func newEdged(enable bool) (*edged, error) {
 		namespace:                 edgedconfig.Config.RegisterNodeNamespace,
 		gpuPluginEnabled:          edgedconfig.Config.GPUPluginEnabled,
 		cgroupDriver:              edgedconfig.Config.CGroupDriver,
+		concurrentConsumers:       edgedconfig.Config.ConcurrentConsumers,
 		podManager:                podManager,
 		podAdditionQueue:          workqueue.New(),
 		podCache:                  kubecontainer.NewCache(),

--- a/keadm/cmd/keadm/app/cmd/common/config.go
+++ b/keadm/cmd/keadm/app/cmd/common/config.go
@@ -167,6 +167,7 @@ func WriteEdgeYamlFile(path string, modifiedEdgeYaml *EdgeYamlSt) error {
 			HostnameOverride:                  edgeID,
 			InterfaceName:                     iface,
 			NodeStatusUpdateFrequency:         10,
+			ConcurrentConsumers:               5,
 			DevicePluginEnabled:               false,
 			GPUPluginEnabled:                  false,
 			ImageGCHighThreshold:              80,

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -229,6 +229,7 @@ type EdgeDSt struct {
 	ImageEndpoint                     string `yaml:"remote-image-endpoint"`
 	RequestTimeout                    uint16 `yaml:"runtime-request-timeout"`
 	PodSandboxImage                   string `yaml:"podsandbox-image"`
+	ConcurrentConsumers               int    `yaml:"concurrent-consumers"`
 }
 type Mesh struct {
 	LB LoadBalance `yaml:"loadbalance"`

--- a/pkg/apis/edgecore/v1alpha1/default.go
+++ b/pkg/apis/edgecore/v1alpha1/default.go
@@ -56,6 +56,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				NodeIP:                      localIP,
 				ClusterDNS:                  "",
 				ClusterDomain:               "",
+				ConcurrentConsumers:         constants.DefaultConcurrentConsumers,
 				EdgedMemoryCapacity:         constants.DefaultEdgedMemoryCapacity,
 				PodSandboxImage:             constants.DefaultPodSandboxImage,
 				ImagePullProgressDeadline:   constants.DefaultImagePullProgressDeadline,

--- a/pkg/apis/edgecore/v1alpha1/types.go
+++ b/pkg/apis/edgecore/v1alpha1/types.go
@@ -157,6 +157,9 @@ type Edged struct {
 	// InterfaceName indicates interface name
 	// default eth0
 	InterfaceName string `json:"interfaceName,omitempty"`
+	// ConcurrentConsumers indicates concurrent consumers for pod add or remove operation
+	// default 5
+	ConcurrentConsumers int `json:"concurrentConsumers,omitempty"`
 	// DevicePluginEnabled indicates enable device plugin
 	// default false
 	// Note: Can not use "omitempty" option,  It will affect the output of the default configuration file


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind feature

**What this PR does / why we need it**:
The `concurrentConsumers` is set to 5 by default, which is too small in some cases.
Modify it to a variable, then users can set it themselves.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
