### PR TITLE
Automated cherry pick of #1697: fix kubectl logs certs

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
 )
 
+var DoneTLSTunnelCerts = make(chan bool, 1)
+
 type cloudHub struct {
 	enable bool
 }
@@ -69,6 +71,9 @@ func (a *cloudHub) Start() {
 	if err := httpserver.PrepareAllCerts(); err != nil {
 		klog.Fatal(err)
 	}
+	// TODO: Will improve in the future
+	DoneTLSTunnelCerts <- true
+	close(DoneTLSTunnelCerts)
 
 	// generate Token
 	if err := httpserver.GenerateToken(); err != nil {

--- a/cloud/pkg/cloudstream/cloudstream.go
+++ b/cloud/pkg/cloudstream/cloudstream.go
@@ -18,6 +18,7 @@ package cloudstream
 
 import (
 	"github.com/kubeedge/beehive/pkg/core"
+	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudstream/config"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
 )
@@ -51,13 +52,18 @@ func (s *cloudStream) Group() string {
 }
 
 func (s *cloudStream) Start() {
-	ts := newTunnelServer()
-	// start new tunnel server
-	go ts.Start()
+	// TODO: Will improve in the future
+	ok := <-cloudhub.DoneTLSTunnelCerts
+	if ok {
+		ts := newTunnelServer()
 
-	server := newStreamServer(ts)
-	// start stream server to accepet kube-apiserver connection
-	go server.Start()
+		// start new tunnel server
+		go ts.Start()
+
+		server := newStreamServer(ts)
+		// start stream server to accepet kube-apiserver connection
+		go server.Start()
+	}
 }
 
 func (s *cloudStream) Enable() bool {

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -22,6 +22,8 @@ const (
 	ModuleNameEdgeHub = "websocket"
 )
 
+var HasTLSTunnelCerts = make(chan bool, 1)
+
 //EdgeHub defines edgehub object structure
 type EdgeHub struct {
 	chClient      clients.Adapter
@@ -77,6 +79,8 @@ func (eh *EdgeHub) Start() {
 			return
 		}
 	}
+	HasTLSTunnelCerts <- true
+	close(HasTLSTunnelCerts)
 
 	for {
 		select {

--- a/edge/pkg/edgestream/edgestream.go
+++ b/edge/pkg/edgestream/edgestream.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/kubeedge/edge/pkg/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgestream/config"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 	"github.com/kubeedge/kubeedge/pkg/stream"
@@ -71,32 +72,33 @@ func (e *edgestream) Enable() bool {
 }
 
 func (e *edgestream) Start() {
-
 	serverURL := url.URL{
 		Scheme: "wss",
 		Host:   config.Config.TunnelServer,
 		Path:   "/v1/kubeedge/connect",
 	}
-
-	cert, err := tls.LoadX509KeyPair(config.Config.TLSTunnelCertFile, config.Config.TLSTunnelPrivateKeyFile)
-	if err != nil {
-		klog.Fatalf("Failed to load x509 key pair: %v", err)
-	}
-
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
-		Certificates:       []tls.Certificate{cert},
-	}
-
-	for range time.NewTicker(time.Second * 2).C {
-		select {
-		case <-beehiveContext.Done():
-			return
-		default:
-		}
-		err := e.TLSClientConnect(serverURL, tlsConfig)
+	// TODO: Will improve in the future
+	ok := <-edgehub.HasTLSTunnelCerts
+	if ok {
+		cert, err := tls.LoadX509KeyPair(config.Config.TLSTunnelCertFile, config.Config.TLSTunnelPrivateKeyFile)
 		if err != nil {
-			klog.Errorf("TLSClientConnect error %v", err)
+			klog.Fatalf("Failed to load x509 key pair: %v", err)
+		}
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+			Certificates:       []tls.Certificate{cert},
+		}
+
+		for range time.NewTicker(time.Second * 2).C {
+			select {
+			case <-beehiveContext.Done():
+				return
+			default:
+			}
+			err := e.TLSClientConnect(serverURL, tlsConfig)
+			if err != nil {
+				klog.Errorf("TLSClientConnect error %v", err)
+			}
 		}
 	}
 }

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/klog"
 
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
 	utilvalidation "github.com/kubeedge/kubeedge/pkg/util/validation"
@@ -149,13 +150,13 @@ func ValidateModuleCloudStream(d v1alpha1.CloudStream) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if !utilvalidation.FileIsExist(d.TLSTunnelPrivateKeyFile) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSTunnelPrivateKeyFile"), d.TLSTunnelPrivateKeyFile, "TLSTunnelPrivateKeyFile not exist"))
+		klog.Warningf("TLSTunnelPrivateKeyFile does not exist in %s, will load from secret", d.TLSTunnelPrivateKeyFile)
 	}
 	if !utilvalidation.FileIsExist(d.TLSTunnelCertFile) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSTunnelCertFile"), d.TLSTunnelCertFile, "TLSTunnelCertFile not exist"))
+		klog.Warningf("TLSTunnelCertFile does not exist in %s, will load from secret", d.TLSTunnelCertFile)
 	}
 	if !utilvalidation.FileIsExist(d.TLSTunnelCAFile) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSTunnelCAFile"), d.TLSTunnelCAFile, "TLSTunnelCAFile not exist"))
+		klog.Warningf("TLSTunnelCAFile does not exist in %s, will load from secret", d.TLSTunnelCAFile)
 	}
 
 	if !utilvalidation.FileIsExist(d.TLSStreamPrivateKeyFile) {

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation.go
@@ -152,21 +152,9 @@ func ValidateModuleEdgeMesh(m v1alpha1.EdgeMesh) field.ErrorList {
 
 // ValidateModuleEdgeStream validates `m` and returns an errorList if it is invalid
 func ValidateModuleEdgeStream(m v1alpha1.EdgeStream) field.ErrorList {
-	if !m.Enable {
-		return field.ErrorList{}
-	}
 	allErrs := field.ErrorList{}
-	if !utilvalidation.FileIsExist(m.TLSTunnelCAFile) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSTunnelCAFile"),
-			m.TLSTunnelCAFile, "TLSTunnelCAFile file not exist"))
-	}
-	if !utilvalidation.FileIsExist(m.TLSTunnelCertFile) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSTunnelCertFile"),
-			m.TLSTunnelCertFile, "TLSTunnelCertFile file not exist"))
-	}
-	if !utilvalidation.FileIsExist(m.TLSTunnelPrivateKeyFile) {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("TLSTunnelPrivateKeyFile"),
-			m.TLSTunnelPrivateKeyFile, "TLSTunnelPrivateKeyFile file not exist"))
+	if !m.Enable {
+		return allErrs
 	}
 	return allErrs
 }


### PR DESCRIPTION
Cherry pick of #1697 on release-1.3.

#1697: fix kubectl logs certs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.