### PR TITLE
Edge: Ignore some log to users

### DIFF
--- a/edge/pkg/metamanager/client/metaclient.go
+++ b/edge/pkg/metamanager/client/metaclient.go
@@ -118,7 +118,7 @@ func (s *send) SendSync(message *model.Message) (*model.Message, error) {
 		resp, err = beehiveContext.SendSync(metamanager.MetaManagerModuleName, *message, syncMsgRespTimeout)
 		retries++
 		if err == nil {
-			klog.Infof("send sync message %s successed and response: %v", message.GetResource(), resp)
+			klog.V(2).Infof("send sync message %s successed and response: %v", message.GetResource(), resp)
 			return true, nil
 		}
 		if retries < 3 {

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -666,7 +666,7 @@ func (m *metaManager) runMetaManager() {
 			default:
 			}
 			if msg, err := beehiveContext.Receive(m.Name()); err == nil {
-				klog.Infof("get a message %+v", msg)
+				klog.V(2).Infof("get a message %+v", msg)
 				m.process(msg)
 			} else {
 				klog.Errorf("get a message %+v: %v", msg, err)


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What this PR does / why we need it**:

Those logs may be useless for users and ignore true error:
```
I0617 15:38:28.789879   24252 process.go:669] get a message {Header:{ID:a5d83aa3-95d2-4830-8be5-66d18ffa29d4 ParentID: Timestamp:1592379508779 ResourceVersion: Sync:true} Router:{Source:edged Group:meta Operation:update Resource:default/nodestatus/edge-node} Content:{UI
D:38796d14-1df3-11e8-8e5a-286ed488f209 Status:{Capacity:map[cpu:{i:{value:4 scale:0} d:{Dec:<nil>} s:4 Format:DecimalSI} memory:{i:{value:8362393600 scale:0} d:{Dec:<nil>} s:7975Mi Format:BinarySI} pods:{i:{value:110 scale:0} d:{Dec:<nil>} s: Format:DecimalSI}] Allocata
ble:map[cpu:{i:{value:4 scale:0} d:{Dec:<nil>} s:4 Format:DecimalSI} memory:{i:{value:8257536000 scale:0} d:{Dec:<nil>} s: Format:BinarySI} pods:{i:{value:110 scale:0} d:{Dec:<nil>} s: Format:DecimalSI}] Phase:Running Conditions:[{Type:Ready Status:True LastHeartbeatTim
e:2020-06-17 15:38:28.774181472 +0800 CST m=+471.643094757 LastTransitionTime:2020-06-17 15:38:28.774181472 +0800 CST m=+471.643094757 Reason:EdgeReady Message:edge is posting ready status}] Addresses:[{Type:InternalIP Address:192.168.1.241} {Type:Hostname Address:edge-
node}] DaemonEndpoints:{KubeletEndpoint:{Port:10350}} NodeInfo:{MachineID: SystemUUID: BootID: KernelVersion:4.15.0-91-generic OSImage:Ubuntu 18.04.4 LTS ContainerRuntimeVersion:remote://19.3.6 KubeletVersion:v1.17.1-kubeedge-v1.4.0-alpha.0.46+63cc8f2ac515c9-dirty KubeP
roxyVersion: OperatingSystem:linux Architecture:amd64} Images:[] VolumesInUse:[] VolumesAttached:[] Config:nil} ExtendResources:map[]}}
I0617 15:38:28.796667   24252 metaclient.go:121] send sync message default/nodestatus/edge-node successed and response: {{a4a69d61-3345-4dda-a19b-f60a04b6a194 a5d83aa3-95d2-4830-8be5-66d18ffa29d4 1592379508796  false} {edged meta response default/nodestatus/edge-node} OK}
I0617 15:38:08.756718   24252 process.go:162] received msg from cloud-hub:{Header:{ID:73aa90ce-6d4d-44f6-b3df-b4bef6e5b90a ParentID:0c4e3fef-5386-4c68-99fa-c71afa948352 Timestamp:1592379488756 ResourceVersion:1909 Sync:false} Router:{Source:edgecontroller Group:resource
 Operation:response Resource:default/node/edge-node} Content:OK}
```