### PR TITLE
CI: use `install: skip` instead of `install: true`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
         travis_terminate 0
       fi
 
-install: true
+install: skip
 
 jobs:
   include:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

Using `install: true` does not skip install step but runs true command. To actually skip install step one should use `install: skip`. See https://docs.travis-ci.com/user/job-lifecycle/#skipping-the-installation-phase and travis-ci/docs-travis-ci-com#2422 (comment)
