### PR TITLE
fix cloudhub api /readyz panic

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -78,6 +78,13 @@ func getCA(w http.ResponseWriter, r *http.Request) {
 //electionHandler returns the status whether the cloudcore is ready
 func electionHandler(w http.ResponseWriter, r *http.Request) {
 	checker := hubconfig.Config.Checker
+	if checker == nil {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("Cloudcore is ready with no leaderelection")); err != nil {
+			klog.Errorf("failed to write http response, err: %v", err)
+		}
+		return
+	}
 	if checker.Check(r) != nil {
 		w.WriteHeader(http.StatusNotFound)
 		if _, err := w.Write([]byte("Cloudcore is not ready")); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> /kind bug

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
I close cloudcore leaderelection, set `leaderelection.LeaderElect: false`. Then the cloudhub api /readyz panic with `runtime error: invalid memory address or nil pointer dereference`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
response with a message like "Cloudcore is ready with no leaderelection" if disable leaderelection,.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
