### PR TITLE
metamanager: fix send sync msg with async SendToCloud

### DIFF
--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -66,7 +66,10 @@ func sendToEdgeMesh(message *model.Message, sync bool) {
 }
 
 func sendToCloud(message *model.Message) {
+	oldSync := message.Header.Sync
+	message.Header.Sync = false
 	beehiveContext.SendToGroup(string(metaManagerConfig.Config.ContextSendGroup), *message)
+	message.Header.Sync = oldSync
 }
 
 // Resource format: <namespace>/<restype>[/resid]


### PR DESCRIPTION
The original msg come from edged to metamanager may be sync,
but later we use SendToCloud, which is async, to send msg to cloud,
then edgehub will wait for response and timeout on some type of
resource update operation, e.g. podstatus update which will have
no response from cloud.

Signed-off-by: Gui Hecheng <guihecheng@cmiot.chinamobile.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2171

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
