### PR TITLE
Automated cherry pick of #1514: get latest version from release instead of set the default

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -44,9 +44,6 @@ const (
 	// DefaultCertPath is the default certificate path in edge node
 	DefaultCertPath = "/etc/kubeedge/certs"
 
-	// DefaultKubeEdgeVersion is the current default version of KubeEdge
-	DefaultKubeEdgeVersion = "1.2.0"
-
 	// DefaultK8SMinimumVersion is the minimum version of K8S
 	DefaultK8SMinimumVersion = 11
 

--- a/keadm/cmd/keadm/app/cmd/util/ubuntuinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/ubuntuinstaller.go
@@ -274,21 +274,6 @@ func (u *UbuntuOS) IsKubeEdgeProcessRunning(proc string) (bool, error) {
 	return false, nil
 }
 
-// runCommandWithShell executes the given command with "sh -c".
-// It returns an error if the command outputs anything on the stderr.
-func runCommandWithShell(command string) (string, error) {
-	cmd := &Command{Cmd: exec.Command("sh", "-c", command)}
-	err := cmd.ExecuteCmdShowOutput()
-	if err != nil {
-		return "", err
-	}
-	errout := cmd.GetStdErr()
-	if errout != "" {
-		return "", fmt.Errorf("%s", errout)
-	}
-	return cmd.GetStdOutput(), nil
-}
-
 // build Config from flags
 func BuildConfig(kubeConfig, master string) (conf *rest.Config, err error) {
 	config, err := clientcmd.BuildConfigFromFlags(master, kubeConfig)


### PR DESCRIPTION
Cherry pick of #1514 on release-1.2.

#1514: get latest version from release instead of set the default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.