### PR TITLE
 documentation：Solve modubs_mapper configuration error

### DIFF
--- a/mappers/modbus_mapper/dpl/deviceProfile.json
+++ b/mappers/modbus_mapper/dpl/deviceProfile.json
@@ -4,13 +4,13 @@
         "name": "modbus-mock-instance-01",
         "model": "modbus-mock-model",
         "protocol": "modbus-tcp-01"
-    }],    
+    }],
 	"deviceModels": [{
         "properties": [{
             "name": "temperature",
             "minimum": 0,
             "maximum": 100,
-            "datatype": "int",
+            "dataType": "int",
             "accessMode": "rw"
         }],
         "name": "modbus-mock-model",
@@ -23,15 +23,16 @@
             "isRegisterSwap": true,
             "register": "HoldingRegister",
             "offset": 1,
-            "isSwap": false
+            "isSwap": false,
+            "limit": 1
         },
         "propertyName": "temperature",
         "modelName": "modbus-mock-model",
-        "protocol": "modbus-tcp",
+        "protocol": "modbus",
         "name": "temperature"
     }],
 	"protocols": [{
-        "protocolConfig": {
+        "protocol_config": {
             "ip": "127.0.0.1",
             "port": 5028,
             "slaveID": 1


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
Solve modubs_mapper configuration error
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
The default configuration does not correspond to the field values, some field names are also wrong, and fields are missing, which causes mobus_mapper to fail to start normally
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
