### PR TITLE
Automated cherry pick of #1628: keadm: fix get version issue

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -117,7 +118,7 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 				return err
 			}
 			if len(version) > 0 {
-				kubeVer = version[1:]
+				kubeVer = strings.TrimPrefix(version, "v")
 				latestVersion = version
 				break
 			}

--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -116,7 +116,7 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 			if err != nil {
 				return err
 			}
-			if len(version) != 0 {
+			if len(version) > 0 {
 				kubeVer = version[1:]
 				latestVersion = version
 				break

--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -112,12 +112,13 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 	if kubeVer == "" {
 		var latestVersion string
 		for i := 0; i < util.RetryTimes; i++ {
-			latestVersion, err := util.GetLatestVersion()
+			version, err := util.GetLatestVersion()
 			if err != nil {
 				return err
 			}
-			if len(latestVersion) != 0 {
-				kubeVer = latestVersion[1:]
+			if len(version) != 0 {
+				kubeVer = version[1:]
+				latestVersion = version
 				break
 			}
 		}


### PR DESCRIPTION
Cherry pick of #1628 on release-1.3.

#1628: keadm: fix get version issue

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.