### PR TITLE
Modify a small error in edgemesh_test_env_guide, for the test command

### DIFF
--- a/docs/guides/edgemesh_test_env_guide.md
+++ b/docs/guides/edgemesh_test_env_guide.md
@@ -98,7 +98,7 @@ To request a server, use url like this: ```<service_name>.<service_namespace>.sv
 
 In our case, from edge node a or b, run the command:
 ```bash
-$ curl http://nginx-svc.default.svc.cluster.local:12345
+$ curl http://nginx-svc.default.svc.cluster:12345
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Change the test command from ```curl http://nginx-svc.default.svc.cluster.local:12345```to ```curl http://nginx-svc.default.svc.cluster:12345```, in`/docs/guide/edgemesh_test_env_guide.md`, 101 Line.

**Why?**
1. According to the document description, the test command should look like ```<service_name>.<service_namespace>.svc.<cluster>:<port>```, so `.local` shouldn't be here.
2. I'm debugging edgemesh moudle. The endpoint in edgemesh can't stop, when I run ```curl http://nginx-svc.default.svc.cluster.local:12345```, but it's stoped when I run ```curl http://nginx-svc.default.svc.cluster:12345```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1619 , Partly.

**Special notes for your reviewer**:

I'm still debugging for the problem that can't get endpoints, in #1619 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
None