### PR TITLE
synccontroller: handle zero length rv strings

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -203,16 +203,21 @@ func GetObjectResourceVersion(obj interface{}) string {
 // ints, so we can easily compare them.
 // If rva>rvb, return 1; rva=rvb, return 0; rva<rvb, return -1
 func CompareResourceVersion(rva, rvb string) int {
-	a, err := strconv.ParseUint(rva, 10, 64)
-	if err != nil {
-		// coder error
-		panic(err)
-	}
-	b, err := strconv.ParseUint(rvb, 10, 64)
-	if err != nil {
-		// coder error
-		panic(err)
-	}
+	var a, b uint64
+	var err error
+
+	if len(rva) > 0 {
+		a, err = strconv.ParseUint(rva, 10, 64)
+		if err != nil {
+			klog.Warningf("parsing ResourceVersion a failed with: %s", err)
+		}
+ 	}
+	if len(rvb) > 0 {
+		b, err = strconv.ParseUint(rvb, 10, 64)
+		if err != nil {
+			klog.Warningf("parsing ResourceVersion b failed with: %s", err)
+		}
+ 	}
 
 	if a > b {
 		return 1

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -211,13 +211,13 @@ func CompareResourceVersion(rva, rvb string) int {
 		if err != nil {
 			klog.Warningf("parsing ResourceVersion a failed with: %s", err)
 		}
- 	}
+	}
 	if len(rvb) > 0 {
 		b, err = strconv.ParseUint(rvb, 10, 64)
 		if err != nil {
 			klog.Warningf("parsing ResourceVersion b failed with: %s", err)
 		}
- 	}
+	}
 
 	if a > b {
 		return 1


### PR DESCRIPTION
check string length before attempting string > uint64 conversion

Fixes #1528

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

synccontroller: handle zero length rv strings
check string length before attempting string > uint64 conversion

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
