### PR TITLE
fix deviceProfile json bug

### DIFF
--- a/mappers/modbus_mapper/dpl/deviceProfile.json
+++ b/mappers/modbus_mapper/dpl/deviceProfile.json
@@ -31,7 +31,7 @@
         "name": "temperature"
     }],
 	"protocols": [{
-        "protocolConfig": {
+        "protocol_config": {
             "ip": "127.0.0.1",
             "port": 5028,
             "slaveID": 1

--- a/mappers/modbus_mapper/dpl/deviceProfile.json
+++ b/mappers/modbus_mapper/dpl/deviceProfile.json
@@ -31,7 +31,7 @@
         "name": "temperature"
     }],
 	"protocols": [{
-        "protocol_config": {
+        "protocolConfig": {
             "ip": "127.0.0.1",
             "port": 5028,
             "slaveID": 1

--- a/mappers/modbus_mapper/src/modbus.js
+++ b/mappers/modbus_mapper/src/modbus.js
@@ -16,9 +16,9 @@ class Modbus {
         let client = this.client;
         switch(protocol.protocol) {
             case 'modbus-tcp':
-                client.connectTCP(protocol.protocol_config.ip, { port: parseInt(protocol.protocol_config.port) }, ()=>{
+                client.connectTCP(protocol.protocolConfig.ip, { port: parseInt(protocol.protocolConfig.port) }, ()=>{
                     client.setTimeout(500);
-                    client.setID(parseInt(protocol.protocol_config.slaveID));
+                    client.setID(parseInt(protocol.protocolConfig.slaveID));
                     callback(client);
                 });
                 break;
@@ -30,9 +30,9 @@ class Modbus {
                         }, 100);
                     },
                     function (callback) {
-                        client.connectRTUBuffered(protocol.protocol_config.serialPort, { baudRate: parseInt(protocol.protocol_config.baudRate) }, ()=>{
+                        client.connectRTUBuffered(protocol.protocolConfig.serialPort, { baudRate: parseInt(protocol.protocolConfig.baudRate) }, ()=>{
                             client.setTimeout(500);
-                            client.setID(parseInt(protocol.protocol_config.slaveID));
+                            client.setID(parseInt(protocol.protocolConfig.slaveID));
                             callback(null, client);
                         });
                     }], (err, res) => {callback(res[1]);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
Once a device is created for  the edge node, deviceController may create a device configMap for this edge node. Then we can monut this configmap to mapper container。 In my knowledge, the deviceProfile.json file is an example for modbus device configmap, but the in the kubeedge code，the filed of protocol config  in configmap is named  protocol_config not protocolConfig. And the mapper also use the protocol_config not protocolConfig to prase the  dpl json. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
