### PR TITLE
fix the invalid memory address panic of common_test in eventbus

### DIFF
--- a/edge/pkg/eventbus/common/util/common_test.go
+++ b/edge/pkg/eventbus/common/util/common_test.go
@@ -34,6 +34,12 @@ import (
 
 var clientOptions = MQTT.NewClientOptions()
 
+func init() {
+	nodeName := "testEdge"
+	cfg := v1alpha1.NewDefaultEdgeCoreConfig()
+	eventconfig.InitConfigure(cfg.Modules.EventBus, nodeName)
+}
+
 //TestCheckKeyExist checks the functionality of CheckKeyExist function
 func TestCheckKeyExist(t *testing.T) {
 	tests := []struct {
@@ -65,9 +71,6 @@ func TestCheckKeyExist(t *testing.T) {
 
 //TestCheckClientToken checks client token received
 func TestCheckClientToken(t *testing.T) {
-	nodeName := "testEdge"
-	cfg := v1alpha1.NewDefaultEdgeCoreConfig()
-	eventconfig.InitConfigure(cfg.Modules.EventBus, nodeName)
 	tests := []struct {
 		name          string
 		token         MQTT.Token


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
The func TestHubClientInit and TestLoopConnect under "kubeedge/edge/pkg/eventbus/common/util/common_test.go" build failed because of "invalid memory address or nil pointer dereference", so I add the init().
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
