### PR TITLE
Automated cherry pick of #2803: keadm: install CRDs corresponding to the version

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -107,13 +107,6 @@ func addJoinOtherFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 
 //Add2ToolsList Reads the flagData (containing val and default val) and join options to fill the list of tools.
 func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string]types.FlagData, initOptions *types.InitOptions) error {
-	toolList["Kubernetes"] = &util.K8SInstTool{
-		Common: util.Common{
-			KubeConfig: initOptions.KubeConfig,
-			Master:     initOptions.Master,
-		},
-	}
-
 	var kubeVer string
 	flgData, ok := flagData[types.KubeEdgeVersion]
 	if ok {
@@ -138,15 +131,19 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 			kubeVer = types.DefaultKubeEdgeVersion
 		}
 	}
+	common := util.Common{
+		ToolVersion: semver.MustParse(kubeVer),
+		KubeConfig:  initOptions.KubeConfig,
+		Master:      initOptions.Master,
+	}
 	toolList["Cloud"] = &util.KubeCloudInstTool{
-		Common: util.Common{
-			ToolVersion: semver.MustParse(kubeVer),
-			KubeConfig:  initOptions.KubeConfig,
-			Master:      initOptions.Master,
-		},
+		Common:           common,
 		AdvertiseAddress: initOptions.AdvertiseAddress,
 		DNSName:          initOptions.DNS,
 		TarballPath:      initOptions.TarballPath,
+	}
+	toolList["Kubernetes"] = &util.K8SInstTool{
+		Common: common,
 	}
 	return nil
 }

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -63,7 +63,7 @@ const (
 
 	EdgeRootDir = "/var/lib/edged"
 
-	KubeEdgeCRDDownloadURL = "https://raw.githubusercontent.com/kubeedge/kubeedge/master/build/crds"
+	KubeEdgeCRDDownloadURL = "https://raw.githubusercontent.com/kubeedge/kubeedge/release-%s/build/crds"
 
 	latestReleaseVersionURL = "https://kubeedge.io/latestversion"
 	RetryTimes              = 5


### PR DESCRIPTION
Cherry pick of #2803 on release-1.6.

#2803: keadm: install CRDs corresponding to the version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.