### PR TITLE
support devices, mounts and env fields for extented resources requeired by container

### DIFF
--- a/edge/pkg/edged/edged_pods.go
+++ b/edge/pkg/edged/edged_pods.go
@@ -568,7 +568,10 @@ func (e *edged) GenerateRunContainerOptions(pod *v1.Pod, container *v1.Container
 	if err != nil {
 		return nil, nil, err
 	}*/
-	opts := kubecontainer.RunContainerOptions{}
+	opts, err := e.containerManager.GetResources(pod, container)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	hostname, hostDomainName, err := e.GeneratePodHostNameAndDomain(pod)
 	if err != nil {
@@ -612,7 +615,7 @@ func (e *edged) GenerateRunContainerOptions(pod *v1.Pod, container *v1.Container
 		}
 	}
 
-	return &opts, nil, nil
+	return opts, nil, nil
 }
 
 // GetPodDNS returns DNS settings for the pod.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
support devices, mounts and env fields for extented resources requeired by container。just sync kubernetes code to kubeedge。
[kubernetes code url](https://github.com/kubernetes/kubernetes/blob/release-1.19/pkg/kubelet/kubelet_pods.go#L452)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
