### PR TITLE
Run cloudcore as service

### DIFF
--- a/build/tools/cloudcore.service
+++ b/build/tools/cloudcore.service
@@ -3,7 +3,7 @@ Description=cloudcore.service
 
 [Service]
 Type=simple
-ExecStart=/etc/kubeedge/cloudcore
+ExecStart=cloudcore
 
 [Install]
 WantedBy=multi-user.target

--- a/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
@@ -167,10 +167,10 @@ func (cu *KubeCloudInstTool) RunCloudCore() error {
 	cmd.Cmd.Env = os.Environ()
 	err = cmd.ExecuteCmdShowOutput()
 	if err!=nil{
+		if errout := cmd.GetStdErr(); errout != "" {
+			fmt.Printf("failed to run cloudcore by {%s}, stderr: %s\n",command,errout)
+		}
 		return err
-	}
-	if errout := cmd.GetStdErr(); errout != "" {
-		return fmt.Errorf("failed to run cloudcore by {%s} : %s",command,errout)
 	}
 	if cu.ToolVersion.GE(semver.MustParse("1.1.0")) {
 		if systemdExist {

--- a/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
@@ -165,7 +165,7 @@ func (cu *KubeCloudInstTool) RunCloudCore() error {
 	}
 	cmd := &Command{Cmd: exec.Command("sh", "-c", command)}
 	cmd.Cmd.Env = os.Environ()
-	err = cmd.ExecuteCmdShowOutput()
+	err = cmd.ExcuteCommandCaptureOutput()
 	if err!=nil{
 		if errout := cmd.GetStdErr(); errout != "" {
 			fmt.Printf("failed to run cloudcore by {%s}, stderr: %s\n",command,errout)

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -125,7 +125,7 @@ func(cm *Command) ExcuteCommandCaptureOutput()error{
 	cm.Cmd.Stderr = &stderr
 	err := cm.Cmd.Run()
 	cm.StdOut = stdout.Bytes()
-	cm.StdErr = stdout.Bytes()
+	cm.StdErr = stderr.Bytes()
 	return err
 }
 

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -161,14 +161,14 @@ func (cm Command) ExecuteCmdShowOutput() error {
 	wg.Wait()
 
 	err = cm.Cmd.Wait()
-	if err != nil {
-		return fmt.Errorf("failed to run '%s' because of error : %s", strings.Join(cm.Cmd.Args, " "), err.Error())
-	}
+	// capture stdout and stderr before return
+	cm.StdOut, cm.StdErr = stdoutBuf.Bytes(), stderrBuf.Bytes()
 	if errStdout != nil || errStderr != nil {
 		return fmt.Errorf("failed to capture stdout or stderr")
 	}
-
-	cm.StdOut, cm.StdErr = stdoutBuf.Bytes(), stderrBuf.Bytes()
+	if err != nil {
+		return fmt.Errorf("failed to run '%s' because of error : %s", strings.Join(cm.Cmd.Args, " "), err.Error())
+	}
 	return nil
 }
 

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -117,6 +117,17 @@ func (cm *Command) ExecuteCommand() {
 		cm.StdErr = []byte(err.Error())
 	}
 }
+//ExcuteCommandCaptureOutput the commadn and capture both output in stdOut and stdErr
+func(cm *Command) ExcuteCommandCaptureOutput()error{
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cm.Cmd.Stdout = &stdout
+	cm.Cmd.Stderr = &stderr
+	err := cm.Cmd.Run()
+	cm.StdOut = stdout.Bytes()
+	cm.StdErr = stdout.Bytes()
+	return err
+}
 
 //GetStdOutput gets StdOut field
 func (cm Command) GetStdOutput() string {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

support cloudcore run as systemd service, so we can restart cloudcore by `systemctl restart cloudcore`

also fix some closely related bugs, so merge them into one pr:

1. Stop to Re-download `service file` if it exsists.
2. More msg about why failed to install.
3. change `klog.Fatal` to `klog.Error`, I think it is too superficial too log func stack here, no help for debug but make user nervers
https://github.com/kubeedge/kubeedge/blob/7c415600ccd66e6cf4c18999939586e71e8ac59d/keadm/cmd/keadm/keadm.go#L27
shown as below:
![image](https://user-images.githubusercontent.com/29768082/92345160-f1f3d300-f0fa-11ea-8a7a-a3b02331ae79.png)
![image](https://user-images.githubusercontent.com/29768082/92346318-f28e6880-f0fe-11ea-9e08-7043457b4c9a.png)


**Which issue(s) this PR fixes**:

Fixes None-related-issue

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
None
```release-note

```
