### PR TITLE
Edged: inject environment var

### DIFF
--- a/edge/pkg/edged/edged_getters.go
+++ b/edge/pkg/edged/edged_getters.go
@@ -224,9 +224,7 @@ func (e *edged) GetPodByName(namespace, name string) (*v1.Pod, bool) {
 
 // GetNode returns the node info for the configured node name of this edged.
 func (e *edged) GetNode() (*v1.Node, error) {
-	node := &v1.Node{}
-	node.Name = e.nodeName
-	return node, nil
+	return e.metaClient.Nodes("default").Get(e.nodeName)
 }
 
 // GetNodeConfig returns the container manager node config.

--- a/edge/pkg/edged/edged_resources.go
+++ b/edge/pkg/edged/edged_resources.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+@CHANGELOG
+KubeEdge Authors: To create mini-kubelet for edge deployment scenario,
+This file is derived from K8S Kubelet code(kubelet_resource.go) with
+reduced set of methods.
+Changes done are
+1. Adjust defaultPodLimitsForDownwardAPI()
+*/
+
+package edged
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/api/v1/resource"
+)
+
+// defaultPodLimitsForDownwardAPI copies the input pod, and optional container,
+// and applies default resource limits. it returns a copy of the input pod,
+// and a copy of the input container (if specified) with default limits
+// applied. if a container has no limit specified, it will default the limit to
+// the node allocatable.
+// TODO: if/when we have pod level resources, we need to update this function
+// to use those limits instead of node allocatable.
+func (e *edged) defaultPodLimitsForDownwardAPI(pod *v1.Pod, container *v1.Container) (*v1.Pod, *v1.Container, error) {
+	if pod == nil {
+		return nil, nil, fmt.Errorf("invalid input, pod cannot be nil")
+	}
+
+	node, err := e.GetNode()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find node object, expected a node")
+	}
+	allocatable := node.Status.Allocatable
+	klog.V(4).Infof("node allocatable: %v", allocatable)
+	outputPod := pod.DeepCopy()
+	for idx := range outputPod.Spec.Containers {
+		resource.MergeContainerResourceLimits(&outputPod.Spec.Containers[idx], allocatable)
+	}
+
+	var outputContainer *v1.Container
+	if container != nil {
+		outputContainer = container.DeepCopy()
+		resource.MergeContainerResourceLimits(outputContainer, allocatable)
+	}
+	return outputPod, outputContainer, nil
+}

--- a/edge/test/integration/utils/helpers/helpers.go
+++ b/edge/test/integration/utils/helpers/helpers.go
@@ -283,10 +283,11 @@ func HandleAddAndDeletePods(operation string, edgedpoint string, UID string, con
 		return false
 	}
 
+	var enableServiceLinks = true
 	payload := &v1.Pod{
 		TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: UID, Namespace: metav1.NamespaceDefault, UID: types.UID(UID)},
