### PR TITLE
Automated cherry pick of #1496: Remove hard code for network plugin settings

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -29,6 +29,10 @@ const (
 	DefaultHostnameOverride            = "default-edge-node"
 	DefaultRegisterNodeNamespace       = "default"
 	DefaultInterfaceName               = "eth0"
+	DefaultCNIConfDir                  = "/etc/cni/net.d"
+	DefaultCNIBinDir                   = "/opt/cni/bin"
+	DefaultCNICacheDir                 = "/var/lib/cni/cache"
+	DefaultNetworkPluginMTU            = 1500
 )
 const (
 	DefaultPodStatusSyncInterval = 60

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -146,14 +146,6 @@ const (
 	NonMasqueradeCIDR = "10.0.0.1/8"
 	//cgroupName used for check if the cgroup is mounted.(default "")
 	cgroupName = ""
-	// PluginName gives the plugin name.(default "",use noop plugin)
-	pluginName = ""
-	//PluginBinDir gives the dir of cni plugin executable file
-	pluginBinDir = "/opt/cni/bin"
-	// PluginConfDir gives the dir of cni plugin confguration file
-	pluginConfDir = "/etc/cni/net.d"
-	//MTU give the default maximum transmission unit of  net interface
-	mtu = 1500
 	// redirectContainerStream decide whether to redirect the container stream
 	redirectContainerStream = false
 	// ResolvConfDefault gives the default dns resolv configration file
@@ -422,12 +414,13 @@ func newEdged(enable bool) (*edged, error) {
 		}
 
 		pluginConfigs := dockershim.NetworkPluginSettings{
-			HairpinMode:       kubeletinternalconfig.HairpinMode(HairpinMode),
-			NonMasqueradeCIDR: NonMasqueradeCIDR,
-			PluginName:        pluginName,
-			PluginBinDirs:     []string{pluginBinDir},
-			PluginConfDir:     pluginConfDir,
-			MTU:               mtu,
+			HairpinMode:        kubeletinternalconfig.HairpinMode(HairpinMode),
+			NonMasqueradeCIDR:  NonMasqueradeCIDR,
+			PluginName:         edgedconfig.Get().NetworkPluginName,
+			PluginBinDirString: edgedconfig.Get().CNIBinDir,
+			PluginConfDir:      edgedconfig.Get().CNIConfDir,
+			PluginCacheDir:     edgedconfig.Get().CNICacheDir,
+			MTU:                int(edgedconfig.Get().NetworkPluginMTU),
 		}
 
 		redirectContainerStream := redirectContainerStream

--- a/pkg/apis/edgecore/v1alpha1/default.go
+++ b/pkg/apis/edgecore/v1alpha1/default.go
@@ -70,6 +70,11 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				ImageGCLowThreshold:         constants.DefaultImageGCLowThreshold,
 				MaximumDeadContainersPerPod: constants.DefaultMaximumDeadContainersPerPod,
 				CGroupDriver:                CGroupDriverCGroupFS,
+				NetworkPluginName:           "",
+				CNIConfDir:                  constants.DefaultCNIConfDir,
+				CNIBinDir:                   constants.DefaultCNIBinDir,
+				CNICacheDir:                 constants.DefaultCNICacheDir,
+				NetworkPluginMTU:            constants.DefaultNetworkPluginMTU,
 			},
 			EdgeHub: &EdgeHub{
 				Enable:            true,

--- a/pkg/apis/edgecore/v1alpha1/types.go
+++ b/pkg/apis/edgecore/v1alpha1/types.go
@@ -178,6 +178,21 @@ type Edged struct {
 	// default cgroupfs
 	// +Required
 	CGroupDriver string `json:"cgroupDriver,omitempty"`
+	//NetworkPluginName indicates the name of the network plugin to be invoked, if an empty string is specified, use noop plugin
+	//default ""
+	NetworkPluginName string `json:"networkPluginName,omitempty"`
+	//CNIConfDir indicates the full path of the directory in which to search for CNI config files
+	//default /etc/cni/net.d
+	CNIConfDir string `json:"cniConfDir,omitempty"`
+	//CNIBinDir indicates a comma-separated list of full paths of directories in which to search for CNI plugin binaries
+	//default /opt/cni/bin
+	CNIBinDir string `json:"cniBinDir,omitempty"`
+	//CNICacheDir indicates the full path of the directory in which CNI should store cache files
+	//default /var/lib/cni/cache
+	CNICacheDir string `json:"cniCacheDirs,omitempty"`
+	//NetworkPluginMTU indicates the MTU to be passed to the network plugin
+	//default 1500
+	NetworkPluginMTU int32 `json:"networkPluginMTU,omitempty"`
 }
 
 // EdgeHub indicates the edgehub module config


### PR DESCRIPTION
Cherry pick of #1496 on release-1.2.

#1496: Remove hard code for network plugin settings

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.