### PR TITLE
Improve metrics connection

### DIFF
--- a/cloud/pkg/cloudstream/containermetrics_connection.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection.go
@@ -35,7 +35,7 @@ type ContainerMetricsConnection struct {
 	MessageID    uint64
 	ctx          context.Context
 	r            *restful.Request
-	flush        io.Writer
+	writer       io.Writer
 	session      *Session
 	edgePeerStop chan struct{}
 }
@@ -53,7 +53,7 @@ func (ms *ContainerMetricsConnection) EdgePeerDone() <-chan struct{} {
 }
 
 func (ms *ContainerMetricsConnection) WriteToAPIServer(p []byte) (n int, err error) {
-	return ms.flush.Write(p)
+	return ms.writer.Write(p)
 }
 
 func (ms *ContainerMetricsConnection) WriteToTunnel(m *stream.Message) error {

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -153,18 +153,11 @@ func (s *StreamServer) getMetrics(r *restful.Request, w *restful.Response) {
 		return
 	}
 
-	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusOK)
-
-	if _, ok := w.ResponseWriter.(http.Flusher); !ok {
-		err = fmt.Errorf("Unable to convert %v into http.Flusher, cannot grab metrics data from edge", reflect.TypeOf(w))
-		return
-	}
-	fw := flushwriter.Wrap(w.ResponseWriter)
 
 	metricsConnection, err := session.AddAPIServerConnection(s, &ContainerMetricsConnection{
 		r:            r,
-		flush:        fw,
+		writer:       w.ResponseWriter,
 		session:      session,
 		ctx:          r.Request.Context(),
 		edgePeerStop: make(chan struct{}),


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature

/kind bug

**What this PR does / why we need it**:
Kubelet uses the chunked method to return Response when processing logs/exec requests, but does not use this method when requesting /stats. Edged uses the ordinary connection in the same way.

**Special notes for your reviewer**:
/cc @kadisi 

```release-note

```
