### PR TITLE
Stop to create listener when application center serve list request

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application.go
+++ b/cloud/pkg/dynamiccontroller/application/application.go
@@ -406,9 +406,6 @@ func (c *Center) ProcessApplication(app *Application) (interface{}, error) {
 		if err := app.OptionTo(option); err != nil {
 			return nil, err
 		}
-		if err := c.HandlerCenter.AddListener(app.ToListener(*option)); err != nil {
-			return nil, fmt.Errorf("failed to add listener, %v", err)
-		}
 		list, err := c.kubeclient.Resource(app.GVR()).Namespace(app.Namespace()).List(context.TODO(), *option)
 		if err != nil {
 			return nil, fmt.Errorf("successfully to add listener but failed to get current list, %v", err)


### PR DESCRIPTION
Signed-off-by: GsssC <914617455@qq.com>
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Now when application center gets a list request, it will response a list and create listener to continuously push watched event to edge, even if edge don't care about these subsequent changes. It cause a large extra resource consumption, when list request increase.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

