### PR TITLE
Fix bot add irrelevant labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,17 +9,16 @@
 
 <!--
 Add one of the following kinds:
-/kind bug
-/kind cleanup
-/kind documentation
-/kind feature
-/kind test
-/kind design
+> /kind bug
+> /kind cleanup
+> /kind documentation
+> /kind feature
+> /kind test
+> /kind design
 
 Optionally add one or more of the following kinds if applicable:
-/kind api-change
-/kind failing-test
-/kind regression
+> /kind api-change
+> /kind failing-test
 -->
 
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fix bot add irrelevant labels, the root cause is that our bot version is slow, cannot ignore label mark in the comment.
