### PR TITLE
supprt sapce and {} in device value

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/util.go
+++ b/edge/pkg/devicetwin/dtcommon/util.go
@@ -48,7 +48,7 @@ func ValidateTwinKey(key string) bool {
 
 //ValidateTwinValue validate twin value
 func ValidateTwinValue(value string) bool {
-	pattern := "^[a-zA-Z0-9-_.,:/@#]{1,512}$"
+	pattern := "^[a-zA-Z0-9-_.\"{}, :/@#]{1,512}$"
 	match, _ := regexp.MatchString(pattern, value)
 	return match
 }


### PR DESCRIPTION
Signed-off-by: guanzuoyu <guanzuoyudev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

It need to support more character in device value, like pass json format to mapper.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2584 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
