### PR TITLE
fixed goroutine leak, when ws connection reconnect, but fifo's channel no close.

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -111,8 +111,8 @@ func (wsc *WebSocketClient) Send(message model.Message) error {
 //Receive reads the binary message through the connection
 func (wsc *WebSocketClient) Receive() (model.Message, error) {
 	message := model.Message{}
-	wsc.connection.ReadMessage(&message)
-	return message, nil
+	err := wsc.connection.ReadMessage(&message)
+	return message, err
 }
 
 //Notify logs info

--- a/staging/src/github.com/kubeedge/viaduct/pkg/conn/ws.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/conn/ws.go
@@ -213,6 +213,7 @@ func (conn *WSConnection) LocalAddr() net.Addr {
 }
 
 func (conn *WSConnection) Close() error {
+	conn.messageFifo.Close()
 	return conn.wsConn.Close()
 }
 

--- a/staging/src/github.com/kubeedge/viaduct/pkg/fifo/msgfifo.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/fifo/msgfifo.go
@@ -2,6 +2,7 @@ package fifo
 
 import (
 	"fmt"
+	"sync"
 
 	"k8s.io/klog"
 
@@ -10,7 +11,8 @@ import (
 )
 
 type MessageFifo struct {
-	fifo chan model.Message
+	fifo      chan model.Message
+	closeOnce sync.Once
 }
 
 // set the fifo capacity to MessageFiFoSizeMax
@@ -42,4 +44,10 @@ func (f *MessageFifo) Get(msg *model.Message) error {
 		return fmt.Errorf("the fifo is broken")
 	}
 	return nil
+}
+
+func (f *MessageFifo) Close() {
+	f.closeOnce.Do(func() {
+		close(f.fifo)
+	})
 }


### PR DESCRIPTION
…l not close

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug


**What this PR does / why we need it**:
fixed goroutine leak: when the edgecore is disconnected from the cloudhub, and edge side's connection will reconnection, but it not close fifo's channel, and it will cause goroutine leak
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2018

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
