### PR TITLE
keadm: reset supports checking the node type according to the default configuration file

### DIFF
--- a/keadm/cmd/keadm/app/cmd/reset.go
+++ b/keadm/cmd/keadm/app/cmd/reset.go
@@ -67,6 +67,16 @@ func NewKubeEdgeReset(out io.Writer, reset *common.ResetOptions) *cobra.Command 
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Check whether the cloudcore default configuration file exists
+			if _, err := os.Stat(util.KubeEdgeCloudCoreNewYaml); err == nil {
+				return nil
+			}
+			// Check whether the edgecore default configuration file exists
+			if _, err := os.Stat(util.KubeEdgeEdgeCoreNewYaml); err == nil {
+				IsEdgeNode = true
+				return nil
+			}
+			// Check the running module
 			whoRunning, err := util.RunningModule()
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind feature

**What this PR does / why we need it**:

`keadm reset` only checks whether the edgecore/cloudcore is running to judge whether to continue the reset operation.Many times when the node is not running properly, it needs to be reset

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2630

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
