### PR TITLE
has systemd double check

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -422,15 +422,15 @@ func isEdgeCoreServiceRunning(serviceName string) (bool, error) {
 }
 
 // check if systemd exist
-// if command run failed,then check it by sd_booted
-// reference http://www.freedesktop.org/software/systemd/man/sd_booted.html
+// if command run failed, then check it by sd_booted
 func hasSystemd() bool {
 	cmd := "file /sbin/init"
 
 	if err := NewCommand(cmd).Exec(); err == nil {
 		return true
 	}
-	//checks whether `SystemdBootPath` exists and is a directory
+	// checks whether `SystemdBootPath` exists and is a directory
+	// reference http://www.freedesktop.org/software/systemd/man/sd_booted.html
 	fi, err := os.Lstat(SystemdBootPath)
 	if err != nil {
 		return false

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -63,6 +63,8 @@ const (
 
 	EdgeRootDir = "/var/lib/edged"
 
+	SystemdBootPath = "/run/systemd/system"
+
 	KubeEdgeCRDDownloadURL = "https://raw.githubusercontent.com/kubeedge/kubeedge/master/build/crds"
 
 	latestReleaseVersionURL = "https://kubeedge.io/latestversion"
@@ -420,14 +422,20 @@ func isEdgeCoreServiceRunning(serviceName string) (bool, error) {
 }
 
 // check if systemd exist
+// if command run failed,then check it by sd_booted
+// reference http://www.freedesktop.org/software/systemd/man/sd_booted.html
 func hasSystemd() bool {
 	cmd := "file /sbin/init"
 
-	if err := NewCommand(cmd).Exec(); err != nil {
+	if err := NewCommand(cmd).Exec(); err == nil {
+		return true
+	}
+	//checks whether `SystemdBootPath` exists and is a directory
+	fi, err := os.Lstat(SystemdBootPath)
+	if err != nil {
 		return false
 	}
-
-	return true
+	return fi.IsDir()
 }
 
 func checkSum(filename, checksumFilename string, version semver.Version, tarballPath string) (bool, error) {


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
In my case, running `keadm int` in a simplified centos machine.there is no `file` command existed,so hasSystemd() always return false,but systemd is surely running there.After false return,we can do check it again by sb_booted.(reference http://www.freedesktop.org/software/systemd/man/sd_booted.html)

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?: