### PR TITLE
skip init edged if disable

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -411,6 +411,12 @@ func (e *edged) cgroupRoots() []string {
 
 //newEdged creates new edged object and initialises it
 func newEdged(enable bool) (*edged, error) {
+	// skip init edged if disabled
+	if !enable {
+		return &edged{
+			enable: enable,
+		}, nil
+	}
 	backoff := flowcontrol.NewBackOff(backOffPeriod, MaxContainerBackOff)
 
 	podManager := podmanager.NewPodManager()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Although user disable edged, it will be created and inited by func newEdged, which cause unnecessary consumption of resources.
**Which issue(s) this PR fixes**:
None

