### PR TITLE
Fix an issue that misuse the name of the modbus register.

### DIFF
--- a/mappers/modbus-go/driver/client.go
+++ b/mappers/modbus-go/driver/client.go
@@ -170,7 +170,7 @@ func (c *ModbusClient) Set(registerType string, addr uint16, value uint16) (resu
 			return nil, errors.New("Wrong value")
 		}
 		results, err = c.Client.WriteSingleCoil(addr, valueSet)
-	case "DiscreteInputRegister":
+	case "HoldingRegister":
 		results, err = c.Client.WriteSingleRegister(addr, value)
 	default:
 		return nil, errors.New("Bad register type")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The register type is wrong and the customer will get the wrong return.

**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
None

