### PR TITLE
make lint: ingore adopters

### DIFF
--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -24,7 +24,7 @@ kubeedge::lint::check() {
     cd ${KUBEEDGE_ROOT}
     # skip deleted files
     set +o pipefail
-    git diff --cached --name-only --diff-filter=ACRMTU master | grep -Ev "externalversions|fake|vendor|images" | xargs --no-run-if-empty sed -i 's/[ \t]*$//'
+    git diff --cached --name-only --diff-filter=ACRMTU master | grep -Ev "externalversions|fake|vendor|images|adopters" | xargs --no-run-if-empty sed -i 's/[ \t]*$//'
 
     [[ $(git diff --name-only) ]] && {
       echo "Some files have white noise issue, please run \`make lint\` to check"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
`make lint` will modify the images, then the images are broken.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1878 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
