### PR TITLE
set PodSandboxImage according to host's architecture automatically

### DIFF
--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -36,6 +36,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 		hostnameOverride = constants.DefaultHostnameOverride
 	}
 	localIP, _ := util.GetLocalIP(hostnameOverride)
+	podSandboxImage := util.GetPodSandboxImage()
 
 	return &EdgeCoreConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -60,7 +61,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				ClusterDomain:               "",
 				ConcurrentConsumers:         constants.DefaultConcurrentConsumers,
 				EdgedMemoryCapacity:         constants.DefaultEdgedMemoryCapacity,
-				PodSandboxImage:             constants.DefaultPodSandboxImage,
+				PodSandboxImage:             podSandboxImage,
 				ImagePullProgressDeadline:   constants.DefaultImagePullProgressDeadline,
 				RuntimeRequestTimeout:       constants.DefaultRuntimeRequestTimeout,
 				HostnameOverride:            hostnameOverride,
@@ -162,6 +163,8 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 		hostnameOverride = constants.DefaultHostnameOverride
 	}
 	localIP, _ := util.GetLocalIP(hostnameOverride)
+	podSandboxImage := util.GetPodSandboxImage()
+
 	return &EdgeCoreConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind,
@@ -179,7 +182,7 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 				NodeIP:                localIP,
 				ClusterDNS:            "",
 				ClusterDomain:         "",
-				PodSandboxImage:       constants.DefaultPodSandboxImage,
+				PodSandboxImage:       podSandboxImage,
 				HostnameOverride:      hostnameOverride,
 				InterfaceName:         constants.DefaultInterfaceName,
 				DevicePluginEnabled:   false,

--- a/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
@@ -36,6 +36,8 @@ func NewDefaultEdgeSiteConfig() *EdgeSiteConfig {
 		hostnameOverride = constants.DefaultHostnameOverride
 	}
 	localIP, _ := util.GetLocalIP(hostnameOverride)
+	podSandboxImage := util.GetPodSandboxImage()
+
 	return &EdgeSiteConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind,
@@ -107,7 +109,7 @@ func NewDefaultEdgeSiteConfig() *EdgeSiteConfig {
 				EdgedMemoryCapacity:         constants.DefaultEdgedMemoryCapacity,
 				RemoteRuntimeEndpoint:       constants.DefaultRemoteRuntimeEndpoint,
 				RemoteImageEndpoint:         constants.DefaultRemoteImageEndpoint,
-				PodSandboxImage:             constants.DefaultPodSandboxImage,
+				PodSandboxImage:             podSandboxImage,
 				ImagePullProgressDeadline:   constants.DefaultImagePullProgressDeadline,
 				RuntimeRequestTimeout:       constants.DefaultRuntimeRequestTimeout,
 				HostnameOverride:            hostnameOverride,
@@ -138,6 +140,8 @@ func NewMinEdgeSiteConfig() *EdgeSiteConfig {
 		hostnameOverride = constants.DefaultHostnameOverride
 	}
 	localIP, _ := util.GetLocalIP(hostnameOverride)
+	podSandboxImage := util.GetPodSandboxImage()
+
 	return &EdgeSiteConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind,
@@ -160,7 +164,7 @@ func NewMinEdgeSiteConfig() *EdgeSiteConfig {
 				RemoteRuntimeEndpoint: constants.DefaultRemoteRuntimeEndpoint,
 				RemoteImageEndpoint:   constants.DefaultRemoteImageEndpoint,
 				//TODO (@kuramal) Automatically set PodSandboxImage according to the architecture.(x86,amd64,arm or arm64)
-				PodSandboxImage:     constants.DefaultPodSandboxImage,
+				PodSandboxImage:     podSandboxImage,
 				HostnameOverride:    hostnameOverride,
 				InterfaceName:       constants.DefaultInterfaceName,
 				DevicePluginEnabled: false,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/klog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 //AddressFamily is uint type var to describe family ips
@@ -534,7 +536,8 @@ func getMachineArchitecture() string {
 }
 
 // GetPodSandboxImage return proper podSandboxImage according to the host architecture.
-// for ARM arch, the podSandboxImage should be "kubeedge/pause-arm:3.1"
+// for x86 arch, DefaultPodSandboxImage is fine,
+// but for ARM arch, the podSandboxImage should be "kubeedge/pause-arm:3.1"
 func GetPodSandboxImage() string {
 	arch := getMachineArchitecture()
 	podSandboxImage := constants.DefaultPodSandboxImage
@@ -544,4 +547,3 @@ func GetPodSandboxImage() string {
 	}
 	return podSandboxImage
 }
-

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"runtime"
 
 	"k8s.io/klog"
 
@@ -527,3 +528,20 @@ func SpliceErrors(errors []error) string {
 	stb.WriteString("]\n")
 	return stb.String()
 }
+
+func getMachineArchitecture() string {
+	return runtime.GOARCH
+}
+
+// GetPodSandboxImage return proper podSandboxImage according to the host architecture.
+// for ARM arch, the podSandboxImage should be "kubeedge/pause-arm:3.1"
+func GetPodSandboxImage() string {
+	arch := getMachineArchitecture()
+	podSandboxImage := constants.DefaultPodSandboxImage
+	if arch == "arm" || arch == "arm64" {
+		s := strings.Split(podSandboxImage,":")
+		podSandboxImage = s[0] + "-arm:" + s[1]
+	}
+	return podSandboxImage
+}
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:
WHAT: set PodSandboxImage according to host's architecture automatically.

WHY: When running edgecore on the Raspberry-Pi, I use the command `./edgecore --defaultconfig > /etc/kubeedge/config/edgecore.yaml`  to generate the `edgecore.yaml` manually. I just follow the official doc to run this demo but I encounter this problem: **the Pod's status is stuck in "ContainerCannotRun",** which is similar with this [issue](https://github.com/kubeedge/kubeedge/issues/1093).

I find where the problem happens by analyzing the source code as below(as well as in /edgesite/v1alpha1/default.go): https://github.com/kubeedge/kubeedge/blob/1d880504f4bf06de9bd6186e851888a66cb782ab/pkg/apis/componentconfig/edgecore/v1alpha1/default.go#L63

Now, It just fill the "PodSandboxImage"  as "**kubeedge/pause:3.1**" by default, well, when we run edgecore on Raspberry-Pi, it should be "**kubeedge/pause-arm:3.1**". Since many edge device is based on ARM arch, I think it will be more user-firendly to identify machine's architecture automaticly rather than modify the config file manually.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1093 

**Special notes for your reviewer**:
NONE

