### PR TITLE
Fix: The server could not find the requested resource

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
@@ -148,9 +148,6 @@ func (s *imitator) List(ctx context.Context, key string) (Resp, error) {
 	if err != nil {
 		return Resp{}, err
 	}
-	if len(*results) == 0 {
-		return Resp{}, fmt.Errorf("the server could not find the requested resource")
-	}
 	resp.Kvs = results
 	return resp, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When applying for a resource without an instance in cluster, APIServer will return an empty list.
But MetaServer' local storage response error "the server could not find the requested resource" when there is no resource , rather than an empty list.

**Which issue(s) this PR fixes**:
Fixes #2801

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
none
