### PR TITLE
CI: update travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 git:
   depth: false
 
-sudo: required
+os: linux
 
 dist: bionic
 


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>



**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

With https://config.travis-ci.com/explore, we miss os tag.

Ref [comment](https://github.com/python/mypy/issues/6675#issuecomment-487447188), `sudo` is default, so remove duplicated tag.
