### PR TITLE
EdgeMesh: support container level proxy

### DIFF
--- a/edgemesh/pkg/protocol/http/http.go
+++ b/edgemesh/pkg/protocol/http/http.go
@@ -35,7 +35,7 @@ func (p *HTTP) Process() {
 		req, err := http.ReadRequest(bufio.NewReader(p.Conn))
 		if err != nil {
 			if err == io.EOF {
-				klog.Infof("[EdgeMesh] http client disconnected.")
+				klog.V(2).Infof("[EdgeMesh] http client disconnected.")
 				return
 			}
 			klog.Errorf("[EdgeMesh] parse http request err: %v", err)


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Now EdgeMesh only support hostPort, uses should specify `hostPort` in the yaml like:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
spec:
  #replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx
        imagePullPolicy: IfNotPresent
        ports:
        - containerPort: 80
          hostPort: 80
```

If not, EdgeMesh can not do proxy.

**Does this PR introduce a user-facing change?**:

```release-note
EdgeMesh: support container level proxy
```
