### PR TITLE
fix bug: cloud send twin_update confirm message to edge

### DIFF
--- a/cloud/pkg/devicecontroller/constants/service.go
+++ b/cloud/pkg/devicecontroller/constants/service.go
@@ -2,6 +2,7 @@ package constants
 
 // Service level constants
 const (
+	ResourceNodeIDIndex         = 1
 	ResourceDeviceIndex         = 2
 	ResourceDeviceIDIndex       = 3
 	ResourceNode                = "node"

--- a/cloud/pkg/devicecontroller/controller/upstream.go
+++ b/cloud/pkg/devicecontroller/controller/upstream.go
@@ -27,6 +27,7 @@ import (
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/cloud/pkg/apis/devices/v1alpha2"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/config"
 	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/constants"
 	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/messagelayer"
@@ -161,6 +162,25 @@ func (uc *UpstreamController) updateDeviceStatus() {
 			result := uc.crdClient.Patch(MergePatchType).Namespace(cacheDevice.Namespace).Resource(ResourceTypeDevices).Name(deviceID).Body(body).Do(context.Background())
 			if result.Error() != nil {
 				klog.Errorf("Failed to patch device status %v of device %v in namespace %v", deviceStatus, deviceID, cacheDevice.Namespace)
+				continue
+			}
+			//send confirm message to edge twin
+			resMsg := model.NewMessage(msg.GetID())
+			nodeID, err := messagelayer.GetNodeID(msg)
+			if err != nil {
+				klog.Warningf("Message: %s process failure, get node id failed with error: %s", msg.GetID(), err)
+				continue
+			}
+			resource, err := messagelayer.BuildResource(nodeID, "twin", "")
+			if err != nil {
+				klog.Warningf("Message: %s process failure, build message resource failed with error: %s", msg.GetID(), err)
+				continue
+			}
+			resMsg.BuildRouter(modules.DeviceControllerModuleName, constants.GroupTwin, resource, model.ResponseOperation)
+			resMsg.Content = "OK"
+			err = uc.messageLayer.Response(*resMsg)
+			if err != nil {
+				klog.Warningf("Message: %s process failure, response failed with error: %s", msg.GetID(), err)
 				continue
 			}
 			klog.Infof("Message: %s process successfully", msg.GetID())

--- a/cloud/pkg/devicecontroller/messagelayer/util.go
+++ b/cloud/pkg/devicecontroller/messagelayer/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kubeedge/beehive/pkg/core/model"
 	deviceconstants "github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/constants"
 	constants "github.com/kubeedge/kubeedge/common/constants"
 )
@@ -37,4 +38,13 @@ func GetResourceType(resource string) (string, error) {
 		return deviceconstants.ResourceTypeTwinEdgeUpdated, nil
 	}
 	return "", errors.New("unknown resource")
+}
+
+// GetNodeID from "beehive/pkg/core/model".Message.Router.Resource
+func GetNodeID(msg model.Message) (string, error) {
+	sli := strings.Split(msg.GetResource(), constants.ResourceSep)
+	if len(sli) <= deviceconstants.ResourceNodeIDIndex {
+		return "", fmt.Errorf("node id not found")
+	}
+	return sli[deviceconstants.ResourceNodeIDIndex], nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
After deviceTwin send twin_update message to cloud, communication module start to wait an confirm message from cloud and then remove related parentID message in confirmmap, but now cloud doesn't send any confirm message to edge, so deviceTwin module will send repeated message. This commit fix the problem above, cloud sends confirm message to edge after successfully updated the device status.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
