### PR TITLE
Lint: remove useless val

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/membership.go
+++ b/edge/pkg/devicetwin/dtmanager/membership.go
@@ -20,7 +20,6 @@ import (
 var (
 	//memActionCallBack map for action to callback
 	memActionCallBack map[string]CallBack
-	mutex             sync.Mutex
 )
 
 //MemWorker deal membership event

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -154,10 +154,6 @@ const (
 	ResolvConfDefault = "/etc/resolv.conf"
 )
 
-var (
-	zeroDuration = metav1.Duration{}
-)
-
 // podReady holds the initPodReady flag and its lock
 type podReady struct {
 	// initPodReady is flag to check Pod ready status

--- a/edge/pkg/edged/volume/csi/csi_controller.go
+++ b/edge/pkg/edged/volume/csi/csi_controller.go
@@ -21,13 +21,10 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"k8s.io/klog"
-
-	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
 )
 
 type Controller struct {
-	metaClient client.CoreInterface
-	csiClient  csiClient
+	csiClient csiClient
 }
 
 func (c *Controller) CreateVolume(req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {

--- a/edge/pkg/edged/volume/csi/csi_plugin.go
+++ b/edge/pkg/edged/volume/csi/csi_plugin.go
@@ -67,10 +67,8 @@ const (
 	fsTypeBlockName = "block"
 
 	// TODO: increase to something useful
-	csiResyncPeriod = time.Minute
+	//csiResyncPeriod = time.Minute
 )
-
-var deprecatedSocketDirVersions = []string{"0.1.0", "0.2.0", "0.3.0", "0.4.0"}
 
 type csiPlugin struct {
 	host            volume.VolumeHost

--- a/edge/pkg/edged/volume/csi/csi_util.go
+++ b/edge/pkg/edged/volume/csi/csi_util.go
@@ -23,10 +23,6 @@ package csi
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"time"
-
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -35,11 +31,8 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	utilstrings "k8s.io/utils/strings"
-)
-
-const (
-	testInformerSyncPeriod  = 100 * time.Millisecond
-	testInformerSyncTimeout = 30 * time.Second
+	"os"
+	"path/filepath"
 )
 
 func getCredentialsFromSecret(k8s kubernetes.Interface, secretRef *api.SecretReference) (map[string]string, error) {

--- a/edge/pkg/edged/volume/csi/csi_util.go
+++ b/edge/pkg/edged/volume/csi/csi_util.go
@@ -23,6 +23,9 @@ package csi
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -31,8 +34,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
 	utilstrings "k8s.io/utils/strings"
-	"os"
-	"path/filepath"
 )
 
 func getCredentialsFromSecret(k8s kubernetes.Interface, secretRef *api.SecretReference) (map[string]string, error) {

--- a/edge/pkg/edgehub/common/certutil/certutil.go
+++ b/edge/pkg/edgehub/common/certutil/certutil.go
@@ -16,8 +16,6 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 )
 
-const privateKeyBits = 2048
-
 // GetCACert gets the cloudcore CA certificate
 func GetCACert(url string) ([]byte, error) {
 	client := http.NewHTTPClient()

--- a/edge/pkg/edgehub/config/config.go
+++ b/edge/pkg/edgehub/config/config.go
@@ -7,18 +7,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 )
 
-const (
-	handshakeTimeoutDefault = 60
-	readDeadlineDefault     = 15
-	writeDeadlineDefault    = 15
-
-	heartbeatDefault = 15
-
-	protocolDefault   = protocolWebsocket
-	protocolWebsocket = "websocket"
-	protocolQuic      = "quic"
-)
-
 var Config Configure
 var once sync.Once
 

--- a/edge/pkg/eventbus/config/config.go
+++ b/edge/pkg/eventbus/config/config.go
@@ -6,20 +6,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 )
 
-const (
-	defaultInternalMqttURL  = "tcp://127.0.0.1:1884"
-	defaultExternalMqttURL  = "tcp://127.0.0.1:1883"
-	defaultQos              = 0
-	defaultRetain           = false
-	defaultSessionQueueSize = 100
-)
-
-const (
-	InternalMqttMode = iota // 0: launch an internal mqtt broker.
-	BothMqttMode            // 1: launch an internal and external mqtt broker.
-	ExternalMqttMode        // 2: launch an external mqtt broker.
-)
-
 var Config Configure
 var once sync.Once
 

--- a/edge/pkg/metamanager/config/config.go
+++ b/edge/pkg/metamanager/config/config.go
@@ -6,10 +6,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 )
 
-const (
-	defaultSyncInterval = 60
-)
-
 var Config Configure
 var once sync.Once
 

--- a/edge/test/cloudhub/stub.go
+++ b/edge/test/cloudhub/stub.go
@@ -26,11 +26,6 @@ type Attributes struct {
 	ProjectID string `json:"project_id"`
 }
 
-type record struct {
-	Data         string `json:"data"`
-	PartitionKey string `json:"partition_key"`
-}
-
 type stubCloudHub struct {
 	wsConn *websocket.Conn
 	enable bool

--- a/edge/test/test.go
+++ b/edge/test/test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"sync"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -31,8 +30,7 @@ func Register(t *v1alpha1.DBTest) {
 }
 
 type testManager struct {
-	moduleWait *sync.WaitGroup
-	enable     bool
+	enable bool
 }
 
 func (tm *testManager) Name() string {

--- a/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
@@ -17,14 +17,9 @@ import (
 
 var (
 	gettokenLongDescription = `
-"keadm gettoken" command prints the token to use for establishing bidirectional trust between edge nodes and cloudcore. 
-A token can be used when a edge node is about to join the cluster. With this token the cloudcore then approve the 
+"keadm gettoken" command prints the token to use for establishing bidirectional trust between edge nodes and cloudcore.
+A token can be used when a edge node is about to join the cluster. With this token the cloudcore then approve the
 certificate request.
-`
-	gettokenExample = `
-keadm gettoken --kube-config = /root/.kube/config
-- kube-config is the absolute path of kubeconfig which used to build secure connectivity between keadm and kube-apiserver
-to get the token. 
 `
 )
 

--- a/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
@@ -21,6 +21,11 @@ var (
 A token can be used when a edge node is about to join the cluster. With this token the cloudcore then approve the
 certificate request.
 `
+	gettokenExample = `
+keadm gettoken --kube-config = /root/.kube/config
+- kube-config is the absolute path of kubeconfig which used to build secure connectivity between keadm and kube-apiserver
+to get the token.
+`
 )
 
 func NewGettoken(out io.Writer, init *common.GettokenOptions) *cobra.Command {
@@ -31,7 +36,7 @@ func NewGettoken(out io.Writer, init *common.GettokenOptions) *cobra.Command {
 		Use:     "gettoken",
 		Short:   "To get the token for edge nodes to join the cluster",
 		Long:    gettokenLongDescription,
-		Example: gettokenLongDescription,
+		Example: gettokenExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			token, err := queryToken(common.NameSpaceCloudCore, common.TokenSecretName, init.Kubeconfig)
 			if err != nil {

--- a/tests/e2e/utils/config.go
+++ b/tests/e2e/utils/config.go
@@ -23,8 +23,6 @@ import (
 	"time"
 )
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyz0123456789"
-
 type vmSpec struct {
 	IP       string `json:"ip"`
 	Username string `json:"username"`


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>


**What type of PR is this?**
/kind cleanup


Use unused linter to check, but only for val.

Too many func do not call by code but by hand, this linter detect them as unused, so do not enable linter here.