### PR TITLE
workaround on cloudcore crash of device without nodeselector

### DIFF
--- a/build/crds/devices/devices_v1alpha1_device.yaml
+++ b/build/crds/devices/devices_v1alpha1_device.yaml
@@ -167,6 +167,7 @@ spec:
               type: object
           required:
             - deviceModelRef
+            - nodeSelector
           type: object
         status:
           properties:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind test
> /kind failing-test
> /kind feature


**What this PR does / why we need it**:
To avoid cloudcore crash on device without NodeSelector.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1913

**Special notes for your reviewer**:
It is a workaroud. 
We should find better way to fix it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Set NodeSelector in device spec to be 'required'. If user do not select a node, you can pass an empty value
Spec:
  nodeSelector:
    nodeSelectorTerms:
```
