### PR TITLE
Fix the syntax issue of script for building edgemesh image

### DIFF
--- a/edgemesh/tools/initContainer/createImg.sh
+++ b/edgemesh/tools/initContainer/createImg.sh
@@ -3,8 +3,8 @@
 echo 'create edgemesh init Container image'
 
 function usage() {
-	echo "execute 'sh createImg.sh [rpm | deb]' to create docker image"
-	echo "execute 'sh createImg.sh help for use help'"
+	echo "execute 'bash createImg.sh [rpm | deb]' to create docker image"
+	echo "execute 'bash createImg.sh help for use help'"
 }
 
 path="${1}"
@@ -28,6 +28,6 @@ if command -v docker > /dev/null 2>&1 ; then
 	# delete iptables script
 	rm ./edgemesh-iptables.sh
 else
-	echo 'the docker command is no found!!'
+	echo 'the docker command is not found!!'
 	exit 1
 fi


### PR DESCRIPTION
`sh` is not always symlink to `bash` on some system, for example,
it's linked to `dash` on ubuntu18 while `dash` doesn't recognize
the parentheses after `func`.

Here is how the error looks like,
createImg.sh: 5: createImg.sh: Syntax error: "(" unexpected

This PR fix a typo btw.

Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
