### PR TITLE
Automated cherry pick of #2304: cloudhub: fix /readyz panic

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -78,6 +78,13 @@ func getCA(w http.ResponseWriter, r *http.Request) {
 //electionHandler returns the status whether the cloudcore is ready
 func electionHandler(w http.ResponseWriter, r *http.Request) {
 	checker := hubconfig.Config.Checker
+	if checker == nil {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("Cloudcore is ready with no leaderelection")); err != nil {
+			klog.Errorf("failed to write http response, err: %v", err)
+		}
+		return
+	}
 	if checker.Check(r) != nil {
 		w.WriteHeader(http.StatusNotFound)
 		if _, err := w.Write([]byte("Cloudcore is not ready")); err != nil {


### PR DESCRIPTION
Cherry pick of #2304 on release-1.5.

#2304: cloudhub: fix /readyz panic

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.