### PR TITLE
Fix RemoveConnect cannot cancel directly

### DIFF
--- a/pkg/stream/edgedmetricsconnection.go
+++ b/pkg/stream/edgedmetricsconnection.go
@@ -74,14 +74,15 @@ func (ms *EdgedMetricsConnection) Serve(tunnel SafeWriteTunneler) error {
 		return err
 	}
 	defer resp.Body.Close()
-	scan := bufio.NewScanner(resp.Body)
+
 	stop := make(chan struct{})
 
 	go func() {
+		defer close(stop)
+
 		for mess := range ms.ReadChan {
 			if mess.MessageType == MessageTypeRemoveConnect {
 				klog.Infof("receive remove client id %v", mess.ConnectID)
-				close(stop)
 				return
 			}
 		}
@@ -98,22 +99,24 @@ func (ms *EdgedMetricsConnection) Serve(tunnel SafeWriteTunneler) error {
 		}
 	}()
 
-	for scan.Scan() {
-		select {
-		case <-stop:
-			klog.Infof("receive stop single, so stop metrics scan ...")
-			return nil
-		default:
+	go func() {
+		defer close(ms.ReadChan)
+
+		scan := bufio.NewScanner(resp.Body)
+		for scan.Scan() {
+			// 10 = \n
+			msg := NewMessage(ms.MessID, MessageTypeData, append(scan.Bytes(), 10))
+			err := tunnel.WriteMessage(msg)
+			if err != nil {
+				klog.Errorf("write tunnel message %v error", msg)
+				return
+			}
+			klog.Infof("%v write metrics data %v", ms.String(), string(scan.Bytes()))
 		}
-		// 10 = \n
-		msg := NewMessage(ms.MessID, MessageTypeData, append(scan.Bytes(), 10))
-		err := tunnel.WriteMessage(msg)
-		if err != nil {
-			klog.Errorf("write tunnel message %v error", msg)
-			return err
-		}
-		klog.Infof("%v write metrics data %v", ms.String(), string(scan.Bytes()))
-	}
+	}()
+
+	<-stop
+	klog.Infof("receive stop single, so stop metrics scan ...")
 	return nil
 }
 


### PR DESCRIPTION
Fix that RemoveConnect cannot directly trigger the end of the connection and it must be triggered by receiving a new message.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
