### PR TITLE
Move e2e cluster cleanup work from e2e binary to script

### DIFF
--- a/tests/e2e/deployment/deployment_suite_test.go
+++ b/tests/e2e/deployment/deployment_suite_test.go
@@ -17,13 +17,11 @@ limitations under the License.
 package deployment
 
 import (
-	"net/http"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/kubeedge/kubeedge/tests/e2e/constants"
 	"github.com/kubeedge/kubeedge/tests/e2e/utils"
 )
 
@@ -49,18 +47,6 @@ func TestEdgecoreAppDeployment(t *testing.T) {
 	})
 	AfterSuite(func() {
 		By("After Suite Execution....!")
-		//Deregister the edge node from master
-		Expect(utils.DeRegisterNodeFromMaster(ctx.Cfg.K8SMasterForKubeEdge+constants.NodeHandler, nodeName)).Should(BeNil())
-		Eventually(func() int {
-			statuscode := utils.CheckNodeDeleteStatus(ctx.Cfg.K8SMasterForKubeEdge+constants.NodeHandler, nodeName)
-			utils.Infof("Node Name: %v, Node Statuscode: %v", nodeName, statuscode)
-			return statuscode
-		}, "60s", "4s").Should(Equal(http.StatusNotFound), "Node register to the k8s master is unsuccessful !!")
-
-		//Run the Cleanup steps to kill edgecore and cloudcore binaries
-		Expect(utils.CleanUp("deployment")).Should(BeNil())
-		//time.Sleep(2 * time.Second)
-		utils.Infof("Cleanup is Successful !!")
 	})
 
 	RunSpecs(t, "kubeedge App Deploymet Suite")

--- a/tests/e2e/scripts/execute.sh
+++ b/tests/e2e/scripts/execute.sh
@@ -27,9 +27,11 @@ which ginkgo &> /dev/null || (
     sudo cp $GOPATH/bin/ginkgo /usr/local/bin/
 )
 
-bash ${curpath}/tests/e2e/scripts/cleanup.sh deployment
-bash ${curpath}/tests/e2e/scripts/cleanup.sh edgesite
-bash ${curpath}/tests/e2e/scripts/cleanup.sh device_crd
+cleanup() {
+    bash ${curpath}/tests/e2e/scripts/cleanup.sh
+}
+
+cleanup
 
 E2E_DIR=${curpath}/tests/e2e
 sudo rm -rf ${E2E_DIR}/deployment/deployment.test
@@ -59,6 +61,8 @@ echo "Number of Test cases PASSED = $passed"
 fail=`grep -e "SUCCESS\!" -e "FAIL\!" /tmp/testcase.log | awk '{print $6}' | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" | awk '{sum+=$1} END {print sum}'`
 echo "Number of Test cases FAILED = $fail"
 echo "==================Result Summary======================="
+
+trap cleanup EXIT
 
 if [ "$fail" != "0" ];then
     echo "Integration suite has failures, Please check !!"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Now we delete edgenode and cleanup other stuff all by e2e binary, just move them to script, e2e binary should only focus on testing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
