### PR TITLE
Automated cherry pick of #2614: remove syncKeeper in edgehub

### DIFF
--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
-	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/clients"
@@ -28,7 +27,6 @@ type EdgeHub struct {
 	certManager   certificate.CertManager
 	chClient      clients.Adapter
 	reconnectChan chan struct{}
-	syncKeeper    map[string]chan model.Message
 	keeperLock    sync.RWMutex
 	enable        bool
 }
@@ -36,7 +34,6 @@ type EdgeHub struct {
 func newEdgeHub(enable bool) *EdgeHub {
 	return &EdgeHub{
 		reconnectChan: make(chan struct{}),
-		syncKeeper:    make(map[string]chan model.Message),
 		enable:        enable,
 	}
 }

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -33,59 +33,6 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 )
 
-//TestAddKeepChannel() tests the addition of channel to the syncKeeper
-func TestAddKeepChannel(t *testing.T) {
-	beehiveContext.InitContext(beehiveContext.MsgCtxTypeChannel)
-	tests := []struct {
-		name  string
-		hub   *EdgeHub
-		msgID string
-	}{
-		{
-			name: "Adding a valid keep channel",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
-			msgID: "test",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.hub.addKeepChannel(tt.msgID)
-			if !reflect.DeepEqual(tt.hub.syncKeeper[tt.msgID], got) {
-				t.Errorf("TestController_addKeepChannel() = %v, want %v", got, tt.hub.syncKeeper[tt.msgID])
-			}
-		})
-	}
-}
-
-//TestDeleteKeepChannel() tests the deletion of channel in the syncKeeper
-func TestDeleteKeepChannel(t *testing.T) {
-	beehiveContext.InitContext(beehiveContext.MsgCtxTypeChannel)
-	tests := []struct {
-		name  string
-		hub   *EdgeHub
-		msgID string
-	}{
-		{
-			name: "Deleting a valid keep channel",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
-			msgID: "test",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.hub.addKeepChannel(tt.msgID)
-			tt.hub.deleteKeepChannel(tt.msgID)
-			if _, exist := tt.hub.syncKeeper[tt.msgID]; exist {
-				t.Errorf("TestController_deleteKeepChannel = %v, want %v", tt.hub.syncKeeper[tt.msgID], nil)
-			}
-		})
-	}
-}
-
 //TestIsSyncResponse() tests whether there exists a channel with the given message_id in the syncKeeper
 func TestIsSyncResponse(t *testing.T) {
 	beehiveContext.InitContext(beehiveContext.MsgCtxTypeChannel)
@@ -96,77 +43,22 @@ func TestIsSyncResponse(t *testing.T) {
 		want  bool
 	}{
 		{
-			name: "Sync message response case",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
+			name:  "Sync message response case",
+			hub:   &EdgeHub{},
 			msgID: "test",
 			want:  true,
 		},
 		{
-			name: "Non sync message response  case",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
+			name:  "Non sync message response  case",
+			hub:   &EdgeHub{},
 			msgID: "",
 			want:  false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.want {
-				tt.hub.addKeepChannel(tt.msgID)
-			}
 			if got := tt.hub.isSyncResponse(tt.msgID); got != tt.want {
 				t.Errorf("TestController_isSyncResponse() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-//TestSendToKeepChannel() tests the reception of response in the syncKeep channel
-func TestSendToKeepChannel(t *testing.T) {
-	beehiveContext.InitContext(beehiveContext.MsgCtxTypeChannel)
-	message := model.NewMessage("test_id")
-	tests := []struct {
-		name                string
-		hub                 *EdgeHub
-		message             *model.Message
-		keepChannelParentID string
-		expectedError       error
-	}{
-		{
-			name: "SyncKeeper Error Case in send to keep channel",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
-			message:             message,
-			keepChannelParentID: "wrong_id",
-			expectedError:       fmt.Errorf("failed to get sync keeper channel, messageID:%+v", *message),
-		},
-		{
-			name: "Send to keep channel with valid input",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
-			message:             model.NewMessage("test_id"),
-			keepChannelParentID: "test_id",
-			expectedError:       nil,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			keep := tt.hub.addKeepChannel(tt.keepChannelParentID)
-			if tt.expectedError == nil {
-				receive := func() {
-					<-keep
-				}
-				go receive()
-			}
-			time.Sleep(1 * time.Second)
-			err := tt.hub.sendToKeepChannel(*tt.message)
-			if !reflect.DeepEqual(err, tt.expectedError) {
-				t.Errorf("TestController_sendToKeepChannel() error = %v, expectedError %v", err, tt.expectedError)
 			}
 		})
 	}
@@ -183,28 +75,22 @@ func TestDispatch(t *testing.T) {
 		isResponse    bool
 	}{
 		{
-			name: "dispatch with valid input",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
+			name:          "dispatch with valid input",
+			hub:           &EdgeHub{},
 			message:       model.NewMessage("").BuildRouter(ModuleNameEdgeHub, module.TwinGroup, "", ""),
 			expectedError: nil,
 			isResponse:    false,
 		},
 		{
-			name: "Error Case in dispatch",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
+			name:          "Error Case in dispatch",
+			hub:           &EdgeHub{},
 			message:       model.NewMessage("test").BuildRouter(ModuleNameEdgeHub, module.EdgedGroup, "", ""),
 			expectedError: fmt.Errorf("msg_group not found"),
 			isResponse:    true,
 		},
 		{
-			name: "Response Case in dispatch",
-			hub: &EdgeHub{
-				syncKeeper: make(map[string]chan model.Message),
-			},
+			name:          "Response Case in dispatch",
+			hub:           &EdgeHub{},
 			message:       model.NewMessage("test").BuildRouter(ModuleNameEdgeHub, module.TwinGroup, "", ""),
 			expectedError: nil,
 			isResponse:    true,
@@ -212,14 +98,6 @@ func TestDispatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.expectedError == nil && !tt.isResponse {
-				receive := func() {
-					keepChannel := tt.hub.addKeepChannel(tt.message.GetParentID())
-					<-keepChannel
-				}
-				go receive()
-			}
-			time.Sleep(1 * time.Second)
 			err := tt.hub.dispatch(*tt.message)
 			if !reflect.DeepEqual(err, tt.expectedError) {
 				t.Errorf("TestController_dispatch() error = %v, wantErr %v", err, tt.expectedError)
@@ -281,44 +159,37 @@ func TestSendToCloud(t *testing.T) {
 		hub             *EdgeHub
 		message         model.Message
 		expectedError   error
-		waitError       bool
 		mockError       error
 		HeartbeatPeriod int32
 	}{
 		{
 			name: "send to cloud with proper input",
 			hub: &EdgeHub{
-				chClient:   mockAdapter,
-				syncKeeper: make(map[string]chan model.Message),
+				chClient: mockAdapter,
 			},
 			HeartbeatPeriod: 6,
 			message:         *msg,
 			expectedError:   nil,
-			waitError:       false,
 			mockError:       nil,
 		},
 		{
 			name: "Wait Error in send to cloud",
 			hub: &EdgeHub{
-				chClient:   mockAdapter,
-				syncKeeper: make(map[string]chan model.Message),
+				chClient: mockAdapter,
 			},
 			HeartbeatPeriod: 3,
 			message:         *msg,
 			expectedError:   nil,
-			waitError:       true,
 			mockError:       nil,
 		},
 		{
 			name: "Send Failure in send to cloud",
 			hub: &EdgeHub{
-				chClient:   mockAdapter,
-				syncKeeper: make(map[string]chan model.Message),
+				chClient: mockAdapter,
 			},
 			HeartbeatPeriod: 3,
 			message:         model.Message{},
 			expectedError:   fmt.Errorf("failed to send message, error: Connection Refused"),
-			waitError:       false,
 			mockError:       errors.New("Connection Refused"),
 		},
 	}
@@ -326,24 +197,9 @@ func TestSendToCloud(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAdapter.EXPECT().Send(gomock.Any()).Return(tt.mockError).Times(1)
 			config.Config.Heartbeat = tt.HeartbeatPeriod
-			if !tt.waitError && tt.expectedError == nil {
-				go tt.hub.sendToCloud(tt.message)
-				time.Sleep(1 * time.Second)
-				tempChannel := tt.hub.syncKeeper["test_id"]
-				tempChannel <- *model.NewMessage("test_id")
-				time.Sleep(1 * time.Second)
-				if _, exist := tt.hub.syncKeeper["test_id"]; exist {
-					t.Errorf("SendToCloud() error in receiving message")
-				}
-				return
-			}
 			err := tt.hub.sendToCloud(tt.message)
 			if !reflect.DeepEqual(err, tt.expectedError) {
 				t.Errorf("SendToCloud() error = %v, wantErr %v", err, tt.expectedError)
-			}
-			time.Sleep(time.Duration(tt.HeartbeatPeriod+2) * time.Second)
-			if _, exist := tt.hub.syncKeeper["test_id"]; exist {
-				t.Errorf("SendToCloud() error in waiting for timeout")
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #2614 on release-1.6.

#2614: remove syncKeeper in edgehub

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.