### PR TITLE
Add type param annotation for cloudcore and edgecore

### DIFF
--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -46,7 +46,7 @@ type KubeAPIConfig struct {
 	// Note: Can not use "omitempty" option,  It will affect the output of the default configuration file
 	Master string `json:"master"`
 	// ContentType indicates the ContentType of message transmission when interacting with k8s
-	// default application/vnd.kubernetes.protobuf
+	// default "application/vnd.kubernetes.protobuf"
 	ContentType string `json:"contentType,omitempty"`
 	// QPS to while talking with kubernetes apiserve
 	// default 100
@@ -265,7 +265,7 @@ type EdgeControllerLoad struct {
 	// default 1
 	UpdateNodeStatusWorkers int32 `json:"updateNodeStatusWorkers,omitempty"`
 	// QueryConfigMapWorkers indicates the load of query config map workers
-	// default 1
+	// default 4
 	QueryConfigMapWorkers int32 `json:"queryConfigMapWorkers,omitempty"`
 	// QuerySecretWorkers indicates the load of query secret workers
 	// default 4
@@ -358,10 +358,10 @@ type CloudStream struct {
 	// default /etc/kubeedge/ca/rootCA.crt
 	TLSTunnelCAFile string `json:"tlsTunnelCAFile,omitempty"`
 	// TLSTunnelCertFile indicates cert file path
-	// default /etc/kubeedge/certs/edge.crt
+	// default /etc/kubeedge/certs/server.crt
 	TLSTunnelCertFile string `json:"tlsTunnelCertFile,omitempty"`
 	// TLSTunnelPrivateKeyFile indicates key file path
-	// default /etc/kubeedge/certs/edge.key
+	// default /etc/kubeedge/certs/server.key
 	TLSTunnelPrivateKeyFile string `json:"tlsTunnelPrivateKeyFile,omitempty"`
 	// TunnelPort set open port for tunnel server
 	// default 10004

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -74,7 +74,7 @@ type DataBase struct {
 	// default "default"
 	AliasName string `json:"aliasName,omitempty"`
 	// DataSource indicates the data source path
-	// default "/var/lib/kubeedge/edge.db"
+	// default "/var/lib/kubeedge/edgecore.db"
 	DataSource string `json:"dataSource,omitempty"`
 }
 
@@ -255,10 +255,10 @@ type EdgeHub struct {
 	// default "/etc/kubeedge/ca/rootCA.crt"
 	TLSCAFile string `json:"tlsCaFile,omitempty"`
 	// TLSCertFile indicates the file containing x509 Certificate for HTTPS
-	// default "/etc/kubeedge/certs/edge.crt"
+	// default "/etc/kubeedge/certs/server.crt"
 	TLSCertFile string `json:"tlsCertFile,omitempty"`
 	// TLSPrivateKeyFile indicates the file containing x509 private key matching tlsCertFile
-	// default "/etc/kubeedge/certs/edge.key"
+	// default "/etc/kubeedge/certs/server.key"
 	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty"`
 	// Quic indicates quic config for EdgeHub module
 	// Optional if websocket is configured
@@ -278,7 +278,7 @@ type EdgeHub struct {
 // EdgeHubQUIC indicates the quic client config
 type EdgeHubQUIC struct {
 	// Enable indicates whether enable this protocol
-	// default true
+	// default false
 	Enable bool `json:"enable,omitempty"`
 	// HandshakeTimeout indicates hand shake timeout (second)
 	// default 30
@@ -376,6 +376,7 @@ type MetaManager struct {
 	// ContextSendModule indicates send module
 	ContextSendModule metaconfig.ModuleName `json:"contextSendModule,omitempty"`
 	// PodStatusSyncInterval indicates pod status sync
+	// default 60
 	PodStatusSyncInterval int32 `json:"podStatusSyncInterval,omitempty"`
 }
 
@@ -410,12 +411,16 @@ type EdgeMesh struct {
 	// default true
 	Enable bool `json:"enable,omitempty"`
 	// lbStrategy indicates load balance strategy name
+	// default "RoundRobin"
 	LBStrategy string `json:"lbStrategy,omitempty"`
 	// ListenInterface indicates the listen interface of EdgeMesh
+	// default "docker0"
 	ListenInterface string `json:"listenInterface,omitempty"`
 	// SubNet indicates the subnet of EdgeMesh
+	// default "9.251.0.0/16"
 	SubNet string `json:"subNet,omitempty"`
 	// ListenPort indicates the listen port of EdgeMesh
+	// default 40001
 	ListenPort int `json:"listenPort,omitempty"`
 }
 
@@ -430,10 +435,10 @@ type EdgeStream struct {
 	TLSTunnelCAFile string `json:"tlsTunnelCAFile,omitempty"`
 
 	// TLSTunnelCertFile indicates the file containing x509 Certificate for HTTPS
-	// default /etc/kubeedge/certs/edge.crt
+	// default /etc/kubeedge/certs/server.crt
 	TLSTunnelCertFile string `json:"tlsTunnelCertFile,omitempty"`
 	// TLSTunnelPrivateKeyFile indicates the file containing x509 private key matching tlsCertFile
-	// default /etc/kubeedge/certs/edge.key
+	// default /etc/kubeedge/certs/server.key
 	TLSTunnelPrivateKeyFile string `json:"tlsTunnelPrivateKeyFile,omitempty"`
 
 	// HandshakeTimeout indicates handshake timeout (second)


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
The type's annotation of cloudcore and edgecore have some mistake and missing contents, which will make misunderstanding or misuse.

Does this PR introduce a user-facing change?:
NONE
