### PR TITLE
Automated cherry pick of #2641: Shorten the reconnect wait time when connect failed

### DIFF
--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -81,10 +81,13 @@ func (eh *EdgeHub) Start() {
 			klog.Fatalf("failed to init controller: %v", err)
 			return
 		}
+
+		waitTime := time.Duration(config.Config.Heartbeat) * time.Second * 2
+
 		err = eh.chClient.Init()
 		if err != nil {
-			klog.Errorf("connection error, try again after 60s: %v", err)
-			time.Sleep(waitConnectionPeriod)
+			klog.Errorf("connection failed: %v, will reconnect after %s", err, waitTime.String())
+			time.Sleep(waitTime)
 			continue
 		}
 		// execute hook func after connect
@@ -102,7 +105,8 @@ func (eh *EdgeHub) Start() {
 		eh.pubConnectInfo(false)
 
 		// sleep one period of heartbeat, then try to connect cloud hub again
-		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second * 2)
+		klog.Warningf("connection is broken, will reconnect after %s", waitTime.String())
+		time.Sleep(waitTime)
 
 		// clean channel
 	clean:


### PR DESCRIPTION
Cherry pick of #2641 on release-1.6.

#2641: Shorten the reconnect wait time when connect failed

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.