### PR TITLE
[WIP] test: add arm64 arch support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ go:
   - 1.14
 
 env:
-  - HOME=/home/travis
+  global:
+    - HOME=/home/travis
+    - MINIKUBE_IN_STYLE=false
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
 
 cache:
   directories:
@@ -111,7 +115,9 @@ jobs:
 
     - stage: "Test on arm64"
       name: "build, smallbuild"
-      arch: arm64
+      arch: arm64-graviton2
+      virt: vm
+      group: edge
       before_script:
         - export GOFLAGS=-mod=vendor
         - sudo apt-get install upx-ucl -y
@@ -122,6 +128,7 @@ jobs:
     - name: "unit test, integration test edge"
       arch: arm64-graviton2
       virt: vm
+      group: edge
       before_script:
         - go get github.com/onsi/ginkgo/ginkgo
         - export GOFLAGS=-mod=mod
@@ -131,35 +138,37 @@ jobs:
     - name: "e2e test"
       arch: arm64-graviton2
       virt: vm
+      group: edge
       before_script:
         - go get github.com/onsi/ginkgo/ginkgo
-        - go get sigs.k8s.io/kind@v0.7.0
         - go mod vendor
         - export GOFLAGS=-mod=vendor
-        - sudo apt-get update && sudo apt-get install -y apt-transport-https
-        - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-        - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
-        - sudo apt-get update
-        - sudo apt-get install -y kubectl
+        - sudo apt-get update && sudo apt-get install -y conntrack
+        - curl -LO https://storage.googleapis.com/minikube/releases/v1.14.2/minikube-linux-arm64 && sudo install minikube-linux-arm64 /usr/local/bin/minikube
+        - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/arm64/kubectl && sudo install kubectl /usr/local/bin/kubectl
       script:
         - travis_retry make e2e
     - name: "keadm e2e test"
       arch: arm64-graviton2
       virt: vm
+      group: edge
       before_script:
         - go get github.com/onsi/ginkgo/ginkgo
-        - go get sigs.k8s.io/kind@v0.7.0
         - go mod vendor
         - export GOFLAGS=-mod=vendor
