### PR TITLE
test: download tarballs before keadm e2e test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,12 @@ jobs:
         - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
         - sudo apt-get update
         - sudo apt-get install -y kubectl
+        - export RELEASE_VERSION=$(wget -qO - https://kubeedge.io/latestversion | cat)
+        - travis_retry sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/checksum_kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz.txt
+        - travis_retry sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz
+        - echo "$(cat /etc/kubeedge/checksum_kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz.txt) /etc/kubeedge/kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz" | sha512sum -c || exit 1
       script:
-        - travis_retry make keadm_e2e
+        - make keadm_e2e
     - name: "build docker images on amd64"
       arch: amd64
       script:


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>


**What type of PR is this?**
/kind failing-test


**What this PR does / why we need it**:

See [ci test reuslt](https://travis-ci.org/github/kubeedge/kubeedge/jobs/737181002#L478-L481), it download part of tarball and return wrong checksum. So download before start begin.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
