### PR TITLE
Remove unused hard code map in synccontroller

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -23,15 +23,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
 )
 
-var forceSet = map[string]string{
-	"pod":       "pods",
-	"configmap": "configmaps",
-	"secret":    "secrets",
-	"service":   "services",
-	"endpoint":  "endpoints",
-	"node":      "nodes",
-}
-
 func (sctl *SyncController) manageObject(sync *v1alpha1.ObjectSync) {
 	var object metav1.Object
 
@@ -39,11 +30,8 @@ func (sctl *SyncController) manageObject(sync *v1alpha1.ObjectSync) {
 	if err != nil {
 		return
 	}
-	resource := sync.Spec.ObjectKind // In fact, ObjdctKind is Object resources like "pods"
-	if v, ok := forceSet[resource]; ok {
-		resource = v
-	}
-	gvr := gv.WithResource(resource)
+	gvr := gv.WithResource(sync.Spec.ObjectKind)
+
 	//ret, err := informers.GetInformersManager().GetDynamicSharedInformerFactory().ForResource(gvr).Lister().ByNamespace(sync.Namespace).Get(sync.Spec.ObjectName)
 	ret, err := sctl.kubeclient.Resource(gvr).Namespace(sync.Namespace).Get(context.TODO(), sync.Spec.ObjectName, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Looks like the objectKind had been [converted to objectresources](https://github.com/kubeedge/kubeedge/blob/master/cloud/pkg/cloudhub/handler/messagehandler.go#L554), so we don't need the unused hard code map in synccontroller.
Without this map, synccontroller will has no hard code resources. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
