### PR TITLE
Keadm: add debian OS support

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"k8s.io/klog"
 	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+
+	"k8s.io/klog"
 
 	"github.com/blang/semver"
 	"github.com/spf13/pflag"
@@ -42,6 +43,7 @@ import (
 const (
 	UbuntuOSType   = "ubuntu"
 	RaspbianOSType = "raspbian"
+	DebianOSType   = "debian"
 	CentOSType     = "centos"
 
 	KubeEdgeDownloadURL          = "https://github.com/kubeedge/kubeedge/releases/download"
@@ -183,7 +185,7 @@ func GetOSVersion() string {
 //GetOSInterface helps in returning OS specific object which implements OSTypeInstaller interface.
 func GetOSInterface() types.OSTypeInstaller {
 	switch GetOSVersion() {
-	case UbuntuOSType, RaspbianOSType:
+	case UbuntuOSType, RaspbianOSType, DebianOSType:
 		return &UbuntuOS{}
 	case CentOSType:
 		return &CentOS{}


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>


**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Debian OS is popular and it uses `apt` as pakeage manager.

**Which issue(s) this PR fixes**:

Fixes #2233

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Keadm: add debian OS support
```
