### PR TITLE
Quic client capture error information

### DIFF
--- a/edge/pkg/edgehub/clients/quicclient/quicclient.go
+++ b/edge/pkg/edgehub/clients/quicclient/quicclient.go
@@ -96,8 +96,8 @@ func (qcc *QuicClient) Send(message model.Message) error {
 //Receive reads the binary message through the connection
 func (qcc *QuicClient) Receive() (model.Message, error) {
 	message := model.Message{}
-	qcc.client.ReadMessage(&message)
-	return message, nil
+	err := qcc.client.ReadMessage(&message)
+	return message, err
 }
 
 //Notify logs info


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Quic client in EdgeHub module add capture error information, which may be printed out by caller.

Does this PR introduce a user-facing change?:
NONE
