### PR TITLE
Automated cherry pick of #1702: configure tls use ECDSA cipher

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/certutil.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/certutil.go
@@ -31,7 +31,7 @@ func NewCertificateAuthorityDer() ([]byte, crypto.Signer, error) {
 	return certDER, caKey, nil
 }
 
-// NewPrivateKey creates an RSA private key
+// NewPrivateKey creates an ECDSA private key
 func NewPrivateKey() (crypto.Signer, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 }

--- a/cloud/pkg/cloudhub/servers/server.go
+++ b/cloud/pkg/cloudhub/servers/server.go
@@ -45,7 +45,8 @@ func createTLSConfig(ca, cert, key []byte) tls.Config {
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{certificate},
 		MinVersion:   tls.VersionTLS12,
-		CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+		// has to match cipher used by NewPrivateKey method, currently is ECDSA
+		CipherSuites: []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #1702 on release-1.3.

#1702: configure tls use ECDSA cipher

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.