### PR TITLE
Use SetWriteDeadline when writing to the socket

### DIFF
--- a/staging/src/github.com/kubeedge/viaduct/pkg/conn/ws.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/conn/ws.go
@@ -176,7 +176,7 @@ func (conn *WSConnection) Write(raw []byte) (int, error) {
 
 func (conn *WSConnection) WriteMessageAsync(msg *model.Message) error {
 	lane := lane.NewLane(api.ProtocolTypeWS, conn.wsConn)
-	lane.SetReadDeadline(conn.WriteDeadline)
+	lane.SetWriteDeadline(conn.WriteDeadline)
 	msg.Header.Sync = false
 	conn.locker.Lock()
 	defer conn.locker.Unlock()


### PR DESCRIPTION
Fixes #1927 
It should use `SetWriteDeadline()` when writing to a socket.