### PR TITLE
Allow container logs to grow bigger than 1 byte before rotation

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -579,7 +579,7 @@ func newEdged(enable bool) (*edged, error) {
 		ed.machineInfo = &machineInfo
 	}
 	// create a log manager
-	logManager, err := logs.NewContainerLogManager(runtimeService, ed.os, "1", 2)
+	logManager, err := logs.NewContainerLogManager(runtimeService, ed.os, "10Mi", 5)
 	if err != nil {
 		return nil, fmt.Errorf("New container log manager failed, err: %s", err.Error())
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the ContainerLogManager will practically rotate logs after each line, which will partly make the use of 'kubectl logs' introduced in v1.3 more or less useless. Only the log follow (-f) function kind of works, but is not reliable within the current setup.

This commit will setup the ContainerLogManager with the [k8s kubelet defaults](https://github.com/kubernetes/kubernetes/blob/release-1.19/pkg/kubelet/apis/config/v1beta1/defaults.go#L222) of LogMaxSize 10 MiB and LogMaxFiles 5.

**Special notes for your reviewer**:
The ContainerLogManager was introduced to pre 1.5.0 [here](https://github.com/kubeedge/kubeedge/commit/840054958e2fcc8a12635254d1e4903ba3752563) and is maybe just a snipped copy of [here](https://github.com/kubernetes/kubernetes/blob/release-1.19/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go#L77)?

**Does this PR introduce a user-facing change?**:
Each running pod is now able to fill up storage space - as long as it is running - with its log output. Maybe in the future it might be a good idea to make this configurable like in the k8s kubelet ("--container-log-max-size") introduced [here](https://github.com/kubernetes/kubernetes/commit/b38f1b901fc82488e4ac96fd2e70a4e0527f2416).