### PR TITLE
Use pidof install ps to check process existence

### DIFF
--- a/edge/test/integration/scripts/execute.sh
+++ b/edge/test/integration/scripts/execute.sh
@@ -17,10 +17,10 @@
 TEST_DIR=$(dirname $(dirname "${BASH_SOURCE[0]}"))
 
 function cleanup() {
-  sudo pkill edgecore || true
   while true; do
+    sudo pkill edgecore || true
     sleep 1
-    ps faux | grep -q [e]dgecore || break
+    pidof edgecore >/dev/null || break
   done
 
   sudo rm -rf $TEST_DIR/appdeployment/appdeployment.test $TEST_DIR/device/device.test

--- a/tests/e2e/scripts/keadm_e2e.sh
+++ b/tests/e2e/scripts/keadm_e2e.sh
@@ -19,8 +19,8 @@ WORKDIR=$(dirname $0)
 E2E_DIR=$(realpath $(dirname $0)/..)
 
 function cleanup() {
-  ps aux | grep '[e]dgecore' | awk '{print $2}' | xargs -r sudo kill
-  ps aux | grep '[c]loudcore' | awk '{print $2}' | xargs -r sudo kill
+  sudo pkill edgecore
+  sudo pkill cloudcore
   kind delete cluster --name test
   sudo rm -rf /var/log/kubeedge /etc/kubeedge /etc/systemd/system/edgecore.service
 }


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:

`ps | grep` would get unexpected result, use `pidof` instead and use `pkill` to kill process.

`pidof` and `pkill` no need to be extra installed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2251

