### PR TITLE
support metaserver to resolve meta request like /api

### DIFF
--- a/edge/pkg/metamanager/metaserver/server.go
+++ b/edge/pkg/metamanager/metaserver/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/serializer"
+	"github.com/kubeedge/kubeedge/pkg/metaserver/metarequset"
 )
 
 const (
@@ -97,6 +98,7 @@ func BuildHandlerChain(handler http.Handler, ls *MetaServer) http.Handler {
 		LegacyAPIGroupPrefixes: sets.NewString(server.DefaultLegacyAPIPrefix),
 	}
 	handler = genericfilters.WithWaitGroup(handler, ls.LongRunningFunc, ls.HandlerChainWaitGroup)
+	handler = metarequset.DecorateMetaRequest(handler)
 	handler = genericapifilters.WithRequestInfo(handler, server.NewRequestInfoResolver(cfg))
 	handler = genericfilters.WithPanicRecovery(handler)
 	return handler

--- a/pkg/metaserver/metarequset/metarequest.go
+++ b/pkg/metaserver/metarequset/metarequest.go
@@ -1,0 +1,140 @@
+package metarequset
+
+import (
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+const (
+	MetaGroup           = "meta"
+	MetaVersion         = "v1"
+	resourceListNameSep = "---" //not export
+
+	APIVersionsKind     = "APIVersions"
+	APIGroupListKind    = "APIGroupList"
+	APIGroupKind        = "APIGroup"
+	APIResourceListKind = "APIResourceList"
+
+	APIVersionsResource     = "apiversions"
+	APIGroupListResource    = "apigrouplists"
+	APIGroupResource        = "apigroups"
+	APIResourceListResource = "apiresourcelists"
+
+	DefaultAPIVersionsObjName  = "cloud-apiversions"
+	DefaultAPIGroupListObjName = "cloud-apigrouplist"
+)
+
+var (
+	MetaGroupVersion = schema.GroupVersion{Group: MetaGroup, Version: MetaVersion}
+	APIVersions      = MetaGroupVersion.WithResource(APIVersionsResource)
+	APIGroupLists    = MetaGroupVersion.WithResource(APIGroupListResource)
+	APIGroups        = MetaGroupVersion.WithResource(APIGroupResource)
+	APIResourceLists = MetaGroupVersion.WithResource(APIResourceListResource)
+)
+
+// DecorateMetaRequest check if the request is meta request and transform it to normal get request.
+// meta request here is that wants to get resources which belongs to Group "meta", and it's request
+// path is abnormal:
+// |     Path     |              NewGetPath                    |         Want Resources        |
+// |--------------|--------------------------------------------|-------------------------------|
+// |/api          |/apis/meta/v1/apiversions/cloud-apiversions |APIVersions      only one      |
+// |/apis         |/apis/meta/v1/apigrouplists/cloud-apigroups |APIGroupList     only one      |
+// |/apis/{g}     |/apis/meta/v1/apigroups/{g}                 |APIGroup                       |
+// |/apis/{g}/{v} |/apis/meta/v1/apiresourcelists/{g}{SEP}{v}  |APIResourcesList below {g}/{v} |
+// |/api/v1       |/apis/meta/v1/apiresourcelists/---v1        |APIResourcesList below /v1     |
+// {g}={group}, {v}={version}, {SEP} = resourceListNameSep
+// "only one" means there is only one obj of this kind resource in cluster-wide
+func DecorateMetaRequest(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		reqInfo, ok := apirequest.RequestInfoFrom(ctx)
+		if ok {
+			if gvr, name, ok := isMetaRequest(reqInfo); ok {
+				// transform to normal get request
+				reqInfo.IsResourceRequest = true
+				reqInfo.Verb = "get"
+				reqInfo.APIPrefix = "apis"
+				reqInfo.APIGroup = gvr.Group
+				reqInfo.APIVersion = gvr.Version
+				reqInfo.Resource = gvr.Resource
+				reqInfo.Path = "/apis/meta/v1/" + gvr.Resource + "/" + name
+				reqInfo.Name = name
+				req = req.WithContext(apirequest.WithRequestInfo(req.Context(), reqInfo))
+			}
+		}
+		handler.ServeHTTP(w, req)
+	})
+}
+
+func isMetaRequest(info *apirequest.RequestInfo) (gvr schema.GroupVersionResource, name string, ok bool) {
+	switch info.Path {
+	case "/api":
+		return APIVersions, DefaultAPIVersionsObjName, true
+	case "/apis":
+		return APIGroupLists, DefaultAPIGroupListObjName, true
+	case "/api/v1":
+		gv := schema.GroupVersion{Group: "", Version: "v1"}
+		return APIResourceLists, ResourceListNameParser.New(gv), true
+	}
+	if strings.HasPrefix(info.Path, "/apis") {
+		path := strings.TrimRight(info.Path, "/")
+		slice := strings.Split(path, "/")
+		switch len(slice) {
+		case 3: // /apis/group
+			groupIndex := 2
+			return APIGroups, slice[groupIndex], true
+		case 4: // /apis/group/version
+			groupIndex, versionIndex := 2, 3
+			gv := schema.GroupVersion{Group: slice[groupIndex], Version: slice[versionIndex]}
+			return APIResourceLists, ResourceListNameParser.New(gv), true
+		}
+	}
+	return schema.GroupVersionResource{}, "", false
+}
+
+// ResourceListName contains information of group and version, which is uesd
+// to construct request's path to API Server.
+type resourceListNameParser struct{}
+
+var ResourceListNameParser = resourceListNameParser{}
+
+// New construct a resouceListName according to given group/version,
+// format is "{Group}{SEP}{Version}"
+func (p *resourceListNameParser) New(gv schema.GroupVersion) string {
+	return gv.Group + resourceListNameSep + gv.Version
+}
+
+// Parse parse out group/version according to given name and format, remember
+// it fails if group or version contains resourceListNameSep.
+func (p *resourceListNameParser) Parse(name string) schema.GroupVersion {
+	slice := strings.Split(name, resourceListNameSep)
+	if len(slice) != 2 { // group/version
+		return schema.GroupVersion{}
+	}
+	groupIndex := 0
+	versionIndex := 1
+	return schema.GroupVersion{Group: slice[groupIndex], Version: slice[versionIndex]}
+}
+
+// meta api miss information of name, it prevents key generation for meta api obj
+// so add this kind of information here.
+type NamedAPIVersions struct {
+	metav1.APIVersions `json:",inline"`
+	metav1.ObjectMeta  `json:"metadata,omitempty"`
+}
+type NamedAPIGroupList struct {
+	metav1.APIGroupList `json:",inline"`
+	metav1.ObjectMeta   `json:"metadata,omitempty"`
+}
+type NamedAPIGroup struct {
+	metav1.APIGroup   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+type NamedAPIResourceList struct {
+	metav1.APIResourceList `json:",inline"`
+	metav1.ObjectMeta      `json:"metadata,omitempty"`
+}

--- a/pkg/metaserver/metarequset/metarequest_test.go
+++ b/pkg/metaserver/metarequset/metarequest_test.go
@@ -1,0 +1,105 @@
+package metarequset
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+type partReqInfo struct {
+	Path     string
+	Resource string
+	Name     string
+}
+
+func TestDecorateMetaRequest(t *testing.T) {
+	baseReqInfo := &apirequest.RequestInfo{
+		IsResourceRequest: true,
+		Verb:              "get",
+		APIPrefix:         "apis",
+		APIGroup:          MetaGroup,
+		APIVersion:        MetaVersion,
+	}
+	Cases := []struct {
+		Path string
+		Want partReqInfo
+	}{
+		{
+			"/api",
+			partReqInfo{
+				"/apis/meta/v1/" + APIVersionsResource + "/" + DefaultAPIVersionsObjName,
+				APIVersionsResource,
+				DefaultAPIVersionsObjName,
+			},
+		},
+		{
+			"/apis",
+			partReqInfo{
+				"/apis/meta/v1/" + APIGroupListResource + "/" + DefaultAPIGroupListObjName,
+				APIGroupListResource,
+				DefaultAPIGroupListObjName,
+			},
+		},
+		{
+			"/apis/apps",
+			partReqInfo{
+				"/apis/meta/v1/" + APIGroupResource + "/" + "apps",
+				APIGroupResource,
+				"apps",
+			},
+		},
+		{
+			"/apis/apps/v1",
+			partReqInfo{
+				"/apis/meta/v1/" + APIResourceListResource + "/" + "apps---v1",
+				APIResourceListResource,
+				"apps---v1",
+			},
+		},
+		{
+			"/api/v1",
+			partReqInfo{
+				"/apis/meta/v1/" + APIResourceListResource + "/" + "---v1",
+				APIResourceListResource,
+				"---v1",
+			},
+		},
+		{
+			"/apis/apps///////",
+			partReqInfo{
+				"/apis/meta/v1/" + APIGroupResource + "/" + "apps",
+				APIGroupResource,
+				"apps",
+			},
+		},
+	}
+	for _, test := range Cases {
+		t.Run("DecorateMetaRequest", func(t *testing.T) {
+			var exportError error
+			baseCheckHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				exportError = nil
+				reqInfo, ok := apirequest.RequestInfoFrom(req.Context())
+				if !ok {
+					exportError = fmt.Errorf("failed to get req info from req ctx")
+					return
+				}
+				stdReqInfo := baseReqInfo
+				stdReqInfo.Path = test.Want.Path
+				stdReqInfo.Resource = test.Want.Resource
+				stdReqInfo.Name = test.Want.Name
+				if !reflect.DeepEqual(stdReqInfo, reqInfo) {
+					exportError = fmt.Errorf("failed to get wanted req info:\nwant(%+v)\n get(%+v)", stdReqInfo, reqInfo)
+				}
+			})
+			req := &http.Request{}
+			req = req.WithContext(apirequest.WithRequestInfo(req.Context(), &apirequest.RequestInfo{Path: test.Path}))
+			DecorateMetaRequest(baseCheckHandler).ServeHTTP(nil, req)
+			if exportError != nil {
+				t.Errorf("DecorateMetaRequest(%v) Error, %v", test.Path, exportError)
+			}
+		})
+	}
+}

