### PR TITLE
fix/keadm: finish to do about checksum validation of the downloaded file every time

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
@@ -345,49 +346,38 @@ func installKubeEdge(componentType types.ComponentType, arch string, version str
 	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.tar.gz.txt", version, arch)
 	filePath := fmt.Sprintf("%s%s", KubeEdgePath, filename)
 	if _, err = os.Stat(filePath); err == nil {
-		fmt.Println("Expected or Default KubeEdge version", version, "is already downloaded")
+		fmt.Println("Expected or Default KubeEdge version", version, "is already downloaded and will checksum for it.")
+		if success, _ := checkSum(filename, checksumFilename, version); !success {
+			fmt.Printf("%v in your path checksum failed and do you want to delete this file and try to download again? \n", filename)
+			for {
+				result, err := ask4confirm()
+				if err != nil {
+					continue
+				}
+				if result == "yes" {
+					cmdStr := fmt.Sprintf("cd %s && rm -f %s", KubeEdgePath, filename)
+					if _, err := runCommandWithStdout(cmdStr); err != nil {
+						return err
+					}
+					klog.Infof("%v have been deleted and will try to download again", filename)
+					if err := retryDownload(filename, checksumFilename, version); err != nil {
+						return err
+					}
+				} else if result == "no" {
+					klog.Warningf("failed to checksum and will continue to install.")
+					return nil
+				}
+			}
+		} else {
+			fmt.Println("Expected or Default KubeEdge version", version, "is already downloaded and checksum successfully.")
+		}
 	} else if !os.IsNotExist(err) {
 		return err
 	} else {
-		try := 0
-		for ; try < downloadRetryTimes; try++ {
-			//Download the tar from repo
-			dwnldURL := fmt.Sprintf("cd %s && wget -k --no-check-certificate --progress=bar:force %s/v%s/%s",
-				KubeEdgePath, KubeEdgeDownloadURL, version, filename)
-			if _, err := runCommandWithShell(dwnldURL); err != nil {
-				return err
-			}
-
-			//Verify the tar with checksum
-			fmt.Printf("%s checksum: \n", filename)
-			cmdStr := fmt.Sprintf("cd %s && sha512sum %s | awk '{split($0,a,\"[ ]\"); print a[1]}'", KubeEdgePath, filename)
-			desiredChecksum, err := runCommandWithStdout(cmdStr)
-			if err != nil {
-				return err
-			}
-
-			fmt.Printf("%s content: \n", checksumFilename)
-			cmdStr = fmt.Sprintf("wget -qO- %s/v%s/%s", KubeEdgeDownloadURL, version, checksumFilename)
-			actualChecksum, err := runCommandWithStdout(cmdStr)
-			if err != nil {
-				return err
-			}
-
-			if desiredChecksum == actualChecksum {
-				break
-			} else {
-				fmt.Printf("Failed to verify the checksum of %s, try to download it again ... \n\n", filename)
-				//Cleanup the downloaded files
-				cmdStr = fmt.Sprintf("cd %s && rm -f %s", KubeEdgePath, filename)
-				_, err := runCommandWithStdout(cmdStr)
-				if err != nil {
-					return err
-				}
-			}
+		if err := retryDownload(filename, checksumFilename, version); err != nil {
+			return err
 		}
-		if try == downloadRetryTimes {
-			return fmt.Errorf("failed to download %s", filename)
-		}
+		return nil
 	}
 
 	/*
@@ -600,4 +590,95 @@ func hasSystemd() bool {
 	}
 
 	return false
+}
+
+func checkSum(filename, checksumFilename, version string) (bool, error) {
+	//Verify the tar with checksum
+	fmt.Printf("%s checksum: \n", filename)
+	cmdStr := fmt.Sprintf("cd %s && sha512sum %s | awk '{split($0,a,\"[ ]\"); print a[1]}'", KubeEdgePath, filename)
+	actualChecksum, err := runCommandWithStdout(cmdStr)
+	if err != nil {
+		return false, err
+	}
+
+	fmt.Printf("%s content: \n", checksumFilename)
+	cmdStr = fmt.Sprintf("wget -qO- %s/v%s/%s", KubeEdgeDownloadURL, version, checksumFilename)
+	desiredChecksum, err := runCommandWithStdout(cmdStr)
+	if err != nil {
+		return false, err
+	}
+
+	if desiredChecksum != actualChecksum {
+		fmt.Printf("Failed to verify the checksum of %s, try to download it again ... \n\n", filename)
+		//Cleanup the downloaded files
+		cmdStr = fmt.Sprintf("cd %s && rm -f %s", KubeEdgePath, filename)
+		_, err = runCommandWithStdout(cmdStr)
+		return false, err
+	}
+	return true, nil
+}
+
+func retryDownload(filename, checksumFilename, version string) error {
+	try := 0
+	for ; try < downloadRetryTimes; try++ {
+		//Download the tar from repo
+		dwnldURL := fmt.Sprintf("cd %s && wget -k --no-check-certificate --progress=bar:force %s/v%s/%s",
+			KubeEdgePath, KubeEdgeDownloadURL, version, filename)
+		if _, err := runCommandWithShell(dwnldURL); err != nil {
+			return err
+		}
+
+		//Verify the tar with checksum
+		fmt.Printf("%s checksum: \n", filename)
+		cmdStr := fmt.Sprintf("cd %s && sha512sum %s | awk '{split($0,a,\"[ ]\"); print a[1]}'", KubeEdgePath, filename)
+		actualChecksum, err := runCommandWithStdout(cmdStr)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s content: \n", checksumFilename)
+		cmdStr = fmt.Sprintf("wget -qO- %s/v%s/%s", KubeEdgeDownloadURL, version, checksumFilename)
+		desiredChecksum, err := runCommandWithStdout(cmdStr)
+		if err != nil {
+			return err
+		}
+
+		if desiredChecksum != actualChecksum {
+			fmt.Printf("Failed to verify the checksum of %s, try to download it again ... \n\n", filename)
+			//Cleanup the downloaded files
+			cmdStr = fmt.Sprintf("cd %s && rm -f %s", KubeEdgePath, filename)
+			if _, err := runCommandWithStdout(cmdStr); err != nil {
+				return err
+			}
+		} else {
+			break
+		}
+	}
+	if try == downloadRetryTimes {
+		return fmt.Errorf("failed to download %s", filename)
+	}
+	return nil
+}
+
+func ask4confirm() (string, error) {
+	var s string
+
+	fmt.Println("(yes/no/quit): ")
+	_, err := fmt.Scan(&s)
+	if err != nil {
+		panic(err)
+	}
+
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+
+	if s == "y" || s == "yes" {
+		return "yes", nil
+	} else if s == "n" || s == "no" {
+		return "no", nil
+	} else if s == "quit" {
+		return "quit", nil
+	} else {
+		return "", fmt.Errorf("Invalid Input")
+	}
 }

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -336,7 +336,6 @@ func installKubeEdge(componentType types.ComponentType, arch string, version str
 	}
 
 	//Check if the same version exists, then skip the download and just untar and continue
-	//TODO: It is always better to have the checksum validation of the downloaded file
 	//and checksum available at download URL. So that both can be compared to see if
 	//proper download has happened and then only proceed further.
 	//Currently it is missing and once checksum is in place, checksum check required

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -664,18 +664,16 @@ func retryDownload(filename, checksumFilename, version string) error {
 func ask4confirm() (bool, error) {
 	var s string
 
-	fmt.Println("(yes/no): ")
-	_, err := fmt.Scan(&s)
-	if err != nil {
-		panic(err)
+	fmt.Println("[y/N]: ")
+	if _, err := fmt.Scan(&s); err != nil {
+		return false, err
 	}
 
-	s = strings.TrimSpace(s)
-	s = strings.ToLower(s)
+	s = strings.ToLower(strings.TrimSpace(s))
 
-	if s == "y" || s == "yes" {
+	if s == "y" {
 		return true, nil
-	} else if s == "n" || s == "no" {
+	} else if s == "n" {
 		return false, nil
 	} else {
 		return false, fmt.Errorf("Invalid Input")

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -352,9 +352,10 @@ func installKubeEdge(componentType types.ComponentType, arch string, version str
 			for {
 				result, err := ask4confirm()
 				if err != nil {
+					fmt.Println(err.Error())
 					continue
 				}
-				if result == "yes" {
+				if result {
 					cmdStr := fmt.Sprintf("cd %s && rm -f %s", KubeEdgePath, filename)
 					if _, err := runCommandWithStdout(cmdStr); err != nil {
 						return err
@@ -363,9 +364,9 @@ func installKubeEdge(componentType types.ComponentType, arch string, version str
 					if err := retryDownload(filename, checksumFilename, version); err != nil {
 						return err
 					}
-				} else if result == "no" {
+				} else {
 					klog.Warningf("failed to checksum and will continue to install.")
-					return nil
+					break
 				}
 			}
 		} else {
@@ -660,10 +661,10 @@ func retryDownload(filename, checksumFilename, version string) error {
 	return nil
 }
 
-func ask4confirm() (string, error) {
+func ask4confirm() (bool, error) {
 	var s string
 
-	fmt.Println("(yes/no/quit): ")
+	fmt.Println("(yes/no): ")
 	_, err := fmt.Scan(&s)
 	if err != nil {
 		panic(err)
@@ -673,12 +674,10 @@ func ask4confirm() (string, error) {
 	s = strings.ToLower(s)
 
 	if s == "y" || s == "yes" {
-		return "yes", nil
+		return true, nil
 	} else if s == "n" || s == "no" {
-		return "no", nil
-	} else if s == "quit" {
-		return "quit", nil
+		return false, nil
 	} else {
-		return "", fmt.Errorf("Invalid Input")
+		return false, fmt.Errorf("Invalid Input")
 	}
 }

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -346,7 +346,7 @@ func installKubeEdge(componentType types.ComponentType, arch string, version str
 	checksumFilename := fmt.Sprintf("checksum_kubeedge-v%s-linux-%s.tar.gz.txt", version, arch)
 	filePath := fmt.Sprintf("%s%s", KubeEdgePath, filename)
 	if _, err = os.Stat(filePath); err == nil {
-		fmt.Println("Expected or Default KubeEdge version", version, "is already downloaded and will checksum for it.")
+		klog.Infof("Expected or Default KubeEdge version %v is already downloaded and will checksum for it.", version)
 		if success, _ := checkSum(filename, checksumFilename, version); !success {
 			fmt.Printf("%v in your path checksum failed and do you want to delete this file and try to download again? \n", filename)
 			for {
@@ -370,7 +370,7 @@ func installKubeEdge(componentType types.ComponentType, arch string, version str
 				}
 			}
 		} else {
-			fmt.Println("Expected or Default KubeEdge version", version, "is already downloaded and checksum successfully.")
+			klog.Infof("Expected or Default KubeEdge version %v is already downloaded and checksum successfully.", version)
 		}
 	} else if !os.IsNotExist(err) {
 		return err


### PR DESCRIPTION
What type of PR is this?
/kind bug
What this PR does / why we need it:
Because of the bad network,when we use keadm tool to join node,It's esential to checksum everytime even though the release file is already existed and have the same name but the release is broken what's more,I think that providing a optional choose for user about whether continue to install is a better way. 
Which issue(s) this PR fixes:
Fixes #
#2057
Special notes for your reviewer:
no
Does this PR introduce a user-facing change?:
uses will see some options in the terminal and just select one to continue.