### PR TITLE
Fix edgehub synckeeper use unbuffer channel error

### DIFF
--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -41,7 +41,7 @@ func (eh *EdgeHub) addKeepChannel(msgID string) chan model.Message {
 	eh.keeperLock.Lock()
 	defer eh.keeperLock.Unlock()
 
-	tempChannel := make(chan model.Message)
+	tempChannel := make(chan model.Message, 1)
 	eh.syncKeeper[msgID] = tempChannel
 
 	return tempChannel

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -145,22 +145,14 @@ func TestSendToKeepChannel(t *testing.T) {
 			expectedError:       fmt.Errorf("failed to get sync keeper channel, messageID:%+v", *message),
 		},
 		{
-			name: "Negative Test Case without syncKeeper Error ",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
-			message:             model.NewMessage("test_id"),
-			keepChannelParentID: "test_id",
-			expectedError:       fmt.Errorf("failed to send message to sync keep channel"),
-		},
-		{
 			name: "Send to keep channel with valid input",
 			hub: &EdgeHub{
 				syncKeeper: make(map[string]chan model.Message),
 			},
 			message:             model.NewMessage("test_id"),
 			keepChannelParentID: "test_id",
-			expectedError:       nil},
+			expectedError:       nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug


<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
EdgeHub Use buffer channel to avoid some error.
![EdgeCore log](https://user-images.githubusercontent.com/37207968/101482827-3a3cbe80-3992-11eb-8bbd-7d252ec8031a.png)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2411

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
