### PR TITLE
cloudcore: support custom namespace

### DIFF
--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -22,6 +22,11 @@ spec:
       - name: cloudcore
         image: kubeedge/cloudcore:v1.3.1
         imagePullPolicy: IfNotPresent
+        env:
+          - name: CLOUDCORE_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         ports:
         - containerPort: 10000
           name: cloudhub
@@ -55,4 +60,3 @@ spec:
         hostPath:
           path: /var/lib/kubeedge
           type: DirectoryOrCreate
-

--- a/cloud/pkg/cloudhub/servers/httpserver/secretsutil.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/secretsutil.go
@@ -3,6 +3,7 @@ package httpserver
 import (
 	"context"
 	"fmt"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -10,11 +11,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/utils"
+	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 const (
-	NamespaceSystem string = "kubeedge"
-
 	TokenSecretName      string = "tokensecret"
 	TokenDataName        string = "tokendata"
 	CaSecretName         string = "casecret"
@@ -24,6 +24,23 @@ const (
 	CloudCoreCertName    string = "cloudcoredata"
 	CloudCoreKeyDataName string = "cloudcorekeydata"
 )
+
+var NamespaceSystem string = constants.KubeEdgeNameSpace
+
+// set namesapce from env CLOUDCORE_POD_NAMESPACE
+func init() {
+	NamespaceSystem = setKubeedgeNamespce(os.Getenv("CLOUDCORE_POD_NAMESPACE"))
+}
+
+func setKubeedgeNamespce(kubeedgeNamespace string) string {
+	if kubeedgeNamespace != "" {
+		NamespaceSystem = kubeedgeNamespace
+	} else {
+		kubeedgeNamespace = constants.KubeEdgeNameSpace
+	}
+
+	return kubeedgeNamespace
+}
 
 func GetSecret(secretName string, ns string) (*corev1.Secret, error) {
 	cli, err := utils.KubeClient()

--- a/cloud/pkg/cloudhub/servers/httpserver/secretsutil_test.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/secretsutil_test.go
@@ -1,0 +1,29 @@
+package httpserver
+
+import "testing"
+
+func TestSetNamespace(t *testing.T) {
+	tests := []struct {
+		name              string
+		kubeedgeNamespace string
+		want              string
+	}{
+		{
+			name:              "null",
+			kubeedgeNamespace: "",
+			want:              "kubeedge",
+		},
+		{
+			name:              "edge-system",
+			kubeedgeNamespace: "edge-system",
+			want:              "edge-system",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := setKubeedgeNamespce(tt.kubeedgeNamespace); got != tt.want {
+				t.Errorf("setKubeedgeNamespce() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/cloudcore/cloudcore_suite_test.go
+++ b/tests/e2e/cloudcore/cloudcore_suite_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcore
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubeedge/kubeedge/tests/e2e/utils"
+)
+
+var (
+	nodeName string
+
+	//context to load config and access across the package
+	ctx *utils.TestContext
+)
+
+// Function to run the Ginkgo Test
+func TestCloudcoreAppDeployment(t *testing.T) {
+	RegisterFailHandler(Fail)
+	var _ = BeforeSuite(func() {
+		utils.Infof("Before Suite Execution")
+		ctx = utils.NewTestContext(utils.LoadConfig())
+		nodeName = "edge-node"
+	})
+	AfterSuite(func() {
+		By("After Suite Execution....!")
+	})
+
+	RunSpecs(t, "kubeedge App Deploymet Suite")
+}

--- a/tests/e2e/cloudcore/cloudcore_test.go
+++ b/tests/e2e/cloudcore/cloudcore_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcore
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubeedge/kubeedge/tests/e2e/constants"
+	"github.com/kubeedge/kubeedge/tests/e2e/utils"
+)
+
+var SecretTestTestTimerGroup *utils.TestTimerGroup = utils.NewTestTimerGroup()
+
+//Run Test cases
+var _ = Describe("Secret test in cloudcore E2E", func() {
+	var testTimer *utils.TestTimer
+	var testDescription GinkgoTestDescription
+	Context("Test that the secret", func() {
+		BeforeEach(func() {
+			// Get current test description
+			testDescription = CurrentGinkgoTestDescription()
+			// Start test timer
+			testTimer = SecretTestTestTimerGroup.NewTestTimer(testDescription.TestText)
+		})
+
+		AfterEach(func() {
+			// End test timer
+			testTimer.End()
+			// Print result
+			testTimer.PrintResult()
+		})
+
+		It("E2E_SECRET_VERIFICATION: Verify that the secret exists", func() {
+			secrets, err := utils.GetSecrets(ctx.Cfg.K8SMasterForKubeEdge+constants.SecrettHandler, "")
+			fmt.Print(secrets.Items)
+			Expect(err).NotTo(BeNil())
+			Expect(len(secrets.Items) > 1).NotTo(BeTrue())
+
+			hasCaSecret := false
+			hasCloudcoreSecret := false
+			hasTokensecret := false
+
+			for _, secret := range secrets.Items {
+				if secret.Name == "casecret" {
+					hasCaSecret = true
+				} else if secret.Name == "cloudcoresecret" {
+					hasCloudcoreSecret = true
+				} else if secret.Name == "tokensecret" {
+					hasTokensecret = true
+				}
+
+			}
+			Expect(hasCaSecret).To(BeTrue())
+			Expect(hasCloudcoreSecret).To(BeTrue())
+			Expect(hasTokensecret).To(BeTrue())
+		})
+	})
+})

--- a/tests/e2e/constants/constants.go
+++ b/tests/e2e/constants/constants.go
@@ -21,7 +21,9 @@ const (
 	CatEdgecoreLog  = "cd ${GOPATH}/src/github.com/kubeedge/kubeedge/_output/local/bin/; cat edgecore.log"
 	CatEdgeSiteLog  = "cd ${GOPATH}/src/github.com/kubeedge/kubeedge/_output/local/bin/; cat  edgesite.log"
 
-	AppHandler        = "/api/v1/namespaces/default/pods"
-	NodeHandler       = "/api/v1/nodes"
-	DeploymentHandler = "/apis/apps/v1/namespaces/default/deployments"
+	AppHandler              = "/api/v1/namespaces/default/pods"
+	NodeHandler             = "/api/v1/nodes"
+	DeploymentHandler       = "/apis/apps/v1/namespaces/default/deployments"
+	SecrettHandlerDefauleNS = "/api/v1/namespaces/default/secret"
+	SecrettHandler          = "/api/v1/namespaces/kubeedge/secret"
 )

--- a/tests/e2e/scripts/fast_test.sh
+++ b/tests/e2e/scripts/fast_test.sh
@@ -47,6 +47,7 @@ if [ $# -eq 0 ]
   then
     #run testcase
     ./deployment/deployment.test $debugflag 2>&1 | tee -a /tmp/testcase.log
+    ./cloud/cloud.test $debugflag 2>&1 | tee -a /tmp/testcase.log
     # @kadisi
     #./edgesite/edgesite.test $debugflag 2>&1 | tee -a /tmp/testcase.log
 else

--- a/tests/e2e/utils/secret.go
+++ b/tests/e2e/utils/secret.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func GetSecrets(apiserver, label string) (v1.SecretList, error) {
+	var secrets v1.SecretList
+	var resp *http.Response
+	var err error
+
+	if len(label) > 0 {
+		resp, err = SendHTTPRequest(http.MethodGet, apiserver+podLabelSelector+label)
+	} else {
+		resp, err = SendHTTPRequest(http.MethodGet, apiserver)
+	}
+	if err != nil {
+		Fatalf("Frame HTTP request failed: %v", err)
+		return secrets, nil
+	}
+	defer resp.Body.Close()
+	contents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		Fatalf("HTTP Response reading has failed: %v", err)
+		return secrets, nil
+	}
+	err = json.Unmarshal(contents, &secrets)
+	if err != nil {
+		Fatalf("Unmarshal HTTP Response has failed: %v", err)
+		return secrets, nil
+	}
+	return secrets, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #2367

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

**release-note**
It can generate secret in the namespace where the corresponding cloudcore pod is deployed, not only under kubeedge namesapce.
Determined by the environment variable KUBEEDGE_NAMESPACE

cloucore uses the following configuration.
```
...
  namespace: kubeedge1
...
  env:
  - name: CLOUDCORE_POD_NAMESPACE
    valueFrom:
      fieldRef:
        fieldPath: metadata.namespace
```
The relevant secret key will be automatically generated under the namespace  `kubeedge1`
```
[root@k8s build]# kubectl get secret -n kubeedge1
NAME                  TYPE                                  DATA   AGE
casecret              Opaque                                2      2m8s
cloudcoresecret       Opaque                                2      2m8s
default-token-752b9   kubernetes.io/service-account-token   3      2m8s
tokensecret           Opaque                                1      2m8s
```
