### PR TITLE
eventbus add tls config when connect to mqtt

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -21,6 +21,10 @@ const (
 	DefaultStreamCAFile   = "/etc/kubeedge/ca/streamCA.crt"
 	DefaultStreamCertFile = "/etc/kubeedge/certs/stream.crt"
 	DefaultStreamKeyFile  = "/etc/kubeedge/certs/stream.key"
+
+	DefaultMqttCAFile   = "/etc/kubeedge/ca/rootCA.crt"
+	DefaultMqttCertFile = "/etc/kubeedge/certs/server.crt"
+	DefaultMqttKeyFile  = "/etc/kubeedge/certs/server.key"
 )
 
 const (

--- a/edge/pkg/eventbus/common/util/common.go
+++ b/edge/pkg/eventbus/common/util/common.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-	eventconfig "github.com/kubeedge/kubeedge/edge/pkg/eventbus/config"
 	"k8s.io/klog"
+
+	eventconfig "github.com/kubeedge/kubeedge/edge/pkg/eventbus/config"
 )
 
 var (
@@ -54,16 +55,16 @@ func HubClientInit(server, clientID, username, password string) *MQTT.ClientOpti
 		}
 	}
 
-	klog.Infof("Start to config MQTT client tls connect")
+	klog.V(4).Infof("Start to set TLS configuration for MQTT client")
 	tlsConfig := &tls.Config{}
