### PR TITLE
Automated cherry pick of #1782: use v1.3.1 as default

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -60,7 +60,7 @@ const (
 	RuntimeType = "runtimetype"
 
 	// DefaultKubeEdgeVersion is the default KubeEdge version
-	DefaultKubeEdgeVersion = "1.3.0"
+	DefaultKubeEdgeVersion = "1.3.1"
 
 	// Token sets the token used when edge applying for the certificate
 	Token = "token"


### PR DESCRIPTION
Cherry pick of #1782 on release-1.3.

#1782: use v1.3.1 as default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.