### PR TITLE
keadm: when the service file does not exist, the rm file command is not executed

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -366,7 +366,12 @@ func killKubeEdgeBinary(proc string) error {
 
 		if systemdExist && serviceName != "" {
 			// remove the system service.
-			binExec = fmt.Sprintf("sudo systemctl stop %s.service && sudo systemctl disable %s.service && sudo rm /etc/systemd/system/%s.service && sudo systemctl daemon-reload", serviceName, serviceName, serviceName)
+			serviceFilePath := fmt.Sprintf("/etc/systemd/system/%s.service", serviceName)
+			serviceFileRemoveExec := fmt.Sprintf("&& sudo rm %s", serviceFilePath)
+			if _, err := os.Stat(serviceFilePath); err != nil && os.IsNotExist(err) {
+				serviceFileRemoveExec = ""
+			}
+			binExec = fmt.Sprintf("sudo systemctl stop %s.service && sudo systemctl disable %s.service %s && sudo systemctl daemon-reload", serviceName, serviceName, serviceFileRemoveExec)
 		} else {
 			binExec = fmt.Sprintf("pkill %s", proc)
 		}


### PR DESCRIPTION
keadm reset:  When the service file does not exist, the rm file command is not executed

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind test
> /kind design

Optionally add one or more of the following kinds if applicable:
> /kind api-change
> /kind failing-test
-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
