### PR TITLE
cloudcore: fix bug. should reassign the result of selector.Add() to s…

### DIFF
--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -262,7 +262,7 @@ func (dc *DownstreamController) syncEdgeNodes() {
 						selector := labels.NewSelector()
 						for k, v := range svc.Spec.Selector {
 							r, _ := labels.NewRequirement(k, selection.Equals, []string{v})
-							selector.Add(*r)
+							selector = selector.Add(*r)
 						}
 
 						pods, err := dc.podLister.Pods(namespace).List(selector)
@@ -425,7 +425,7 @@ func (dc *DownstreamController) syncEndpoints() {
 					selector := labels.NewSelector()
 					for k, v := range svc.Spec.Selector {
 						r, _ := labels.NewRequirement(k, selection.Equals, []string{v})
-						selector.Add(*r)
+						selector = selector.Add(*r)
 					}
 					pods, _ = dc.podLister.Pods(svc.GetNamespace()).List(selector)
 				}


### PR DESCRIPTION
…elector

Signed-off-by: LIYUNFAN <leeyunfans@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
`selector.Add()` not modify the `selector`. need reassign the result to `selector`.
if not, cloudcore will send all pods as podlist to edge.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
