### PR TITLE
Fix the hard coded links of docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Welcome to KubeEdge!
 
 ## Code of Conduct
 
-Please make sure to read and observe our [Code of Conduct](https://github.com/kubeedge/kubeedge/blob/master/CODE_OF_CONDUCT.md).
+Please make sure to read and observe our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
 ## Community Expectations
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KubeEdge
 [![Build Status](https://travis-ci.org/kubeedge/kubeedge.svg?branch=master)](https://travis-ci.org/kubeedge/kubeedge)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeedge/kubeedge)](https://goreportcard.com/report/github.com/kubeedge/kubeedge)
-[![LICENSE](https://img.shields.io/github/license/kubeedge/kubeedge.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/blob/master/LICENSE)
+[![LICENSE](https://img.shields.io/github/license/kubeedge/kubeedge.svg?style=flat-square)](/LICENSE)
 [![Releases](https://img.shields.io/github/release/kubeedge/kubeedge/all.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/releases)
 [![Documentation Status](https://readthedocs.org/projects/kubeedge/badge/?version=latest)](https://kubeedge.readthedocs.io/en/latest/?badge=latest)
 
@@ -35,18 +35,18 @@ KubeEdge consists of cloud part and edge part.
 </div>
 
 ### In the Cloud
-- [CloudHub](https://github.com/kubeedge/kubeedge/blob/master/docs/components/cloud/cloudhub.md): a web socket server responsible for watching changes at the cloud side, caching and sending messages to EdgeHub.
-- [EdgeController](https://github.com/kubeedge/kubeedge/blob/master/docs/components/cloud/controller.md): an extended kubernetes controller which manages edge nodes and pods metadata so that the data can be targeted to a specific edge node.
-- [DeviceController](https://github.com/kubeedge/kubeedge/blob/master/docs/components/cloud/device_controller.md): an extended kubernetes controller which manages devices so that the device metadata/status data can be synced between edge and cloud.
+- [CloudHub](/docs/components/cloud/cloudhub.md): a web socket server responsible for watching changes at the cloud side, caching and sending messages to EdgeHub.
+- [EdgeController](/docs/components/cloud/controller.md): an extended kubernetes controller which manages edge nodes and pods metadata so that the data can be targeted to a specific edge node.
+- [DeviceController](/docs/components/cloud/device_controller.md): an extended kubernetes controller which manages devices so that the device metadata/status data can be synced between edge and cloud.
 
 
 ### On the Edge
-- [EdgeHub](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/edgehub.md): a web socket client responsible for interacting with Cloud Service for the edge computing (like Edge Controller as in the KubeEdge Architecture). This includes syncing cloud-side resource updates to the edge, and reporting edge-side host and device status changes to the cloud.
-- [Edged](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/edged.md): an agent that runs on edge nodes and manages containerized applications.
-- [EventBus](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/eventbus.md): a MQTT client to interact with MQTT servers (mosquitto), offering publish and subscribe capabilities to other components.
+- [EdgeHub](/docs/components/edge/edgehub.md): a web socket client responsible for interacting with Cloud Service for the edge computing (like Edge Controller as in the KubeEdge Architecture). This includes syncing cloud-side resource updates to the edge, and reporting edge-side host and device status changes to the cloud.
+- [Edged](/docs/components/edge/edged.md): an agent that runs on edge nodes and manages containerized applications.
+- [EventBus](/docs/components/edge/eventbus.md): a MQTT client to interact with MQTT servers (mosquitto), offering publish and subscribe capabilities to other components.
 - ServiceBus: a HTTP client to interact with HTTP servers (REST), offering HTTP client capabilities to components of cloud to reach HTTP servers running at edge.
-- [DeviceTwin](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/devicetwin.md): responsible for storing device status and syncing device status to the cloud. It also provides query interfaces for applications.
-- [MetaManager](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/metamanager.md): the message processor between edged and edgehub. It is also responsible for storing/retrieving metadata to/from a lightweight database (SQLite).
+- [DeviceTwin](/docs/components/edge/devicetwin.md): responsible for storing device status and syncing device status to the cloud. It also provides query interfaces for applications.
+- [MetaManager](/docs/components/edge/metamanager.md): the message processor between edged and edgehub. It is also responsible for storing/retrieving metadata to/from a lightweight database (SQLite).
 
 ## Kubernetes compatibility
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,7 +1,7 @@
 # KubeEdge
 [![Build Status](https://travis-ci.org/kubeedge/kubeedge.svg?branch=master)](https://travis-ci.org/kubeedge/kubeedge)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeedge/kubeedge)](https://goreportcard.com/report/github.com/kubeedge/kubeedge)
-[![LICENSE](https://img.shields.io/github/license/kubeedge/kubeedge.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/blob/master/LICENSE)
+[![LICENSE](https://img.shields.io/github/license/kubeedge/kubeedge.svg?style=flat-square)](/LICENSE)
 [![Releases](https://img.shields.io/github/release/kubeedge/kubeedge/all.svg?style=flat-square)](https://github.com/kubeedge/kubeedge/releases)
 [![Documentation Status](https://readthedocs.org/projects/kubeedge/badge/?version=latest)](https://kubeedge.readthedocs.io/en/latest/?badge=latest)
 
@@ -33,18 +33,18 @@ KubeEdge 是一个开源的系统，可将本机容器化应用编排和管理�
 KubeEdge 由以下组件构成:
 
 ### 云上部分
-- [CloudHub](https://github.com/kubeedge/kubeedge/blob/master/docs/components/cloud/cloudhub.md): CloudHub 是一个 Web Socket 服务端，负责监听云端的变化, 缓存并发送消息到 EdgeHub。
-- [EdgeController](https://github.com/kubeedge/kubeedge/blob/master/docs/components/cloud/controller.md): EdgeController 是一个扩展的 Kubernetes 控制器，管理边缘节点和 Pods 的元数据确保数据能够传递到指定的边缘节点。
-- [DeviceController](https://github.com/kubeedge/kubeedge/blob/master/docs/components/cloud/device_controller.md): DeviceController 是一个扩展的 Kubernetes 控制器，管理边缘设备，确保设备信息、设备状态的云边同步。
+- [CloudHub](/docs/components/cloud/cloudhub.md): CloudHub 是一个 Web Socket 服务端，负责监听云端的变化, 缓存并发送消息到 EdgeHub。
+- [EdgeController](/docs/components/cloud/controller.md): EdgeController 是一个扩展的 Kubernetes 控制器，管理边缘节点和 Pods 的元数据确保数据能够传递到指定的边缘节点。
+- [DeviceController](/docs/components/cloud/device_controller.md): DeviceController 是一个扩展的 Kubernetes 控制器，管理边缘设备，确保设备信息、设备状态的云边同步。
 
 
 ### 边缘部分
-- [EdgeHub](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/edgehub.md): EdgeHub 是一个 Web Socket 客户端，负责与边缘计算的云服务（例如 KubeEdge 架构图中的 Edge Controller）交互，包括同步云端资源更新、报告边缘主机和设备状态变化到云端等功能。
-- [Edged](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/edged.md): Edged 是运行在边缘节点的代理，用于管理容器化的应用程序。
-- [EventBus](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/eventbus.md): EventBus 是一个与 MQTT 服务器（mosquitto）交互的 MQTT 客户端，为其他组件提供订阅和发布功能。
+- [EdgeHub](/docs/components/edge/edgehub.md): EdgeHub 是一个 Web Socket 客户端，负责与边缘计算的云服务（例如 KubeEdge 架构图中的 Edge Controller）交互，包括同步云端资源更新、报告边缘主机和设备状态变化到云端等功能。
+- [Edged](/docs/components/edge/edged.md): Edged 是运行在边缘节点的代理，用于管理容器化的应用程序。
+- [EventBus](/docs/components/edge/eventbus.md): EventBus 是一个与 MQTT 服务器（mosquitto）交互的 MQTT 客户端，为其他组件提供订阅和发布功能。
 - ServiceBus: ServiceBus是一个运行在边缘的HTTP客户端，接受来自云上服务的请求，与运行在边缘端的HTTP服务器交互，提供了云上服务通过HTTP协议访问边缘端HTTP服务器的能力。
-- [DeviceTwin](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/devicetwin.md): DeviceTwin 负责存储设备状态并将设备状态同步到云，它还为应用程序提供查询接口。
-- [MetaManager](https://github.com/kubeedge/kubeedge/blob/master/docs/components/edge/metamanager.md): MetaManager 是消息处理器，位于 Edged 和 Edgehub 之间，它负责向轻量级数据库（SQLite）存储/检索元数据。
+- [DeviceTwin](/docs/components/edge/devicetwin.md): DeviceTwin 负责存储设备状态并将设备状态同步到云，它还为应用程序提供查询接口。
+- [MetaManager](/docs/components/edge/metamanager.md): MetaManager 是消息处理器，位于 Edged 和 Edgehub 之间，它负责向轻量级数据库（SQLite）存储/检索元数据。
 
 
 ### 架构

--- a/docs/components/cloud/device_controller.md
+++ b/docs/components/cloud/device_controller.md
@@ -8,9 +8,9 @@
 
 The device controller makes use of device model and device instance to implement device management :
  - **Device Model**: A `device model` describes the device properties exposed by the device and property visitors to access these properties. A device model is like a reusable template using which many devices can be created and managed.
- Details on device model definition can be found [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/device-crd.md#device-model-type-definition).
+ Details on device model definition can be found [here](/docs/proposals/device-crd.md#device-model-type-definition).
  - **Device Instance**: A `device` instance represents an actual device object. It is like an instantiation of the `device model` and references properties defined in the model. The device spec is static while the device status contains dynamically changing data like the desired state of a device property and the state reported by the device.
- Details on device instance definition can be found [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/device-crd.md#device-instance-type-definition).
+ Details on device instance definition can be found [here](/docs/proposals/device-crd.md#device-instance-type-definition).
 
  **Note**: Sample device model and device instance for a few protocols can be found at $GOPATH/src/github.com/kubeedge/kubeedge/build/crd-samples/devices
 

--- a/docs/components/edge/edgehub.md
+++ b/docs/components/edge/edgehub.md
@@ -71,5 +71,5 @@ The major steps involved in this process are as follows :-
 
 EdgeHub can be configured to communicate in two ways as mentioned below:
 
-- **Through websocket protocol**: Click [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/quic-design.md#edgehub-connect-to-cloudhub-through-websocket-protocol) for details.
-- **Through QUIC protocol**: Click [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/quic-design.md#edgehub-connect-to-cloudhub-through-quic) for details.
+- **Through websocket protocol**: Click [here](/docs/proposals/quic-design.md#edgehub-connect-to-cloudhub-through-websocket-protocol) for details.
+- **Through QUIC protocol**: Click [here](/docs/proposals/quic-design.md#edgehub-connect-to-cloudhub-through-quic) for details.

--- a/docs/components/edgesite.md
+++ b/docs/components/edgesite.md
@@ -185,7 +185,7 @@ Run below steps:
 
 + Modify node.json
 
-  Replace `edge-node` in [node.json](https://github.com/kubeedge/kubeedge/blob/master/build/node.json#L5) file, to the id/name of the edgesite node. ID/Name should be same as used before while updating `edgesite.yaml`
+  Replace `edge-node` in [node.json](/build/node.json#L5) file, to the id/name of the edgesite node. ID/Name should be same as used before while updating `edgesite.yaml`
 
   ```json
     {

--- a/docs/contributing/community.md
+++ b/docs/contributing/community.md
@@ -114,5 +114,5 @@ Has deep understanding of KubeEdge and related domain and facilitates major agre
 
 **Note :** These roles are applicable only for KubeEdge github organization and repositories. Currently KubeEdge doesn't have a formal process for review and acceptance into these roles. We will come-up with a process soon.
 
-[Code of Conduct]: https://github.com/kubeedge/kubeedge/blob/master/CODE_OF_CONDUCT.md
+[Code of Conduct]: /CODE_OF_CONDUCT.md
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication

--- a/docs/contributing/device_crd_guide.md
+++ b/docs/contributing/device_crd_guide.md
@@ -8,18 +8,18 @@ We currently manage devices from the cloud and synchronize the device updates be
 
 A `device model` describes the device properties exposed by the device and property visitors to access these properties. A device model is like a reusable template using which many devices can be created and managed.
 
-Details on device model definition can be found [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/device-crd.md#device-model-type-definition).
+Details on device model definition can be found [here](/docs/proposals/device-crd.md#device-model-type-definition).
 
-A sample device model can be found [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/device-crd.md#device-model-sample)
+A sample device model can be found [here](/docs/proposals/device-crd.md#device-model-sample)
 
 
 ## Device Instance
 
 A `device` instance represents an actual device object. It is like an instantiation of the `device model` and references properties defined in the model. The device spec is static while the device status contains dynamically changing data like the desired state of a device property and the state reported by the device.
 
-Details on device instance definition can be found [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/device-crd.md#device-instance-type-definition).
+Details on device instance definition can be found [here](/docs/proposals/device-crd.md#device-instance-type-definition).
 
-A sample device model can be found [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/device-crd.md#device-instance-sample).
+A sample device model can be found [here](/docs/proposals/device-crd.md#device-instance-sample).
 
 
 ## Device Mapper
@@ -35,7 +35,7 @@ A sample device model can be found [here](https://github.com/kubeedge/kubeedge/b
 
  Mapper can be specific to a protocol where standards are defined i.e Bluetooth, Zigbee, etc or specific to a device if it a custom protocol.
 
- Mapper design details can be found [here](https://github.com/kubeedge/kubeedge/blob/master/docs/proposals/mapper-design.md#mapper-design)
+ Mapper design details can be found [here](/docs/proposals/mapper-design.md#mapper-design)
 
  An example of a mapper application created to support bluetooth protocol can be found [here](https://github.com/kubeedge/kubeedge/tree/master/mappers/bluetooth_mapper#bluetooth-mapper)
 

--- a/docs/contributing/unit_test_guide.md
+++ b/docs/contributing/unit_test_guide.md
@@ -28,15 +28,15 @@ There is gomock package in kubeedge vendor directory without mockgen. Please use
 
  Read [godoc](https://godoc.org/github.com/onsi/ginkgo) for more information about ginkgo.
 
-See a [sample](https://github.com/kubeedge/kubeedge/blob/master/edge/pkg/metamanager/dao/meta_test.go) in kubeedge where go builtin package testing and gomock is used for writing unit tests.
+See a [sample](/edge/pkg/metamanager/dao/meta_test.go) in kubeedge where go builtin package testing and gomock is used for writing unit tests.
 
-See a [sample](https://github.com/kubeedge/kubeedge/blob/master/edge/pkg/devicetwin/dtmodule/dtmodule_test.go) in kubeedge where ginkgo is used for testing.
+See a [sample](/edge/pkg/devicetwin/dtmodule/dtmodule_test.go) in kubeedge where ginkgo is used for testing.
 
 ## Writing UT using GoMock
 
 ### Example : metamanager/dao/meta.go
 
-After reading the code of meta.go, we can find that there are 3 interfaces of beego which are used. They are [Ormer](https://github.com/kubeedge/kubeedge/blob/master/vendor/github.com/astaxie/beego/orm/types.go), [QuerySeter](https://github.com/kubeedge/kubeedge/blob/master/vendor/github.com/astaxie/beego/orm/types.go) and [RawSeter](https://github.com/kubeedge/kubeedge/blob/master/vendor/github.com/astaxie/beego/orm/types.go).
+After reading the code of meta.go, we can find that there are 3 interfaces of beego which are used. They are [Ormer](/vendor/github.com/astaxie/beego/orm/types.go), [QuerySeter](/vendor/github.com/astaxie/beego/orm/types.go) and [RawSeter](/vendor/github.com/astaxie/beego/orm/types.go).
 
 We need to create fake implementations of these interfaces so that we do not rely on the original implementation of this interface and their function calls.
 

--- a/docs/setup/build.md
+++ b/docs/setup/build.md
@@ -20,7 +20,7 @@ export CC=arm-linux-gnueabi-gcc
 make edgecore
 ```
 
-If you are compiling KubeEdge edgecore for Raspberry Pi and check the [Makefile](https://github.com/kubeedge/kubeedge/blob/master/Makefile) for the edge.
+If you are compiling KubeEdge edgecore for Raspberry Pi and check the [Makefile](/Makefile) for the edge.
 
 In that CC has been defined as
 ```


### PR DESCRIPTION
The links of docs linking for this repo should be relative, mainly:
For already released docs would be 404 in the future since the corresponding
doc of master branch would be moved, renamed or deleted etc.

Note, the docs in vendor dir keep unchanged.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
