### PR TITLE
add _tmp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ edge/edgecore
 edgesite/edgesite
 keadm/keadm
 _output
+_tmp


### PR DESCRIPTION
it's created by hack/verify-vendor-licenses.sh. Though we can update hack/verify-vendor-licenses.sh
to clean up this directory at exiting, we prefer to keep it being same with
https://github.com/kubernetes/kubernetes/blob/master/hack/verify-vendor-licenses.sh#L32

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
