### PR TITLE
Minor optimization for edgecontroller.

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -172,8 +172,6 @@ func (uc *UpstreamController) dispatchMessage() {
 			continue
 		}
 		klog.Infof("message: %s, resource type is: %s", msg.GetID(), resourceType)
-		operationType := msg.GetOperation()
-		klog.Infof("message: %s, operation type is: %s", msg.GetID(), operationType)
 
 		switch resourceType {
 		case model.ResourceTypeNodeStatus:
@@ -195,17 +193,19 @@ func (uc *UpstreamController) dispatchMessage() {
 		case common.ResourceTypeVolumeAttachment:
 			uc.volumeAttachmentChan <- msg
 		case model.ResourceTypeNode:
-			switch operationType {
+			switch msg.GetOperation() {
 			case model.QueryOperation:
 				uc.queryNodeChan <- msg
 			case model.UpdateOperation:
 				uc.updateNodeChan <- msg
 			default:
-				klog.Errorf("message: %s, operation type: %s unsupported", msg.GetID(), operationType)
+				klog.Errorf("message: %s, operation type: %s unsupported", msg.GetID(), msg.GetOperation())
 			}
 		case model.ResourceTypePod:
 			if msg.GetOperation() == model.DeleteOperation {
 				uc.podDeleteChan <- msg
+			} else {
+				klog.Errorf("message: %s, operation type: %s unsupported", msg.GetID(), msg.GetOperation())
 			}
 		default:
 			klog.Errorf("message: %s, resource type: %s unsupported", msg.GetID(), resourceType)


### PR DESCRIPTION
Move the "msg.GetOperation" to the place which uses it to reduce "print" and "get".

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Optimize the routine to reduce unnecessary processes.

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
None
