### PR TITLE
fix edgemesh caching serviceList bug

### DIFF
--- a/edgemesh/pkg/listener/listener.go
+++ b/edgemesh/pkg/listener/listener.go
@@ -312,21 +312,21 @@ func MsgProcess(msg model.Message) {
 	// process services
 	if svcs := filterResourceTypeService(msg); len(svcs) != 0 {
 		klog.Infof("[EdgeMesh] %s services: %d resource: %s", msg.GetOperation(), len(svcs), msg.Router.Resource)
-		for _, svc := range svcs {
-			svcName := svc.Namespace + "." + svc.Name
-			svcPorts := getSvcPorts(svc, svcName)
+		for i := range svcs {
+			svcName := svcs[i].Namespace + "." + svcs[i].Name
+			svcPorts := getSvcPorts(svcs[i], svcName)
 			switch msg.GetOperation() {
 			case "insert":
-				cache.GetMeshCache().Add("service"+"."+svcName, &svc)
-				klog.Infof("[EdgeMesh] insert svc %s.%s into cache", svc.Namespace, svc.Name)
+				cache.GetMeshCache().Add("service"+"."+svcName, &svcs[i])
+				klog.Infof("[EdgeMesh] insert svc %s.%s into cache", svcs[i].Namespace, svcs[i].Name)
 				addServer(svcName, svcPorts)
 			case "update":
-				cache.GetMeshCache().Add("service"+"."+svcName, &svc)
-				klog.Infof("[EdgeMesh] update svc %s.%s in cache", svc.Namespace, svc.Name)
+				cache.GetMeshCache().Add("service"+"."+svcName, &svcs[i])
+				klog.Infof("[EdgeMesh] update svc %s.%s in cache", svcs[i].Namespace, svcs[i].Name)
 				updateServer(svcName, svcPorts)
 			case "delete":
 				cache.GetMeshCache().Remove("service" + "." + svcName)
-				klog.Infof("[EdgeMesh] delete svc %s.%s from cache", svc.Namespace, svc.Name)
+				klog.Infof("[EdgeMesh] delete svc %s.%s from cache", svcs[i].Namespace, svcs[i].Name)
 				delServer(svcName)
 			default:
 				klog.Warningf("[EdgeMesh] invalid %s operation on services", msg.GetOperation())

--- a/edgemesh/pkg/listener/listener_test.go
+++ b/edgemesh/pkg/listener/listener_test.go
@@ -1,0 +1,72 @@
+package listener
+
+import (
+	"testing"
+
+	"github.com/hashicorp/golang-lru"
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCacheServiceList(t *testing.T) {
+	fakeServiceList := make([]v1.Service, 0)
+	fakeService1 := v1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "svc1",
+		},
+	}
+	fakeService2 := v1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "svc2",
+		},
+	}
+	fakeService3 := v1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "svc3",
+		},
+	}
+	fakeService4 := v1.Service{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name: "svc4",
+		},
+	}
+	fakeServiceList = append(fakeServiceList, fakeService1, fakeService2, fakeService3, fakeService4)
+	// bug case
+	testCache1, err := lru.New(10)
+	if err != nil {
+		t.Errorf("create testCache1 err: %v", err)
+	}
+	for _, svc := range fakeServiceList {
+		testCache1.Add(svc.Name, &svc)
+	}
+	if v, ok := testCache1.Get("svc1"); !ok {
+		t.Errorf("can't get svc1 from testCache1")
+	} else {
+		if svc, ok := v.(*v1.Service); !ok {
+			t.Errorf("can't convert to *v1.Service")
+		} else {
+			if svc.Name != "svc4" {
+				t.Errorf("svc name is not svc4")
+			}
+		}
+	}
+	// after fixing bug
+	testCache2, err := lru.New(10)
+	if err != nil {
+		t.Errorf("create testCache2 err: %v", err)
+	}
+	for i := range fakeServiceList {
+		testCache2.Add(fakeServiceList[i].Name, &fakeServiceList[i])
+	}
+	if v, ok := testCache2.Get("svc1"); !ok {
+		t.Errorf("can't get svc1 from testCache2")
+	} else {
+		if svc, ok := v.(*v1.Service); !ok {
+			t.Errorf("can't convert to *v1.Service")
+		} else {
+			if svc.Name != "svc1" {
+				t.Errorf("svc name is not svc1")
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug


**What this PR does / why we need it**:
There is a bug inside edgemesh when caching serviceList. When edgemesh tries to cache a serviceList, say {svc1, svc2, svc3}, it would cache them like {svc1Key, svc3Addr}, {svc2Key, svc3Addr}, {svc3Key, svc3Addr}. This bug came from incorrect usage of "slice" of golang. This PR would fix the bug and make it like {svc1Key, svc1Addr}, {svc2Key, svc2Addr}, {svc3Key, svc3Addr}. 
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
