### PR TITLE
Automated cherry pick of #1640: change the token separator space to dot

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -88,13 +88,13 @@ func edgeCoreClientCert(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("Invalid authorization token")))
 		return
 	}
-	bearerToken := strings.Split(authorizationHeader, ".")
-	if len(bearerToken) != 4 {
+	bearerToken := strings.Split(authorizationHeader, " ")
+	if len(bearerToken) != 2 {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(fmt.Sprintf("Invalid authorization token")))
 		return
 	}
-	token, err := jwt.Parse(strings.Join(bearerToken[1:], "."), func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(bearerToken[1], func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("There was an error")
 		}

--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -88,7 +88,7 @@ func edgeCoreClientCert(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("Invalid authorization token")))
 		return
 	}
-	bearerToken := strings.Split(authorizationHeader, " ")
+	bearerToken := strings.Split(authorizationHeader, ".")
 	if len(bearerToken) != 2 {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(fmt.Sprintf("Invalid authorization token")))

--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -89,12 +89,12 @@ func edgeCoreClientCert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	bearerToken := strings.Split(authorizationHeader, ".")
-	if len(bearerToken) != 2 {
+	if len(bearerToken) != 4 {
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(fmt.Sprintf("Invalid authorization token")))
 		return
 	}
-	token, err := jwt.Parse(bearerToken[1], func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(strings.Join(bearerToken[1:], "."), func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("There was an error")
 		}

--- a/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
@@ -71,7 +71,7 @@ func GenerateToken() {
 
 	caHash := getCaHash()
 	// combine caHash and tokenString into caHashAndToken
-	caHashToken := strings.Join([]string{caHash, tokenString}, " ")
+	caHashToken := strings.Join([]string{caHash, tokenString}, ".")
 	// save caHashAndToken to secret
 	CreateTokenSecret([]byte(caHashToken))
 
@@ -96,7 +96,7 @@ func refreshToken() string {
 	tokenString, _ := token.SignedString(keyPEM)
 	caHash := getCaHash()
 	//put caHash in token
-	caHashAndToken := strings.Join([]string{caHash, tokenString}, " ")
+	caHashAndToken := strings.Join([]string{caHash, tokenString}, ".")
 	return caHashAndToken
 }
 

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -43,7 +43,7 @@ func (eh *EdgeHub) applyCerts() error {
 	}
 
 	// validate the CA certificate by hashcode
-	tokenParts := strings.Split(config.Config.Token, " ")
+	tokenParts := strings.Split(config.Config.Token, ".")
 	if len(tokenParts) != 2 {
 		return fmt.Errorf("token credentials are in the wrong format")
 	}

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -44,7 +44,7 @@ func (eh *EdgeHub) applyCerts() error {
 
 	// validate the CA certificate by hashcode
 	tokenParts := strings.Split(config.Config.Token, ".")
-	if len(tokenParts) != 2 {
+	if len(tokenParts) != 4 {
 		return fmt.Errorf("token credentials are in the wrong format")
 	}
 	ok, hash, newHash := certutil.ValidateCACerts(cacert, tokenParts[0])
@@ -66,7 +66,7 @@ func (eh *EdgeHub) applyCerts() error {
 
 	// get the edge.crt
 	url = config.Config.HTTPServer + certURL
-	edgecert, err := certutil.GetEdgeCert(url, cacert, tokenParts[1])
+	edgecert, err := certutil.GetEdgeCert(url, cacert, strings.Join(tokenParts[1:], "."))
 	if err != nil {
 		klog.Errorf("failed to get edge certificate from the cloudcore, error: %v", err)
 		return fmt.Errorf("failed to get edge certificate from the cloudcore, error: %v", err)


### PR DESCRIPTION
Cherry pick of #1640 on release-1.3.

#1640: change the token separator space to dot

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.