### PR TITLE
cloudcore: Use LocalIP as advertise address in New config like edgecore

### DIFF
--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -17,20 +17,25 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"os"
 	"path"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
 	componentbaseconfig "k8s.io/component-base/config"
 
 	"github.com/kubeedge/kubeedge/common/constants"
 	metaconfig "github.com/kubeedge/kubeedge/pkg/apis/componentconfig/meta/v1alpha1"
+	"github.com/kubeedge/kubeedge/pkg/util"
 )
 
 // NewDefaultCloudCoreConfig returns a full CloudCoreConfig object
 func NewDefaultCloudCoreConfig() *CloudCoreConfig {
-	advertiseAddress, _ := utilnet.ChooseHostInterface()
+	hostnameOverride, err := os.Hostname()
+	if err != nil {
+		hostnameOverride = constants.DefaultHostnameOverride
+	}
+	advertiseAddress, _ := util.GetLocalIP(hostnameOverride)
 
 	c := &CloudCoreConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -54,7 +59,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				TLSCertFile:             constants.DefaultCertFile,
 				TLSPrivateKeyFile:       constants.DefaultKeyFile,
 				WriteTimeout:            30,
-				AdvertiseAddress:        []string{advertiseAddress.String()},
+				AdvertiseAddress:        []string{advertiseAddress},
 				DNSNames:                []string{""},
 				EdgeCertSigningDuration: 365,
 				Quic: &CloudHubQUIC{
@@ -166,7 +171,11 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 
 // NewMinCloudCoreConfig returns a min CloudCoreConfig object
 func NewMinCloudCoreConfig() *CloudCoreConfig {
-	advertiseAddress, _ := utilnet.ChooseHostInterface()
+	hostnameOverride, err := os.Hostname()
+	if err != nil {
+		hostnameOverride = constants.DefaultHostnameOverride
+	}
+	advertiseAddress, _ := util.GetLocalIP(hostnameOverride)
 
 	return &CloudCoreConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -184,7 +193,7 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 				TLSCAKeyFile:      constants.DefaultCAKeyFile,
 				TLSCertFile:       constants.DefaultCertFile,
 				TLSPrivateKeyFile: constants.DefaultKeyFile,
-				AdvertiseAddress:  []string{advertiseAddress.String()},
+				AdvertiseAddress:  []string{advertiseAddress},
 				UnixSocket: &CloudHubUnixSocket{
 					Enable:  true,
 					Address: "unix:///var/lib/kubeedge/kubeedge.sock",


### PR DESCRIPTION
both cloudcore and edgecore provide --minconfig to print their default
config. However they call different methods to get the pair ip addresss
before which are possible different. In this case `./hack/local-up-kubeedge.sh`
will fail with below errors:
F1207 09:55:14.851562 1549579 certmanager.go:91] Error: failed to get edge certificate from the cloudcore, error: Get "https://a.b.c.d:10002/edge.crt": x509: certificate is valid for u.x.y.z, not a.b.c.d

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
