### PR TITLE
fix bug #1361 ,if rva or rvb would be "",parseUint will return error, This will caus…

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -203,15 +203,24 @@ func GetObjectResourceVersion(obj interface{}) string {
 // ints, so we can easily compare them.
 // If rva>rvb, return 1; rva=rvb, return 0; rva<rvb, return -1
 func CompareResourceVersion(rva, rvb string) int {
-	a, err := strconv.ParseUint(rva, 10, 64)
-	if err != nil {
-		// coder error
-		panic(err)
+	var err error
+	a := uint64(0)
+	b := uint64(0)
+	if rva != "" {
+		a, err = strconv.ParseUint(rva, 10, 64)
+		if err != nil {
+			// coder error
+			panic(err)
+		}
 	}
-	b, err := strconv.ParseUint(rvb, 10, 64)
-	if err != nil {
-		// coder error
-		panic(err)
+
+	if rvb != "" {
+		b, err = strconv.ParseUint(rvb, 10, 64)
+		if err != nil {
+			// coder error
+			panic(err)
+		}
+
 	}
 
 	if a > b {


### PR DESCRIPTION
…e cloud-core panic

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
