### PR TITLE
Automated cherry pick of #1476: Set PluginBinDirString instead of PluginBinDirs directly

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -422,12 +422,12 @@ func newEdged(enable bool) (*edged, error) {
 		}
 
 		pluginConfigs := dockershim.NetworkPluginSettings{
-			HairpinMode:       kubeletinternalconfig.HairpinMode(HairpinMode),
-			NonMasqueradeCIDR: NonMasqueradeCIDR,
-			PluginName:        pluginName,
-			PluginBinDirs:     []string{pluginBinDir},
-			PluginConfDir:     pluginConfDir,
-			MTU:               mtu,
+			HairpinMode:        kubeletinternalconfig.HairpinMode(HairpinMode),
+			NonMasqueradeCIDR:  NonMasqueradeCIDR,
+			PluginName:         pluginName,
+			PluginBinDirString: pluginBinDir,
+			PluginConfDir:      pluginConfDir,
+			MTU:                mtu,
 		}
 
 		redirectContainerStream := redirectContainerStream


### PR DESCRIPTION
Cherry pick of #1476 on release-1.2.

#1476: Set PluginBinDirString instead of PluginBinDirs directly

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.