### PR TITLE
edge/test/integration/scripts/generate_cert.sh: fix no rnd file issue

### DIFF
--- a/edge/test/integration/scripts/generate_cert.sh
+++ b/edge/test/integration/scripts/generate_cert.sh
@@ -32,6 +32,7 @@ password=root
 
 echo "Generating key request for kubeedge"
 
+sudo touch ~/.rnd
 # Generete Root Key
 sudo openssl genrsa -des3 -passout pass:$password -out rootCA.key 4096
 # Generate Root Certificate


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

Fix following error:
```
Generating key request for kubeedge
Generating RSA private key, 4096 bit long modulus (2 primes)
..............................++++
..............++++
e is 65537 (0x010001)
Can't load /root/.rnd into RNG
140398593622464:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/root/.rnd <===
Generating RSA private key, 2048 bit long modulus (2 primes)
.........................+++++
...........................+++++
e is 65537 (0x010001)
Can't load /root/.rnd into RNG
139774337278400:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/root/.rnd <===
Signature ok
```