### PR TITLE
adjust nsswitch configuration to fix dns lookup error

### DIFF
--- a/docs/contributing/edgemesh_guide.md
+++ b/docs/contributing/edgemesh_guide.md
@@ -20,7 +20,7 @@ Modify `/etc/nsswitch.conf`, make sure `dns` is first order, like below:
 
 ```
 $ grep hosts /etc/nsswitch.conf
-hosts:          dns file mdns4_minimal [NOTFOUND=return]
+hosts:          dns files mdns4_minimal [NOTFOUND=return]
 ```
 
 ### IP Forward Setting


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
As metioned at #2647, if we don't apply this change, it would bring in a huge error by executing `nslookup localhost `, and the edgecore would not  start properly on some operating system.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
To fix #2647

**Special notes for your reviewer**:
A description mentioned [here](https://en.wikipedia.org/wiki/Name_Service_Switch#nsswitch.conf)