### PR TITLE
Automated cherry pick of #1708: fix using same namespace while sync podstatus to cloud

### DIFF
--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -512,7 +512,7 @@ func (m *metaManager) processSync(message model.Message) {
 }
 
 func (m *metaManager) syncPodStatus() {
-	klog.Infof("start to sync pod status")
+	klog.Infof("start to sync pod status in edge-store to cloud")
 	podStatusRecords, err := dao.QueryAllMeta("type", model.ResourceTypePodStatus)
 	if err != nil {
 		klog.Errorf("list pod status failed: %v", err)
@@ -522,13 +522,9 @@ func (m *metaManager) syncPodStatus() {
 		klog.Infof("list pod status, no record, skip sync")
 		return
 	}
-
-	var namespace string
-	content := make([]interface{}, 0, len(*podStatusRecords))
+	contents := make(map[string][]interface{})
 	for _, v := range *podStatusRecords {
-		if namespace == "" {
-			namespace, _, _, _ = util.ParseResourceEdge(v.Key, model.QueryOperation)
-		}
+		namespaceParsed, _, _, _ := util.ParseResourceEdge(v.Key, model.QueryOperation)
 		podKey := strings.Replace(v.Key, constants.ResourceSep+model.ResourceTypePodStatus+constants.ResourceSep, constants.ResourceSep+model.ResourceTypePod+constants.ResourceSep, 1)
 		podRecord, err := dao.QueryMeta("key", podKey)
 		if err != nil {
@@ -549,12 +545,13 @@ func (m *metaManager) syncPodStatus() {
 			klog.Errorf("unmarshal podstatus[%s] failed, content[%s]: %v", v.Key, v.Value, err)
 			continue
 		}
-		content = append(content, podStatus)
+		contents[namespaceParsed] = append(contents[namespaceParsed], podStatus)
 	}
-
-	msg := model.NewMessage("").BuildRouter(MetaManagerModuleName, GroupResource, namespace+constants.ResourceSep+model.ResourceTypePodStatus, model.UpdateOperation).FillBody(content)
-	sendToCloud(msg)
-	klog.Infof("sync pod status successful, %s", msgDebugInfo(msg))
+	for namespace, content := range contents {
+		msg := model.NewMessage("").BuildRouter(MetaManagerModuleName, GroupResource, namespace+constants.ResourceSep+model.ResourceTypePodStatus, model.UpdateOperation).FillBody(content)
+		sendToCloud(msg)
+		klog.V(3).Infof("sync pod status successfully for namespaces %s, %s", namespace, msgDebugInfo(msg))
+	}
 }
 
 func (m *metaManager) processFunctionAction(message model.Message) {


### PR DESCRIPTION
Cherry pick of #1708 on release-1.3.

#1708: fix using same namespace while sync podstatus to cloud

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.