### PR TITLE
Shorten the reconnect wait time when connect failed

### DIFF
--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -81,10 +81,13 @@ func (eh *EdgeHub) Start() {
 			klog.Fatalf("failed to init controller: %v", err)
 			return
 		}
+
+		waitTime := time.Duration(config.Config.Heartbeat) * time.Second * 2
+
 		err = eh.chClient.Init()
 		if err != nil {
-			klog.Errorf("connection error, try again after 60s: %v", err)
-			time.Sleep(waitConnectionPeriod)
+			klog.Errorf("connection failed: %v, will reconnect after %s", err, waitTime.String())
+			time.Sleep(waitTime)
 			continue
 		}
 		// execute hook func after connect
@@ -102,7 +105,8 @@ func (eh *EdgeHub) Start() {
 		eh.pubConnectInfo(false)
 
 		// sleep one period of heartbeat, then try to connect cloud hub again
-		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second * 2)
+		klog.Warningf("connection is broken, will reconnect after %s", waitTime.String())
+		time.Sleep(waitTime)
 
 		// clean channel
 	clean:


### PR DESCRIPTION
Signed-off-by: fisherxu <xufei40@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Shorten the reconnect wait time when connect failed and add warnning log when reconnecting.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
