### PR TITLE
fix E2E_UPDATE_DEVICE_3 failure

### DIFF
--- a/tests/e2e/deployment/device_crd_test.go
+++ b/tests/e2e/deployment/device_crd_test.go
@@ -336,6 +336,14 @@ var _ = Describe("Device Management test in E2E scenario", func() {
 			IsDeviceCreated, statusCode := utils.HandleDeviceInstance(http.MethodPost, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "", "led")
 			Expect(IsDeviceCreated).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusCreated))
+
+			newLedDevice := utils.NewLedDeviceInstance(nodeName)
+			time.Sleep(2 * time.Second)
+			Eventually(func() bool {
+				_, err := utils.GetDevice(&deviceList, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, &newLedDevice)
+				return err == nil
+			}, "20s", "2s").Should(Equal(true), "Device creation is not finished!!")
+
 			IsDeviceUpdated, statusCode := utils.HandleDeviceInstance(http.MethodPatch, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "/"+utils.UpdatedLedDeviceInstance(nodeName).Name, "led")
 			Expect(IsDeviceUpdated).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusOK))
@@ -369,6 +377,14 @@ var _ = Describe("Device Management test in E2E scenario", func() {
 			IsDeviceCreated, statusCode := utils.HandleDeviceInstance(http.MethodPost, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "", "bluetooth")
 			Expect(IsDeviceCreated).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusCreated))
+
+			newBluetoothDevice := utils.NewBluetoothDeviceInstance(nodeName)
+			time.Sleep(2 * time.Second)
+			Eventually(func() bool {
+				_, err := utils.GetDevice(&deviceList, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, &newBluetoothDevice)
+				return err == nil
+			}, "20s", "2s").Should(Equal(true), "Device creation is not finished!!")
+
 			IsDeviceUpdated, statusCode := utils.HandleDeviceInstance(http.MethodPatch, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "/"+utils.UpdatedBluetoothDeviceInstance(nodeName).Name, "bluetooth")
 			Expect(IsDeviceUpdated).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusOK))
@@ -402,6 +418,14 @@ var _ = Describe("Device Management test in E2E scenario", func() {
 			IsDeviceCreated, statusCode := utils.HandleDeviceInstance(http.MethodPost, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "", "modbus")
 			Expect(IsDeviceCreated).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusCreated))
+
+			newModbusDevice := utils.NewModbusDeviceInstance(nodeName)
+			time.Sleep(2 * time.Second)
+			Eventually(func() bool {
+				_, err := utils.GetDevice(&deviceList, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, &newModbusDevice)
+				return err == nil
+			}, "20s", "2s").Should(Equal(true), "Device creation is not finished!!")
+
 			IsDeviceUpdated, statusCode := utils.HandleDeviceInstance(http.MethodPatch, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "/"+utils.UpdatedModbusDeviceInstance(nodeName).Name, "modbus")
 			Expect(IsDeviceUpdated).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusOK))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
to solve e2e test occasional failure on E2E_UPDATE_DEVICE_3

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1627

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
