### PR TITLE
Lint: add transfer sign for hint

### DIFF
--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -27,7 +27,7 @@ kubeedge::lint::check() {
     git diff --cached --name-only --diff-filter=ACRMTU master | grep -Ev "externalversions|fake|vendor" | xargs --no-run-if-empty sed -i 's/[ \t]*$//'
 
     [[ $(git diff --name-only) ]] && {
-      echo "Some files have white noise issue, please run `make lint` to check"
+      echo "Some files have white noise issue, please run \`make lint\` to check"
       return 1
     }
     golangci-lint run


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

If there are some files not committed, run `make lint` would run into a endless loop.

Reproduce:
```
$ echo >> README.md
$ make lint
```