### PR TITLE
fix synccontroller manage same name object error

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -7,6 +7,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
@@ -23,6 +24,15 @@ func (sctl *SyncController) managePod(sync *v1alpha1.ObjectSync) {
 	pod, err := sctl.podLister.Pods(sync.Namespace).Get(sync.Spec.ObjectName)
 
 	nodeName := getNodeName(sync.Name)
+	if pod != nil {
+		syncObjUID := getObjectUID(sync.Name)
+		if syncObjUID != string(pod.GetUID()) {
+			err = apierrors.NewNotFound(schema.GroupResource{
+				Group:    "",
+				Resource: "pods",
+			}, sync.Spec.ObjectName)
+		}
+	}
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -45,6 +55,15 @@ func (sctl *SyncController) manageConfigMap(sync *v1alpha1.ObjectSync) {
 	configmap, err := sctl.configMapLister.ConfigMaps(sync.Namespace).Get(sync.Spec.ObjectName)
 
 	nodeName := getNodeName(sync.Name)
+	if configmap != nil {
+		syncObjUID := getObjectUID(sync.Name)
+		if syncObjUID != string(configmap.GetUID()) {
+			err = apierrors.NewNotFound(schema.GroupResource{
+				Group:    "",
+				Resource: "configmaps",
+			}, sync.Spec.ObjectName)
+		}
+	}
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -68,6 +87,16 @@ func (sctl *SyncController) manageSecret(sync *v1alpha1.ObjectSync) {
 
 	nodeName := getNodeName(sync.Name)
 
+	if secret != nil {
+		syncObjUID := getObjectUID(sync.Name)
+		if syncObjUID != string(secret.GetUID()) {
+			err = apierrors.NewNotFound(schema.GroupResource{
+				Group:    "",
+				Resource: "secrets",
+			}, sync.Spec.ObjectName)
+		}
+	}
+
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			secret = &v1.Secret{
@@ -89,6 +118,15 @@ func (sctl *SyncController) manageService(sync *v1alpha1.ObjectSync) {
 	service, err := sctl.serviceLister.Services(sync.Namespace).Get(sync.Spec.ObjectName)
 
 	nodeName := getNodeName(sync.Name)
+	if service != nil {
+		syncObjUID := getObjectUID(sync.Name)
+		if syncObjUID != string(service.GetUID()) {
+			err = apierrors.NewNotFound(schema.GroupResource{
+				Group:    "",
+				Resource: "services",
+			}, sync.Spec.ObjectName)
+		}
+	}
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -111,6 +149,16 @@ func (sctl *SyncController) manageEndpoint(sync *v1alpha1.ObjectSync) {
 	endpoint, err := sctl.endpointLister.Endpoints(sync.Namespace).Get(sync.Spec.ObjectName)
 
 	nodeName := getNodeName(sync.Name)
+	
+	if endpoint != nil {
+		syncObjUID := getObjectUID(sync.Name)
+		if syncObjUID != string(endpoint.GetUID()) {
+			err = apierrors.NewNotFound(schema.GroupResource{
+				Group:    "",
+				Resource: "endpoints",
+			}, sync.Spec.ObjectName)
+		}
+	}
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
 Use stateful set to manage pod. new pod  will use the same name but the pod uid is different when the old pod is deleted. when synccontroller to managepod ,we need to distinguish them by uid。Otherwise we may find the pod with the same name will run in two different node, and three different objectsync but the spec.objectName is same.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
