### PR TITLE
Fix --version issue in compoment container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,18 +249,19 @@ endif
 QEMU_ARCH ?= x86_64
 ARCH ?= amd64
 IMAGE_TAG ?= $(shell git describe --tags)
+GO_LDFLAGS='$(shell hack/make-rules/version.sh)'
 
 .PHONY: cloudimage
 cloudimage:
-	docker build -t kubeedge/cloudcore:${IMAGE_TAG} -f build/cloud/Dockerfile .
+	docker build --build-arg GO_LDFLAGS=${GO_LDFLAGS} -t kubeedge/cloudcore:${IMAGE_TAG} -f build/cloud/Dockerfile .
 
 .PHONY: admissionimage
 admissionimage:
-	docker build -t kubeedge/admission:${IMAGE_TAG} -f build/admission/Dockerfile .
+	docker build --build-arg GO_LDFLAGS=${GO_LDFLAGS} -t kubeedge/admission:${IMAGE_TAG} -f build/admission/Dockerfile .
 
 .PHONY: csidriverimage
 csidriverimage:
-	docker build -t kubeedge/csidriver:${IMAGE_TAG} -f build/csidriver/Dockerfile .
+	docker build --build-arg GO_LDFLAGS=${GO_LDFLAGS} -t kubeedge/csidriver:${IMAGE_TAG} -f build/csidriver/Dockerfile .
 
 .PHONY: edgeimage
 edgeimage:
@@ -269,7 +270,8 @@ edgeimage:
 	curl -L -o ./build/edge/tmp/qemu-${QEMU_ARCH}-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/v3.0.0/qemu-${QEMU_ARCH}-static.tar.gz
 	tar -xzf ./build/edge/tmp/qemu-${QEMU_ARCH}-static.tar.gz -C ./build/edge/tmp
 	docker build -t kubeedge/edgecore:${IMAGE_TAG} \
-	--build-arg BUILD_FROM=${ARCH}/golang:1.12-alpine3.10 \
+	--build-arg GO_LDFLAGS=${GO_LDFLAGS} \
+	--build-arg BUILD_FROM=${ARCH}/golang:1.13.8-alpine3.10 \
 	--build-arg RUN_FROM=${ARCH}/docker:dind \
 	-f build/edge/Dockerfile .
 
@@ -280,7 +282,8 @@ edgesiteimage:
 	curl -L -o ./build/edgesite/tmp/qemu-${QEMU_ARCH}-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/v3.0.0/qemu-${QEMU_ARCH}-static.tar.gz
 	tar -xzf ./build/edgesite/tmp/qemu-${QEMU_ARCH}-static.tar.gz -C ./build/edgesite/tmp
 	docker build -t kubeedge/edgesite:${IMAGE_TAG} \
-	--build-arg BUILD_FROM=${ARCH}/golang:1.12-alpine3.10 \
+	--build-arg GO_LDFLAGS=${GO_LDFLAGS} \
+	--build-arg BUILD_FROM=${ARCH}/golang:1.13.8-alpine3.10 \
 	--build-arg RUN_FROM=${ARCH}/docker:dind \
 	-f build/edgesite/Dockerfile .
 

--- a/build/admission/Dockerfile
+++ b/build/admission/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.12-alpine3.10 AS builder
+FROM golang:1.13.8-alpine3.10 AS builder
+
+ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/admission -ldflags="-w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/admission -ldflags="${GO_LDFLAGS} -w -s" \
 github.com/kubeedge/kubeedge/cloud/cmd/admission
 
 

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.12-alpine3.10 AS builder
+FROM golang:1.13.8-alpine3.10 AS builder
+
+ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/cloudcore -ldflags="-w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/cloudcore -ldflags "$GO_LDFLAGS -w -s" \
 github.com/kubeedge/kubeedge/cloud/cmd/cloudcore
 
 

--- a/build/csidriver/Dockerfile
+++ b/build/csidriver/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.12-alpine3.10 AS builder
+FROM golang:1.13.8-alpine3.10 AS builder
+
+ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/csidriver -ldflags="-w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/csidriver -ldflags="${GO_LDFLAGS} -w -s" \
 github.com/kubeedge/kubeedge/cloud/cmd/csidriver
 
 FROM alpine:3.9

--- a/build/edge/Dockerfile
+++ b/build/edge/Dockerfile
@@ -1,16 +1,18 @@
-ARG BUILD_FROM=golang:1.12-alpine3.10
+ARG BUILD_FROM=golang:1.13.8-alpine3.10
 ARG RUN_FROM=docker:dind
 
 FROM ${BUILD_FROM} AS builder
 
