### PR TITLE
add clean namespace in keadm reset

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
@@ -6,13 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog"
 
 	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 )
 
 var (
@@ -64,7 +61,7 @@ func newGettokenOptions() *common.GettokenOptions {
 
 // queryToken gets token from k8s
 func queryToken(namespace string, name string, kubeConfigPath string) ([]byte, error) {
-	client, err := kubeClient(kubeConfigPath)
+	client, err := util.KubeClient(kubeConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -82,26 +79,4 @@ func showToken(data []byte, out io.Writer) error {
 		return err
 	}
 	return nil
-}
-
-func kubeConfig(kubeconfigPath string) (conf *rest.Config, err error) {
-	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	kubeConfig.QPS = float32(constants.DefaultKubeQPS)
-	kubeConfig.Burst = int(constants.DefaultKubeBurst)
-	kubeConfig.ContentType = constants.DefaultKubeContentType
-
-	return kubeConfig, nil
-}
-
-// KubeClient from config
-func kubeClient(kubeConfigPath string) (*kubernetes.Clientset, error) {
-	kubeConfig, err := kubeConfig(kubeConfigPath)
-	if err != nil {
-		klog.Warningf("get kube config failed with error: %s", err)
-		return nil, err
-	}
-	return kubernetes.NewForConfig(kubeConfig)
 }

--- a/keadm/cmd/keadm/app/cmd/cmd.go
+++ b/keadm/cmd/keadm/app/cmd/cmd.go
@@ -70,7 +70,7 @@ func NewKubeedgeCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds.ResetFlags()
 	cmds.AddCommand(cloud.NewCloudInit(out, nil))
 	cmds.AddCommand(edge.NewEdgeJoin(out, nil))
-	cmds.AddCommand(NewKubeEdgeReset(out))
+	cmds.AddCommand(NewKubeEdgeReset(out, nil))
 	cmds.AddCommand(NewCmdVersion(out))
 	cmds.AddCommand(cloud.NewGettoken(out, nil))
 

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -41,6 +41,10 @@ type JoinOptions struct {
 	CertPort              string
 }
 
+type ResetOptions struct {
+	Kubeconfig string
+}
+
 type GettokenOptions struct {
 	Kubeconfig string
 }

--- a/keadm/cmd/keadm/app/cmd/util/centosinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/centosinstaller.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
 

--- a/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
@@ -181,6 +181,10 @@ func (cu *KubeCloudInstTool) TearDown() error {
 
 	//Kill cloudcore process
 	cu.KillKubeEdgeBinary(KubeCloudBinaryName)
-
+	// clean kubeedge namespace
+	err := cu.cleanNameSpace("kubeedge", cu.KubeConfig)
+	if err != nil {
+		return fmt.Errorf("fail to clean kubeedge namespace, err:%v", err)
+	}
 	return nil
 }

--- a/keadm/cmd/keadm/app/cmd/util/kubeclient.go
+++ b/keadm/cmd/keadm/app/cmd/util/kubeclient.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+
+	"github.com/kubeedge/kubeedge/common/constants"
+)
+
+func kubeConfig(kubeconfigPath string) (conf *rest.Config, err error) {
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	kubeConfig.QPS = float32(constants.DefaultKubeQPS)
+	kubeConfig.Burst = int(constants.DefaultKubeBurst)
+	kubeConfig.ContentType = constants.DefaultKubeContentType
+
+	return kubeConfig, nil
+}
+
+// KubeClient from config
+func KubeClient(kubeConfigPath string) (*kubernetes.Clientset, error) {
+	kubeConfig, err := kubeConfig(kubeConfigPath)
+	if err != nil {
+		klog.Warningf("get kube config failed with error: %s", err)
+		return nil, err
+	}
+	return kubernetes.NewForConfig(kubeConfig)
+}
+
+func (co *Common) cleanNameSpace(ns, kubeConfigPath string) error {
+	cli, err := KubeClient(kubeConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to create KubeClient, error: %s", err)
+	}
+	return cli.CoreV1().Namespaces().Delete(ns, nil)
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind cleanup
/kind bug


**What this PR does / why we need it**:
when we use `keadm reset`, it can automatically clean the kubeedge namespace. It can reduce some problems about certificates when users use keadm reset.
we should use keadm like `keadm reset --kube-config $HOME/.kube/config`.
I will update the docs of keadm after the pr was merged.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
