### PR TITLE
keadm: clean useless file after keadm_e2e test

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -398,7 +398,7 @@ func killKubeEdgeBinary(proc string) error {
 
 //isKubeEdgeProcessRunning checks if the given process is running or not
 func isKubeEdgeProcessRunning(proc string) (bool, error) {
-	procRunning := fmt.Sprintf("pidof %s 2&>1", proc)
+	procRunning := fmt.Sprintf("pidof %s 2>&1", proc)
 	cmd := NewCommand(procRunning)
 
 	err := cmd.Exec()

--- a/tests/e2e/scripts/keadm_e2e.sh
+++ b/tests/e2e/scripts/keadm_e2e.sh
@@ -22,7 +22,7 @@ function cleanup() {
   sudo pkill edgecore
   sudo pkill cloudcore
   kind delete cluster --name test
-  sudo rm -rf /var/log/kubeedge /etc/kubeedge /etc/systemd/system/edgecore.service
+  sudo rm -rf /var/log/kubeedge /etc/kubeedge /etc/systemd/system/edgecore.service $E2E_DIR/keadm/keadm.test $E2E_DIR/config.json
 }
 
 function build_keadm() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->
/kind feature

**What this PR does / why we need it**:
1. remove keadm.test and config.json before keadm_e2e.sh exit. keep directory clean.
2. should use `2>&1` to redirect stderr to stdout.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
```
NONE
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
