### PR TITLE
support more metric path in cloud

### DIFF
--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -89,6 +89,10 @@ func (s *StreamServer) installDebugHandler() {
 		To(s.getMetrics))
 	ws.Route(ws.GET("/cadvisor").
 		To(s.getMetrics))
+	ws.Route(ws.GET("/probes").
+		To(s.getMetrics))
+	ws.Route(ws.GET("/resource").
+		To(s.getMetrics))
 	s.container.Add(ws)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->
/kind bug

**What this PR does / why we need it**:

cloud has support some kubelet metrics path, include `/metrics` and `/metrics/cadvisor` 
but kubernetes 1.19 has more path:
`/metrics`
`/metrics/cadvisor`
`/metrics/probes`
`/metrics/resource/v1alpha1` ( [deprecated in k8s v1.20](https://github.com/kubernetes/kubernetes/pull/94272))
`/metrics/resource`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
