### PR TITLE
CI: enable go module cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ services:
 go:
   - 1.14
 
+env:
+  - HOME=/home/travis
+
+cache:
+  directories:
+    - $HOME/.cache/go-build
+    - $HOME/gopath/pkg/mod
+
 before_install:
   - |
       if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.png)|(\.pdf)|(\.html)|^(LICENSE)|^(docs)|^(OWNERS)|^(MAINTAINERS)'


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>


**What type of PR is this?**

 /kind test


**What this PR does / why we need it**:

Cache go module to speed up.

Refer to this [blog](https://restic.net/blog/2018-09-02/travis-build-cache/).