-        - sudo apt-get update && sudo apt-get install -y apt-transport-https
-        - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-        - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
-        - sudo apt-get update
-        - sudo apt-get install -y kubectl
+        - sudo apt-get update && sudo apt-get install -y conntrack
+        - curl -LO https://storage.googleapis.com/minikube/releases/v1.14.2/minikube-linux-arm64 && sudo install minikube-linux-arm64 /usr/local/bin/minikube
+        - curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/arm64/kubectl && sudo install kubectl /usr/local/bin/kubectl
+        - export RELEASE_VERSION=$(wget -qO - https://kubeedge.io/latestversion | cat)
+        - travis_retry sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/checksum_kubeedge-${RELEASE_VERSION}-linux-arm64.tar.gz.txt
+        - travis_retry sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/kubeedge-${RELEASE_VERSION}-linux-arm64.tar.gz
+        - echo "$(cat /etc/kubeedge/checksum_kubeedge-${RELEASE_VERSION}-linux-arm64.tar.gz.txt) /etc/kubeedge/kubeedge-${RELEASE_VERSION}-linux-arm64.tar.gz" | sha512sum -c || exit 1
       script:
         - travis_retry make keadm_e2e
     - name: "build docker images on arm64"
-      arch: arm64
+      arch: arm64-graviton2
+      virt: vm
+      group: edge
       script:
         - make cloudimage
         - make admissionimage

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ DESTDIR?=
 USR_DIR?=/usr/local
 INSTALL_DIR?=${DESTDIR}${USR_DIR}
 INSTALL_BIN_DIR?=${INSTALL_DIR}/bin
+
+ARCH?=$(shell uname -m)
+
 # make all builds both cloud and edge binaries
 
 BINARIES=cloudcore \

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -47,6 +47,22 @@ function check_kind {
   fi
 }
 
+
+# check if minikube installed
+function check_minikube {
+  echo "checking minikube"
+  command -v minikube >/dev/null 2>&1
+  if [[ $? -ne 0 ]]; then
+    echo "installing minikube ."
+    eval $(go env)
+    curl -LO https://storage.googleapis.com/minikube/releases/v1.14.0/minikube-linux-${GOARCH} || exit 1
+    mv minikube-linux-${GOARCH} /usr/local/bin/minikube || exit 1
+    chmod +x /usr/local/bin/minikube || exit 1
+  else
+    echo -n "found minikube, version: " && minikube version
+  fi
+}
+
 verify_go_version(){
   if [[ -z "$(command -v go)" ]]; then
     echo "Can't find 'go' in PATH, please fix and retry.

--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -18,6 +18,7 @@ package deployment
 
 import (
 	"net/http"
+	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -80,6 +81,9 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 		})
 
 		It("E2E_APP_DEPLOYMENT_3: Create deployment and check deployment ctrler re-creating pods when user deletes the pods manually", func() {
+			if runtime.GOARCH != "amd64" {
+				Skip("Skip test since only support on amd64 arch")
+			}
 			replica := 3
 			//Generate the random string and assign as a UID
 			UID = "edgecore-depl-app-" + utils.GetRandomString(5)
@@ -122,6 +126,9 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 		})
 
 		It("E2E_POD_DEPLOYMENT_1: Create a pod and check the pod is coming up correctly", func() {
+			if runtime.GOARCH != "amd64" {
+				Skip("Skip test since only support on amd64 arch")
+			}
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
 			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
@@ -130,6 +137,9 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 		})
 
 		It("E2E_POD_DEPLOYMENT_2: Create the pod and delete pod happening successfully", func() {
+			if runtime.GOARCH != "amd64" {
+				Skip("Skip test since only support on amd64 arch")
+			}
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
 			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
@@ -142,6 +152,9 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
 		})
 		It("E2E_POD_DEPLOYMENT_3: Create pod and delete the pod successfully, and delete already deleted pod and check the behaviour", func() {
+			if runtime.GOARCH != "amd64" {
+				Skip("Skip test since only support on amd64 arch")
+			}
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
 			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
@@ -156,6 +169,9 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			Expect(StatusCode).Should(Equal(http.StatusNotFound))
 		})
 		It("E2E_POD_DEPLOYMENT_4: Create and delete pod multiple times and check all the Pod created and deleted successfully", func() {
+			if runtime.GOARCH != "amd64" {
+				Skip("Skip test since only support on amd64 arch")
+			}
 			//Generate the random string and assign as a UID
 			for i := 0; i < 10; i++ {
 				//Generate the random string and assign as podName
@@ -171,6 +187,9 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			}
 		})
 		It("E2E_POD_DEPLOYMENT_5: Create pod with hostpath volume successfully", func() {
+			if runtime.GOARCH != "amd64" {
+				Skip("Skip test since only support on amd64 arch")
+			}
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
 			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)

--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/kubeedge/kubeedge/tests/e2e/utils"
 )
 
+const amd64 = "amd64"
+
 var DeploymentTestTimerGroup *utils.TestTimerGroup = utils.NewTestTimerGroup()
 
 //Run Test cases
@@ -81,7 +83,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 		})
 
 		It("E2E_APP_DEPLOYMENT_3: Create deployment and check deployment ctrler re-creating pods when user deletes the pods manually", func() {
-			if runtime.GOARCH != "amd64" {
+			if runtime.GOARCH != amd64 {
 				Skip("Skip test since only support on amd64 arch")
 			}
 			replica := 3
@@ -126,7 +128,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 		})
 
 		It("E2E_POD_DEPLOYMENT_1: Create a pod and check the pod is coming up correctly", func() {
-			if runtime.GOARCH != "amd64" {
+			if runtime.GOARCH != amd64 {
 				Skip("Skip test since only support on amd64 arch")
 			}
 			//Generate the random string and assign as podName
@@ -137,7 +139,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 		})
 
 		It("E2E_POD_DEPLOYMENT_2: Create the pod and delete pod happening successfully", func() {
-			if runtime.GOARCH != "amd64" {
+			if runtime.GOARCH != amd64 {
 				Skip("Skip test since only support on amd64 arch")
 			}
 			//Generate the random string and assign as podName
@@ -152,7 +154,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
 		})
 		It("E2E_POD_DEPLOYMENT_3: Create pod and delete the pod successfully, and delete already deleted pod and check the behaviour", func() {
-			if runtime.GOARCH != "amd64" {
+			if runtime.GOARCH != amd64 {
 				Skip("Skip test since only support on amd64 arch")
 			}
 			//Generate the random string and assign as podName
@@ -169,7 +171,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			Expect(StatusCode).Should(Equal(http.StatusNotFound))
 		})
 		It("E2E_POD_DEPLOYMENT_4: Create and delete pod multiple times and check all the Pod created and deleted successfully", func() {
-			if runtime.GOARCH != "amd64" {
+			if runtime.GOARCH != amd64 {
 				Skip("Skip test since only support on amd64 arch")
 			}
 			//Generate the random string and assign as a UID
@@ -187,7 +189,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			}
 		})
 		It("E2E_POD_DEPLOYMENT_5: Create pod with hostpath volume successfully", func() {
-			if runtime.GOARCH != "amd64" {
+			if runtime.GOARCH != amd64 {
 				Skip("Skip test since only support on amd64 arch")
 			}
 			//Generate the random string and assign as podName

--- a/tests/e2e/scripts/fast_test.sh
+++ b/tests/e2e/scripts/fast_test.sh
@@ -25,7 +25,12 @@ debugflag="-test.v -ginkgo.v"
 #setup env
 cd ../
 
-export MASTER_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' test-control-plane`
+if [[ "${ARCH}" = "x86_64" ]]; then
+  export MASTER_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' test-control-plane):6443"
+else
+  export MASTER_IP="$(minikube ip):8443"
+fi
+
 export KUBECONFIG=$HOME/.kube/config
 
 export CHECK_EDGECORE_ENVIRONMENT="false"
@@ -35,7 +40,7 @@ export CHECK_EDGECORE_ENVIRONMENT="false"
 cat >config.json<<END
 {
         "image_url": ["nginx", "nginx"],
-        "k8smasterforkubeedge":"https://$MASTER_IP:6443",
+        "k8smasterforkubeedge":"https://${MASTER_IP}",
         "dockerhubusername":"user",
         "dockerhubpassword":"password",
         "mqttendpoint":"tcp://127.0.0.1:1884",


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

**What type of PR is this?**


Add one of the following kinds:

/kind feature
/kind test

/kind failing-test



**What this PR does / why we need it**:

From [travis blog](https://blog.travis-ci.com/2020-09-11-arm-on-aws), only `virt: vm` tag can not enable arm64 feature, need `group` tag too.

Also from [CI log](https://travis-ci.org/github/kubeedge/kubeedge/jobs/736281853#L470-L494), it stills run on amd64 machine.

`kind` can not run well at arm64, so use `minikube` instead.

