### PR TITLE
Skip init device controller if disable

### DIFF
--- a/cloud/pkg/devicecontroller/devicecontroller.go
+++ b/cloud/pkg/devicecontroller/devicecontroller.go
@@ -21,6 +21,9 @@ type DeviceController struct {
 }
 
 func newDeviceController(enable bool) *DeviceController {
+	if !enable {
+		return &DeviceController{enable: enable}
+	}
 	downstream, err := controller.NewDownstreamController(informers.GetInformersManager().GetCRDInformerFactory())
 	if err != nil {
 		klog.Fatalf("New downstream controller failed with error: %s", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
Although user disable device controller, it will be still created and inited, which cause unnecessary consumption of resources.
