### PR TITLE
fix wrong parse operation when service url is short

### DIFF
--- a/edgemesh/pkg/plugin/registry/registry.go
+++ b/edgemesh/pkg/plugin/registry/registry.go
@@ -126,8 +126,9 @@ func (esd *EdgeServiceDiscovery) AutoSync() {}
 func (esd *EdgeServiceDiscovery) Close() error { return nil }
 
 // parseServiceURL parses serviceURL to ${service_name}.${namespace}.svc.${cluster}:${port}, keeps with k8s service
-func parseServiceURL(serviceURL string) (name, namespace string, port int, err error) {
-	name, namespace = common.SplitServiceKey(serviceURL)
+func parseServiceURL(serviceURL string) (string, string, int, error) {
+	var port int
+	var err error
 	serviceURLSplit := strings.Split(serviceURL, ":")
 	if len(serviceURLSplit) == 1 {
 		// default
@@ -136,13 +137,15 @@ func parseServiceURL(serviceURL string) (name, namespace string, port int, err e
 		port, err = strconv.Atoi(serviceURLSplit[1])
 		if err != nil {
 			klog.Errorf("[EdgeMesh] service url %s invalid", serviceURL)
-			return
+			return "", "", 0, err
 		}
 	} else {
 		klog.Errorf("[EdgeMesh] service url %s invalid", serviceURL)
 		err = fmt.Errorf("service url %s invalid", serviceURL)
+		return "", "", 0, err
 	}
-	return
+	name, namespace := common.SplitServiceKey(serviceURLSplit[0])
+	return name, namespace, port, nil
 }
 
 // getService get k8s service from either lruCache or metaManager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:

fix wrong parse operation when service url is short in edgemesh load balancer chain

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
