### PR TITLE
Close response body when request done

### DIFF
--- a/cloud/pkg/router/listener/message.go
+++ b/cloud/pkg/router/listener/message.go
@@ -3,6 +3,7 @@ package listener
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -76,9 +77,14 @@ func (mh *MessageHandler) HandleMessage(message *model.Message) error {
 		return err
 	}
 	go func(message *model.Message) {
-		_, err := handler(message)
+		resp, err := handler(message)
 		if err != nil {
 			klog.Errorf("handle message occur error, msgID: %s, reason: %s", message.GetID(), err.Error())
+		}
+		if resp != nil {
+			if err = resp.(*http.Response).Body.Close(); err != nil {
+				klog.Errorf("close response occur error, msgID: %s, reason: %s", message.GetID(), err.Error())
+			}
 		}
 	}(message)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Increase the concurrency of sending messages from eventbus to rest:
```bash
# In edge node:
# It means publish "hello" to topic for 1050 times.
[root@centos78-edge-0 ~]# ./kubeedge-router-manager-bench -t er -b tcp://127.0.0.1:1883 -e "default/test-1" -m "hello" -n 1050
2021/03/26 18:36:13 eventbus.go:30: Sending start: 2021-03-26 10:36:13.857187449 +0000 UTC
2021/03/26 18:36:15 eventbus.go:44: Sending end: 2021-03-26 10:36:15.281538685 +0000 UTC
2021/03/26 18:36:15 eventbus.go:47: Test done.
Sum: 1050, Faild: 0, Time-Spending: 1.424350994s

# In cloud node:
# It means creates a listener and expects to receive message for 1050 times
[root@10 kubeedge-router-manager-bench]# ./kubeedge-router-manager-bench -t er -r 127.0.0.1:8080/test-1 -n 1050
2021/03/26 18:36:16 rest.go:65: Test done.
Sum: 1050, Faild: 0, Time-Spending: 1.422007239s
```
You can get this bench here: https://github.com/JackZxj/kubeedge-router-manager-bench

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2730

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

