### PR TITLE
Automated cherry pick of #1670: fix too long time to get node ready when reconnect

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -70,17 +70,8 @@ func (q *ChannelMessageQueue) DispatchMessage() {
 }
 
 func (q *ChannelMessageQueue) addListMessageToQueue(nodeID string, msg *beehiveModel.Message) {
-	nodeListQueue, err := q.GetNodeListQueue(nodeID)
-	if err != nil {
-		klog.Errorf("fail to get nodeListQueue for Node: %s", nodeID)
-		return
-	}
-
-	nodeListStore, err := q.GetNodeListStore(nodeID)
-	if err != nil {
-		klog.Errorf("fail to get nodeListStore for Node: %s", nodeID)
-		return
-	}
+	nodeListQueue := q.GetNodeListQueue(nodeID)
+	nodeListStore := q.GetNodeListStore(nodeID)
 
 	messageKey, _ := getListMsgKey(msg)
 
@@ -93,17 +84,8 @@ func (q *ChannelMessageQueue) addMessageToQueue(nodeID string, msg *beehiveModel
 		return
 	}
 
-	nodeQueue, err := q.GetNodeQueue(nodeID)
-	if err != nil {
-		klog.Errorf("fail to get nodeQueue for Node: %s", nodeID)
-		return
-	}
-
-	nodeStore, err := q.GetNodeStore(nodeID)
-	if err != nil {
-		klog.Errorf("fail to get nodeStore for Node: %s", nodeID)
-		return
-	}
+	nodeQueue := q.GetNodeQueue(nodeID)
+	nodeStore := q.GetNodeStore(nodeID)
 
 	messageKey, err := getMsgKey(msg)
 	if err != nil {
@@ -289,59 +271,59 @@ func (q *ChannelMessageQueue) Publish(msg *beehiveModel.Message) error {
 }
 
 // GetNodeQueue returns the queue for given node
-func (q *ChannelMessageQueue) GetNodeQueue(nodeID string) (workqueue.RateLimitingInterface, error) {
+func (q *ChannelMessageQueue) GetNodeQueue(nodeID string) workqueue.RateLimitingInterface {
 	queue, ok := q.queuePool.Load(nodeID)
 	if !ok {
 		klog.Warningf("nodeQueue for edge node %s not found and created now", nodeID)
 		nodeQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), nodeID)
 		q.queuePool.Store(nodeID, nodeQueue)
-		return nodeQueue, nil
+		return nodeQueue
 	}
 
 	nodeQueue := queue.(workqueue.RateLimitingInterface)
-	return nodeQueue, nil
+	return nodeQueue
 }
 
 // GetNodeListQueue returns the listQueue for given node
-func (q *ChannelMessageQueue) GetNodeListQueue(nodeID string) (workqueue.RateLimitingInterface, error) {
+func (q *ChannelMessageQueue) GetNodeListQueue(nodeID string) workqueue.RateLimitingInterface {
 	queue, ok := q.listQueuePool.Load(nodeID)
 	if !ok {
 		klog.Warningf("nodeListQueue for edge node %s not found and created now", nodeID)
 		nodeListQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), nodeID)
 		q.listQueuePool.Store(nodeID, nodeListQueue)
-		return nodeListQueue, nil
+		return nodeListQueue
 	}
 
 	nodeListQueue := queue.(workqueue.RateLimitingInterface)
-	return nodeListQueue, nil
+	return nodeListQueue
 }
 
 // GetNodeStore returns the store for given node
