### PR TITLE
Fix dynamiccontroller returned error missing

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application_test.go
+++ b/cloud/pkg/dynamiccontroller/application/application_test.go
@@ -1,0 +1,55 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestApplicationReason(t *testing.T) {
+	type args struct {
+		set  error
+		want error
+	}
+	normalErr := fmt.Errorf("a normal error include %w", errors.New("internal error"))
+	app := newApplication(context.Background(), "", "", "", nil, nil)
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "TestApplicationReason(): Case 1: no reason",
+			args: args{
+				nil,
+				nil,
+			},
+		},
+		{
+			name: "TestApplicationReason(): Case 2: apierrors.",
+			args: args{
+				apierrors.NewAlreadyExists(schema.GroupResource{Resource: "foos"}, "bar"),
+				apierrors.NewAlreadyExists(schema.GroupResource{Resource: "foos"}, "bar"),
+			},
+		},
+		{
+			name: "TestApplicationReason(): Case 3: normal error should return a wrapped internal error",
+			args: args{
+				normalErr,
+				apierrors.NewInternalError(normalErr),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app.setReason(tt.args.set)
+			if reason := app.getReason(); !reflect.DeepEqual(reason, tt.args.want) {
+				t.Errorf("TestApplicationReason error = %v  wantErr %v", reason, tt.args.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:

The dynamiccontroller need return raw error to caller.Otherwise caller use kubernetes built-in methods like `errors.IsNotFound(err)` will get unexpected result.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
