### PR TITLE
modify devicetwin module configuration package visibility

### DIFF
--- a/edge/pkg/devicetwin/config/config.go
+++ b/edge/pkg/devicetwin/config/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 )
 
-var Config Configure
+var config Configure
 var once sync.Once
 
 type Configure struct {
@@ -16,7 +16,7 @@ type Configure struct {
 
 func InitConfigure(deviceTwin *v1alpha1.DeviceTwin, nodeName string) {
 	once.Do(func() {
-		Config = Configure{
+		config = Configure{
 			DeviceTwin: *deviceTwin,
 			NodeName:   nodeName,
 		}
@@ -24,5 +24,5 @@ func InitConfigure(deviceTwin *v1alpha1.DeviceTwin, nodeName string) {
 }
 
 func Get() *Configure {
-	return &Config
+	return &config
 }

--- a/edge/pkg/devicetwin/dtcontext/dtcontext.go
+++ b/edge/pkg/devicetwin/dtcontext/dtcontext.go
@@ -36,7 +36,7 @@ type DTContext struct {
 func InitDTContext() (*DTContext, error) {
 	return &DTContext{
 		GroupID:       "",
-		NodeName:      deviceconfig.Config.NodeName,
+		NodeName:      deviceconfig.Get().NodeName,
 		CommChan:      make(map[string]chan interface{}),
 		ConfirmChan:   make(chan interface{}, 1000),
 		ConfirmMap:    &sync.Map{},


### PR DESCRIPTION

Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
devicetwin module provides the Get() method to obtain configure, so we don't need upper case 'Configure'
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
