### PR TITLE
hack/lib/lint.sh: fix lint error when running on master

### DIFF
--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -23,6 +23,7 @@ set -o pipefail
 kubeedge::lint::check() {
     cd ${KUBEEDGE_ROOT}
     # skip deleted files
+    set +o pipefail
     git diff --cached --name-only --diff-filter=ACRMTU master | grep -Ev "externalversions|fake|vendor" | xargs --no-run-if-empty sed -i 's/[ \t]*$//'
 
     [[ $(git diff --name-only) ]] && {
@@ -31,4 +32,5 @@ kubeedge::lint::check() {
     }
     golangci-lint run
     gofmt -l -w staging
+    set -o pipefail
 }


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix [merge issue](https://travis-ci.org/github/kubeedge/kubeedge/jobs/698780226#L673-L677).

If set pipefail, when merge, the grep regex always fail and return 1, so here disable pipefail.

Can not disable pipefail outside function, since we would source other scripts.