-		Spec:       v1.PodSpec{RestartPolicy: restartPolicy, Containers: container},
+		Spec:       v1.PodSpec{RestartPolicy: restartPolicy, Containers: container, EnableServiceLinks: &enableServiceLinks},
 	}
 	respbytes, err := json.Marshal(payload)
 	if err != nil {

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/envvars/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/envvars/BUILD
@@ -1,0 +1,43 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "envvars.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/envvars",
+    deps = [
+        "//pkg/apis/core/v1/helper:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["envvars_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/envvars/doc.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/envvars/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package envvars is the package that build the environment variables that kubernetes provides
+// to the containers run by it.
+package envvars // import "k8s.io/kubernetes/pkg/kubelet/envvars"

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/envvars/envvars.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/envvars/envvars.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envvars
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+// FromServices builds environment variables that a container is started with,
+// which tell the container where to find the services it may need, which are
+// provided as an argument.
+func FromServices(services []*v1.Service) []v1.EnvVar {
+	var result []v1.EnvVar
+	for i := range services {
+		service := services[i]
+
+		// ignore services where ClusterIP is "None" or empty
+		// the services passed to this method should be pre-filtered
+		// only services that have the cluster IP set should be included here
+		if !v1helper.IsServiceIPSet(service) {
+			continue
+		}
+
+		// Host
+		name := makeEnvVariableName(service.Name) + "_SERVICE_HOST"
+		result = append(result, v1.EnvVar{Name: name, Value: service.Spec.ClusterIP})
+		// First port - give it the backwards-compatible name
+		name = makeEnvVariableName(service.Name) + "_SERVICE_PORT"
+		result = append(result, v1.EnvVar{Name: name, Value: strconv.Itoa(int(service.Spec.Ports[0].Port))})
+		// All named ports (only the first may be unnamed, checked in validation)
+		for i := range service.Spec.Ports {
+			sp := &service.Spec.Ports[i]
+			if sp.Name != "" {
+				pn := name + "_" + makeEnvVariableName(sp.Name)
+				result = append(result, v1.EnvVar{Name: pn, Value: strconv.Itoa(int(sp.Port))})
+			}
+		}
+		// Docker-compatible vars.
+		result = append(result, makeLinkVariables(service)...)
+	}
+	return result
+}
+
+func makeEnvVariableName(str string) string {
+	// TODO: If we simplify to "all names are DNS1123Subdomains" this
+	// will need two tweaks:
+	//   1) Handle leading digits
+	//   2) Handle dots
+	return strings.ToUpper(strings.Replace(str, "-", "_", -1))
+}
+
+func makeLinkVariables(service *v1.Service) []v1.EnvVar {
+	prefix := makeEnvVariableName(service.Name)
+	all := []v1.EnvVar{}
+	for i := range service.Spec.Ports {
+		sp := &service.Spec.Ports[i]
+
+		protocol := string(v1.ProtocolTCP)
+		if sp.Protocol != "" {
+			protocol = string(sp.Protocol)
+		}
+
+		hostPort := net.JoinHostPort(service.Spec.ClusterIP, strconv.Itoa(int(sp.Port)))
+
+		if i == 0 {
+			// Docker special-cases the first port.
+			all = append(all, v1.EnvVar{
+				Name:  prefix + "_PORT",
+				Value: fmt.Sprintf("%s://%s", strings.ToLower(protocol), hostPort),
+			})
+		}
+		portPrefix := fmt.Sprintf("%s_PORT_%d_%s", prefix, sp.Port, strings.ToUpper(protocol))
+		all = append(all, []v1.EnvVar{
+			{
+				Name:  portPrefix,
+				Value: fmt.Sprintf("%s://%s", strings.ToLower(protocol), hostPort),
+			},
+			{
+				Name:  portPrefix + "_PROTO",
+				Value: strings.ToLower(protocol),
+			},
+			{
+				Name:  portPrefix + "_PORT",
+				Value: strconv.Itoa(int(sp.Port)),
+			},
+			{
+				Name:  portPrefix + "_ADDR",
+				Value: service.Spec.ClusterIP,
+			},
+		}...)
+	}
+	return all
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1558,6 +1558,7 @@ k8s.io/kubernetes/pkg/kubelet/dockershim/network/hostport
 k8s.io/kubernetes/pkg/kubelet/dockershim/network/kubenet
 k8s.io/kubernetes/pkg/kubelet/dockershim/network/metrics
 k8s.io/kubernetes/pkg/kubelet/dockershim/remote
+k8s.io/kubernetes/pkg/kubelet/envvars
 k8s.io/kubernetes/pkg/kubelet/events
 k8s.io/kubernetes/pkg/kubelet/eviction/api
 k8s.io/kubernetes/pkg/kubelet/images


### PR DESCRIPTION
Support inject environment var into container, including services, configMaps and secrets.

Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

Enable environment var inject at edge side.

**Which issue(s) this PR fixes**:

Fixes #2229

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support environment var inject, including configmaps, services and secrets.
```
