### PR TITLE
metamanager remote query timeout configurable

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -74,6 +74,7 @@ const (
 
 	// MetaManager
 	DefaultPodStatusSyncInterval = 60
+	DefaultRemoteQueryTimeout    = 60
 
 	// Config
 	DefaultKubeContentType         = "application/vnd.kubernetes.protobuf"

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -455,7 +455,7 @@ func (m *metaManager) processRemoteQuery(message model.Message) {
 		resp, err := beehiveContext.SendSync(
 			string(metaManagerConfig.Config.ContextSendModule),
 			message,
-			60*time.Second) // TODO: configurable
+			time.Duration(metaManagerConfig.Config.RemoteQueryTimeout)*time.Second)
 		klog.Infof("########## process get: req[%+v], resp[%+v], err[%+v]", message, resp, err)
 		if err != nil {
 			klog.Errorf("remote query failed: %v", err)

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -131,6 +131,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				ContextSendGroup:      metaconfig.GroupNameHub,
 				ContextSendModule:     metaconfig.ModuleNameEdgeHub,
 				PodStatusSyncInterval: constants.DefaultPodStatusSyncInterval,
+				RemoteQueryTimeout:    constants.DefaultRemoteQueryTimeout,
 			},
 			ServiceBus: &ServiceBus{
 				Enable: false,

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -378,6 +378,9 @@ type MetaManager struct {
 	// PodStatusSyncInterval indicates pod status sync
 	// default 60
 	PodStatusSyncInterval int32 `json:"podStatusSyncInterval,omitempty"`
+	// RemoteQueryTimeout indicates remote query timeout (second)
+	// default 60
+	RemoteQueryTimeout int32 `json:"remoteQueryTimeout,omitempty"`
 }
 
 // ServiceBus indicates the ServiceBus module config

--- a/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
@@ -125,6 +125,7 @@ func NewDefaultEdgeSiteConfig() *EdgeSiteConfig {
 				ContextSendGroup:      metaconfig.GroupNameEdgeController,
 				ContextSendModule:     metaconfig.ModuleNameEdgeController,
 				PodStatusSyncInterval: constants.DefaultPodStatusSyncInterval,
+				RemoteQueryTimeout:    constants.DefaultRemoteQueryTimeout,
 			},
 		},
 	}


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Make remote query param timeout in metamanager configrable, then the modification will become easier.

Does this PR introduce a user-facing change?:
NONE
