### PR TITLE
reorganize edge module name into one file

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -11,9 +11,6 @@ const (
 	// SyncController
 	DefaultContextSendModuleName = "cloudhub"
 
-	// DeviceTwin
-	DeviceTwinModuleName = "twin"
-
 	// NodeName is for the clearer log of cloudcore.
 	NodeName = "NodeName"
 

--- a/edge/pkg/common/modules/group.go
+++ b/edge/pkg/common/modules/group.go
@@ -15,4 +15,6 @@ const (
 	UserGroup = "user"
 	// MeshGroup group
 	MeshGroup = "mesh"
+	// StreamGroup group
+	StreamGroup = "edgestream"
 )

--- a/edge/pkg/common/modules/names.go
+++ b/edge/pkg/common/modules/names.go
@@ -3,7 +3,14 @@ package modules
 const (
 	// EdgedModuleName name
 	EdgedModuleName = "edged"
-
 	// EdgeMeshModuleName name
 	EdgeMeshModuleName = "edgemesh"
+	// EventBusModuleName name
+	EventBusModuleName = "eventbus"
+	// ServiceBusModuleName name
+	ServiceBusModuleName = "servicebus"
+	// EdgeStreamModuleName name
+	EdgeStreamModuleName = "edgestream"
+	// DeviceTwinModuleName name
+	DeviceTwinModuleName = "twin"
 )

--- a/edge/pkg/devicetwin/devicetwin.go
+++ b/edge/pkg/devicetwin/devicetwin.go
@@ -4,7 +4,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/kubeedge/beehive/pkg/core"
-	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	deviceconfig "github.com/kubeedge/kubeedge/edge/pkg/devicetwin/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtclient"
@@ -39,7 +38,7 @@ func Register(deviceTwin *v1alpha1.DeviceTwin, nodeName string) {
 
 // Name get name of the module
 func (dt *DeviceTwin) Name() string {
-	return constants.DeviceTwinModuleName
+	return modules.DeviceTwinModuleName
 }
 
 // Group get group of the module

--- a/edge/pkg/edgestream/edgestream.go
+++ b/edge/pkg/edgestream/edgestream.go
@@ -27,16 +27,11 @@ import (
 
 	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgestream/config"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 	"github.com/kubeedge/kubeedge/pkg/stream"
-)
-
-//define edgestream module name
-const (
-	ModuleNameEdgeStream = "edgestream"
-	GroupNameEdgeStream  = "edgestream"
 )
 
 type edgestream struct {
@@ -60,11 +55,11 @@ func Register(s *v1alpha1.EdgeStream, hostnameOverride, nodeIP string) {
 }
 
 func (e *edgestream) Name() string {
-	return ModuleNameEdgeStream
+	return modules.EdgeStreamModuleName
 }
 
 func (e *edgestream) Group() string {
-	return GroupNameEdgeStream
+	return modules.StreamGroup
 }
 
 func (e *edgestream) Enable() bool {

--- a/edge/pkg/eventbus/eventbus.go
+++ b/edge/pkg/eventbus/eventbus.go
@@ -36,7 +36,7 @@ func Register(eventbus *v1alpha1.EventBus, nodeName string) {
 }
 
 func (*eventbus) Name() string {
-	return "eventbus"
+	return modules.EventBusModuleName
 }
 
 func (*eventbus) Group() string {

--- a/edge/pkg/servicebus/servicebus.go
+++ b/edge/pkg/servicebus/servicebus.go
@@ -40,7 +40,7 @@ func Register(s *v1alpha1.ServiceBus) {
 }
 
 func (*servicebus) Name() string {
-	return "servicebus"
+	return modules.ServiceBusModuleName
 }
 
 func (*servicebus) Group() string {


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Reorganize the constatnts which is some edge module name into one file in the path of edge/pkg/common/modules/names.go. Could makes the project code has stronger maintainability and more readable.

Does this PR introduce a user-facing change?:
NONE
