### PR TITLE
bugfix: Process of bluetooth mapper scheduler seems wrong 

### DIFF
--- a/mappers/bluetooth_mapper/scheduler/scheduler.go
+++ b/mappers/bluetooth_mapper/scheduler/scheduler.go
@@ -24,8 +24,8 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/kubeedge/kubeedge/mappers/bluetooth_mapper/action_manager"
-	"github.com/kubeedge/kubeedge/mappers/bluetooth_mapper/data_converter"
+	actionmanager "github.com/kubeedge/kubeedge/mappers/bluetooth_mapper/action_manager"
+	dataconverter "github.com/kubeedge/kubeedge/mappers/bluetooth_mapper/data_converter"
 	"github.com/kubeedge/kubeedge/mappers/bluetooth_mapper/helper"
 )
 
@@ -78,6 +78,9 @@ func (schedule *Schedule) ExecuteSchedule(actionManager []actionmanager.Action, 
 // performScheduleOperation is responsible for performing the operations associated with the schedule
 func (schedule *Schedule) performScheduleOperation(actionManager []actionmanager.Action, dataConverter dataconverter.DataRead, deviceID string) {
 	var scheduleResult ScheduleResult
+	if schedule.Interval == 0 {
+		schedule.Interval = defaultEventFrequency
+	}
 	for _, actionName := range schedule.Actions {
 		actionExists := false
 		for _, action := range actionManager {
@@ -90,9 +93,6 @@ func (schedule *Schedule) performScheduleOperation(actionManager []actionmanager
 				scheduleResult.EventResult = fmt.Sprintf("%s", action.Operation.Value)
 				publishScheduleResult(scheduleResult, deviceID)
 			}
-		}
-		if schedule.Interval == 0 {
-			schedule.Interval = defaultEventFrequency
 		}
 		if !actionExists {
 			klog.Errorf("Action %s does not exist.", actionName)

--- a/mappers/bluetooth_mapper/scheduler/scheduler.go
+++ b/mappers/bluetooth_mapper/scheduler/scheduler.go
@@ -78,8 +78,8 @@ func (schedule *Schedule) ExecuteSchedule(actionManager []actionmanager.Action, 
 // performScheduleOperation is responsible for performing the operations associated with the schedule
 func (schedule *Schedule) performScheduleOperation(actionManager []actionmanager.Action, dataConverter dataconverter.DataRead, deviceID string) {
 	var scheduleResult ScheduleResult
-	actionExists := false
 	for _, actionName := range schedule.Actions {
+		actionExists := false
 		for _, action := range actionManager {
 			if strings.EqualFold(action.Name, actionName) {
 				actionExists = true
@@ -95,8 +95,8 @@ func (schedule *Schedule) performScheduleOperation(actionManager []actionmanager
 			schedule.Interval = defaultEventFrequency
 		}
 		if !actionExists {
-			klog.Errorf("Action %s does not exist. Exiting from schedule !!!", actionName)
-			break
+			klog.Errorf("Action %s does not exist.", actionName)
+			continue
 		}
 		time.Sleep(time.Duration(time.Duration(schedule.Interval) * time.Millisecond))
 	}


### PR DESCRIPTION
The action in one schedule can be more than one. "actionExists" will always be true once it enters line 85,
which is not expected. Morever, if one action cannot be found, other actions should be run.

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
The process is wrong.

**Which issue(s) this PR fixes**:
Fixes #1824 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None

