### PR TITLE
Stop to output the detail of licenses diff

### DIFF
--- a/hack/verify-vendor-licenses.sh
+++ b/hack/verify-vendor-licenses.sh
@@ -24,6 +24,7 @@
 # KubeEdge Authors:
 # - File derived from kubernetes v1.19.0-beta.2
 # - Changed KUBE_ROOT value to use absolute path
+# - Stop echo "_out" to avoid long-winded output of license diff
 
 
 set -o errexit
@@ -61,6 +62,6 @@ LICENSE_ROOT="${_tmpdir}" "${KUBE_ROOT}/hack/update-vendor-licenses.sh"
 # Compare licenses
 if ! _out="$(diff -Naupr -x OWNERS "${KUBE_ROOT}/LICENSES" "${_tmpdir}/LICENSES")"; then
   echo "Your LICENSES tree is out of date. Run hack/update-vendor-licenses.sh and commit the results." >&2
-  echo "${_out}" >&2
+  #echo "${_out}" >&2
   exit 1
 fi


### PR DESCRIPTION
**What type of PR is this?**
Improvment
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
When developer use make verify to vefity vendor-license, it log out too long information and make it hard to get useful information
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2168

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
