### PR TITLE
Automated cherry pick of #1491: fix writing mistake in synccontroller

### DIFF
--- a/cloud/pkg/synccontroller/synccontroller.go
+++ b/cloud/pkg/synccontroller/synccontroller.go
@@ -218,7 +218,7 @@ func (sctl *SyncController) manageObjectSync(syncs []*v1alpha1.ObjectSync) {
 			sctl.manageEndpoint(sync)
 		// TODO: add device here
 		default:
-			klog.Errorf("Unsupported object kind： %v", sync.Spec.ObjectKind)
+			klog.Errorf("Unsupported object kind: %v", sync.Spec.ObjectKind)
 		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #1491 on release-1.2.

#1491: fix writing mistake in synccontroller

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.