### PR TITLE
Fix bash array usage in hack/lib/golang.sh

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -140,7 +140,7 @@ kubeedge::check::env() {
   # check lenth of errors
   if [[ ${#errors[@]} -ne 0 ]] ; then
     local error
-    for error in ${errors[@]}; do
+    for error in "${errors[@]}"; do
       echo "Error: "$error
     done
     exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design
/kind bug
Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
Fix bash array usage in `kubeedge::check::env` of 'hack/lib/golang.sh'.
The build command below
```sh
export GOPATH=
make all WHAT=edgecore
```
will output the misleading messages:
```
bash hack/verify-golang.sh
go detail version: go version go1.14.7 linux/amd64
go version: 1.14.7
hack/make-rules/build.sh keadm 
Error: GOPATH
Error: environment
Error: value
Error: not
Error: set
Makefile:41: recipe for target 'all' failed
make: *** [all] Error 1
```
which intends to be 
```sh
bash hack/verify-golang.shgo detail version: go version go1.14.7 linux/amd64
go version: 1.14.7
hack/make-rules/build.sh keadm 
Error: GOPATH environment value not set
Makefile:41: recipe for target 'all' failedmake: *** [all] Error 1
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