-	if eventconfig.Config.Tls.Enable == true {
-		cert, err := tls.LoadX509KeyPair(eventconfig.Config.Tls.TLSMqttCertFile, eventconfig.Config.Tls.TLSMqttPrivateKeyFile)
+	if eventconfig.Config.TLS.Enable {
+		cert, err := tls.LoadX509KeyPair(eventconfig.Config.TLS.TLSMqttCertFile, eventconfig.Config.TLS.TLSMqttPrivateKeyFile)
 		if err != nil {
 			klog.Errorf("Failed to load x509 key pair: %v", err)
 			return nil
 		}
 
-		caCert, err := ioutil.ReadFile(eventconfig.Config.Tls.TLSMqttCAFile)
+		caCert, err := ioutil.ReadFile(eventconfig.Config.TLS.TLSMqttCAFile)
 		if err != nil {
 			klog.Errorf("Failed to read TLSMqttCAFile")
 			return nil
@@ -84,7 +85,7 @@ func HubClientInit(server, clientID, username, password string) *MQTT.ClientOpti
 		tlsConfig = &tls.Config{InsecureSkipVerify: true, ClientAuth: tls.NoClientCert}
 	}
 	opts.SetTLSConfig(tlsConfig)
-	klog.Infof("config MQTT client tls connect successful")
+	klog.V(4).Infof("set TLS configuration for MQTT client successfully")
 
 	return opts
 }

--- a/edge/pkg/eventbus/common/util/common_test.go
+++ b/edge/pkg/eventbus/common/util/common_test.go
@@ -27,6 +27,9 @@ import (
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog"
+
+	eventconfig "github.com/kubeedge/kubeedge/edge/pkg/eventbus/config"
+	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 )
 
 var clientOptions = MQTT.NewClientOptions()
@@ -62,6 +65,9 @@ func TestCheckKeyExist(t *testing.T) {
 
 //TestCheckClientToken checks client token received
 func TestCheckClientToken(t *testing.T) {
+	nodeName := "testEdge"
+	cfg := v1alpha1.NewDefaultEdgeCoreConfig()
+	eventconfig.InitConfigure(cfg.Modules.EventBus, nodeName)
 	tests := []struct {
 		name          string
 		token         MQTT.Token

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -214,6 +214,12 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 				MqttServerExternal: "tcp://127.0.0.1:1883",
 				MqttServerInternal: "tcp://127.0.0.1:1884",
 				MqttMode:           MqttModeExternal,
+				Tls: &EventBusTls{
+					Enable:                false,
+					TLSMqttCAFile:         constants.DefaultMqttCAFile,
+					TLSMqttCertFile:       constants.DefaultMqttCertFile,
+					TLSMqttPrivateKeyFile: constants.DefaultMqttKeyFile,
+				},
 			},
 		},
 	}

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -120,6 +120,12 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				MqttServerExternal:   "tcp://127.0.0.1:1883",
 				MqttServerInternal:   "tcp://127.0.0.1:1884",
 				MqttMode:             MqttModeExternal,
+				TLS: &EventBusTLS{
+					Enable:                false,
+					TLSMqttCAFile:         constants.DefaultMqttCAFile,
+					TLSMqttCertFile:       constants.DefaultMqttCertFile,
+					TLSMqttPrivateKeyFile: constants.DefaultMqttKeyFile,
+				},
 			},
 			MetaManager: &MetaManager{
 				Enable:                true,
@@ -214,12 +220,6 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 				MqttServerExternal: "tcp://127.0.0.1:1883",
 				MqttServerInternal: "tcp://127.0.0.1:1884",
 				MqttMode:           MqttModeExternal,
-				Tls: &EventBusTls{
-					Enable:                false,
-					TLSMqttCAFile:         constants.DefaultMqttCAFile,
-					TLSMqttCertFile:       constants.DefaultMqttCertFile,
-					TLSMqttPrivateKeyFile: constants.DefaultMqttKeyFile,
-				},
 			},
 		},
 	}

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -344,6 +344,23 @@ type EventBus struct {
 	// +Required
 	// default: 2
 	MqttMode MqttMode `json:"mqttMode"`
+	// Tls indicates tls config for EventBus module
+	Tls *EventBusTls `json:"tls,omitempty"`
+}
+
+type EventBusTls struct {
+	// Enable indicates whether enable this protocol
+	// default false
+	Enable bool `json:"enable,omitempty"`
+	// TLSMqttCAFile set ca file path
+	// default "/etc/kubeedge/ca/rootCA.crt"
+	TLSMqttCAFile string `json:"tlsMqttCAFile,omitempty"`
+	// TLSMqttCertFile indicates the file containing x509 Certificate for HTTPS
+	// default "/etc/kubeedge/certs/server.crt"
+	TLSMqttCertFile string `json:"tlsMqttCertFile,omitempty"`
+	// TLSMqttPrivateKeyFile indicates the file containing x509 private key matching tlsMqttCertFile
+	// default "/etc/kubeedge/certs/server.key"
+	TLSMqttPrivateKeyFile string `json:"tlsMqttPrivateKeyFile,omitempty"`
 }
 
 // MetaManager indicates the MetaManager module config

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -345,14 +345,15 @@ type EventBus struct {
 	// default: 2
 	MqttMode MqttMode `json:"mqttMode"`
 	// Tls indicates tls config for EventBus module
-	Tls *EventBusTls `json:"tls,omitempty"`
+	TLS *EventBusTLS `json:"eventBusTLS,omitempty"`
 }
 
-type EventBusTls struct {
-	// Enable indicates whether enable this protocol
+// EventBusTLS indicates the EventBus tls config with MQTT broker
+type EventBusTLS struct {
+	// Enable indicates whether enable tls connection
 	// default false
 	Enable bool `json:"enable,omitempty"`
-	// TLSMqttCAFile set ca file path
+	// TLSMqttCAFile sets ca file path
 	// default "/etc/kubeedge/ca/rootCA.crt"
 	TLSMqttCAFile string `json:"tlsMqttCAFile,omitempty"`
 	// TLSMqttCertFile indicates the file containing x509 Certificate for HTTPS


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
There is a possibility that eventbus connect to mqtt broker need security verify. 
This patch provide a optional function that if we config EventBusTls.Enable=true, we could through a security way connect to mqtt broker.
If we config EventBusTls.Enable=false, then business as usual.

**Special notes for your reviewer**:
This patch do not attention the certificates generate of mqtt broker and client, because these certificates are generally generated by mqtt broker.

**Does this PR introduce a user-facing change?**:
NONE
