### PR TITLE
keadm: support init kubeedge with package manager `pacman`

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -64,16 +64,21 @@ const (
 	latestReleaseVersionURL = "https://kubeedge.io/latestversion"
 	RetryTimes              = 5
 
-	APT string = "apt"
-	YUM string = "yum"
+	OSArchAMD64 string = "amd64"
+	OSArchARM64 string = "arm64"
+	OSArchARM32 string = "arm"
+
+	APT    string = "apt"
+	YUM    string = "yum"
+	PACMAN string = "pacman"
 )
 
-//AddToolVals gets the value and default values of each flags and collects them in temporary cache
+// AddToolVals gets the value and default values of each flags and collects them in temporary cache
 func AddToolVals(f *pflag.Flag, flagData map[string]types.FlagData) {
 	flagData[f.Name] = types.FlagData{Val: f.Value.String(), DefVal: f.DefValue}
 }
 
-//CheckIfAvailable checks is val of a flag is empty then return the default value
+// CheckIfAvailable checks is val of a flag is empty then return the default value
 func CheckIfAvailable(val, defval string) string {
 	if val == "" {
 		return defval
@@ -81,7 +86,7 @@ func CheckIfAvailable(val, defval string) string {
 	return val
 }
 
-//Common struct contains OS and Tool version properties and also embeds OS interface
+// Common struct contains OS and Tool version properties and also embeds OS interface
 type Common struct {
 	types.OSTypeInstaller
 	OSVersion   string
@@ -90,38 +95,43 @@ type Common struct {
 	Master      string
 }
 
-//SetOSInterface defines a method to set the implemtation of the OS interface
+// SetOSInterface defines a method to set the implemtation of the OS interface
 func (co *Common) SetOSInterface(intf types.OSTypeInstaller) {
 	co.OSTypeInstaller = intf
 }
 
-//GetPackageManager get package manager of OS
+// GetPackageManager get package manager of OS
 func GetPackageManager() string {
-	cmd := NewCommand("command -v apt || command -v yum")
+	cmd := NewCommand("command -v apt || command -v yum || command -v pacman")
 	err := cmd.Exec()
 	if err != nil {
 		fmt.Println(err)
 		return ""
 	}
+
 	if strings.HasSuffix(cmd.GetStdOut(), APT) {
 		return APT
 	} else if strings.HasSuffix(cmd.GetStdOut(), YUM) {
 		return YUM
+	} else if strings.HasSuffix(cmd.GetStdOut(), PACMAN) {
+		return PACMAN
 	} else {
 		return ""
 	}
 }
 
-//GetOSInterface helps in returning OS specific object which implements OSTypeInstaller interface.
+// GetOSInterface helps in returning OS specific object which implements OSTypeInstaller interface.
 func GetOSInterface() types.OSTypeInstaller {
 	switch GetPackageManager() {
 	case APT:
 		return &DebOS{}
 	case YUM:
 		return &RpmOS{}
+	case PACMAN:
+		return &PacmanOS{}
 	default:
-		fmt.Println("Failed to detect supported package manager command(apt, yum), exit")
-		panic("Failed to detect supported package manager command(apt, yum), exit")
+		fmt.Println("Failed to detect supported package manager command(apt, yum, pacman), exit")
+		panic("Failed to detect supported package manager command(apt, yum, pacman), exit")
 	}
 }
 
@@ -227,9 +237,9 @@ func checkKubernetesVersion(serverVersion *version.Info) error {
 	return fmt.Errorf("Your minor version of K8s is lower than %d, please reinstall newer version", types.DefaultK8SMinimumVersion)
 }
 
-//installKubeEdge downloads the provided version of KubeEdge.
-//Untar's in the specified location /etc/kubeedge/ and then copies
-//the binary to excecutables' path (eg: /usr/local/bin)
+// installKubeEdge downloads the provided version of KubeEdge.
+// Untar's in the specified location /etc/kubeedge/ and then copies
+// the binary to excecutables' path (eg: /usr/local/bin)
 func installKubeEdge(options types.InstallOptions, arch string, version semver.Version) error {
 	// create the storage path of the kubeedge installation packages
 	if options.TarballPath == "" {
@@ -324,8 +334,8 @@ func installKubeEdge(options types.InstallOptions, arch string, version semver.V
 	return nil
 }
 
-//runEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
-//and the starts edgecore with logs being captured
+// runEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
+// and the starts edgecore with logs being captured
 func runEdgeCore(version semver.Version) error {
 	// create the log dir for kubeedge
 	err := os.MkdirAll(KubeEdgeLogPath, os.ModePerm)
@@ -396,7 +406,7 @@ func killKubeEdgeBinary(proc string) error {
 	return nil
 }
 
-//isKubeEdgeProcessRunning checks if the given process is running or not
+// isKubeEdgeProcessRunning checks if the given process is running or not
 func isKubeEdgeProcessRunning(proc string) (bool, error) {
 	procRunning := fmt.Sprintf("pidof %s 2>&1", proc)
 	cmd := NewCommand(procRunning)
@@ -421,7 +431,7 @@ func isEdgeCoreServiceRunning(serviceName string) (bool, error) {
 	return true, nil
 }
 
-//	check if systemd exist
+// check if systemd exist
 func hasSystemd() bool {
 	cmd := "file /sbin/init"
 
@@ -639,7 +649,7 @@ func IsContain(items []string, item string) bool {
 	return false
 }
 
-//print fail
+// print fail
 func PrintFail(cmd string, s string) {
 	v := fmt.Sprintf("|%s %s failed|", s, cmd)
 	printResult(v)

--- a/keadm/cmd/keadm/app/cmd/util/debinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/debinstaller.go
@@ -25,20 +25,20 @@ import (
 
 const downloadRetryTimes int = 3
 
-//DebOS struct objects shall have information of the tools version to be installed
-//on Hosts having Ubuntu OS.
-//It implements OSTypeInstaller interface
+// DebOS struct objects shall have information of the tools version to be installed
+// on Hosts having Ubuntu OS.
+// It implements OSTypeInstaller interface
 type DebOS struct {
 	KubeEdgeVersion semver.Version
 	IsEdgeNode      bool //True - Edgenode False - Cloudnode
 }
 
-//SetKubeEdgeVersion sets the KubeEdge version for the objects instance
+// SetKubeEdgeVersion sets the KubeEdge version for the objects instance
 func (d *DebOS) SetKubeEdgeVersion(version semver.Version) {
 	d.KubeEdgeVersion = version
 }
 
-//InstallMQTT checks if MQTT is already installed and running, if not then install it from OS repo
+// InstallMQTT checks if MQTT is already installed and running, if not then install it from OS repo
 func (d *DebOS) InstallMQTT() error {
 	cmd := NewCommand("ps aux |awk '/mosquitto/ {print $1}' | awk '/mosquit/ {print}'")
 	if err := cmd.Exec(); err != nil {
@@ -79,18 +79,18 @@ func (d *DebOS) InstallKubeEdge(options types.InstallOptions) error {
 	return installKubeEdge(options, arch, d.KubeEdgeVersion)
 }
 
-//RunEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
-//and the starts edgecore with logs being captured
+// RunEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
+// and the starts edgecore with logs being captured
 func (d *DebOS) RunEdgeCore() error {
 	return runEdgeCore(d.KubeEdgeVersion)
 }
 
-//KillKubeEdgeBinary will search for KubeEdge process and forcefully kill it
+// KillKubeEdgeBinary will search for KubeEdge process and forcefully kill it
 func (d *DebOS) KillKubeEdgeBinary(proc string) error {
 	return killKubeEdgeBinary(proc)
 }
 
-//IsKubeEdgeProcessRunning checks if the given process is running or not
+// IsKubeEdgeProcessRunning checks if the given process is running or not
 func (d *DebOS) IsKubeEdgeProcessRunning(proc string) (bool, error) {
 	return isKubeEdgeProcessRunning(proc)
 }

--- a/keadm/cmd/keadm/app/cmd/util/pacmaninstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/pacmaninstaller.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+
+	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+// PacmanOS struct objects shall have information of the tools version to be installed
+// on Hosts having PacmanOS.
+// It implements OSTypeInstaller interface
+type PacmanOS struct {
+	KubeEdgeVersion semver.Version
+	IsEdgeNode      bool
+}
+
+// SetKubeEdgeVersion sets the KubeEdge version for the objects instance
+func (o *PacmanOS) SetKubeEdgeVersion(version semver.Version) {
+	o.KubeEdgeVersion = version
+}
+
+// InstallMQTT checks if MQTT is already installed and running, if not then install it from OS repo
+func (o *PacmanOS) InstallMQTT() error {
+	cmd := NewCommand("ps aux |awk '/mosquitto/ {print $1}' | awk '/mosquit/ {print}'")
+	if err := cmd.Exec(); err != nil {
+		return err
+	}
+
+	if stdout := cmd.GetStdOut(); stdout != "" {
+		fmt.Println("Host has", stdout, "already installed and running. Hence skipping the installation steps !!!")
+		return nil
+	}
+
+	// Install mqttInst
+	cmd = NewCommand("pacman -Syy --noconfirm mosquitto")
+	if err := cmd.Exec(); err != nil {
+		return err
+	}
+	fmt.Println(cmd.GetStdOut())
+
+	fmt.Println("MQTT is installed in this host")
+
+	return nil
+}
+
+// IsK8SComponentInstalled checks if said K8S version is already installed in the host
+func (o *PacmanOS) IsK8SComponentInstalled(kubeConfig, master string) error {
+	return isK8SComponentInstalled(kubeConfig, master)
+}
+
+// InstallKubeEdge downloads the provided version of KubeEdge.
+// Untar's in the specified location /etc/kubeedge/ and then copies
+// the binary to excecutables' path (eg: /usr/local/bin)
+func (o *PacmanOS) InstallKubeEdge(options types.InstallOptions) error {
+	arch := "amd64"
+	cmd := NewCommand("uname -m")
+	if err := cmd.Exec(); err != nil {
+		return err
+	}
+	result := cmd.GetStdOut()
+	switch result {
+	case "armv7l":
+		arch = OSArchARM32
+	case "aarch64":
+		arch = OSArchARM64
+	case "x86_64":
+		arch = OSArchAMD64
+	default:
+		return fmt.Errorf("can't support this architecture of PacmanOS: %s", result)
+	}
+
+	return installKubeEdge(options, arch, o.KubeEdgeVersion)
+}
+
+// RunEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
+// and the starts edgecore with logs being captured
+func (o *PacmanOS) RunEdgeCore() error {
+	return runEdgeCore(o.KubeEdgeVersion)
+}
+
+// KillKubeEdgeBinary will search for KubeEdge process and forcefully kill it
+func (o *PacmanOS) KillKubeEdgeBinary(proc string) error {
+	return killKubeEdgeBinary(proc)
+}
+
+// IsKubeEdgeProcessRunning checks if the given process is running or not
+func (o *PacmanOS) IsKubeEdgeProcessRunning(proc string) (bool, error) {
+	return isKubeEdgeProcessRunning(proc)
+}
+
+// IsKubeEdgeProcessRunning checks if the given process is running or not
+func (o *PacmanOS) IsProcessRunning(proc string) (bool, error) {
+	return isKubeEdgeProcessRunning(proc)
+}

--- a/keadm/cmd/keadm/app/cmd/util/rpminstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/rpminstaller.go
@@ -24,21 +24,21 @@ import (
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
 
-//RpmOS struct objects shall have information of the tools version to be installed
-//on Hosts having RpmOS OS.
-//It implements OSTypeInstaller interface
+// RpmOS struct objects shall have information of the tools version to be installed
+// on Hosts having RpmOS OS.
+// It implements OSTypeInstaller interface
 type RpmOS struct {
 	KubeEdgeVersion semver.Version
 	IsEdgeNode      bool //True - Edgenode False - Cloudnode
 }
 
-//SetKubeEdgeVersion sets the KubeEdge version for the objects instance
+// SetKubeEdgeVersion sets the KubeEdge version for the objects instance
 func (r *RpmOS) SetKubeEdgeVersion(version semver.Version) {
 	r.KubeEdgeVersion = version
 }
 
-//InstallMQTT checks if MQTT is already installed and running, if not then install it from OS repo
-//Information is used from https://www.digitalocean.com/community/tutorials/how-to-install-and-secure-the-mosquitto-mqtt-messaging-broker-on-centos-7
+// InstallMQTT checks if MQTT is already installed and running, if not then install it from OS repo
+// Information is used from https://www.digitalocean.com/community/tutorials/how-to-install-and-secure-the-mosquitto-mqtt-messaging-broker-on-centos-7
 func (r *RpmOS) InstallMQTT() error {
 	// check MQTT
 	cmd := NewCommand("ps aux |awk '/mosquitto/ {print $1}' | awk '/mosquit/ {print}'")
@@ -68,14 +68,14 @@ func (r *RpmOS) InstallMQTT() error {
 	return nil
 }
 
-//IsK8SComponentInstalled checks if said K8S version is already installed in the host
+// IsK8SComponentInstalled checks if said K8S version is already installed in the host
 func (r *RpmOS) IsK8SComponentInstalled(kubeConfig, master string) error {
 	return isK8SComponentInstalled(kubeConfig, master)
 }
 
-//InstallKubeEdge downloads the provided version of KubeEdge.
-//Untar's in the specified location /etc/kubeedge/ and then copies
-//the binary to excecutables' path (eg: /usr/local/bin)
+// InstallKubeEdge downloads the provided version of KubeEdge.
+// Untar's in the specified location /etc/kubeedge/ and then copies
+// the binary to excecutables' path (eg: /usr/local/bin)
 func (r *RpmOS) InstallKubeEdge(options types.InstallOptions) error {
 	arch := "amd64"
 	cmd := NewCommand("arch")
@@ -85,11 +85,11 @@ func (r *RpmOS) InstallKubeEdge(options types.InstallOptions) error {
 	result := cmd.GetStdOut()
 	switch result {
 	case "armv7l":
-		arch = "arm"
+		arch = OSArchARM32
 	case "aarch64":
-		arch = "arm64"
+		arch = OSArchARM64
 	case "x86_64":
-		arch = "amd64"
+		arch = OSArchAMD64
 	default:
 		return fmt.Errorf("can't support this architecture of RpmOS: %s", result)
 	}
@@ -97,23 +97,23 @@ func (r *RpmOS) InstallKubeEdge(options types.InstallOptions) error {
 	return installKubeEdge(options, arch, r.KubeEdgeVersion)
 }
 
-//RunEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
-//and the starts edgecore with logs being captured
+// RunEdgeCore sets the environment variable GOARCHAIUS_CONFIG_PATH for the configuration path
+// and the starts edgecore with logs being captured
 func (r *RpmOS) RunEdgeCore() error {
 	return runEdgeCore(r.KubeEdgeVersion)
 }
 
-//KillKubeEdgeBinary will search for KubeEdge process and forcefully kill it
+// KillKubeEdgeBinary will search for KubeEdge process and forcefully kill it
 func (r *RpmOS) KillKubeEdgeBinary(proc string) error {
 	return killKubeEdgeBinary(proc)
 }
 
-//IsKubeEdgeProcessRunning checks if the given process is running or not
+// IsKubeEdgeProcessRunning checks if the given process is running or not
 func (r *RpmOS) IsKubeEdgeProcessRunning(proc string) (bool, error) {
 	return isKubeEdgeProcessRunning(proc)
 }
 
-//IsKubeEdgeProcessRunning checks if the given process is running or not
+// IsKubeEdgeProcessRunning checks if the given process is running or not
 func (r *RpmOS) IsProcessRunning(proc string) (bool, error) {
 	return isKubeEdgeProcessRunning(proc)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
I work with manjaro os, a os like arch linux. I can't join the kubeedge cluster. I hope keam support my os type.

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->
/kind feature

**What this PR does / why we need it**:
just want keadm can support my os.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I believe nobody use this os for production. But I hope keadm can support it. :)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
keadm can init kubeedge with package manager `pacman`.
```
