### PR TITLE
Fix: print token with newline

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
@@ -25,6 +25,7 @@ to get the token.
 `
 )
 
+// NewGettoken gets the token for edge nodes to join the cluster
 func NewGettoken(out io.Writer, init *common.GettokenOptions) *cobra.Command {
 	if init == nil {
 		init = newGettokenOptions()
@@ -74,7 +75,8 @@ func queryToken(namespace string, name string, kubeConfigPath string) ([]byte, e
 
 // showToken prints the token
 func showToken(data []byte, out io.Writer) error {
-	_, err := out.Write(data)
+	token := append(data, byte('\n'))
+	_, err := out.Write(token)
 	if err != nil {
 		return err
 	}

--- a/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
@@ -75,8 +75,7 @@ func queryToken(namespace string, name string, kubeConfigPath string) ([]byte, e
 
 // showToken prints the token
 func showToken(data []byte, out io.Writer) error {
-	token := append(data, byte('\n'))
-	_, err := out.Write(token)
+	_, err := fmt.Fprintln(out, string(data))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

For a more friendly user interface when get token.

**Which issue(s) this PR fixes**:

Nope.

**Special notes for your reviewer**:

I just noticed when `keadm gettoken`, the next command line prompt begins with the end of token (which is difficult to get the token).

![before](https://user-images.githubusercontent.com/32200887/88293979-451dec00-cd2e-11ea-8aad-eb7051439fbf.png)

And I added a newline here:

![after](https://user-images.githubusercontent.com/32200887/88294020-52d37180-cd2e-11ea-8ef3-594ffa2abef9.png)

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
