### PR TITLE
support specify edgecore file path by os.env

### DIFF
--- a/edge/cmd/edgecore/app/options/options.go
+++ b/edge/cmd/edgecore/app/options/options.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -33,8 +34,12 @@ type EdgeCoreOptions struct {
 }
 
 func NewEdgeCoreOptions() *EdgeCoreOptions {
+	edgecorePath := os.Getenv("EDGECORE_CONFIG_PATH")
+	if edgecorePath == "" {
+		edgecorePath = constants.DefaultConfigDir
+	}
 	return &EdgeCoreOptions{
-		ConfigFile: path.Join(constants.DefaultConfigDir, "edgecore.yaml"),
+		ConfigFile: path.Join(edgecorePath, "edgecore.yaml"),
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Allow users to use the os.env to config the edgecore file path