### PR TITLE
Automated cherry pick of #2599: Fix the warning log when edgemesh is disabled

### DIFF
--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/beehive/pkg/common/util"
+	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
 	cloudmodules "github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
@@ -60,6 +61,10 @@ func sendToEdged(message *model.Message, sync bool) {
 }
 
 func sendToEdgeMesh(message *model.Message, sync bool) {
+	// if edgeMesh module disabled, then return
+	if _, ok := core.GetModules()[modules.EdgeMeshModuleName]; !ok {
+		return
+	}
 	if sync {
 		beehiveContext.SendResp(*message)
 	} else {


### PR DESCRIPTION
Cherry pick of #2599 on release-1.6.

#2599: Fix the warning log when edgemesh is disabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.