### PR TITLE
Remove Msg WriteTo

### DIFF
--- a/cloud/pkg/cloudstream/session.go
+++ b/cloud/pkg/cloudstream/session.go
@@ -45,7 +45,7 @@ type Session struct {
 }
 
 func (s *Session) WriteMessageToTunnel(m *stream.Message) error {
-	return m.WriteTo(s.tunnel)
+	return s.tunnel.WriteMessage(m)
 }
 
 func (s *Session) Close() {

--- a/pkg/stream/edgedexecconnection.go
+++ b/pkg/stream/edgedexecconnection.go
@@ -85,7 +85,7 @@ func (e *EdgedExecConnection) Serve(tunnel SafeWriteTunneler) error {
 	defer func() {
 		for retry := 0; retry < 3; retry++ {
 			msg := NewMessage(e.MessID, MessageTypeRemoveConnect, nil)
-			if err := msg.WriteTo(tunnel); err != nil {
+			if err := tunnel.WriteMessage(msg); err != nil {
 				klog.Errorf("%v send %s message error %v", e, msg.MessageType, err)
 			} else {
 				break
@@ -112,7 +112,7 @@ func (e *EdgedExecConnection) Serve(tunnel SafeWriteTunneler) error {
 			continue
 		}
 		msg := NewMessage(e.MessID, MessageTypeData, data[:n])
-		if err := msg.WriteTo(tunnel); err != nil {
+		if err := tunnel.WriteMessage(msg); err != nil {
 			klog.Errorf("%v failed to write to tunnel, msg: %+v, err: %v", e.String(), msg, err)
 			return err
 		}

--- a/pkg/stream/edgedlogconnection.go
+++ b/pkg/stream/edgedlogconnection.go
@@ -85,7 +85,7 @@ func (l *EdgedLogsConnection) Serve(tunnel SafeWriteTunneler) error {
 	defer func() {
 		for retry := 0; retry < 3; retry++ {
 			msg := NewMessage(l.MessID, MessageTypeRemoveConnect, nil)
-			if err := msg.WriteTo(tunnel); err != nil {
+			if err := tunnel.WriteMessage(msg); err != nil {
 				klog.Errorf("%v send %s message error %v", l, msg.MessageType, err)
 			} else {
 				break
@@ -113,7 +113,7 @@ func (l *EdgedLogsConnection) Serve(tunnel SafeWriteTunneler) error {
 		}
 		msg := NewMessage(l.MessID, MessageTypeData, data[:n])
 
-		err = msg.WriteTo(tunnel)
+		err = tunnel.WriteMessage(msg)
 		if err != nil {
 			klog.Errorf("write tunnel message %v error", msg)
 			return err

--- a/pkg/stream/edgedmetricsconnection.go
+++ b/pkg/stream/edgedmetricsconnection.go
@@ -90,7 +90,7 @@ func (ms *EdgedMetricsConnection) Serve(tunnel SafeWriteTunneler) error {
 	defer func() {
 		for retry := 0; retry < 3; retry++ {
 			msg := NewMessage(ms.MessID, MessageTypeRemoveConnect, nil)
-			if err := msg.WriteTo(tunnel); err != nil {
+			if err := tunnel.WriteMessage(msg); err != nil {
 				klog.Errorf("%v send %s message error %v", ms, msg.MessageType, err)
 			} else {
 				break
@@ -107,7 +107,7 @@ func (ms *EdgedMetricsConnection) Serve(tunnel SafeWriteTunneler) error {
 		}
 		// 10 = \n
 		msg := NewMessage(ms.MessID, MessageTypeData, append(scan.Bytes(), 10))
-		err := msg.WriteTo(tunnel)
+		err := tunnel.WriteMessage(msg)
 		if err != nil {
 			klog.Errorf("write tunnel message %v error", msg)
 			return err

--- a/pkg/stream/message.go
+++ b/pkg/stream/message.go
@@ -67,10 +67,6 @@ func NewMessage(id uint64, messType MessageType, data []byte) *Message {
 	}
 }
 
-func (m *Message) WriteTo(tunneler SafeWriteTunneler) error {
-	return tunneler.WriteMessage(m)
-}
-
 func (m *Message) Bytes() []byte {
 	// connectID + MessageType + Data
 	buf, offset := make([]byte, 16), 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
```
func (m *Message) WriteTo(tunneler SafeWriteTunneler) error {
	return tunneler.WriteMessage(m)
}
```
`WriteTo` has the same name as the interface `io.WriterTo` of the standard library, and I think the function does not make much sense.

https://golang.org/src/io/io.go?s=6763:6830#L185

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
