### PR TITLE
edged.go: Don't restart when container exited

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -763,12 +763,16 @@ func (e *edged) syncLoopIteration(plegCh <-chan *pleg.PodLifecycleEvent, houseke
 							break
 						}
 					}
-					klog.Errorf("sync loop get event container died, restart pod [%s]", pod.Name)
-					key := types.NamespacedName{
-						Namespace: pod.Namespace,
-						Name:      pod.Name,
+					if pod.Status.Phase == v1.PodPending {
+						klog.Infof("sync loop ignore die event in pod [%s] pending phase", pod.Name)
+					} else {
+						klog.Errorf("sync loop get event container died, restart pod [%s]", pod.Name)
+						key := types.NamespacedName{
+							Namespace: pod.Namespace,
+							Name:      pod.Name,
+						}
+						e.podAdditionQueue.Add(key.String())
 					}
-					e.podAdditionQueue.Add(key.String())
 				} else {
 					klog.Infof("sync loop get event [%s], ignore it now.", plegEvent.Type)
 				}


### PR DESCRIPTION
see issue #1364.
When sandbox container is started but not ready, PLEG relist will
generate a container die event. Func syncLoopIteration will add the pod to
restart queue. This is unexpected compared to kubelet's op of deleting
container of the pod.
Latest container will be kept in default in kubelet.
This is a lazy way of doing to ignore the die event.
By the way, the restart logic is probmatic because the app container is
not restarted.

Signed-off-by: Faicker Mo <faicker.mo@gmail.com>

/kind bug
Fixes #1364