### PR TITLE
Add built-in labels when auto registering node

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -320,14 +320,6 @@ func (uc *UpstreamController) updatePodStatus() {
 // createNode create new edge node to kubernetes
 func (uc *UpstreamController) createNode(name string, node *v1.Node) (*v1.Node, error) {
 	node.Name = name
-
-	//add default labels
-	if node.Labels == nil {
-		node.Labels = make(map[string]string)
-	}
-	node.Labels["name"] = name
-	node.Labels["node-role.kubernetes.io/edge"] = ""
-
 	return uc.kubeClient.CoreV1().Nodes().Create(node)
 }
 

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -76,6 +76,17 @@ func (e *edged) initialNode() (*v1.Node, error) {
 		hostname = e.nodeName
 	}
 
+	node.Labels = map[string]string{
+		// Kubernetes built-in labels
+		v1.LabelHostname:   hostname,
+		v1.LabelOSStable:   runtime.GOOS,
+		v1.LabelArchStable: runtime.GOARCH,
+
+		// KubeEdge specific labels
+		"node-role.kubernetes.io/edge":  "",
+		"node-role.kubernetes.io/agent": "",
+	}
+
 	ip, err := e.getIP()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature


**What this PR does / why we need it**:

Ref: [Kubernetes built-in node labels](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#built-in-node-labels)

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Edge nodes are now registered with kubernetes.io/arch kubernetes.io/os labels automatically
```
