### PR TITLE
Automated cherry pick of #2056: update kubernetes version

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -117,7 +117,7 @@ const (
 	CSIOperationTypeControllerUnpublishVolume = "controllerunpublishvolume"
 	CSISyncMsgRespTimeout                     = 1 * time.Minute
 
-	CurrentSupportK8sVersion = "v1.17.1"
+	CurrentSupportK8sVersion = "v1.18.6"
 )
 
 const (


### PR DESCRIPTION
Cherry pick of #2056 on release-1.4.

#2056: update kubernetes version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.