-func (q *ChannelMessageQueue) GetNodeStore(nodeID string) (cache.Store, error) {
+func (q *ChannelMessageQueue) GetNodeStore(nodeID string) cache.Store {
 	store, ok := q.storePool.Load(nodeID)
 	if !ok {
 		klog.Warningf("nodeStore for edge node %s not found and created now", nodeID)
 		nodeStore := cache.NewStore(getMsgKey)
 		q.storePool.Store(nodeID, nodeStore)
-		return nodeStore, nil
+		return nodeStore
 	}
 
 	nodeStore := store.(cache.Store)
-	return nodeStore, nil
+	return nodeStore
 }
 
 // GetNodeListStore returns the listStore for given node
-func (q *ChannelMessageQueue) GetNodeListStore(nodeID string) (cache.Store, error) {
+func (q *ChannelMessageQueue) GetNodeListStore(nodeID string) cache.Store {
 	store, ok := q.listStorePool.Load(nodeID)
 	if !ok {
 		klog.Warningf("nodeListStore for edge node %s not found and created now", nodeID)
 		nodeListStore := cache.NewStore(getListMsgKey)
 		q.listStorePool.Store(nodeID, nodeListStore)
-		return nodeListStore, nil
+		return nodeListStore
 	}
 
 	nodeListStore := store.(cache.Store)
-	return nodeListStore, nil
+	return nodeListStore
 }
 
 // GetMessageUID returns the UID of the object in message

--- a/cloud/pkg/cloudhub/common/model/types.go
+++ b/cloud/pkg/cloudhub/common/model/types.go
@@ -55,6 +55,10 @@ const (
 	NodeID    = "node_id"
 )
 
+const (
+	StopGetFromQueue = "stopgetfromqueue"
+)
+
 // HubInfo saves identifier information for edge hub
 type HubInfo struct {
 	ProjectID string

--- a/cloud/pkg/cloudhub/common/model/types_test.go
+++ b/cloud/pkg/cloudhub/common/model/types_test.go
@@ -83,17 +83,12 @@ func TestIsNodeStopped(t *testing.T) {
 		"timestamp":  time.Now().Unix(),
 	}
 	content, _ := json.Marshal(body)
-	bodyAction := map[string]interface{}{
-		"event_type": OpConnect,
-		"timestamp":  time.Now().Unix(),
-		"action":     "stop",
-	}
+
 	msgResource := modelMessage("", "", 0, "", "", "", "Resource1", nil)
-	msgOpDelete := modelMessage("", "", 0, "", "", OpDelete, "node/Node1", nil)
-	msgNoContent := modelMessage("", "", 0, "", "", "", "node/Node1", nil)
-	msgContent := modelMessage("", "", 0, "", "", OpUpdate, "node/Node1", content)
-	msgNoAction := modelMessage("", "", 0, "", "", OpUpdate, "node/Node1", body)
-	msgActionStop := modelMessage("", "", 0, "", "", OpUpdate, "node/Node1", bodyAction)
+	msgOpDelete := modelMessage("", "", 0, "", "", model.DeleteOperation, "node/edge-node/default/node/Node1", nil)
+	msgNoContent := modelMessage("", "", 0, "", "", "", "node/edge-node/default/node/Node1", nil)
+	msgContent := modelMessage("", "", 0, "", "", model.UpdateOperation, "node/edge-node/default/node/Node1", content)
+	msgNoAction := modelMessage("", "", 0, "", "", model.UpdateOperation, "node/edge-node/default/node/Node1", body)
 	tests := []struct {
 		name      string
 		msg       *model.Message
@@ -123,11 +118,6 @@ func TestIsNodeStopped(t *testing.T) {
 			name:      "TestIsNodeStopped(): Case 5: msg.Content[action] is nil",
 			msg:       &msgNoAction,
 			errorWant: false,
-		},
-		{
-			name:      "TestIsNodeStopped(): Case 6: msg.Content[action]=stop",
-			msg:       &msgActionStop,
-			errorWant: true,
 		},
 	}
 	for _, test := range tests {

--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -162,8 +162,16 @@ func (mh *MessageHandle) KeepaliveCheckLoop(hi hubio.CloudHubIO, info *model.Hub
 		case <-keepaliveTicker.C:
 			klog.Warningf("Timeout to receive heart beat from edge node %s for project %s",
 				info.NodeID, info.ProjectID)
+
 			stopServe <- nodeDisconnect
 			close(stopSendMsg)
+
+			nodeQueue, err := mh.MessageQueue.GetNodeQueue(info.NodeID)
+			if err != nil {
+				klog.Errorf("Failed to get nodeQueue for node %s: %v", info.NodeID, err)
+				return
+			}
+			nodeQueue.Add(model.StopGetFromQueue)
 			return
 		}
 	}
@@ -362,35 +370,43 @@ func (mh *MessageHandle) MessageWriteLoop(hi hubio.CloudHubIO, info *model.HubIn
 			klog.Errorf("Node %s disconnected and stopped sending messages", info.NodeID)
 			return
 		default:
-			mh.handleMessage(nodeQueue, nodeStore, hi, info, stopServe, "message")
+			err := mh.handleMessage(nodeQueue, nodeStore, hi, info, stopServe, "message")
+			if err != nil {
+				return
+			}
 		}
 	}
 }
 
 func (mh *MessageHandle) handleMessage(nodeQueue workqueue.RateLimitingInterface,
 	nodeStore cache.Store, hi hubio.CloudHubIO,
-	info *model.HubInfo, stopServe chan ExitCode, msgType string) {
+	info *model.HubInfo, stopServe chan ExitCode, msgType string) error {
 	key, quit := nodeQueue.Get()
 	if quit {
 		klog.Errorf("nodeQueue for node %s has shutdown", info.NodeID)
-		return
+		return fmt.Errorf("nodeQueue for node %s has shutdown", info.NodeID)
 	}
+	if key.(string) == model.StopGetFromQueue {
+		klog.Errorf("stop get item from nodeQueue for node %s", info.NodeID)
+		return fmt.Errorf("stop get item from nodeQueue for node %s", info.NodeID)
+	}
+
 	obj, exist, _ := nodeStore.GetByKey(key.(string))
 	if !exist {
 		klog.Errorf("nodeStore for node %s doesn't exist", info.NodeID)
-		return
+		return fmt.Errorf("nodeStore for node %s doesn't exist", info.NodeID)
 	}
 
 	msg := obj.(*beehiveModel.Message)
 
 	if model.IsNodeStopped(msg) {
-		klog.Infof("node %s is stopped, will disconnect", info.NodeID)
+		klog.Warningf("node %s is stopped, will disconnect", info.NodeID)
 		stopServe <- nodeStop
-		return
+		return fmt.Errorf("node %s is stopped, will disconnect", info.NodeID)
 	}
 	if !model.IsToEdge(msg) {
 		klog.Infof("skip only to cloud event for node %s, %s, content %s", info.NodeID, dumpMessageMetadata(msg), msg.Content)
-		return
+		return fmt.Errorf("skip only to cloud event for node %s, %s, content %s", info.NodeID, dumpMessageMetadata(msg), msg.Content)
 	}
 	klog.V(4).Infof("event to send for node %s, %s, content %s", info.NodeID, dumpMessageMetadata(msg), msg.Content)
 
@@ -400,20 +416,26 @@ func (mh *MessageHandle) handleMessage(nodeQueue workqueue.RateLimitingInterface
 	if err != nil {
 		klog.Errorf("SetWriteDeadline error, %s", err.Error())
 		stopServe <- hubioWriteFail
-		return
+		return err
 	}
 	if msgType == "listMessage" {
-		mh.send(hi, info, msg)
+		err := mh.send(hi, info, msg)
+		if err != nil {
+			return err
+		}
 		// delete successfully sent events from the queue/store
 		nodeStore.Delete(msg)
-	} else {
-		mh.sendMsg(hi, info, msg, copyMsg, nodeStore)
+	}
+	err = mh.sendMsg(hi, info, msg, copyMsg, nodeStore)
+	if err != nil {
+		return err
 	}
 
 	nodeQueue.Done(key)
+	return nil
 }
 
-func (mh *MessageHandle) sendMsg(hi hubio.CloudHubIO, info *model.HubInfo, msg, copyMsg *beehiveModel.Message, nodeStore cache.Store) {
+func (mh *MessageHandle) sendMsg(hi hubio.CloudHubIO, info *model.HubInfo, msg, copyMsg *beehiveModel.Message, nodeStore cache.Store) error {
 	ackChan := make(chan struct{})
 	mh.MessageAcks.Store(msg.GetID(), ackChan)
 
@@ -423,7 +445,10 @@ func (mh *MessageHandle) sendMsg(hi hubio.CloudHubIO, info *model.HubInfo, msg, 
 		retryInterval time.Duration = 5
 	)
 	ticker := time.NewTimer(retryInterval * time.Second)
-	mh.send(hi, info, msg)
+	err := mh.send(hi, info, msg)
+	if err != nil {
+		return err
+	}
 
 LOOP:
 	for {
@@ -435,20 +460,25 @@ LOOP:
 			if retry == 4 {
 				break LOOP
 			}
-			mh.send(hi, info, msg)
+			err := mh.send(hi, info, msg)
+			if err != nil {
+				return err
+			}
 			retry++
 			ticker.Reset(time.Second * retryInterval)
 		}
 	}
+	return nil
 }
 
-func (mh *MessageHandle) send(hi hubio.CloudHubIO, info *model.HubInfo, msg *beehiveModel.Message) {
+func (mh *MessageHandle) send(hi hubio.CloudHubIO, info *model.HubInfo, msg *beehiveModel.Message) error {
 	err := mh.hubIoWrite(hi, info.NodeID, msg)
 	if err != nil {
 		klog.Errorf("write error, connection for node %s will be closed, affected event %s, reason %s",
 			info.NodeID, dumpMessageMetadata(msg), err.Error())
-		return
+		return err
 	}
+	return nil
 }
 
 func (mh *MessageHandle) saveSuccessPoint(msg *beehiveModel.Message, info *model.HubInfo, nodeStore cache.Store) {

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -423,6 +423,10 @@ func (e *edged) syncNodeStatus() {
 	if !e.registrationCompleted {
 		if err := e.registerNode(); err != nil {
 			klog.Errorf("Register node failed: %v", err)
+			return
+		}
+		if err := e.updateNodeStatus(); err != nil {
+			klog.Errorf("Unable to update node status: %v", err)
 		}
 	} else {
 		if err := e.updateNodeStatus(); err != nil {


### PR DESCRIPTION
Cherry pick of #1670 on release-1.3.

#1670: fix too long time to get node ready when reconnect

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.