### PR TITLE
Change `/isCloudcoreReady` to `/readyz`

### DIFF
--- a/docs/proposals/cloudcore-ha-design.md
+++ b/docs/proposals/cloudcore-ha-design.md
@@ -157,6 +157,6 @@ func (l *ReadyzAdaptor) Check(req *http.Request) error {
 	return l.le.Check(l.timeout)
 }
 ```
-At present, it is tentatively decided that this handle path is `/isCloudcoreReady`.And register the handle to cloudhub https server.
+At present, it is tentatively decided that this handle path is `/readyz`.And register the handle to cloudhub https server.
 
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Change the handle Path from `/isCloudcoreReady` to `/readyz`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
