### PR TITLE
Add tips to clean up certificates in secret

### DIFF
--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -96,7 +96,7 @@ modules:
 
 Refer [here](deploy-edge-node.md) to add edge nodes.
 
-#### Check the existence of certificates (cloud side) (Before KubeEdge v1.3)
+#### Check the existence of certificates (cloud side) (Required for pre 1.3 releases)
 
 **Note:** From KubeEdge v1.3, just skip the follow steps of checking the existence of certificates. However, if you configure the cloudcore certificate manually, you must check if the path of certificate is right. And there is no need to transfer certificate file from the cloud side to edge side.
 
@@ -129,7 +129,7 @@ At this point we have completed all configuration changes related to cloudcore.
 
 ## Configuration Edge side (KubeEdge Worker Node)
 
-### Manually copy certs.tgz from cloud host to edge host(s)  (Before KubeEdge v1.3)
+### Manually copy certs.tgz from cloud host to edge host(s)  (Required for pre 1.3 releases)
 
 **Note:**  From KubeEdge v1.3 just skip this step, the edgecore will apply for the certificate automatically from the cloudcore when starting. You can also configure the local certificate(The CA certificate in edge site must be the same with cloudcore now). Any directory is OK as long as you configure it in the edgecore.yaml below.
 
@@ -243,7 +243,7 @@ Verify the configurations before running `edgecore`
     type: Opaque
     ```
 
-    Decode the token string by base64:
+    Decode the tokendata field by base64:
 
     ```shell
     echo ODEzNTZjY2MwODIzMmIxMTU0Y2ExYmI5MmRlZjY4YWQwMGQ3ZDcwOTIzYmU3YjcyZWZmOTVlMTdiZTk5MzdkNS5leUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKbGVIQWlPakUxT0RreE5qRTVPRGw5LmpxNENXNk1WNHlUVkpVOWdBUzFqNkRCdE5qeVhQT3gxOHF5RnFfOWQ4WFkK |base64 -d

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -79,7 +79,7 @@ In the cloudcore.yaml, modify the below settings.
     
     **Note:** If your KubeEdge version is before the v1.3, then just skip the step 3.
     
-3. Configure the IP addresses of CloudCore which are exposed to the edge nodes(like floating IP) in the `advertiseAddress`
+3. Configure all the IP addresses of CloudCore which are exposed to the edge nodes(like floating IP) in the `advertiseAddress`, which will be add to SANs in cert of cloudcore. 
 
     ```yaml
     modules:

--- a/docs/setup/kubeedge_configure.md
+++ b/docs/setup/kubeedge_configure.md
@@ -74,6 +74,19 @@ In the cloudcore.yaml, modify the below settings.
 2. Before KubeEdge v1.3: check whether the cert files for `modules.cloudhub.tlsCAFile`, `modules.cloudhub.tlsCertFile`,`modules.cloudhub.tlsPrivateKeyFile` exists.
 
     From KubeEdge v1.3: just skip the above check. If you configure the CloudCore certificate manually, you must check if the path of certificate is right. 
+    
+    
+    
+    **Note:** If your KubeEdge version is before the v1.3, then just skip the step 3.
+    
+3. Configure the IP addresses of CloudCore which are exposed to the edge nodes(like floating IP) in the `advertiseAddress`
+
+    ```yaml
+    modules:
+      cloudHub:
+        advertiseAddress:
+        - 10.1.11.85
+    ```
 
 ### Adding the edge nodes (KubeEdge Worker Node) on the Cloud side (KubeEdge Master)
 
@@ -209,6 +222,8 @@ Verify the configurations before running `edgecore`
     ```
 
 5. If your runtime-type is remote, follow this guide [KubeEdge CRI Configuration](kubeedge_cri_configure.md) to setup KubeEdge with the remote/CRI based runtimes.
+
+    
 
     **Note:** If your KubeEdge version is before the v1.3, then just skip the steps 6-7.
 

--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -15,7 +15,11 @@ cd $GOPATH/src/github.com/kubeedge/kubeedge
 
 ### Generate Certificates (Required for pre 1.3 releases)
 
-**Note: KubeEdge v1.3 needs to skip this step Generate Certificates and clean up the local certificates in `/etc/kubeedge/ca` and `/etc/kubeedge/certs`. Because KubeEdge v1.3 has added the feature of generating certificates automatically.**
+**Note: KubeEdge v1.3 needs to skip this step Generate Certificates and clean up the local certificates in `/etc/kubeedge/ca` and `/etc/kubeedge/certs`. Because KubeEdge v1.3 has added the feature of generating certificates automatically. If you have ever manually configured the certificates locally and CloudCore fails to start. You'd better delete the certificates in the secret, just execute the script:**
+```bash
+kubectl delete secret casecret -nkubeedge
+kubectl delete secret cloudcoresecret -nkubeedge
+```
 
 RootCA certificate and a cert/ key pair is required to have a setup for KubeEdge. Same cert/ key pair can be used in both cloud and edge.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind documentation

**What this PR does / why we need it**:
when users have ever manually configured the wrong certificates locally,  the cloudcore won't generate the certificates automatically because there are certs in secret. Users need to delete certs in secret. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
