### PR TITLE
fix the wrong TestStart in metamanager_test.go

### DIFF
--- a/edge/pkg/metamanager/metamanager_test.go
+++ b/edge/pkg/metamanager/metamanager_test.go
@@ -59,6 +59,7 @@ func TestNameAndGroup(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
+	core.Register(&metaManager{enable: true})
 	modules := core.GetModules()
 	for name, module := range modules {
 		if name == MetaManagerModuleName {
@@ -66,7 +67,7 @@ func TestStart(t *testing.T) {
 			break
 		}
 	}
-	core.Register(&metaManager{enable: true})
+
 	if metaModule == nil {
 		t.Errorf("failed to register to beehive")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
Func TestStart in metamanager_test.go  runs failed due to error: invalid memory address or nil pointer dereference.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
