### PR TITLE
fix: CloudStream cannot be enable when in the cloudcore HA deployment pattern

### DIFF
--- a/build/cloud/ha/03-ha-deployment.yaml.example
+++ b/build/cloud/ha/03-ha-deployment.yaml.example
@@ -60,6 +60,8 @@ spec:
           volumeMounts:
             - name: conf
               mountPath: /etc/kubeedge/config
+            - name: certs  # mount the cloudstream certificate directory for cloudcore
+              mountPath: /etc/kubeedge
           env:
             - name: CLOUDCORE_POD_NAME
               valueFrom:
@@ -76,4 +78,8 @@ spec:
         - name: conf
           configMap:
             name: cloudcore
+        - name: certs
+          hostPath:
+            path: "/etc/kubeedge"
+            type: DirectoryOrCreate
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:

mount the cloudstream certificate directory for cloudcore pod in the cloudcore HA deployment pattern

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2565

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
