### PR TITLE
Automated cherry pick of #1645: log errors in function NewCloudCoreCertDERandKey

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -24,12 +24,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/gorilla/mux"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
+	"github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/mux"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog"
 
@@ -230,9 +230,13 @@ func PrepareAllCerts() error {
 		// Check whether the CloudCore certificates exist in the secret
 		secretHasCert := CheckCertExistsFromSecret()
 		if !secretHasCert {
-			certDER, keyDER := SignCerts()
+			certDER, keyDER, err := SignCerts()
+			if err != nil {
+				klog.Errorf("failed to sign a certificate, error: %v", err)
+				return err
+			}
 
-			err := CreateCloudCoreSecret(certDER, keyDER)
+			err = CreateCloudCoreSecret(certDER, keyDER)
 			if err != nil {
 				klog.Errorf("failed to create cloudcore cert to secrets, error: %v", err)
 				return err

--- a/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
@@ -20,20 +20,19 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
-	"fmt"
-	"github.com/dgrijalva/jwt-go"
-	"k8s.io/klog"
 	"net"
 	"strings"
 	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog"
 
 	hubconfig "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/config"
 )
 
 // SignCerts creates server's certificate and key
-func SignCerts() ([]byte, []byte) {
+func SignCerts() ([]byte, []byte, error) {
 	cfg := &certutil.Config{
 		CommonName:   "KubeEdge",
 		Organization: []string{"KubeEdge"},
@@ -47,10 +46,10 @@ func SignCerts() ([]byte, []byte) {
 
 	certDER, keyDER, err := NewCloudCoreCertDERandKey(cfg)
 	if err != nil {
-		fmt.Printf("%v", err)
+		return nil, nil, err
 	}
 
-	return certDER, keyDER
+	return certDER, keyDER, nil
 }
 
 func GenerateToken() {
@@ -93,7 +92,10 @@ func refreshToken() string {
 	claims.ExpiresAt = expirationTime.Unix()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	keyPEM := getCaKey()
-	tokenString, _ := token.SignedString(keyPEM)
+	tokenString, err := token.SignedString(keyPEM)
+	if err != nil {
+		klog.Errorf("Failed to generate token signed by caKey, err: %v", err)
+	}
 	caHash := getCaHash()
 	//put caHash in token
 	caHashAndToken := strings.Join([]string{caHash, tokenString}, " ")

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -7,13 +7,15 @@ import (
 )
 
 const (
-	DefaultConfigDir = "/etc/kubeedge/config/"
-	DefaultCAFile    = "/etc/kubeedge/ca/rootCA.crt"
-	DefaultCAKeyFile = "/etc/kubeedge/ca/rootCA.key"
-	DefaultCertFile  = "/etc/kubeedge/certs/server.crt"
-	DefaultKeyFile   = "/etc/kubeedge/certs/server.key"
-	DefaultCADir     = "/etc/kubeedge/ca"
-	DefaultCertDir   = "/etc/kubeedge/certs"
+	DefaultConfigDir    = "/etc/kubeedge/config/"
+	DefaultCAFile       = "/etc/kubeedge/ca/rootCA.crt"
+	DefaultCAKeyFile    = "/etc/kubeedge/ca/rootCA.key"
+	DefaultCertFile     = "/etc/kubeedge/certs/server.crt"
+	DefaultKeyFile      = "/etc/kubeedge/certs/server.key"
+	DefaultEdgeCertFile = "/etc/kubeedge/certs/edge.crt"
+	DefaultEdgeKeyFile  = "/etc/kubeedge/certs/edge.key"
+	DefaultCADir        = "/etc/kubeedge/ca"
+	DefaultCertDir      = "/etc/kubeedge/certs"
 
 	DefaultStreamCAFile   = "/etc/kubeedge/ca/streamCA.crt"
 	DefaultStreamCertFile = "/etc/kubeedge/certs/stream.crt"


### PR DESCRIPTION
Cherry pick of #1645 on release-1.3.

#1645: log errors in function NewCloudCoreCertDERandKey

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.