### PR TITLE
Add config of cloudcore token refresh frequence

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
@@ -61,7 +61,9 @@ func getIps(advertiseAddress []string) (Ips []net.IP) {
 
 // GenerateToken will create a token consisting of caHash and jwt Token and save it to secret
 func GenerateToken() error {
-	expiresAt := time.Now().Add(time.Hour * 24).Unix()
+	// set double TokenRefreshDuration as expirationTime, which can guarantee that the validity period
+	// of the token obtained at anytime is greater than or equal to TokenRefreshDuration
+	expiresAt := time.Now().Add(time.Hour * hubconfig.Config.CloudHub.TokenRefreshDuration * 2).Unix()
 
 	token := jwt.New(jwt.SigningMethodHS256)
 
@@ -85,7 +87,7 @@ func GenerateToken() error {
 		return fmt.Errorf("Failed to create tokenSecret, err: %v", err)
 	}
 
-	t := time.NewTicker(time.Hour * 12)
+	t := time.NewTicker(time.Hour * hubconfig.Config.CloudHub.TokenRefreshDuration)
 	go func() {
 		for {
 			<-t.C
@@ -101,7 +103,7 @@ func GenerateToken() error {
 
 func refreshToken() string {
 	claims := &jwt.StandardClaims{}
-	expirationTime := time.Now().Add(time.Hour * 12)
+	expirationTime := time.Now().Add(time.Hour * hubconfig.Config.CloudHub.TokenRefreshDuration * 2)
 	claims.ExpiresAt = expirationTime.Unix()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	keyPEM := getCaKey()

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -57,6 +57,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				AdvertiseAddress:        []string{advertiseAddress.String()},
 				DNSNames:                []string{""},
 				EdgeCertSigningDuration: 365,
+				TokenRefreshDuration:    12,
 				Quic: &CloudHubQUIC{
 					Enable:             false,
 					Address:            "0.0.0.0",

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -124,6 +124,9 @@ type CloudHub struct {
 	// EdgeCertSigningDuration indicates the validity period of edge certificate
 	// default 365d
 	EdgeCertSigningDuration time.Duration `json:"edgeCertSigningDuration,omitempty"`
+	// TokenRefreshDuration indicates the interval of cloudcore token refresh, unit is hour
+	// default 12h
+	TokenRefreshDuration time.Duration `json:"tokenRefreshDuration,omitempty"`
 }
 
 // CloudHubQUIC indicates the quic server config

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
@@ -108,6 +108,10 @@ func ValidateModuleCloudHub(c v1alpha1.CloudHub) field.ErrorList {
 					c.UnixSocket.Address, path.Dir(s[1]), err)))
 		}
 	}
+	if c.TokenRefreshDuration <= 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("TokenRefreshDuration"),
+			c.TokenRefreshDuration, "TokenRefreshDuration must be positive"))
+	}
 	return allErrs
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind feature

**What this PR does / why we need it**:
Add config of cloudcore token refresh frequence
--default token refresh interval is 12h
--token expirationTime is double refresh interval

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2779 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
if need, CloudHub.TokenRefreshDuration can be configed in cloudcore.yaml 
```
