### PR TITLE
Add timeout for github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Verify vendor, licenses, do lint
     env:
       GOPATH: /home/runner/work/${{ github.repository }}
@@ -43,6 +44,7 @@ jobs:
         working-directory: ./src/github.com/${{ github.repository }}
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Multiple build
     steps:
       - name: Install Go
@@ -75,6 +77,7 @@ jobs:
 
   basic_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Unit test, integration test edge
     env:
       GO111MODULE: on
@@ -104,6 +107,7 @@ jobs:
 
   e2e_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: E2e test
     env:
       GO111MODULE: on
@@ -133,6 +137,7 @@ jobs:
 
   keadm_e2e_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Keadm e2e test
     env:
       GO111MODULE: on
@@ -166,6 +171,7 @@ jobs:
 
   docker_build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     name: Multiple docker image build
     steps:
       - name: Install Go


### PR DESCRIPTION
Signed-off-by: fisherxu <xufei40@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

Set timeout for all github actions.  Because the default timeout value is 360 mins, it's too long to report the result if the job get stucked. And usually our jobs will not run for more than 20 mins.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
