### PR TITLE
Fix no rnd error

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -176,6 +176,8 @@ function generate_streamserver_cert {
   SUBJECTALTNAME="subjectAltName = IP.1:127.0.0.1"
   echo $SUBJECTALTNAME > /tmp/server-extfile.cnf
 
+  touch ~/.rnd
+
   openssl genrsa -out ${STREAM_KEY_FILE}  2048
   openssl req -new -key ${STREAM_KEY_FILE} -subj ${streamsubject} -out ${STREAM_CSR_FILE}
   openssl x509 -req -in ${STREAM_CSR_FILE} -CA ${K8SCA_FILE} -CAkey ${K8SCA_KEY_FILE} -CAcreateserial -out ${STREAM_CRT_FILE} -days 5000 -sha256 -extfile /tmp/server-extfile.cnf


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:

Fix no file error, from CI log:
```
Can't load /home/travis/.rnd into RNG
139798443250112:error:2406F079:random number
generator:RAND_load_file:Cannot open
file:../crypto/rand/randfile.c:88:Filename=/home/travis/.rnd
```
