### PR TITLE
EdgeMesh: remove docker0 dependence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,20 @@ jobs:
     - name: "unit test, integration test edge"
       arch: amd64
       before_script:
+        - sudo apt-get install bridge-utils -y
         - go get github.com/onsi/ginkgo/ginkgo
         - export GOFLAGS=-mod=mod
+        - git checkout .
+        # travis-ci own dns is too slow
+        - echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
       script:
         - make test
         - make integrationtest
     - name: "e2e test"
       arch: amd64
       before_script:
+        # travis-ci own dns is too slow
+        - echo "nameserver 8.8.8.8" | sudo tee -a /etc/resolv.conf
         - go get github.com/onsi/ginkgo/ginkgo
         - go get sigs.k8s.io/kind@v0.7.0
         - go mod vendor
@@ -71,7 +77,7 @@ jobs:
         - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
         - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
         - sudo apt-get update
-        - sudo apt-get install -y kubectl
+        - sudo apt-get install -y kubectl bridge-utils
       script:
         - travis_retry make e2e
     - name: "keadm e2e test"
@@ -80,7 +86,6 @@ jobs:
         - go get github.com/onsi/ginkgo/ginkgo
         - go get sigs.k8s.io/kind@v0.7.0
         - go mod vendor
-        - export GOFLAGS=-mod=vendor
         - sudo apt-get update && sudo apt-get install -y apt-transport-https
         - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
         - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list

--- a/edgemesh/pkg/config/config.go
+++ b/edgemesh/pkg/config/config.go
@@ -6,7 +6,6 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/kubeedge/kubeedge/edgemesh/pkg/common"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 )
 
@@ -26,13 +25,7 @@ func InitConfigure(e *v1alpha1.EdgeMesh) {
 			EdgeMesh: *e,
 		}
 		if Config.Enable {
-			// get listen ip
-			var err error
-			Config.ListenIP, err = common.GetInterfaceIP(Config.ListenInterface)
-			if err != nil {
-				klog.Errorf("[EdgeMesh] get listen ip err: %v", err)
-				return
-			}
+			Config.ListenIP = net.ParseIP(e.InterfaceAddr)
 			// get listener
 			tmpPort := 0
 			listenAddr := &net.TCPAddr{

--- a/edgemesh/pkg/module.go
+++ b/edgemesh/pkg/module.go
@@ -17,13 +17,18 @@ import (
 
 //EdgeMesh defines EdgeMesh object structure
 type EdgeMesh struct {
-	enable bool
+	enable        bool
+	interfaceAddr string
 }
 
 // Register register edgemesh
 func Register(m *v1alpha1.EdgeMesh) {
+	dns.Init(m.InterfaceAddr)
 	meshconfig.InitConfigure(m)
-	core.Register(&EdgeMesh{enable: m.Enable})
+	core.Register(&EdgeMesh{
+		enable:        m.Enable,
+		interfaceAddr: m.InterfaceAddr,
+	})
 }
 
 // Name returns the name of EdgeMesh module
@@ -52,7 +57,7 @@ func (em *EdgeMesh) Start() {
 	// start proxy listener
 	go listener.Start()
 	// start dns server
-	go dns.Start()
+	go dns.Start(em.interfaceAddr)
 	// we need watch message to update the cache of instances
 	for {
 		select {

--- a/edgemesh/pkg/proxy/proxy.go
+++ b/edgemesh/pkg/proxy/proxy.go
@@ -40,8 +40,8 @@ func Init() {
 	iptInterface := utiliptables.New(exec, protocol)
 	proxier = &Proxier{
 		iptables:     iptInterface,
-		inboundRule:  "-p tcp -d " + config.Config.SubNet + " -i " + config.Config.ListenInterface + " -j " + meshChain,
-		outboundRule: "-p tcp -d " + config.Config.SubNet + " -o " + config.Config.ListenInterface + " -j " + meshChain,
+		inboundRule:  "-p tcp -d " + config.Config.SubNet + " -i docker0 -j " + meshChain,
+		outboundRule: "-p tcp -d " + config.Config.SubNet + " -o docker0 -j " + meshChain,
 		dNatRule:     "-p tcp -j DNAT --to-destination " + config.Config.Listener.Addr().String(),
 	}
 	// read and clean iptables rules

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -137,11 +137,11 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				Enable: false,
 			},
 			EdgeMesh: &EdgeMesh{
-				Enable:          true,
-				LBStrategy:      EdgeMeshDefaultLoadBalanceStrategy,
-				ListenInterface: EdgeMeshDefaultInterface,
-				ListenPort:      EdgeMeshDefaultListenPort,
-				SubNet:          EdgeMeshDefaultSubNet,
+				Enable:        true,
+				LBStrategy:    EdgeMeshDefaultLoadBalanceStrategy,
+				InterfaceAddr: EdgeMeshDefaultInterfaceAddr,
+				ListenPort:    EdgeMeshDefaultListenPort,
+				SubNet:        EdgeMeshDefaultSubNet,
 			},
 			EdgeStream: &EdgeStream{
 				Enable:                  false,

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	EdgeMeshDefaultLoadBalanceStrategy = "RoundRobin"
-	EdgeMeshDefaultInterface           = "docker0"
+	EdgeMeshDefaultInterfaceAddr       = "169.254.251.4"
 	EdgeMeshDefaultSubNet              = "9.251.0.0/16"
 	EdgeMeshDefaultListenPort          = 40001
 )
@@ -392,8 +392,8 @@ type EdgeMesh struct {
 	Enable bool `json:"enable,omitempty"`
 	// lbStrategy indicates load balance strategy name
 	LBStrategy string `json:"lbStrategy,omitempty"`
-	// ListenInterface indicates the listen interface of EdgeMesh
-	ListenInterface string `json:"listenInterface,omitempty"`
+	// InterfaceAddr indicates the address of EdgeMesh interface
+	InterfaceAddr string `json:"InterfaceAddr,omitempty"`
 	// SubNet indicates the subnet of EdgeMesh
 	SubNet string `json:"subNet,omitempty"`
 	// ListenPort indicates the listen port of EdgeMesh


### PR DESCRIPTION
**What this PR does / why we need it**:

Now EdgeMesh bind docker0 to work as a DNS server, this pr is to remove this dependence.

**Special notes for your reviewer**:

The proxy part of EdgeMesh still depends on docker0 network interface, which would be optimized after related proposal confirmed.
