### PR TITLE
EdgeMesh: fix panic error

### DIFF
--- a/edgemesh/pkg/plugin/plugin.go
+++ b/edgemesh/pkg/plugin/plugin.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-chassis/go-chassis/core/registry"
 
 	meshConfig "github.com/kubeedge/kubeedge/edgemesh/pkg/config"
+	// Register panel to aviod panic error
+	_ "github.com/kubeedge/kubeedge/edgemesh/pkg/plugin/panel"
 	meshRegistry "github.com/kubeedge/kubeedge/edgemesh/pkg/plugin/registry"
 )
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What this PR does / why we need it**:

The panic is here:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x2bb9e9d]

goroutine 22733 [running]:
github.com/go-chassis/go-chassis/core/handler.(*LBHandler).Handle(0x4d42eb8, 0xc0005a0a80, 0xc0007f6000, 0xc000ccc470)
    /test/pkg/mod/github.com/go-chassis/go-chassis@v1.7.1/core/handler/loadbalance_handler.go:81 +0xbd
github.com/go-chassis/go-chassis/core/handler.(*Chain).Next(0xc0005a0a80, 0xc0007f6000, 0xc000ccc470)
    /test/pkg/mod/github.com/go-chassis/go-chassis@v1.7.1/core/handler/handler_chain.go:41 +0x73
github.com/kubeedge/kubeedge/edgemesh/pkg/protocol/http.(*HTTP).Process(0xc0005a0a40)
    /test/src/github.com/daixiang0/kubeedge/edgemesh/pkg/protocol/http/http.go:69 +0x97
created by github.com/kubeedge/kubeedge/edgemesh/pkg/listener.Start
    /test/src/github.com/daixiang0/kubeedge/edgemesh/pkg/listener/listener.go:163 +0x256
```

The LBHandle Handle function:
```
// Handle to handle the load balancing
func (lb *LBHandler) Handle(chain *Chain, i *invocation.Invocation, cb invocation.ResponseCallBack) {
	lbConfig := control.DefaultPanel.GetLoadBalancing(*i)  <=== Panel is nil
	if !lbConfig.RetryEnabled {
		lb.handleWithNoRetry(chain, i, lbConfig, cb)
	} else {
		lb.handleWithRetry(chain, i, lbConfig, cb)
	}
}
```

**Which issue(s) this PR fixes**:

Fixes #1436
