### PR TITLE
Fix bug: the websocket connection timeout setting doesn't take effect

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -105,6 +105,10 @@ func (wsc *WebSocketClient) UnInit() {
 
 //Send sends the message as JSON object through the connection
 func (wsc *WebSocketClient) Send(message model.Message) error {
+	err := wsc.connection.SetWriteDeadline(time.Now().Add(wsc.config.WriteDeadline))
+	if err != nil {
+		return err
+	}
 	return wsc.connection.WriteMessageAsync(&message)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design
/kind bug

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->


**What this PR does / why we need it**:
Set the timeout period before sending and reading data from the long connection

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
