### PR TITLE
Automated cherry pick of #1666: Add tips to clean up certificates in secret

### DIFF
--- a/docs/setup/kubeedge_install_source.md
+++ b/docs/setup/kubeedge_install_source.md
@@ -15,8 +15,11 @@ cd $GOPATH/src/github.com/kubeedge/kubeedge
 
 ### Generate Certificates (Required for pre 1.3 releases)
 
-**Note: KubeEdge v1.3 needs to skip this step Generate Certificates and clean up the local certificates in `/etc/kubeedge/ca` and `/etc/kubeedge/certs`. Because KubeEdge v1.3 has added the feature of generating certificates automatically.**
-
+**Note: KubeEdge v1.3 needs to skip this step Generate Certificates and clean up the local certificates in `/etc/kubeedge/ca` and `/etc/kubeedge/certs`. Because KubeEdge v1.3 has added the feature of generating certificates automatically. If you have ever manually configured the certificates locally and CloudCore fails to start. You'd better delete the certificates in the secret, just execute the script:**
+```bash
+kubectl delete secret casecret -nkubeedge
+kubectl delete secret cloudcoresecret -nkubeedge
+```
 RootCA certificate and a cert/ key pair is required to have a setup for KubeEdge. Same cert/ key pair can be used in both cloud and edge.
 
 ```bash


### PR DESCRIPTION
Cherry pick of #1666 on release-1.3.

#1666: Add tips to clean up certificates in secret

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.