### PR TITLE
cloudstream: fix panic of concurrent map read and map write.

### DIFF
--- a/cloud/pkg/cloudstream/session.go
+++ b/cloud/pkg/cloudstream/session.go
@@ -41,7 +41,7 @@ type Session struct {
 
 	// apiServerConn indicates a connection request made by multiple apiserver to one edgecore
 	apiServerConn map[uint64]APIServerConnection
-	apiConnlock   *sync.Mutex
+	apiConnlock   *sync.RWMutex
 }
 
 func (s *Session) WriteMessageToTunnel(m *stream.Message) error {
@@ -49,6 +49,8 @@ func (s *Session) WriteMessageToTunnel(m *stream.Message) error {
 }
 
 func (s *Session) Close() {
+	s.apiConnlock.Lock()
+	defer s.apiConnlock.Unlock()
 	for _, c := range s.apiServerConn {
 		c.SetEdgePeerDone()
 	}
@@ -84,6 +86,8 @@ func (s *Session) Serve() {
 }
 
 func (s *Session) ProxyTunnelMessageToApiserver(message *stream.Message) error {
+	s.apiConnlock.RLock()
+	defer s.apiConnlock.RUnlock()
 	kubeCon, ok := s.apiServerConn[message.ConnectID]
 	if !ok {
 		return fmt.Errorf("Can not find apiServer connection id %v in %v",

--- a/cloud/pkg/cloudstream/tunnelserver.go
+++ b/cloud/pkg/cloudstream/tunnelserver.go
@@ -94,7 +94,7 @@ func (s *TunnelServer) connect(r *restful.Request, w *restful.Response) {
 	session := &Session{
 		tunnel:        stream.NewDefaultTunnel(con),
 		apiServerConn: make(map[uint64]APIServerConnection),
-		apiConnlock:   &sync.Mutex{},
+		apiConnlock:   &sync.RWMutex{},
 		sessionID:     hostNameOverride,
 	}
 


### PR DESCRIPTION
use sync.RWMutex. add RLock in ProxyTunnelMessageToApiserver.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
fix the panic of concurrent map read and map write. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2453  

**Special notes for your reviewer**:
add a `RLock` while reading conn from map `s.apiServerConn`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
