### PR TITLE
Docs: add OWNERS file

### DIFF
--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - kevin-wangzefeng
+  - fisherxu
+  - daixiang0
+reviewers:
+  - kevin-wangzefeng
+  - fisherxu
+  - daixiang0


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

What this PR does / why we need it:

Some doc issues have post pr while slow to merge, it is not good for users to search pr to get answers.

Add this file then we can choose some members foucs on docs review to speed up merge process.
