### PR TITLE
Automated cherry pick of #2170: fix re-dowload bug when use keadm

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -59,6 +59,9 @@ const (
 	// DefaultKubeEdgeVersion is the default KubeEdge version
 	DefaultKubeEdgeVersion = "1.4.0"
 
+	// LastestKubeEdgeVersion specifies lastest KubeEdge (major.minor) version supported by keadm
+	LatestKubeEdgeVersion = "1.5.0"
+
 	// Token sets the token used when edge applying for the certificate
 	Token = "token"
 

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -57,10 +57,7 @@ const (
 	RuntimeType = "runtimetype"
 
 	// DefaultKubeEdgeVersion is the default KubeEdge version
-	DefaultKubeEdgeVersion = "1.4.0"
-
-	// LastestKubeEdgeVersion specifies lastest KubeEdge (major.minor) version supported by keadm
-	LatestKubeEdgeVersion = "1.5.0"
+	DefaultKubeEdgeVersion = "1.5.0"
 
 	// Token sets the token used when edge applying for the certificate
 	Token = "token"

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -17,9 +17,20 @@ limitations under the License.
 package util
 
 import (
-	"k8s.io/apimachinery/pkg/version"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
+
+	"github.com/blang/semver"
+	"k8s.io/apimachinery/pkg/version"
+
+	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
+
+var PrivateDownloadServiceFile = downloadServiceFile
 
 func TestManagedKubernetesVersion(t *testing.T) {
 	vers := version.Info{Minor: "17"}
@@ -68,5 +79,141 @@ func TestManagedKubernetesVersion(t *testing.T) {
 		if err == nil {
 			t.Fatalf("check should return an error and didn't")
 		}
+	})
+}
+
+func TestPrivateDownloadServiceFile(t *testing.T) {
+	var (
+		componentType   types.ComponentType
+		targetVersion   semver.Version
+		serviceFilePath string
+	)
+	var check = func(serviceFilePath string) error {
+		_, err := os.Stat(serviceFilePath)
+		if err != nil {
+			return err
+		}
+		files, _ := ioutil.ReadDir(path.Dir(serviceFilePath))
+		if len(files) > 1 {
+			return fmt.Errorf("download redundancy files")
+		}
+		return err
+	}
+	var clean = func(testTmpDir string) {
+		dir, err := ioutil.ReadDir(testTmpDir)
+		if err != nil {
+			t.Fatalf("failed to clean test tmp dir!\n")
+		}
+		for _, d := range dir {
+			if err = os.RemoveAll(path.Join(testTmpDir, d.Name())); err != nil {
+				t.Fatalf("failed to clean test tmp dir!\n")
+			}
+		}
+	}
+
+	testTmpDir, err := ioutil.TempDir("", "kubeedge")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for testing:{%s}\n", err.Error())
+	}
+
+	componentType = types.CloudCore
+	targetVersion = semver.Version{Major: 1, Minor: 0}
+	serviceFilePath = testTmpDir + "/" + CloudServiceFile
+	t.Run("test with downloading cloudcore service file if version < 1.1.0", func(t *testing.T) {
+		err := downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("download should not return an error:{%s}\n", err.Error())
+		}
+		if err = check(serviceFilePath); !os.IsNotExist(err) {
+			if err == nil {
+				err = errors.New("nil")
+			}
+			t.Fatalf("check should return error{%s} but not,error:{%s}\n", os.ErrNotExist, err.Error())
+		}
+		clean(testTmpDir)
+	})
+
+	componentType = types.CloudCore
+	targetVersion = semver.Version{Major: 1, Minor: 1}
+	serviceFilePath = testTmpDir + "/" + CloudServiceFile
+	t.Run("test with downloading cloudcore service file if version = 1.1.0", func(t *testing.T) {
+		err := downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("download should not return an error:{%s}\n", err.Error())
+		}
+		if err = check(serviceFilePath); !os.IsNotExist(err) {
+			if err == nil {
+				err = errors.New("nil")
+			}
+			t.Fatalf("check should return error{%s} but not,error:{%s}\n", os.ErrNotExist, err.Error())
+		}
+		clean(testTmpDir)
+	})
+
+	componentType = types.CloudCore
+	targetVersion, _ = semver.Make(types.LatestKubeEdgeVersion)
+	serviceFilePath = testTmpDir + "/" + CloudServiceFile
+	t.Run("test with reDownloading cloudcore service file if version = latest", func(t *testing.T) {
+		err := downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("download should not return an error:{%s}\n", err.Error())
+		}
+		err = downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("second download should not return an error:{%s}\n", err.Error())
+		}
+		if err = check(serviceFilePath); err != nil {
+			t.Fatalf("check should not return an error{%s}\n", err.Error())
+		}
+		clean(testTmpDir)
+	})
+
+	componentType = types.EdgeCore
+	targetVersion = semver.Version{Major: 1, Minor: 0}
+	serviceFilePath = testTmpDir + "/" + EdgeServiceFile
+	t.Run("test with downloading edgecore service file if version < 1.1.0", func(t *testing.T) {
+		err := downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("download should not return an error:{%s}\n", err.Error())
+		}
+		if err = check(serviceFilePath); !os.IsNotExist(err) {
+			if err == nil {
+				err = errors.New("nil")
+			}
+			t.Fatalf("check should return error{%s} but not,error:{%s}\n", os.ErrNotExist, err.Error())
+		}
+		clean(testTmpDir)
+	})
+
+	componentType = types.EdgeCore
+	targetVersion = semver.Version{Major: 1, Minor: 1}
+	serviceFilePath = testTmpDir + "/" + OldEdgeServiceFile
+	t.Run("test with downloading edgecore service file if version = 1.1.0", func(t *testing.T) {
+		err := downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("download should not return an error:{%s}\n", err.Error())
+		}
+		if err = check(serviceFilePath); err != nil {
+			t.Fatalf("check should not return an error{%s}\n", err.Error())
+		}
+		clean(testTmpDir)
+	})
+
+	componentType = types.EdgeCore
+	targetVersion, _ = semver.Make(types.LatestKubeEdgeVersion)
+	serviceFilePath = testTmpDir + "/" + EdgeServiceFile
+	t.Run("test with reDownloading edgecore service file if version = latest", func(t *testing.T) {
+		err := downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("download should not return an error:{%s}\n", err.Error())
+		}
+		err = downloadServiceFile(componentType, targetVersion, testTmpDir)
+		if err != nil {
+			t.Fatalf("second download should not return an error:{%s}\n", err.Error())
+		}
+		if err = check(serviceFilePath); err != nil {
+			t.Fatalf("check should not return an error{%s}\n", err.Error())
+		}
+		clean(testTmpDir)
 	})
 }

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -151,7 +151,7 @@ func TestPrivateDownloadServiceFile(t *testing.T) {
 	})
 
 	componentType = types.CloudCore
-	targetVersion, _ = semver.Make(types.LatestKubeEdgeVersion)
+	targetVersion, _ = semver.Make(types.DefaultKubeEdgeVersion)
 	serviceFilePath = testTmpDir + "/" + CloudServiceFile
 	t.Run("test with reDownloading cloudcore service file if version = latest", func(t *testing.T) {
 		err := downloadServiceFile(componentType, targetVersion, testTmpDir)
@@ -200,7 +200,7 @@ func TestPrivateDownloadServiceFile(t *testing.T) {
 	})
 
 	componentType = types.EdgeCore
-	targetVersion, _ = semver.Make(types.LatestKubeEdgeVersion)
+	targetVersion, _ = semver.Make(types.DefaultKubeEdgeVersion)
 	serviceFilePath = testTmpDir + "/" + EdgeServiceFile
 	t.Run("test with reDownloading edgecore service file if version = latest", func(t *testing.T) {
 		err := downloadServiceFile(componentType, targetVersion, testTmpDir)


### PR DESCRIPTION
Cherry pick of #2170 on release-1.5.

#2170: fix re-dowload bug when use keadm

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.