### PR TITLE
Keadm: support arm/arm64 for CentOS

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/centosinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/centosinstaller.go
@@ -82,8 +82,11 @@ func (c *CentOS) InstallKubeEdge(componentType types.ComponentType) error {
 		return err
 	}
 
-	// TODO: may support more case
 	switch result {
+	case "armv7l":
+		arch = "arm"
+	case "aarch64":
+		arch = "arm64"
 	case "x86_64":
 		arch = "amd64"
 	default:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

`arch` output:
```
root:[~]$ docker run --privileged linuxkit/binfmt:v0.7
root:[~]$ docker run -it arm64v8/centos arch
aarch64
root:[~]$ docker run -it arm32v7/centos arch
armv7l
```

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2124

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Keadm: support arm/arm64 for CentOS
```
