### PR TITLE
Add tips to clean up certificates in secret

### DIFF
--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -15,8 +15,11 @@ cd $GOPATH/src/github.com/kubeedge/kubeedge
 
 ### Generate Certificates (Required for pre 1.3 releases)
 
-**Note: KubeEdge v1.3 needs to skip this step Generate Certificates and clean up the local certificates in `/etc/kubeedge/ca` and `/etc/kubeedge/certs`. Because KubeEdge v1.3 has added the feature of generating certificates automatically.**
-
+**Note: KubeEdge v1.3 needs to skip this step Generate Certificates and clean up the local certificates in `/etc/kubeedge/ca` and `/etc/kubeedge/certs`. Because KubeEdge v1.3 has added the feature of generating certificates automatically. If you have ever manually configured the certificates locally and CloudCore fails to start. You'd better delete the certificates in the secret, just execute the script:**
+```bash
+kubectl delete secret casecret -nkubeedge
+kubectl delete secret cloudcoresecret -nkubeedge
+```
 RootCA certificate and a cert/ key pair is required to have a setup for KubeEdge. Same cert/ key pair can be used in both cloud and edge.
 
 ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind documentation

**What this PR does / why we need it**:
when users have ever manually configured the wrong certificates locally, the cloudcore won't generate the certificates automatically because there are certs in secret. Users need to delete certs in secret.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
