### PR TITLE
Get EdgeNode ip before registerModules to fix stream module problem

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/beehive/pkg/core"
+	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/dbm"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin"
@@ -77,6 +78,16 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 				if err := environmentCheck(); err != nil {
 					klog.Fatal(fmt.Errorf("Failed to check the running environment: %v", err))
 				}
+			}
+
+			// get edge node local ip
+			if config.Modules.Edged.NodeIP == "" {
+				hostnameOverride, err := os.Hostname()
+				if err != nil {
+					hostnameOverride = constants.DefaultHostnameOverride
+				}
+				localIP, _ := util.GetLocalIP(hostnameOverride)
+				config.Modules.Edged.NodeIP = localIP
 			}
 
 			registerModules(config)

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -89,12 +89,8 @@ func (e *edged) initialNode() (*v1.Node, error) {
 		"node-role.kubernetes.io/agent": "",
 	}
 
-	ip, err := e.getIP()
-	if err != nil {
-		return nil, err
-	}
 	node.Status.Addresses = []v1.NodeAddress{
-		{Type: v1.NodeInternalIP, Address: ip},
+		{Type: v1.NodeInternalIP, Address: e.nodeIP.String()},
 		{Type: v1.NodeHostName, Address: hostname},
 	}
 
@@ -316,17 +312,6 @@ func (e *edged) setGPUInfo(nodeStatus *edgeapi.NodeStatusRequest) error {
 
 	nodeStatus.ExtendResources[apis.NvidiaGPUResource] = gpuResources
 	return nil
-}
-
-func (e *edged) getIP() (string, error) {
-	if nodeIP := config.Config.NodeIP; nodeIP != "" {
-		return nodeIP, nil
-	}
-	hostName, _ := os.Hostname()
-	if hostName == "" {
-		hostName = e.nodeName
-	}
-	return util.GetLocalIP(hostName)
 }
 
 func (e *edged) setMemInfo(total, allocated v1.ResourceList) error {


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
Premise: we set edged.nodeIP="" in edgecore.yaml.

After that when edgestream register to cloudstream, the SessionInternalIP of connection header  is null, so cloudstream will set Request.RemoteAddr as interalIP. Refer to https://github.com/kubeedge/kubeedge/pull/2020.

But, the Request.RemoteAddr is public network ip, it is different with internalIP most of time. So the problem will happen when use stream module.

Does this PR introduce a user-facing change?:
NONE