### PR TITLE
WIP: auto Patch readiness to false after leader lost

### DIFF
--- a/cloud/pkg/leaderelection/leaderelection.go
+++ b/cloud/pkg/leaderelection/leaderelection.go
@@ -57,7 +57,7 @@ func Run(cfg *config.CloudCoreConfig, readyzAdaptor *ReadyzAdaptor) {
 			// Start all modules,
 			core.StartModules()
 			// Patch PodReadinessGate if program run in pod
-			err := TryToPatchPodReadinessGate()
+			err := TryToPatchPodReadinessGate(corev1.ConditionTrue)
 			if err != nil {
 				// Terminate the program gracefully
 				klog.Errorf("Error patching pod readinessGate: %v", err)
@@ -65,7 +65,10 @@ func Run(cfg *config.CloudCoreConfig, readyzAdaptor *ReadyzAdaptor) {
 			}
 		},
 		OnStoppedLeading: func() {
-			// TODO: is it necessary to terminate the program gracefully?
+			err := TryToPatchPodReadinessGate(corev1.ConditionFalse)
+			if err != nil {
+				klog.Errorf("Error patching pod readinessGate: %v", err)
+			}
 			//klog.Fatalf("leaderelection lost, rudely terminate program")
 			klog.Errorf("leaderelection lost, gracefully terminate program")
 			// Trigger core.GracefulShutdown()
@@ -123,7 +126,7 @@ func makeLeaderElectionConfig(config componentbaseconfig.LeaderElectionConfigura
 }
 
 // Try to patch PodReadinessGate if program runs in pod
-func TryToPatchPodReadinessGate() error {
+func TryToPatchPodReadinessGate(ConditionStatus corev1.ConditionStatus) error {
 	podname, isInPod := os.LookupEnv("CLOUDCORE_POD_NAME")
 	if isInPod == true {
 		namespace := os.Getenv("CLOUDCORE_POD_NAMESPACE")
@@ -141,7 +144,7 @@ func TryToPatchPodReadinessGate() error {
 			return fmt.Errorf("failed to marshal modified pod %q into JSON: %v", podname, err)
 		}
 		//Todo: Read PodReadinessGate from CloudCore configuration or env
-		condition := corev1.PodCondition{Type: "kubeedge.io/CloudCoreIsLeader", Status: corev1.ConditionTrue}
+		condition := corev1.PodCondition{Type: "kubeedge.io/CloudCoreIsLeader", Status: ConditionStatus}
 		podutil.UpdatePodCondition(&getPod.Status, &condition)
 		newJSON, err := json.Marshal(getPod)
 		patchBytes, err := strategicpatch.CreateTwoWayMergePatch(originalJSON, newJSON, corev1.Pod{})


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
For now, CloudCore which losts leader position and restart will not  dePatch the ReadinessGate. It cause two cloudcore pod both have Readiness to true at the same time, not as expected.
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
