### PR TITLE
Fix device configMap can not be re-created

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -654,8 +654,10 @@ func (dc *DownstreamController) deleteFromConfigMap(device *v1alpha1.Device) {
 
 		dc.deleteFromDeviceProfile(device, nodeConfigMap)
 
-		// no device is bound to the configMap, then remove the configMap directly.
-		if nodeConfigMap.Data[DeviceProfileJSON] == "{}" {
+		// There are two cases we can delete configMap:
+		// 1. no device bound to it, as Data[DeviceProfileJSON] is "{}"
+		// 2. device instance created alone then removed, as Data[DeviceProfileJSON] is ""
+		if nodeConfigMap.Data[DeviceProfileJSON] == "{}" || nodeConfigMap.Data[DeviceProfileJSON] == "" {
 			deleteOptions := &metav1.DeleteOptions{}
 			dc.kubeClient.CoreV1().ConfigMaps(device.Namespace).Delete(nodeConfigMap.Name, deleteOptions)
 			// remove from cache

--- a/tests/e2e/deployment/device_crd_test.go
+++ b/tests/e2e/deployment/device_crd_test.go
@@ -486,6 +486,20 @@ var _ = Describe("Device Management test in E2E scenario", func() {
 			Expect(IsDeviceDeleted).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusNotFound))
 		})
+		It("E2E_DELETE_DEVICE_3: Delete device instance without device model", func() {
+			IsDeviceCreated, statusCode := utils.HandleDeviceInstance(http.MethodPost, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "", "led")
+			Expect(IsDeviceCreated).Should(BeTrue())
+			Expect(statusCode).Should(Equal(http.StatusCreated))
+			time.Sleep(1 * time.Second)
+			statusCode, _ = utils.GetConfigmap(ctx.Cfg.K8SMasterForKubeEdge + ConfigmapHandler + "/" + "device-profile-config-" + nodeName)
+			Expect(statusCode).Should(Equal(http.StatusOK))
+			IsDeviceDeleted, statusCode := utils.HandleDeviceInstance(http.MethodDelete, ctx.Cfg.K8SMasterForKubeEdge+DeviceInstanceHandler, nodeName, "/"+utils.NewLedDeviceInstance(nodeName).Name, "")
+			Expect(IsDeviceDeleted).Should(BeTrue())
+			Expect(statusCode).Should(Equal(http.StatusOK))
+			time.Sleep(1 * time.Second)
+			statusCode, _ = utils.GetConfigmap(ctx.Cfg.K8SMasterForKubeEdge + ConfigmapHandler + "/" + "device-profile-config-" + nodeName)
+			Expect(statusCode).Should(Equal(http.StatusNotFound))
+		})
 	})
 	Context("Test Change in device twin", func() {
 		BeforeEach(func() {


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

When device crd deleted, related configMap still exist in cache, then re-create device crd would not create configMap.


**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #1948 
