### PR TITLE
Add kill signal support

### DIFF
--- a/staging/src/github.com/kubeedge/beehive/pkg/core/core.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/core.go
@@ -28,7 +28,7 @@ func StartModules() {
 // GracefulShutdown is if it gets the special signals it does modules cleanup
 func GracefulShutdown() {
 	c := make(chan os.Signal)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM,
+	signal.Notify(c, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGKILL,
 		syscall.SIGQUIT, syscall.SIGILL, syscall.SIGTRAP, syscall.SIGABRT)
 	select {
 	case s := <-c:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

For test, `kill -9 $pid` is a common way to stop process, while we do not support. Then next test would fail since bad exit can not clean up as expected.

**Special notes for your reviewer**:

```
$ kill -l
 1) SIGHUP	 2) SIGINT	 3) SIGQUIT	 4) SIGILL	 5) SIGTRAP
 6) SIGABRT	 7) SIGBUS	 8) SIGFPE	 9) SIGKILL <===	10) SIGUSR1
11) SIGSEGV	12) SIGUSR2	13) SIGPIPE	14) SIGALRM	15) SIGTERM

```

Now we use some SIGKILL to stop process even if `keadm reset`:
```
$ git grep "kill -9"
edge/hack/clean.sh:17:     pkill -9 edgecore
edge/test/integration/scripts/execute.sh:20:  sudo pkill -9 edgecore || true
edge/test/integration/utils/test_setup.go:19:   RunEdgecore           = "sudo pkill -9 edgecore; cd ${KUBEEDGE_ROOT}/_output/local/bin/; sudo nohup ./edgecore --config=" + EdgeCoreConfigFile + " > edgecore.log 2>&1 &"
keadm/cmd/keadm/app/cmd/util/common.go:463:     binExec := fmt.Sprintf("kill -9 $(ps aux | grep '[%s]%s' | awk '{print $2}')", proc[0:1], proc[1:])
tests/e2e/scripts/keadm_e2e.sh:22:  ps aux | grep '[e]dgecore' | awk '{print $2}' | xargs -r sudo kill -9
tests/e2e/scripts/keadm_e2e.sh:23:  ps aux | grep '[c]loudcore' | awk '{print $2}' | xargs -r sudo kill -9
root:[222]$ less /tmp/edgecore.log
```
