### PR TITLE
Two minor changes:

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/util.go
+++ b/edge/pkg/devicetwin/dtcommon/util.go
@@ -2,6 +2,7 @@ package dtcommon
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,7 +14,7 @@ func ValidateValue(valueType string, value string) error {
 	case "":
 		valueType = "string"
 		return nil
-	case "string":
+	case "string", "bytes":
 		return nil
 	case "int", "integer":
 		_, err := strconv.ParseInt(value, 10, 64)
@@ -21,7 +22,7 @@ func ValidateValue(valueType string, value string) error {
 			return errors.New("the value is not int or integer")
 		}
 		return nil
-	case "float":
+	case "float", "double":
 		_, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return errors.New("the value is not float")
@@ -35,7 +36,7 @@ func ValidateValue(valueType string, value string) error {
 	case "deleted":
 		return nil
 	default:
-		return errors.New("the value type is not allowed")
+		return fmt.Errorf("the value type is not allowed %s", valueType)
 	}
 }
 

--- a/edge/pkg/devicetwin/dtcommon/util.go
+++ b/edge/pkg/devicetwin/dtcommon/util.go
@@ -36,7 +36,7 @@ func ValidateValue(valueType string, value string) error {
 	case "deleted":
 		return nil
 	default:
-		return fmt.Errorf("the value type is not allowed %s", valueType)
+		return fmt.Errorf("the value type is not allowed: %s", valueType)
 	}
 }
 

--- a/edge/pkg/devicetwin/dtcommon/util_test.go
+++ b/edge/pkg/devicetwin/dtcommon/util_test.go
@@ -73,7 +73,7 @@ func TestValidateValue(t *testing.T) {
 		name:      "ValidateValueNotSupportedErrorCase",
 		valueType: "test",
 		value:     "test",
-		wantErr:   errors.New("the value type is not allowed"),
+		wantErr:   errors.New("the value type is not allowed: test"),
 	}, {
 		// int success
 		name:      "ValidateValueIntSuccessCase",

--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -169,12 +169,14 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 	klog.Infof("Begin to deal device twin of the device %s", deviceID)
 	now := time.Now().UnixNano() / 1e6
 	result := []byte("")
+
 	device, isExist := context.GetDevice(deviceID)
 	if !isExist {
 		klog.Errorf("Update twin rejected due to the device %s is not existed", deviceID)
 		dealUpdateResult(context, deviceID, eventID, dtcommon.NotFoundCode, errors.New("Update rejected due to the device is not existed"), result)
 		return errors.New("Update rejected due to the device is not existed")
 	}
+
 	content := msgTwin
 	var err error
 	if content == nil {
@@ -183,16 +185,18 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 		dealUpdateResult(context, deviceID, eventID, dtcommon.BadRequestCode, err, result)
 		return err
 	}
-	dealTwinResult := DealMsgTwin(context, deviceID, content, dealType)
 
+	dealTwinResult := DealMsgTwin(context, deviceID, content, dealType)
 	add, deletes, update := dealTwinResult.Add, dealTwinResult.Delete, dealTwinResult.Update
 	if dealType == RestDealType && dealTwinResult.Err != nil {
+		klog.Errorf("Deal message twin error: %#v", dealTwinResult.Err)
 		SyncDeviceFromSqlite(context, deviceID)
 		err = dealTwinResult.Err
 		updateResult, _ := dttype.BuildDeviceTwinResult(dttype.BaseMessage{EventID: eventID, Timestamp: now}, dealTwinResult.Result, 0)
 		dealUpdateResult(context, deviceID, eventID, dtcommon.BadRequestCode, err, updateResult)
 		return err
 	}
+
 	if len(add) != 0 || len(deletes) != 0 || len(update) != 0 {
 		for i := 1; i <= dtcommon.RetryTimes; i++ {
 			err = dtclient.DeviceTwinTrans(add, deletes, update)
@@ -206,16 +210,17 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 			klog.Errorf("Update device twin failed due to writing sql error: %v", err)
 		}
 	}
-
 	if err != nil && dealType == RestDealType {
 		updateResult, _ := dttype.BuildDeviceTwinResult(dttype.BaseMessage{EventID: eventID, Timestamp: now}, dealTwinResult.Result, dealType)
 		dealUpdateResult(context, deviceID, eventID, dtcommon.InternalErrorCode, err, updateResult)
 		return err
 	}
+
 	if dealType == RestDealType {
 		updateResult, _ := dttype.BuildDeviceTwinResult(dttype.BaseMessage{EventID: eventID, Timestamp: now}, dealTwinResult.Result, dealType)
 		dealUpdateResult(context, deviceID, eventID, dtcommon.InternalErrorCode, nil, updateResult)
 	}
+
 	if len(dealTwinResult.Document) > 0 {
 		dealDocument(context, deviceID, dttype.BaseMessage{EventID: eventID, Timestamp: now}, dealTwinResult.Document)
 	}

--- a/edge/pkg/devicetwin/dtmanager/twin_test.go
+++ b/edge/pkg/devicetwin/dtmanager/twin_test.go
@@ -19,6 +19,7 @@ package dtmanager
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -525,10 +526,11 @@ func TestDealDeviceTwinResult(t *testing.T) {
 	str := typeString
 	optionTrue := true
 	value := valueType
+	typeNil := "nil"
 	msgTwinValue := make(map[string]*dttype.MsgTwin)
 	msgTwinValue[deviceB] = &dttype.MsgTwin{
 		Expected: &dttype.TwinValue{Value: &value},
-		Metadata: &dttype.TypeMetadata{Type: "nil"},
+		Metadata: &dttype.TypeMetadata{Type: typeNil},
 	}
 	contextDeviceA := contextFunc(deviceB)
 	twinDeviceA := make(map[string]*dttype.MsgTwin)
@@ -560,7 +562,7 @@ func TestDealDeviceTwinResult(t *testing.T) {
 			deviceID:         deviceB,
 			msgTwin:          msgTwinValue,
 			dealType:         RestDealType,
-			err:              errors.New("the value type is not allowed"),
+			err:              fmt.Errorf("the value type is not allowed: %s", typeNil),
 			filterReturn:     mockQuerySeter,
 			allReturnInt:     int64(1),
 			allReturnErr:     nil,


### PR DESCRIPTION
1. Add debug info for error.
2. Add type validation according to the device model definition.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The type in edgecore-device twin is not aligned with cloudcore-devicecontroller and device profile. Refine it.
