### PR TITLE
keadm: add error message for GetLatestVersion()'s exec.Output()

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -122,8 +122,9 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 	}
 	if kubeVer == "" {
 		var latestVersion string
+		var err error
 		for i := 0; i < util.RetryTimes; i++ {
-			latestVersion, err := util.GetLatestVersion()
+			latestVersion, err = util.GetLatestVersion()
 			if err != nil {
 				return err
 			}

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -27,13 +27,13 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kubeedge/kubeedge/pkg/util"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"github.com/kubeedge/kubeedge/pkg/util"
 
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
@@ -226,7 +226,7 @@ func IsCloudCore() (types.ModuleRunning, error) {
 func GetLatestVersion() (string, error) {
 	//Download the tar from repo
 	versionURL := "curl -k " + latestReleaseVersionURL
-	latestReleaseData, err := util.Command("sh",[]string{"-c",versionURL})
+	latestReleaseData, err := util.Command("sh", []string{"-c", versionURL})
 	if err != nil {
 		return "", err
 	}

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -226,9 +226,11 @@ func GetLatestVersion() (string, error) {
 	//Download the tar from repo
 	versionURL := "curl -k " + latestReleaseVersionURL
 	cmd := exec.Command("sh", "-c", versionURL)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	latestReleaseData, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%v:%v", err, stderr.String())
 	}
 
 	latestRelease := &latestReleaseVersion{}

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"github.com/kubeedge/kubeedge/pkg/util"
 
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
@@ -225,16 +226,13 @@ func IsCloudCore() (types.ModuleRunning, error) {
 func GetLatestVersion() (string, error) {
 	//Download the tar from repo
 	versionURL := "curl -k " + latestReleaseVersionURL
-	cmd := exec.Command("sh", "-c", versionURL)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	latestReleaseData, err := cmd.Output()
+	latestReleaseData, err := util.Command("sh",[]string{"-c",versionURL})
 	if err != nil {
-		return "", fmt.Errorf("%v:%v", err, stderr.String())
+		return "", err
 	}
 
 	latestRelease := &latestReleaseVersion{}
-	err = json.Unmarshal(latestReleaseData, latestRelease)
+	err = json.Unmarshal([]byte(latestReleaseData), latestRelease)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -453,8 +454,11 @@ func ValidateNodeIP(nodeIP net.IP) error {
 //Command executes command and returns output
 func Command(name string, arg []string) (string, error) {
 	cmd := exec.Command(name, arg...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	ret, err := cmd.Output()
 	if err != nil {
+		err = fmt.Errorf("%v: %v", err, stderr.String())
 		klog.Errorf("exec command failed: %v", err)
 		return string(ret), err
 	}


### PR DESCRIPTION



**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test

/kind feature


**What this PR does / why we need it**:
reason: 
We need more info about errors of exec.Command,but not just one 'exit status number'.
this may cause it to look a little bloated when related error occurs.
And i only changed the GetLatestVersion()'s exec.Output() , so it will be nice if we can provide unified management for exec.Command.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

i'm not sure , just adding more log to error returned

```release-note

```
