### PR TITLE
edged support update pod status after consume added pod

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -1206,6 +1206,10 @@ func (e *edged) handlePodListFromMetaManager(content []byte) (err error) {
 			return err
 		}
 		e.addPod(&pod)
+		if err = e.updatePodStatus(&pod); err != nil {
+			klog.Errorf("handlePodListFromMetaManager: update pod %s status error", pod.Name)
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
Once the EdgeCore service is restarted,  if not update pods status after pods consumed, we could not acquired pods metric data by call URL: 127.0.0.1:10350/stats/summary

Which issue(s) this PR fixes:
Fixes #2107

Does this PR introduce a user-facing change?:
None