--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/klog/v2"
 
 	beehiveModel "github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/pkg/metaserver/metarequset"
 )
 
 const (
@@ -50,9 +51,13 @@ func UnsafeResourceToKind(r string) string {
 		return r
 	}
 	unusualResourceToKind := map[string]string{
-		"endpoints": "Endpoints",
-		"nodes":     "Node",
-		"services":  "Service",
+		"endpoints":                         "Endpoints",
+		"nodes":                             "Node",
+		"services":                          "Service",
+		metarequset.APIVersionsResource:     metarequset.APIVersionsKind,
+		metarequset.APIGroupListResource:    metarequset.APIGroupListKind,
+		metarequset.APIGroupResource:        metarequset.APIGroupKind,
+		metarequset.APIResourceListResource: metarequset.APIResourceListKind,
 	}
 	if v, isUnusual := unusualResourceToKind[r]; isUnusual {
 		return v
@@ -74,7 +79,8 @@ func UnsafeKindToResource(k string) string {
 		return k
 	}
 	unusualKindToResource := map[string]string{
-		"Endpoints": "endpoints",
+		"Endpoints":                 "endpoints",
+		metarequset.APIVersionsKind: metarequset.APIVersionsResource,
 	}
 	if v, isUnusual := unusualKindToResource[k]; isUnusual {
 		return v


### PR DESCRIPTION
# About This PR
**What type of PR is this?**
/kind feature
**What this PR does / why we need it**:
Some MetaServer 's clients will send meta request which is generated by a kind of kube-client called [Discovery](https://github.com/kubernetes/kubernetes/blob/93c7b24562d80959f45c308e7412456a410b9b25/staging/src/k8s.io/client-go/discovery/discovery_client.go#L53-L61):
```go
// DiscoveryInterface holds the methods that discover server-supported API groups,
// versions and resources.
type DiscoveryInterface interface {
	RESTClient() restclient.Interface
	ServerGroupsInterface
	ServerResourcesInterface
	ServerVersionInterface
	OpenAPISchemaInterface
}
``` 
And the REST path of this kind of meta request like below:
1. /api
2. /apis
3. /api/v1

Some native kubernetes application will use this kind of client For example:
1. **kube-proxy**,https://github.com/kubernetes/kubernetes/blob/fc4f91f10b0ea36c0be002a3810e36ae6ac5fe54/cmd/kube-proxy/app/server.go#L747
2. **kubectl**, https://github.com/kubernetes/kubernetes/blob/6c96a059dd4a64f1917378b4a0c13899dff31918/staging/src/k8s.io/kubectl/pkg/cmd/util/factory_client_access.go#L71
3. **event-broker**, https://github.com/kubernetes/kubernetes/blob/ade242288346d968ab97f42ffb30e0855e235afc/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go#L344

To Compatible with it, metaserver must to have the abblity to resolve such meta request. **And I think it is a universal demand that an edge application will use Discovery client to check if an crd are supported or registerd in cluster.**



# Appendix: How to connect metaserver with **kubectl**
The kubectl command line tool lets you control Kubernetes clusters. How to use kubectl please refer to [kubernetes offical guidance document](https://kubernetes.io/docs/reference/kubectl/overview/). Now we:
1.  support part of commands like **get, delete, create, describe, -o yaml**,  
2.  but do not support **No-Object** command like **attach, top, exec, proxy,logs and so on**.
## Enable AKE feature
Plz refer to #2760
## Config kubeconfig
Before using kubectl, we need to prepare a kubeconfig which points to metaserver. There are two ways to achieve it:
**1. create a new kubeconfig**
The content of new kubeconfig is like below, name it _ake-kubeconfig.yaml_, and then use `kubectl --kubeconfig=ake-kubeconfig.yaml` every time when access metaserver.
```yaml
apiVersion: v1
kind: Config
clusters:
- cluster:
    server: http://127.0.0.1:10550
  name: ake-test-cluster
contexts:
- context:
    cluster: ake-test-cluster
    user: ""
  name: ake-test-ctx
current-context: ake-test-ctx
preferences: {}
users: null
```
**2. modify default kubeconfig file at _~/.kube/config_ if have.**
Add a new context called _ake-test-ctx_ and change _current-context_ to it. Use `kubectl config view` to show whether the modified kubeconfig is in effect.
```yaml
apiVersion: v1
kind: Config
clusters:
- cluster: #old cluster, don not touch
  ...
- cluster: #add a new cluster
    server: http://127.0.0.1:10550
  name: ake-test-cluster
contexts:
- context: #old context, do not touch
  ...
- context: #add a new context
    cluster: ake-test-cluster
    user: "" 
  name: ake-test-ctx
current-context: ake-test-ctx #change old context to new
preferences: {} #do not touch
users: #do not touch 
  ...
```
## Example
![image](https://user-images.githubusercontent.com/29768082/114646189-5fa95280-9d0d-11eb-9f7a-e9ad68887a5e.png)
![image](https://user-images.githubusercontent.com/29768082/114646221-7354b900-9d0d-11eb-9a19-bb6afb16017d.png)

![image](https://user-images.githubusercontent.com/29768082/114536689-e7e31580-9c83-11eb-9317-c580f9adf956.png)

![image](https://user-images.githubusercontent.com/29768082/114536798-05b07a80-9c84-11eb-9979-92f861b5e7a2.png)


