### PR TITLE
Revert "Don't omitempty for enable field for all modules"

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -100,12 +100,11 @@ function start_cloudcore {
   CLOUD_CONFIGFILE=${KUBEEDGE_ROOT}/_output/local/bin/cloudcore.yaml
   CLOUD_BIN=${KUBEEDGE_ROOT}/_output/local/bin/cloudcore
   ${CLOUD_BIN} --defaultconfig >  ${CLOUD_CONFIGFILE}
-
+  sed -i '/modules:/a\  cloudStream:\n    enable: true\n    streamPort: 10003\n    tlsStreamCAFile: /etc/kubeedge/ca/streamCA.crt\n    tlsStreamCertFile: /etc/kubeedge/certs/stream.crt\n    tlsStreamPrivateKeyFile: /etc/kubeedge/certs/stream.key\n    tlsTunnelCAFile: /etc/kubeedge/ca/rootCA.crt\n    tlsTunnelCertFile: /etc/kubeedge/certs/server.crt\n    tlsTunnelPrivateKeyFile: /etc/kubeedge/certs/server.key\n    tunnelPort: 10004' ${CLOUD_CONFIGFILE}
   sed -i -e "s|kubeConfig: .*|kubeConfig: ${KUBECONFIG}|g" \
     -e "s|/var/lib/kubeedge/|/tmp&|g" \
     -e "s|/etc/|/tmp/etc/|g" \
-    -e "s|enable: false|enable: true|g" ${CLOUD_CONFIGFILE}
-
+    -e '/router:/a\    enable: true' ${CLOUD_CONFIGFILE}
   CLOUDCORE_LOG=${LOG_DIR}/cloudcore.log
   echo "start cloudcore..."
   nohup sudo ${CLOUD_BIN} --config=${CLOUD_CONFIGFILE} > "${CLOUDCORE_LOG}" 2>&1 &
@@ -125,13 +124,13 @@ function start_edgecore {
   EDGE_BIN=${KUBEEDGE_ROOT}/_output/local/bin/edgecore
   ${EDGE_BIN} --defaultconfig >  ${EDGE_CONFIGFILE}
 
+  sed -i '/modules:/a\  edgeStream:\n    enable: true\n    handshakeTimeout: 30\n    readDeadline: 15\n    server: 127.0.0.1:10004\n    tlsTunnelCAFile: /etc/kubeedge/ca/rootCA.crt\n    tlsTunnelCertFile: /etc/kubeedge/certs/server.crt\n    tlsTunnelPrivateKeyFile: /etc/kubeedge/certs/server.key\n    writeDeadline: 15' ${EDGE_CONFIGFILE}
   token=`kubectl get secret -nkubeedge tokensecret -o=jsonpath='{.data.tokendata}' | base64 -d`
 
   sed -i -e "s|token: .*|token: ${token}|g" \
       -e "s|hostnameOverride: .*|hostnameOverride: edge-node|g" \
       -e "s|/etc/|/tmp/etc/|g" \
       -e "s|/var/lib/kubeedge/|/tmp&|g" \
-      -e "s|enable: false|enable: true|g" \
       -e "s|mqttMode: .*|mqttMode: 0|g" ${EDGE_CONFIGFILE}
 
   EDGECORE_LOG=${LOG_DIR}/edgecore.log

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -85,7 +85,7 @@ type CloudHub struct {
 	// Enable indicates whether CloudHub is enabled, if set to false (for debugging etc.),
 	// skip checking other CloudHub configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// KeepaliveInterval indicates keep-alive interval (second)
 	// default 30
 	KeepaliveInterval int32 `json:"keepaliveInterval,omitempty"`
@@ -130,7 +130,7 @@ type CloudHub struct {
 type CloudHubQUIC struct {
 	// Enable indicates whether enable quic protocol
 	// default false
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// Address set server ip address
 	// default 0.0.0.0
 	Address string `json:"address,omitempty"`
@@ -146,7 +146,7 @@ type CloudHubQUIC struct {
 type CloudHubUnixSocket struct {
 	// Enable indicates whether enable unix domain socket protocol
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// Address indicates unix domain socket address
 	// default "unix:///var/lib/kubeedge/kubeedge.sock"
 	Address string `json:"address,omitempty"`
@@ -156,7 +156,7 @@ type CloudHubUnixSocket struct {
 type CloudHubWebSocket struct {
 	// Enable indicates whether enable websocket protocol
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// Address indicates server ip address
 	// default 0.0.0.0
 	Address string `json:"address,omitempty"`
@@ -169,7 +169,7 @@ type CloudHubWebSocket struct {
 type CloudHubHTTPS struct {
 	// Enable indicates whether enable Https protocol
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// Address indicates server ip address
 	// default 0.0.0.0
 	Address string `json:"address,omitempty"`
@@ -183,7 +183,7 @@ type EdgeController struct {
 	// Enable indicates whether EdgeController is enabled,
 	// if set to false (for debugging etc.), skip checking other EdgeController configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// NodeUpdateFrequency indicates node update frequency (second)
 	// default 10
 	NodeUpdateFrequency int32 `json:"nodeUpdateFrequency,omitempty"`
@@ -313,7 +313,7 @@ type DeviceController struct {
 	// Enable indicates whether deviceController is enabled,
 	// if set to false (for debugging etc.), skip checking other deviceController configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// Context indicates send,receive,response modules for deviceController module
 	Context *ControllerContext `json:"context,omitempty"`
 	// Buffer indicates Device controller buffer
@@ -347,7 +347,7 @@ type SyncController struct {
 	// Enable indicates whether syncController is enabled,
 	// if set to false (for debugging etc.), skip checking other syncController configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 }
 
 // DynamicController indicates the dynamic controller
@@ -355,7 +355,7 @@ type DynamicController struct {
 	// Enable indicates whether dynamicController is enabled,
 	// if set to false (for debugging etc.), skip checking other dynamicController configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 }
 
 // CloudSream indicates the stream controller
@@ -393,7 +393,7 @@ type CloudStream struct {
 
 type Router struct {
 	// default true
-	Enable      bool   `json:"enable"`
+	Enable      bool   `json:"enable,omitempty"`
 	Address     string `json:"address,omitempty"`
 	Port        uint32 `json:"port,omitempty"`
 	RestTimeout uint32 `json:"restTimeout,omitempty"`

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -113,7 +113,7 @@ type Edged struct {
 	// Enable indicates whether edged is enabled,
 	// if set to false (for debugging etc.), skip checking other edged configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// Labels indicates current node labels
 	Labels map[string]string `json:"labels,omitempty"`
 	// Annotations indicates current node annotations
@@ -251,7 +251,7 @@ type EdgeHub struct {
 	// Enable indicates whether EdgeHub is enabled,
 	// if set to false (for debugging etc.), skip checking other EdgeHub configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// Heartbeat indicates heart beat (second)
 	// default 15
 	Heartbeat int32 `json:"heartbeat,omitempty"`
@@ -286,7 +286,7 @@ type EdgeHub struct {
 type EdgeHubQUIC struct {
 	// Enable indicates whether enable this protocol
 	// default false
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// HandshakeTimeout indicates hand shake timeout (second)
 	// default 30
 	HandshakeTimeout int32 `json:"handshakeTimeout,omitempty"`
@@ -305,7 +305,7 @@ type EdgeHubQUIC struct {
 type EdgeHubWebSocket struct {
 	// Enable indicates whether enable this protocol
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// HandshakeTimeout indicates handshake timeout (second)
 	// default  30
 	HandshakeTimeout int32 `json:"handshakeTimeout,omitempty"`
@@ -325,7 +325,7 @@ type EventBus struct {
 	// Enable indicates whether EventBus is enabled, if set to false (for debugging etc.),
 	// skip checking other EventBus configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// MqttQOS indicates mqtt qos
 	// 0: QOSAtMostOnce, 1: QOSAtLeastOnce, 2: QOSExactlyOnce
 	// default 0
@@ -360,7 +360,7 @@ type EventBus struct {
 type EventBusTLS struct {
 	// Enable indicates whether enable tls connection
 	// default false
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// TLSMqttCAFile sets ca file path
 	// default "/etc/kubeedge/ca/rootCA.crt"
 	TLSMqttCAFile string `json:"tlsMqttCAFile,omitempty"`
@@ -377,7 +377,7 @@ type MetaManager struct {
 	// Enable indicates whether MetaManager is enabled,
 	// if set to false (for debugging etc.), skip checking other MetaManager configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// ContextSendGroup indicates send group
 	ContextSendGroup metaconfig.GroupName `json:"contextSendGroup,omitempty"`
 	// ContextSendModule indicates send module
@@ -393,7 +393,7 @@ type MetaManager struct {
 }
 
 type MetaServer struct {
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	Debug  bool `json:"debug,omitempty"`
 }
 
@@ -410,7 +410,7 @@ type DeviceTwin struct {
 	// Enable indicates whether DeviceTwin is enabled,
 	// if set to false (for debugging etc.), skip checking other DeviceTwin configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 }
 
 // DBTest indicates the DBTest module config
@@ -426,7 +426,7 @@ type EdgeMesh struct {
 	// Enable indicates whether EdgeMesh is enabled,
 	// if set to false (for debugging etc.), skip checking other EdgeMesh configs.
 	// default true
-	Enable bool `json:"enable"`
+	Enable bool `json:"enable,omitempty"`
 	// lbStrategy indicates load balance strategy name
 	// default "RoundRobin"
 	LBStrategy string `json:"lbStrategy,omitempty"`


### PR DESCRIPTION
Reverts kubeedge/kubeedge#2607

The ci hadn't passed, looks like the bot will merge the pr though ci failed.