### PR TITLE
Add CLOUDCOREDOMAIN variable to certgen.sh when generate stream cert

### DIFF
--- a/build/tools/certgen.sh
+++ b/build/tools/certgen.sh
@@ -57,8 +57,8 @@ stream() {
     readonly K8SCA_FILE=/etc/kubernetes/pki/ca.crt
     readonly K8SCA_KEY_FILE=/etc/kubernetes/pki/ca.key
 
-    if [ -z ${CLOUDCOREIPS} ]; then
-        echo "You must set CLOUDCOREIPS Env,The environment variable is set to specify the IP addresses of all cloudcore"
+    if [ -z ${CLOUDCOREIPS} -a -z ${CLOUDCOREDOMAIN} ]; then
+        echo "You must set CLOUDCOREIPS or CLOUDCOREDOMAIN Env,The environment variable is set to specify the IP/DOMAIN addresses of all cloudcore"
         echo "If there are more than one IP need to be separated with space."
         exit 1
     fi
@@ -70,6 +70,19 @@ stream() {
         index=$(($index+1))
         SUBJECTALTNAME="${SUBJECTALTNAME}IP.${index}:${ip}"
     done
+
+
+    if [ -n "${CLOUDCOREDOMAIN}" ]; then
+        index=0
+        SUBJECTALTNAME="subjectAltName = "
+        for domain in ${CLOUDCOREDOMAIN}; do
+            if [ ${index} -gt 0 ];then
+                SUBJECTALTNAME="${SUBJECTALTNAME},"
+            fi
+            index=$(($index+1))
+            SUBJECTALTNAME="${SUBJECTALTNAME}DNS.${index}:${domain}"
+        done
+    fi
 
     cp /etc/kubernetes/pki/ca.crt ${caPath}/streamCA.crt
     echo $SUBJECTALTNAME > /tmp/server-extfile.cnf


### PR DESCRIPTION
Signed-off-by: hackers365 <hackers365@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Add CLOUDCOREDOMAIN variable to certgen.sh when generate stream cert

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2741

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
