### PR TITLE
cloud: fix the warning log for printing object type

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -87,7 +87,7 @@ func (dc *DownstreamController) syncDeviceModel() {
 		case e := <-dc.deviceModelManager.Events():
 			deviceModel, ok := e.Object.(*v1alpha2.DeviceModel)
 			if !ok {
-				klog.Warningf("object type: %T unsupported", deviceModel)
+				klog.Warningf("object type: %T unsupported", e.Object)
 				continue
 			}
 			switch e.Type {
@@ -155,7 +155,7 @@ func (dc *DownstreamController) syncDevice() {
 		case e := <-dc.deviceManager.Events():
 			device, ok := e.Object.(*v1alpha2.Device)
 			if !ok {
-				klog.Warningf("Object type: %T unsupported", device)
+				klog.Warningf("Object type: %T unsupported", e.Object)
 				continue
 			}
 			switch e.Type {

--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -64,7 +64,7 @@ func (dc *DownstreamController) syncPod() {
 		case e := <-dc.podManager.Events():
 			pod, ok := e.Object.(*v1.Pod)
 			if !ok {
-				klog.Warningf("object type: %T unsupported", pod)
+				klog.Warningf("object type: %T unsupported", e.Object)
 				continue
 			}
 			if !dc.lc.IsEdgeNode(pod.Spec.NodeName) {
@@ -108,7 +108,7 @@ func (dc *DownstreamController) syncConfigMap() {
 		case e := <-dc.configmapManager.Events():
 			configMap, ok := e.Object.(*v1.ConfigMap)
 			if !ok {
-				klog.Warningf("object type: %T unsupported", configMap)
+				klog.Warningf("object type: %T unsupported", e.Object)
 				continue
 			}
 			var operation string
@@ -160,7 +160,7 @@ func (dc *DownstreamController) syncSecret() {
 		case e := <-dc.secretManager.Events():
 			secret, ok := e.Object.(*v1.Secret)
 			if !ok {
-				klog.Warningf("object type: %T unsupported", secret)
+				klog.Warningf("object type: %T unsupported", e.Object)
 				continue
 			}
 			var operation string
@@ -213,7 +213,7 @@ func (dc *DownstreamController) syncEdgeNodes() {
 		case e := <-dc.nodeManager.Events():
 			node, ok := e.Object.(*v1.Node)
 			if !ok {
-				klog.Warningf("Object type: %T unsupported", node)
+				klog.Warningf("Object type: %T unsupported", e.Object)
 				continue
 			}
 			switch e.Type {
@@ -325,7 +325,7 @@ func (dc *DownstreamController) syncService() {
 		case e := <-dc.serviceManager.Events():
 			svc, ok := e.Object.(*v1.Service)
 			if !ok {
-				klog.Warningf("Object type: %T unsupported", svc)
+				klog.Warningf("Object type: %T unsupported", e.Object)
 				continue
 			}
 			switch e.Type {
@@ -378,7 +378,7 @@ func (dc *DownstreamController) syncEndpoints() {
 		case e := <-dc.endpointsManager.Events():
 			eps, ok := e.Object.(*v1.Endpoints)
 			if !ok {
-				klog.Warningf("Object type: %T unsupported", eps)
+				klog.Warningf("Object type: %T unsupported", e.Object)
 				continue
 			}
 
@@ -469,7 +469,7 @@ func (dc *DownstreamController) syncRule() {
 			klog.V(4).Infof("Get rule events: event type: %s.", e.Type)
 			rule, ok := e.Object.(*routerv1.Rule)
 			if !ok {
-				klog.Warningf("object type: %T unsupported", e)
+				klog.Warningf("object type: %T unsupported", e.Object)
 				continue
 			}
 			klog.V(4).Infof("Get rule events: rule object: %+v.", rule)
@@ -512,7 +512,7 @@ func (dc *DownstreamController) syncRuleEndpoint() {
 			klog.V(4).Infof("Get ruleEndpoint events: event type: %s.", e.Type)
 			ruleEndpoint, ok := e.Object.(*routerv1.RuleEndpoint)
 			if !ok {
-				klog.Warningf("object type: %T unsupported", ruleEndpoint)
+				klog.Warningf("object type: %T unsupported", e.Object)
 				continue
 			}
 			klog.V(4).Infof("Get ruleEndpoint events: ruleEndpoint object: %+v.", ruleEndpoint)


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
The type of the value after the assertion is the type of the assertion.
Here we need to print the type of the `e.Object`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
