### PR TITLE
Automated cherry pick of #1655: add env status.hostIP for pods

### DIFF
--- a/edge/pkg/edged/edged_pods.go
+++ b/edge/pkg/edged/edged_pods.go
@@ -708,7 +708,12 @@ func (e *edged) podFieldSelectorRuntimeValue(fs *v1.ObjectFieldSelector, pod *v1
 		return pod.Spec.NodeName, nil
 	case "spec.serviceAccountName":
 		return pod.Spec.ServiceAccountName, nil
-	// TODO: Add status.hostIP here
+	case "status.hostIP":
+		hostIP, err := e.getHostIPByInterface()
+		if err != nil {
+			return "", err
+		}
+		return hostIP, nil
 	case "status.podIP":
 		return podIP, nil
 	case "status.podIPs":


### PR DESCRIPTION
Cherry pick of #1655 on release-1.3.

#1655: add env status.hostIP for pods

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.