### PR TITLE
Add the build option to make the binaries debuggable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ define ALL_HELP_INFO
 #   make all
 #   make all HELP=y
 #   make all WHAT=cloudcore
+#   make all WHAT=cloudcore GOLDFLAGS="" GOGCFLAGS="-N -l"
+#     Note: Specify GOLDFLAGS as an empty string for building unstripped binaries, specify GOGCFLAGS
+#     to "-N -l" to disable optimizations and inlining, this will be helpful when you want to
+#     use the debugging tools like delve. When GOLDFLAGS is unspecified, it defaults to "-s -w" which strips
+#     debug information, see https://golang.org/cmd/link for other flags.
+
 endef
 .PHONY: all
 ifeq ($(HELP),y)

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -202,15 +202,17 @@ kubeedge::golang::build_binaries() {
   local -a binaries
   while IFS="" read -r binary; do binaries+=("$binary"); done < <(kubeedge::golang::binaries_from_targets "${targets[@]}")
 
-  local ldflags
-  read -r ldflags <<< "$(kubeedge::version::ldflags)"
+  local goldflags gogcflags
+  # If GOLDFLAGS is unset, then set it to the a default of "-s -w".
+  goldflags="${GOLDFLAGS=-s -w -buildid=} $(kubeedge::version::ldflags)"
+  gogcflags="${GOGCFLAGS:-}"
 
   mkdir -p ${KUBEEDGE_OUTPUT_BINPATH}
   for bin in ${binaries[@]}; do
     echo "building $bin"
     local name="${bin##*/}"
     set -x
-    go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -ldflags "$ldflags" $bin
+    go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -gcflags="${gogcflags:-}" -ldflags "${goldflags:-}" $bin
     set +x
   done
 


### PR DESCRIPTION
By default, the debug info will be stripped for the binaries, `cloudcore` for example, to keep the binary as small as possible.

This behavior can be overwritten by adding the options `GOLDFLAGS` or `GOGCFLAGS` when building the binaries.

As a example, the binary `cloudcore` built with the below command will have DWARF and symbol table kept, the optimizations and inline will also been disabled, this is helpful when you want to use the debugging tools like `delve`.

`make all WHAT=cloudcore GOLDFLAGS="" GOGCFLAGS="-N -l"`


Signed-off-by: Dave Chen <dave.chen@arm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
