### PR TITLE
fix issue minor version of full managed k8s instances

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -369,6 +369,13 @@ kubeedge::golang::get_cloud_test_dirs() {
   )
 }
 
+kubeedge::golang::get_keadm_test_dirs() {
+    cd ${KUBEEDGE_ROOT}
+    findDirs=$(find -L ./keadm \
+	    -name '*_test.go' -print | xargs -0n1 dirname | uniq)
+    echo "${findDirs}"
+}
+
 kubeedge::golang::get_edge_test_dirs() {
   (
     local findDirs
@@ -382,15 +389,18 @@ kubeedge::golang::get_edge_test_dirs() {
 
 read -ra KUBEEDGE_CLOUD_TESTCASES <<< "$(kubeedge::golang::get_cloud_test_dirs)"
 read -ra KUBEEDGE_EDGE_TESTCASES <<< "$(kubeedge::golang::get_edge_test_dirs)"
+read -ra KUBEEDGE_KEADM_TESTCASES <<< "$(kubeedge::golang::get_keadm_test_dirs)"
 
 readonly KUBEEDGE_ALL_TESTCASES=(
   ${KUBEEDGE_CLOUD_TESTCASES[@]}
   ${KUBEEDGE_EDGE_TESTCASES[@]}
+  ${KUBEEDGE_KEADM_TESTCASES[@]}
 )
 
 ALL_COMPONENTS_AND_GETTESTDIRS_FUNCTIONS=(
   cloud::::kubeedge::golang::get_cloud_test_dirs
   edge::::kubeedge::golang::get_edge_test_dirs
+  keadm::::kubeedge::golang::get_keadm_test_dirs
 )
 
 kubeedge::golang::get_testdirs_by_component() {

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Kubeedge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/version"
+	"testing"
+)
+
+func TestManagedKubernetesVersion(t *testing.T) {
+	vers := version.Info{Minor: "17"}
+	t.Run("test with minor version of 17", func(t *testing.T) {
+		err := checkKubernetesVersion(&vers)
+		if err != nil {
+			t.Fatalf("checked errored with: %s\n", err)
+		}
+	})
+
+	vers.Minor = "17+"
+	t.Run("test with minor version of 17+", func(t *testing.T) {
+		err := checkKubernetesVersion(&vers)
+		if err != nil {
+			t.Fatalf("checked errored with: %s\n", err)
+		}
+	})
+
+	vers.Minor = "100"
+	t.Run("test with minor version of 100", func(t *testing.T) {
+		err := checkKubernetesVersion(&vers)
+		if err != nil {
+			t.Fatalf("checked errored with: %s\n", err)
+		}
+	})
+
+	vers.Minor = "100+"
+	t.Run("test with minor version of 100+", func(t *testing.T) {
+		err := checkKubernetesVersion(&vers)
+		if err != nil {
+			t.Fatalf("checked errored with: %s\n", err)
+		}
+	})
+
+	vers.Minor = "3"
+	t.Run("test with minor version of 3", func(t *testing.T) {
+		err := checkKubernetesVersion(&vers)
+		if err == nil {
+			t.Fatalf("check should return an error and didn't")
+		}
+	})
+
+	vers.Minor = "3+"
+	t.Run("test with minor version of 3+", func(t *testing.T) {
+		err := checkKubernetesVersion(&vers)
+		if err == nil {
+			t.Fatalf("check should return an error and didn't")
+		}
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix extracting minor version of full managed k8s instances

**Which issue(s) this PR fixes**:
Fixes #1546

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
- enabled unit-test in keadm
```
