### PR TITLE
support 2 device of multiple namespaces bind to same node

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -180,7 +180,6 @@ func (dc *DownstreamController) addToConfigMap(device *v1alpha2.Device) {
 		nodeConfigMap.Name = DeviceProfileConfigPrefix + device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0]
 		nodeConfigMap.Namespace = device.Namespace
 		nodeConfigMap.Data = make(map[string]string)
-		// TODO: how to handle 2 device of multiple namespaces bind to same node ?
 		dc.addDeviceProfile(device, nodeConfigMap)
 		// store new config map
 		dc.configMapManager.ConfigMap.Store(device.Namespace+device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0], nodeConfigMap)


### PR DESCRIPTION

**What type of PR is this?**
kind bug



**What this PR does / why we need it**:
It's a TODO job of kubeedge.Now ,it's ubable to handle 2 device of multiple namespaces bind to same node.

**Which issue(s) this PR fixes**:

Fixes #2129

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note

```
