### PR TITLE
edge/pkg/edged: fix dropped error

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -534,6 +534,9 @@ func newEdged(enable bool) (*edged, error) {
 	}
 
 	ed.clcm, err = clcm.NewContainerLifecycleManager(DefaultRootDir)
+	if err != nil {
+		return nil, err
+	}
 
 	useLegacyCadvisorStats := cadvisor.UsingLegacyCadvisorStats(edgedconfig.Config.RuntimeType, edgedconfig.Config.RemoteRuntimeEndpoint)
 	if edgedconfig.Config.EnableMetrics {


### PR DESCRIPTION
This fixes a dropped error in `edge/pkg/edged`.
```release-note
NONE
```
