### PR TITLE
fix：modify a key name called protocol in deviceInstance

### DIFF
--- a/mappers/modbus-go/configmap/configmap_test.json
+++ b/mappers/modbus-go/configmap/configmap_test.json
@@ -2,7 +2,7 @@
 	"deviceInstances": [{
 		"id": "sensor-tag-instance-01",
 		"name": "sensor-tag-instance-01",
-		"protocol": "modbus-sensor-tag-instance-01",
+		"protocolName": "modbus-sensor-tag-instance-01",
 		"model": "sensor-tag-model",
 		"twins": [{
 			"propertyName": "temperature-enable",


### PR DESCRIPTION
There if an error key name which called 'protocol' in deviceInstance and it should be 'protocolName'.This is because the key is used in kubeedge/mappers/modbus-go/configmap/parse.go, and it's name is 'protocol' in that file.This error can cause unit tests to go wrong

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
