### PR TITLE
Automated cherry pick of #1661: modify logs for node reconnect

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -228,7 +228,7 @@ func (q *ChannelMessageQueue) Connect(info *model.HubInfo) {
 	_, listStoreExit := q.listStorePool.Load(info.NodeID)
 
 	if queueExist && storeExit && listQueueExist && listStoreExit {
-		klog.Infof("edge node %s is already connected", info.NodeID)
+		klog.Infof("Message queue and store for edge node %s are already exist", info.NodeID)
 		return
 	}
 


### PR DESCRIPTION
Cherry pick of #1661 on release-1.3.

#1661: modify logs for node reconnect

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.