### PR TITLE
CloudCoreConfig:  'DeletePodWorkers'  is wrong

### DIFF
--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -115,7 +115,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					QueryVolumeAttachmentWorkers:      constants.DefaultQueryVolumeAttachmentWorkers,
 					QueryNodeWorkers:                  constants.DefaultQueryNodeWorkers,
 					UpdateNodeWorkers:                 constants.DefaultUpdateNodeWorkers,
-					DeletePodWorkers:                  constants.DefaultDeletePodBuffer,
+					DeletePodWorkers:                  constants.DefaultDeletePodWorkers,
 				},
 			},
 			DeviceController: &DeviceController{


### PR DESCRIPTION
Error Config:
DeletePodWorkers:                  constants.DefaultDeletePodBuffer,
Fixed Config:
DeletePodWorkers:                  constants.DefaultDeletePodWorkers,

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

> /kind bug
 


**What this PR does / why we need it**:
wrong config  that will creat 1024 delete pod workers

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
