### PR TITLE
Automated cherry pick of #1682: change tunnel port from 10002 to 10004

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -45,6 +45,7 @@ const (
 	DefaultConcurrentConsumers         = 5
 	DefaultCgroupRoot                  = ""
 	DefaultVolumeStatsAggPeriod        = time.Minute
+	DefaultTunnelPort                  = 10004
 )
 const (
 	DefaultPodStatusSyncInterval = 60

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -142,7 +142,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				TLSTunnelCAFile:         constants.DefaultCAFile,
 				TLSTunnelCertFile:       constants.DefaultCertFile,
 				TLSTunnelPrivateKeyFile: constants.DefaultKeyFile,
-				TunnelPort:              10002,
+				TunnelPort:              constants.DefaultTunnelPort,
 				TLSStreamCAFile:         constants.DefaultStreamCAFile,
 				TLSStreamCertFile:       constants.DefaultStreamCertFile,
 				TLSStreamPrivateKeyFile: constants.DefaultStreamKeyFile,

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -357,7 +357,7 @@ type CloudStream struct {
 	// default /etc/kubeedge/certs/edge.key
 	TLSTunnelPrivateKeyFile string `json:"tlsTunnelPrivateKeyFile,omitempty"`
 	// TunnelPort set open port for tunnel server
-	// default 10002
+	// default 10004
 	TunnelPort uint32 `json:"tunnelPort,omitempty"`
 
 	// TLSStreamCAFile indicates kube-apiserver ca file path

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -144,7 +144,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				TLSTunnelPrivateKeyFile: constants.DefaultKeyFile,
 				HandshakeTimeout:        30,
 				ReadDeadline:            15,
-				TunnelServer:            "127.0.0.1:10002",
+				TunnelServer:            fmt.Sprintf("127.0.0.1:%v", constants.DefaultTunnelPort),
 				WriteDeadline:           15,
 			},
 		},


### PR DESCRIPTION
Cherry pick of #1682 on release-1.3.

#1682: change tunnel port from 10002 to 10004

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.