### PR TITLE
Automated cherry pick of #2037: panic when multiple goroutine concurrency access same map

### DIFF
--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -61,7 +61,7 @@ type MessageHandle struct {
 	MessageQueue      *channelq.ChannelMessageQueue
 	Handlers          []HandleFunc
 	NodeLimit         int
-	KeepaliveChannel  map[string]chan struct{}
+	KeepaliveChannel  sync.Map
 	MessageAcks       sync.Map
 }
 
@@ -82,7 +82,6 @@ func InitHandler(eventq *channelq.ChannelMessageQueue) {
 			NodeLimit:         int(hubconfig.Config.NodeLimit),
 		}
 
-		CloudhubHandler.KeepaliveChannel = make(map[string]chan struct{})
 		CloudhubHandler.Handlers = []HandleFunc{
 			CloudhubHandler.KeepaliveCheckLoop,
 			CloudhubHandler.MessageWriteLoop,
@@ -110,7 +109,13 @@ func (mh *MessageHandle) HandleServer(container *mux.MessageContainer, writer mu
 
 	if container.Message.GetOperation() == model.OpKeepalive {
 		klog.Infof("Keepalive message received from node: %s", nodeID)
-		mh.KeepaliveChannel[nodeID] <- struct{}{}
+
+		nodeKeepalive, ok := mh.KeepaliveChannel.Load(nodeID)
+		if !ok {
+			klog.Errorf("Failed to load node : %s", nodeID)
+			return
+		}
+		nodeKeepalive.(chan struct{}) <- struct{}{}
 		return
 	}
 
@@ -141,8 +146,8 @@ func (mh *MessageHandle) OnRegister(connection conn.Connection) {
 	nodeID := connection.ConnectionState().Headers.Get("node_id")
 	projectID := connection.ConnectionState().Headers.Get("project_id")
 
-	if _, ok := mh.KeepaliveChannel[nodeID]; !ok {
-		mh.KeepaliveChannel[nodeID] = make(chan struct{}, 1)
+	if _, ok := mh.KeepaliveChannel.Load(nodeID); !ok {
+		mh.KeepaliveChannel.Store(nodeID, make(chan struct{}, 1))
 	}
 
 	io := &hubio.JSONIO{Connection: connection}
@@ -161,9 +166,11 @@ func (mh *MessageHandle) OnRegister(connection conn.Connection) {
 // KeepaliveCheckLoop checks whether the edge node is still alive
 func (mh *MessageHandle) KeepaliveCheckLoop(info *model.HubInfo, stopServe chan ExitCode) {
 	keepaliveTicker := time.NewTimer(time.Duration(mh.KeepaliveInterval) * time.Second)
+	nodeKeepaliveChannel, _ := mh.KeepaliveChannel.Load(info.NodeID)
+
 	for {
 		select {
-		case _, ok := <-mh.KeepaliveChannel[info.NodeID]:
+		case _, ok := <-nodeKeepaliveChannel.(chan struct{}):
 			if !ok {
 				klog.Warningf("Stop keepalive check for node: %s", info.NodeID)
 				return
@@ -305,8 +312,13 @@ func (mh *MessageHandle) UnregisterNode(info *model.HubInfo, code ExitCode) {
 	mh.nodeLocks.Delete(info.NodeID)
 	mh.nodeConns.Delete(info.NodeID)
 	mh.nodeRegistered.Delete(info.NodeID)
-	close(mh.KeepaliveChannel[info.NodeID])
-	delete(mh.KeepaliveChannel, info.NodeID)
+	nodeKeepalive, ok := mh.KeepaliveChannel.Load(info.NodeID)
+	if !ok {
+		klog.Errorf("fail to load node %s", info.NodeID)
+	} else {
+		close(nodeKeepalive.(chan struct{}))
+		mh.KeepaliveChannel.Delete(info.NodeID)
+	}
 
 	err := mh.MessageQueue.Publish(constructConnectMessage(info, false))
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #2037 on release-1.4.

#2037: panic when multiple goroutine concurrency access same map

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.