### PR TITLE
Fix outtaded docs

### DIFF
--- a/docs/setup/cross-compilation.md
+++ b/docs/setup/cross-compilation.md
@@ -20,7 +20,7 @@ export CC=arm-linux-gnueabi-gcc
 make edgecore
 ```
 
-If you are compiling KubeEdge edgecore for Raspberry Pi and check the [Makefile](https://github.com/kubeedge/kubeedge/blob/master/edge/Makefile) for the edge.
+If you are compiling KubeEdge edgecore for Raspberry Pi and check the [Makefile](https://github.com/kubeedge/kubeedge/blob/master/Makefile) for the edge.
 
 In that CC has been defined as
 ```

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -102,7 +102,7 @@ Please follow the instructions given below or click [Cross Compilation](cross-co
 
 ```shell
 cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
-make cross_build
+make crossbuild
 ```
 
 KubeEdge can also be compiled with a small binary size. Please follow the below steps to build a binary of lesser size:
@@ -110,7 +110,7 @@ KubeEdge can also be compiled with a small binary size. Please follow the below 
 ```shell
 apt-get install upx-ucl
 cd $GOPATH/src/github.com/kubeedge/kubeedge/edge
-make edge_small_build
+make smallbuild
 ```
 
 **Note:** If you are using the smaller version of the binary, it is compressed using upx, therefore the possible side effects of using upx compressed binaries like more RAM usage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind documentation



**What this PR does / why we need it**:

This fixes outdated docs in a few places:
* outtaded option names in `docs/setup/kubeedge_install_source.md`
* 404 link to Makefile in `docs/setup/cross-compilation.md`

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix:
* outtaded option names in `docs/setup/kubeedge_install_source.md`
* wrong link to Makefile in `docs/setup/cross-compilation.md`
```
