### PR TITLE
Fix downwardAPI volume cannot get true value

### DIFF
--- a/edge/pkg/edged/edged_getters.go
+++ b/edge/pkg/edged/edged_getters.go
@@ -224,9 +224,7 @@ func (e *edged) GetPodByName(namespace, name string) (*v1.Pod, bool) {
 
 // GetNode returns the node info for the configured node name of this edged.
 func (e *edged) GetNode() (*v1.Node, error) {
-	node := &v1.Node{}
-	node.Name = e.nodeName
-	return node, nil
+	return e.metaClient.Nodes("default").Get(e.nodeName)
 }
 
 // GetNodeConfig returns the container manager node config.

--- a/edge/pkg/edged/volume_host.go
+++ b/edge/pkg/edged/volume_host.go
@@ -135,9 +135,17 @@ func (evh *edgedVolumeHost) GetConfigMapFunc() func(namespace, name string) (*ap
 		return evh.edge.metaClient.ConfigMaps(namespace).Get(name)
 	}
 }
-func (evh *edgedVolumeHost) GetExec(pluginName string) utilexec.Interface  { return nil }
-func (evh *edgedVolumeHost) GetHostIP() (net.IP, error)                    { return nil, nil }
-func (evh *edgedVolumeHost) GetNodeAllocatable() (api.ResourceList, error) { return nil, nil }
+func (evh *edgedVolumeHost) GetExec(pluginName string) utilexec.Interface { return nil }
+func (evh *edgedVolumeHost) GetHostIP() (net.IP, error)                   { return nil, nil }
+
+func (evh *edgedVolumeHost) GetNodeAllocatable() (api.ResourceList, error) {
+	node, err := evh.edge.GetNode()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving node: %v", err)
+	}
+	return node.Status.Allocatable, nil
+}
+
 func (evh *edgedVolumeHost) GetNodeLabels() (map[string]string, error) {
 	node, err := evh.edge.initialNode()
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:

DownwardAPI uses `host.GetNodeAllocatable` to get value from node if no set, see https://github.com/kubeedge/kubeedge/blob/master/vendor/k8s.io/kubernetes/pkg/volume/downwardapi/downwardapi.go#L270.

**Which issue(s) this PR fixes**:

Fixes #2231 

**Special notes for your reviewer**:
