### PR TITLE
support 2 device of multiple namespaces bind to same node

### DIFF
--- a/cloud/pkg/devicecontroller/constants/default.go
+++ b/cloud/pkg/devicecontroller/constants/default.go
@@ -13,6 +13,8 @@ const (
 
 	DefaultMessageLayer = "context"
 
+	ConfigmapNamespace = "default"
+
 	DefaultContextSendModuleName     = CloudHubControllerModuleName
 	DefaultContextReceiveModuleName  = DeviceControllerModuleName
 	DefaultContextResponseModuleName = CloudHubControllerModuleName

--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -178,19 +178,19 @@ func (dc *DownstreamController) addToConfigMap(device *v1alpha2.Device) {
 		nodeConfigMap.Kind = ConfigMapKind
 		nodeConfigMap.APIVersion = ConfigMapVersion
 		nodeConfigMap.Name = DeviceProfileConfigPrefix + device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0]
-		nodeConfigMap.Namespace = "default"
+		nodeConfigMap.Namespace = constants.ConfigmapNamespace
 		nodeConfigMap.Data = make(map[string]string)
 		dc.addDeviceProfile(device, nodeConfigMap)
 		// store new config map
 		dc.configMapManager.ConfigMap.Store(device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0], nodeConfigMap)
 
-		if _, err := dc.kubeClient.CoreV1().ConfigMaps("default").Get(context.Background(), nodeConfigMap.Name, metav1.GetOptions{}); err != nil {
-			if _, err := dc.kubeClient.CoreV1().ConfigMaps("default").Create(context.Background(), nodeConfigMap, metav1.CreateOptions{}); err != nil {
+		if _, err := dc.kubeClient.CoreV1().ConfigMaps(constants.ConfigmapNamespace).Get(context.Background(), nodeConfigMap.Name, metav1.GetOptions{}); err != nil {
+			if _, err := dc.kubeClient.CoreV1().ConfigMaps(constants.ConfigmapNamespace).Create(context.Background(), nodeConfigMap, metav1.CreateOptions{}); err != nil {
 				klog.Errorf("Failed to create config map %v, error %v", nodeConfigMap, err)
 				return
 			}
 		}
-		if _, err := dc.kubeClient.CoreV1().ConfigMaps("default").Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
+		if _, err := dc.kubeClient.CoreV1().ConfigMaps(constants.ConfigmapNamespace).Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Failed to update config map %v, error %v", nodeConfigMap, err)
 			return
 		}
@@ -204,7 +204,7 @@ func (dc *DownstreamController) addToConfigMap(device *v1alpha2.Device) {
 	dc.addDeviceProfile(device, nodeConfigMap)
 	// store new config map
 	dc.configMapManager.ConfigMap.Store(device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0], nodeConfigMap)
-	if _, err := dc.kubeClient.CoreV1().ConfigMaps("default").Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
+	if _, err := dc.kubeClient.CoreV1().ConfigMaps(constants.ConfigmapNamespace).Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
 		klog.Errorf("Failed to update config map %v, error %v", nodeConfigMap, err)
 		return
 	}
@@ -574,7 +574,7 @@ func (dc *DownstreamController) updateConfigMap(device *v1alpha2.Device) {
 		nodeConfigMap.Data[DeviceProfileJSON] = string(bytes)
 		// store new config map
 		dc.configMapManager.ConfigMap.Store(device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0], nodeConfigMap)
-		if _, err := dc.kubeClient.CoreV1().ConfigMaps("default").Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
+		if _, err := dc.kubeClient.CoreV1().ConfigMaps(constants.ConfigmapNamespace).Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Failed to update config map %v, error %v", nodeConfigMap, err)
 			return
 		}
@@ -738,7 +738,7 @@ func (dc *DownstreamController) deleteFromConfigMap(device *v1alpha2.Device) {
 		// 1. no device bound to it, as Data[DeviceProfileJSON] is "{}"
 		// 2. device instance created alone then removed, as Data[DeviceProfileJSON] is ""
 		if nodeConfigMap.Data[DeviceProfileJSON] == "{}" || nodeConfigMap.Data[DeviceProfileJSON] == "" {
-			dc.kubeClient.CoreV1().ConfigMaps("default").Delete(context.Background(), nodeConfigMap.Name, metav1.DeleteOptions{})
+			dc.kubeClient.CoreV1().ConfigMaps(constants.ConfigmapNamespace).Delete(context.Background(), nodeConfigMap.Name, metav1.DeleteOptions{})
 			// remove from cache
 			dc.configMapManager.ConfigMap.Delete(device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0])
 			return
@@ -746,7 +746,7 @@ func (dc *DownstreamController) deleteFromConfigMap(device *v1alpha2.Device) {
 
 		// store new config map
 		dc.configMapManager.ConfigMap.Store(device.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values[0], nodeConfigMap)
-		if _, err := dc.kubeClient.CoreV1().ConfigMaps("default").Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
+		if _, err := dc.kubeClient.CoreV1().ConfigMaps(constants.ConfigmapNamespace).Update(context.Background(), nodeConfigMap, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Failed to update config map %v, error %v", nodeConfigMap, err)
 			return
 		}

--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -492,7 +492,7 @@ func (uc *UpstreamController) updateNodeStatus() {
 func kubeClientGet(uc *UpstreamController, namespace string, name string, queryType string) (interface{}, string, error) {
 	switch queryType {
 	case model.ResourceTypeConfigmap:
-		configMap, err := uc.kubeClient.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metaV1.GetOptions{})
+		configMap, err := uc.kubeClient.CoreV1().ConfigMaps("default").Get(context.Background(), name, metaV1.GetOptions{})
 		resourceVersion := configMap.ResourceVersion
 		return configMap, resourceVersion, err
 	case model.ResourceTypeSecret:

--- a/mappers/bluetooth_mapper/watcher/watcher.go
+++ b/mappers/bluetooth_mapper/watcher/watcher.go
@@ -32,6 +32,7 @@ import (
 )
 
 var DeviceConnected = make(chan bool)
+var ConfigmapChanged = make(chan struct{})
 var done = make(chan struct{})
 var deviceName string
 var deviceID string

--- a/mappers/bluetooth_mapper/watcher/watcher.go
+++ b/mappers/bluetooth_mapper/watcher/watcher.go
@@ -32,7 +32,6 @@ import (
 )
 
 var DeviceConnected = make(chan bool)
-var ConfigmapChanged = make(chan struct{})
 var done = make(chan struct{})
 var deviceName string
 var deviceID string


### PR DESCRIPTION
…same node ?

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
It's a TODO job of kubeedge.Now ,it's ubable to handle 2 device of multiple namespaces bind to same node.

**Which issue(s) this PR fixes**:
Fixes #2129 

**Special notes for your reviewer**:
When we create 2 device of multiple namespaces bind to same node, KE will create two multiple namespaces configmap。 But now, KE doesn't support it. So cloudcore.log will report error, and this node's configmap will be in trouble.

Although we can store all devices in one namespace, sometimes we need to store a kind of devices in a namespace, like temperatureSensor.

What I do is to merge all device's config to a configmap, stored in "default" Namespace(as we usually use, it's ok to stored in another namespace, like "keConfigmap"). And we can create  devices of different namespaces.

**Does this PR introduce a user-facing change?**:
None
```release-note

```
