### PR TITLE
fixed bug: edgesite pods do not start

### DIFF
--- a/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
@@ -112,6 +112,7 @@ func NewDefaultEdgeSiteConfig() *EdgeSiteConfig {
 				RuntimeRequestTimeout:       constants.DefaultRuntimeRequestTimeout,
 				HostnameOverride:            hostnameOverride,
 				RegisterNode:                true,
+				ConcurrentConsumers:         constants.DefaultConcurrentConsumers,
 				RegisterNodeNamespace:       constants.DefaultRegisterNodeNamespace,
 				DevicePluginEnabled:         false,
 				GPUPluginEnabled:            false,


### PR DESCRIPTION
EdgeSite configuration file didn't have concurrentConsumers parameter.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Fixed Edgesite pods deployment bug.
**Which issue(s) this PR fixes**:
Fixes [#2370](https://github.com/kubeedge/kubeedge/issues/2370)


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
