### PR TITLE
set node.status.Address use hostnameoverride

### DIFF
--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -70,6 +70,10 @@ func (e *edged) initialNode() (*v1.Node, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		klog.Errorf("couldn't determine hostname: %v", err)
+		return nil, err
+	}
+	if len(e.nodeName) != 0 {
+		hostname = e.nodeName
 	}
 
 	ip, err := e.getIP()


### PR DESCRIPTION
Signed-off-by: kadisi <iamkadisi@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

 /kind feature

**What this PR does / why we need it**:

set node.status.Address use hostnameoverride when address type is Hostname

when edgecore set hostnameoveride field
```
modules:
  edged:
    hostnameOverride: test-edge
```
`node.status.address` should has hostnameOverride's values when type is `Hostname`

such as
```
status:
  addresses:
  - address: 172.20.11.41
    type: InternalIP
  - address: test-edge
    type: Hostname
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
set node.status.Address use hostnameoverride when address type is Hostname
```
