### PR TITLE
Support metrics-server in cloud

### DIFF
--- a/cloud/pkg/cloudhub/servers/server.go
+++ b/cloud/pkg/cloudhub/servers/server.go
@@ -60,7 +60,7 @@ func startWebsocketServer() {
 		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.WebSocket.Address, hubconfig.Config.WebSocket.Port),
 		ExOpts:     api.WSServerOption{Path: "/"},
 	}
-	klog.Infof("Startting cloudhub %s server", api.ProtocolTypeWS)
+	klog.Infof("Starting cloudhub %s server", api.ProtocolTypeWS)
 	klog.Fatal(svc.ListenAndServeTLS("", ""))
 }
 
@@ -75,6 +75,6 @@ func startQuicServer() {
 		ExOpts:     api.QuicServerOption{MaxIncomingStreams: int(hubconfig.Config.Quic.MaxIncomingStreams)},
 	}
 
-	klog.Infof("Startting cloudhub %s server", api.ProtocolTypeQuic)
+	klog.Infof("Starting cloudhub %s server", api.ProtocolTypeQuic)
 	klog.Fatal(svc.ListenAndServeTLS("", ""))
 }

--- a/cloud/pkg/cloudstream/apiserverconnection.go
+++ b/cloud/pkg/cloudstream/apiserverconnection.go
@@ -1,0 +1,29 @@
+package cloudstream
+
+import (
+	"fmt"
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+// APIServerConnection indicates a connection request originally made by kube-apiserver to kubelet
+// There are basically three types of connection requests : containersLogs, containerExec, Metric
+// Cloudstream module first intercepts the connection request and then sends the request data through the tunnel (websocket) to edgestream module
+type APIServerConnection interface {
+	fmt.Stringer
+	// SendConnection indicates send EdgedConnection to edge
+	SendConnection() (stream.EdgedConnection, error)
+	// WriteToTunnel indicates writing message to tunnel
+	WriteToTunnel(m *stream.Message) error
+	// WriteToAPIServer indicates writing data to apiserver response
+	WriteToAPIServer(p []byte) (n int, err error)
+	// SetMessageID inidecates set messageid for it`s connection
+	// Every APIServerConnection has his unique message id
+	SetMessageID(id uint64)
+	GetMessageID() uint64
+	// Serve indicates handling his own logic
+	Serve() error
+	// SetEdgePeerDone indicates send specifical message to let edge peer exist
+	SetEdgePeerDone()
+	// EdgePeerDone indicates whether edge peer ends
+	EdgePeerDone() <-chan struct{}
+}

--- a/cloud/pkg/cloudstream/containerlog_connection.go
+++ b/cloud/pkg/cloudstream/containerlog_connection.go
@@ -29,29 +29,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
-// APIServerConnection indicates a connection request originally made by kube-apiserver to kubelet
-// There are basically three types of connection requests : containersLogs, containerExec, Metric
-// Cloudstream module first intercepts the connection request and then sends the request data through the tunnel (websocket) to edgestream module
-type APIServerConnection interface {
-	fmt.Stringer
-	// SendConnection indicates send EdgedConnection to edge
-	SendConnection() (stream.EdgedConnection, error)
-	// WriteToTunnel indicates writing message to tunnel
-	WriteToTunnel(m *stream.Message) error
-	// WriteToAPIServer indicates writing data to apiserver response
-	WriteToAPIServer(p []byte) (n int, err error)
-	// SetMessageID inidecates set messageid for it`s connection
-	// Every APIServerConnection has his unique message id
-	SetMessageID(id uint64)
-	GetMessageID() uint64
-	// Serve indicates handling his own logic
-	Serve() error
-	// SetEdgePeerDone indicates send specifical message to let edge peer exist
-	SetEdgePeerDone()
-	// EdgePeerDone indicates whether edge peer ends
-	EdgePeerDone() <-chan struct{}
-}
-
 // ContainerLogsConnection indicates the containerlogs request initiated by kube-apiserver
 type ContainerLogsConnection struct {
 	// MessageID indicate the unique id to create his message

--- a/cloud/pkg/cloudstream/containermetrics_connection.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudstream
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"k8s.io/klog"
+
+	"github.com/emicklei/go-restful"
+	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+// ContainerMetricsConnection indicates the containerMetrics request initiated by kube-apiserver
+type ContainerMetricsConnection struct {
+	// MessageID indicate the unique id to create his message
+	MessageID    uint64
+	ctx          context.Context
+	r            *restful.Request
+	flush        io.Writer
+	session      *Session
+	edgePeerStop chan struct{}
+}
+
+func (ms *ContainerMetricsConnection) GetMessageID() uint64 {
+	return ms.MessageID
+}
+
+func (ms *ContainerMetricsConnection) SetEdgePeerDone() {
+	close(ms.edgePeerStop)
+}
+
+func (ms *ContainerMetricsConnection) EdgePeerDone() <-chan struct{} {
+	return ms.edgePeerStop
+}
+
+func (ms *ContainerMetricsConnection) WriteToAPIServer(p []byte) (n int, err error) {
+	return ms.flush.Write(p)
+}
+
+func (ms *ContainerMetricsConnection) WriteToTunnel(m *stream.Message) error {
+	return ms.session.WriteMessageToTunnel(m)
+}
+
+func (ms *ContainerMetricsConnection) SetMessageID(id uint64) {
+	ms.MessageID = id
+}
+
+func (ms *ContainerMetricsConnection) String() string {
+	return fmt.Sprintf("APIServer_MetricsConnection MessageID %v", ms.MessageID)
+}
+
+func (ms *ContainerMetricsConnection) SendConnection() (stream.EdgedConnection, error) {
+	connector := &stream.EdgedMetricsConnection{
+		MessID: ms.MessageID,
+		URL:    *ms.r.Request.URL,
+		Header: ms.r.Request.Header,
+	}
+	connector.URL.Scheme = "http"
+	connector.URL.Host = net.JoinHostPort("127.0.0.1", fmt.Sprintf("%v", constants.ServerPort))
+	m, err := connector.CreateConnectMessage()
+	if err != nil {
+		return nil, err
+	}
+	if err := ms.WriteToTunnel(m); err != nil {
+		klog.Errorf("%s write %s error %v", ms.String(), connector.String(), err)
+		return nil, err
+	}
+	return connector, nil
+}
+
+func (ms *ContainerMetricsConnection) Serve() error {
+	defer func() {
+		klog.Infof("%s end successful", ms.String())
+	}()
+
+	// first send connect message
+	if _, err := ms.SendConnection(); err != nil {
+		klog.Errorf("%s send %s info error %v", ms.String(), stream.MessageTypeMetricConnect, err)
+		return err
+	}
+
+	for {
+		select {
+		case <-ms.ctx.Done():
+			// if apiserver request end, send close message to edge
+			msg := stream.NewMessage(ms.MessageID, stream.MessageTypeRemoveConnect, nil)
+			for retry := 0; retry < 3; retry++ {
+				if err := ms.WriteToTunnel(msg); err != nil {
+					klog.Warningf("%v send %s message to edge error %v", ms, msg.MessageType, err)
+				} else {
+					break
+				}
+			}
+			klog.Infof("%s send close message to edge successfully", ms.String())
+			return nil
+		case <-ms.EdgePeerDone():
+			klog.Infof("%s find edge peer done, so stop this connection", ms.String())
+			return nil
+		}
+	}
+}
+
+var _ APIServerConnection = &ContainerMetricsConnection{}

--- a/pkg/stream/edgedconnection.go
+++ b/pkg/stream/edgedconnection.go
@@ -1,0 +1,12 @@
+package stream
+
+import "fmt"
+
+// EdgedConnection indicate the connection request to the edged
+type EdgedConnection interface {
+	CreateConnectMessage() (*Message, error)
+	Serve(tunnel SafeWriteTunneler) error
+	CacheTunnelMessage(msg *Message)
+	GetMessageID() uint64
+	fmt.Stringer
+}

--- a/pkg/stream/edgedlogconnection.go
+++ b/pkg/stream/edgedlogconnection.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/klog"
+)
+
+type EdgedLogsConnection struct {
+	MessID   uint64        // message id
+	URL      url.URL       `json:"url"`
+	Header   http.Header   `json:"header"`
+	ReadChan chan *Message `json:"-"`
+}
+
+func (l *EdgedLogsConnection) GetMessageID() uint64 {
+	return l.MessID
+}
+
+func (l *EdgedLogsConnection) CacheTunnelMessage(msg *Message) {
+	l.ReadChan <- msg
+}
+
+func (l *EdgedLogsConnection) CreateConnectMessage() (*Message, error) {
+	data, err := json.Marshal(l)
+	if err != nil {
+		return nil, err
+	}
+	return NewMessage(l.MessID, MessageTypeLogsConnect, data), nil
+}
+
+func (l *EdgedLogsConnection) String() string {
+	return fmt.Sprintf("EDGE_LOGS_CONNECTOR Message MessageID %v", l.MessID)
+}
+
+func (l *EdgedLogsConnection) Serve(tunnel SafeWriteTunneler) error {
+	//connect edged
+	client := http.Client{}
+	req, err := http.NewRequest("GET", l.URL.String(), nil)
+	if err != nil {
+		klog.Errorf("create new logs request error %v", err)
+		return err
+	}
+	req.Header = l.Header
+	resp, err := client.Do(req)
+	if err != nil {
+		klog.Errorf("request logs error %v", err)
+		return err
+	}
+	defer resp.Body.Close()
+	scan := bufio.NewScanner(resp.Body)
+	stop := make(chan struct{})
+
+	go func() {
+		for mess := range l.ReadChan {
+			if mess.MessageType == MessageTypeRemoveConnect {
+				klog.Infof("receive remove client id %v", mess.ConnectID)
+				close(stop)
+				return
+			}
+		}
+	}()
+
+	defer func() {
+		for retry := 0; retry < 3; retry++ {
+			msg := NewMessage(l.MessID, MessageTypeRemoveConnect, nil)
+			if err := msg.WriteTo(tunnel); err != nil {
+				klog.Errorf("%v send %s message error %v", l, msg.MessageType, err)
+			} else {
+				break
+			}
+		}
+	}()
+
+	for scan.Scan() {
+		select {
+		case <-stop:
+			klog.Infof("receive stop single, so stop logs scan ...")
+			return nil
+		default:
+		}
+		// 10 = \n
+		msg := NewMessage(l.MessID, MessageTypeData, append(scan.Bytes(), 10))
+		err := msg.WriteTo(tunnel)
+		if err != nil {
+			klog.Errorf("write tunnel message %v error", msg)
+			return err
+		}
+		klog.Infof("%v write logs %v", l.String(), string(scan.Bytes()))
+	}
+	return nil
+}
+
+var _ EdgedConnection = &EdgedLogsConnection{}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind feature

**What this PR does / why we need it**:
By multiplexing the cloudstream and edgestream tunnels, the /stats/summary on the edge can be exposed to the metrics-server on the cloud. By setting --kubelet-port = 10350, metrics-server can capture the monitoring data of the edge node.

**Which issue(s) this PR fixes**:
Fixes #1561

**Special notes for your reviewer**:
The metrics-server 0.3.x is not yet compatible with kubeedge. If you need to use this feature urgently, you can download the metrics-sever source code and remake the image through the "make container" command. By using the flag --kubelet-use-node-status-port and hostNetwork: true, metrics-server can run normally on kubeedge,ref https://github.com/kubernetes-sigs/metrics-server.

The most important point is that the cloudstream and edgestream modules must be turned on.

![image](https://user-images.githubusercontent.com/26862112/84367383-c00bc700-ac06-11ea-8e11-5f83d8fd7aca.png)

![image](https://user-images.githubusercontent.com/26862112/84367026-3d830780-ac06-11ea-98f3-d76784159484.png)

```release-note
Now cloud can use the /stats,/stats/summary,/stats/containerAPI to access the edge monitoring information.
```