+ARG GO_LDFLAGS
 ARG QEMU_ARCH=x86_64
+
 COPY ./build/edge/tmp/qemu-${QEMU_ARCH}-static /usr/bin/
 COPY . /go/src/github.com/kubeedge/kubeedge
 
 RUN apk --no-cache update && \
 apk --no-cache upgrade && \
 apk --no-cache add build-base linux-headers sqlite-dev binutils-gold && \
-CGO_ENABLED=1 go build -v -o /usr/local/bin/edgecore -ldflags="-w -s -extldflags -static" \
+CGO_ENABLED=1 go build -v -o /usr/local/bin/edgecore -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
 github.com/kubeedge/kubeedge/edge/cmd/edgecore
 
 FROM ${RUN_FROM}
@@ -22,7 +24,7 @@ COPY --from=builder /usr/bin/qemu* /usr/bin/
 ENV GOARCHAIUS_CONFIG_PATH /etc/kubeedge/edge
 ENV database.source /var/lib/kubeedge/edge.db
 
-VOLUME ["/etc/kubeedge/certs", "/var/lib/edged", "/var/lib/kubeedge", "/var/run/docker.sock"]
+# VOLUME ["/etc/kubeedge/certs", "/var/lib/edged", "/var/lib/kubeedge", "/var/run/docker.sock"]
 
 COPY --from=builder /usr/local/bin/edgecore /usr/local/bin/edgecore
 

--- a/build/edge/Dockerfile
+++ b/build/edge/Dockerfile
@@ -24,8 +24,6 @@ COPY --from=builder /usr/bin/qemu* /usr/bin/
 ENV GOARCHAIUS_CONFIG_PATH /etc/kubeedge/edge
 ENV database.source /var/lib/kubeedge/edge.db
 
-# VOLUME ["/etc/kubeedge/certs", "/var/lib/edged", "/var/lib/kubeedge", "/var/run/docker.sock"]
-
 COPY --from=builder /usr/local/bin/edgecore /usr/local/bin/edgecore
 
 ENTRYPOINT ["edgecore"]

--- a/build/edgesite/Dockerfile
+++ b/build/edgesite/Dockerfile
@@ -1,8 +1,9 @@
-ARG BUILD_FROM=golang:1.12-alpine3.10
+ARG BUILD_FROM=golang:1.13.8-alpine3.10
 ARG RUN_FROM=docker:dind
 
 FROM ${BUILD_FROM} AS builder
 
+ARG GO_LDFLAGS
 ARG QEMU_ARCH=x86_64
 COPY ./build/edgesite/tmp/qemu-${QEMU_ARCH}-static /usr/bin/
 COPY . /go/src/github.com/kubeedge/kubeedge
@@ -10,7 +11,7 @@ COPY . /go/src/github.com/kubeedge/kubeedge
 RUN apk --no-cache update && \
 apk --no-cache upgrade && \
 apk --no-cache add build-base linux-headers sqlite-dev && \
-CGO_ENABLED=1 go build -v -o /usr/local/bin/edgesite -ldflags="-w -s -extldflags -static" \
+CGO_ENABLED=1 go build -v -o /usr/local/bin/edgesite -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
 github.com/kubeedge/kubeedge/edgesite/cmd/edgesite
 
 FROM ${RUN_FROM}

--- a/build/edgesite/Dockerfile
+++ b/build/edgesite/Dockerfile
@@ -21,8 +21,6 @@ COPY --from=builder /usr/bin/qemu* /usr/bin/
 ENV GOARCHAIUS_CONFIG_PATH /etc/kubeedge/edgesite
 ENV database.source /var/lib/kubeedge/edge.db
 
-VOLUME ["/etc/kubeedge/certs", "/var/lib/edged", "/var/lib/kubeedge", "/var/run/docker.sock"]
-
 COPY --from=builder /usr/local/bin/edgesite /usr/local/bin/edgesite
 
 ENTRYPOINT ["edgesite"]

--- a/hack/make-rules/version.sh
+++ b/hack/make-rules/version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+###
+#Copyright 2020 The KubeEdge Authors.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+###
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "${KUBEEDGE_ROOT}/hack/lib/init.sh"
+
+
+kubeedge::version::ldflags


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
Fix --version issue in images.

If user execute e.g. `cloudcore --version` in container
Before: 
```
KubeEdge v0.0.0-master+$Format:%h$
```
After:
```
KubeEdge v1.2.1
```
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
