### PR TITLE
Automated cherry pick of #1643: add advitise address in cloudcore

### DIFF
--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -27,6 +27,10 @@ type Configure struct {
 
 func InitConfigure(hub *v1alpha1.CloudHub, kubeAPIConfig *v1alpha1.KubeAPIConfig) {
 	once.Do(func() {
+		if len(hub.AdvertiseAddress) == 0 {
+			klog.Fatal("AdvertiseAddress must be specified!")
+		}
+
 		Config = Configure{
 			CloudHub:      *hub,
 			KubeAPIConfig: kubeAPIConfig,

--- a/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
@@ -39,9 +39,7 @@ func SignCerts() ([]byte, []byte) {
 		Organization: []string{"KubeEdge"},
 		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		AltNames: certutil.AltNames{
-			IPs: []net.IP{
-				net.ParseIP("127.0.0.1"),
-			},
+			IPs: getIps(hubconfig.Config.AdvertiseAddress),
 		},
 	}
 
@@ -51,6 +49,13 @@ func SignCerts() ([]byte, []byte) {
 	}
 
 	return certDER, keyDER
+}
+
+func getIps(advertiseAddress []string) (Ips []net.IP) {
+	for _, addr := range advertiseAddress {
+		Ips = append(Ips, net.ParseIP(addr))
+	}
+	return
 }
 
 func GenerateToken() {

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	componentbaseconfig "k8s.io/component-base/config"
 
 	"github.com/kubeedge/kubeedge/common/constants"
@@ -29,6 +30,8 @@ import (
 
 // NewDefaultCloudCoreConfig returns a full CloudCoreConfig object
 func NewDefaultCloudCoreConfig() *CloudCoreConfig {
+	advertiseAddress, _ := utilnet.ChooseHostInterface()
+
 	c := &CloudCoreConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind,
@@ -51,6 +54,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				TLSCertFile:       constants.DefaultCertFile,
 				TLSPrivateKeyFile: constants.DefaultKeyFile,
 				WriteTimeout:      30,
+				AdvertiseAddress:  []string{advertiseAddress.String()},
 				Quic: &CloudHubQUIC{
 					Enable:             false,
 					Address:            "0.0.0.0",
@@ -160,6 +164,8 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 
 // NewMinCloudCoreConfig returns a min CloudCoreConfig object
 func NewMinCloudCoreConfig() *CloudCoreConfig {
+	advertiseAddress, _ := utilnet.ChooseHostInterface()
+
 	return &CloudCoreConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind,
@@ -176,6 +182,7 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 				TLSCAKeyFile:      constants.DefaultCAKeyFile,
 				TLSCertFile:       constants.DefaultCertFile,
 				TLSPrivateKeyFile: constants.DefaultKeyFile,
+				AdvertiseAddress:  []string{advertiseAddress.String()},
 				UnixSocket: &CloudHubUnixSocket{
 					Enable:  true,
 					Address: "unix:///var/lib/kubeedge/kubeedge.sock",

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -111,6 +111,8 @@ type CloudHub struct {
 	// HTTPS indicates https server info
 	// +Required
 	Https *CloudHubHttps `json:"https,omitempty"`
+	// AdvertiseAddress sets the IP address for the cloudcore to advertise.
+	AdvertiseAddress []string `json:"advertiseAddress,omitempty"`
 }
 
 // CloudHubQUIC indicates the quic server config

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -92,17 +93,17 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 					Enable:           false,
 					HandshakeTimeout: 30,
 					ReadDeadline:     15,
-					Server:           "127.0.0.1:10001",
+					Server:           localIP + ":10001",
 					WriteDeadline:    15,
 				},
 				WebSocket: &EdgeHubWebSocket{
 					Enable:           true,
 					HandshakeTimeout: 30,
 					ReadDeadline:     15,
-					Server:           "127.0.0.1:10000",
+					Server:           localIP + ":10000",
 					WriteDeadline:    15,
 				},
-				HTTPServer: "https://127.0.0.1:10002",
+				HTTPServer: fmt.Sprintf("https://%s:10002", localIP),
 				Token:      "",
 			},
 			EventBus: &EventBus{
@@ -192,10 +193,10 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 					Enable:           true,
 					HandshakeTimeout: 30,
 					ReadDeadline:     15,
-					Server:           "127.0.0.1:10000",
+					Server:           localIP + ":10000",
 					WriteDeadline:    15,
 				},
-				HTTPServer: "https://127.0.0.1:10002",
+				HTTPServer: fmt.Sprintf("https://%s:10002", localIP),
 				Token:      "",
 			},
 			EventBus: &EventBus{


### PR DESCRIPTION
Cherry pick of #1643 on release-1.3.

#1643: add advitise address in cloudcore

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.