### PR TITLE
makefile: add a script which can help genrate crds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,34 @@ crossbuild: clean
 	hack/make-rules/crossbuild.sh $(WHAT) $(GOARM)
 endif
 
+crdVersions ?= v1
+crdOutputs ?= build/crds
+devicesVersion ?= v1alpha2
+reliablesyncsVersion ?= v1alpha1
+listCrdParams := crdVersions crdOutputs devicesVersion reliablesyncsVersion
+
+define GENERATE_CRDS_HELP_INFO
+# generate crds.
+#
+# Args:
+#     crdVersions, default: v1
+#     crdOutputs, default: build/crd
+#     devicesVersion, default: v1alpha2
+#     reliablesyncsVersion, default: v1alpha1
+#
+# Example:
+#     make generate 
+#     make generate -e crdVersions=v1 -e crdOutputs=build/crds
+#
+endef
+.PHONY: generate
+ifeq ($(HELP),y)
+generate:
+	@echo "$$GENERATE_CRDS_HELP_INFO"
+else
+generate:
+	 hack/generate-crds.sh $(foreach p, $(listCrdParams),--$(p)=$($(p)) ) || true
+endif
 
 
 SMALLBUILD_COMPONENTS=edgecore \

--- a/cloud/pkg/apis/devices/v1alpha2/device_instance_types.go
+++ b/cloud/pkg/apis/devices/v1alpha2/device_instance_types.go
@@ -374,6 +374,8 @@ type DeviceList struct {
 	Items           []Device `json:"items"`
 }
 
+// +kubebuilder:validation:XPreserveUnknownFields
+// +kubebuilder:validation:Type=object
 type CustomizedValue map[string]interface{}
 
 func (in *CustomizedValue) DeepCopyInto(out *CustomizedValue) {

--- a/hack/generate-crds.sh
+++ b/hack/generate-crds.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Authors of Arktos.
+# Copyright 2020 The KubeEdge Authors - file modified.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+crdVersions=v1
+crdOutputs=build/crds
+devicesVersion=v1alpha2
+reliablesyncsVersion=v1alpha1
+
+# install controller-gen tool if not exsit
+if [ $(which controller-gen) == "" ]; then
+    echo "Start to install controller-gen tool"
+    GO111MODULE=on go get -v sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0
+fi
+
+# try to parse named parameters
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --crdVersions=*)
+      crdVersions="${1#*=}"
+      ;;
+    --crdOutputs=*)
+      crdOutputs="${1#*=}"
+      ;;
+    --devicesVersion=*)
+      devicesVersion="${1#*=}"
+      ;;
+    --reliablesyncsVersion=*)
+      reliablesyncsVersion="${1#*=}"
+      ;;
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n"
+      printf "***************************\n"
+      exit 1
+  esac
+  shift
+done
+
+# generate crds, grep the warnings from the std err, then print it. 
+msg=$($(which controller-gen) paths="./..." crd:crdVersions=$crdVersions,allowDangerousTypes=true output:crd:artifacts:config=/tmp/crds  2> >(grep -i InterfaceType))
+if  [ "$msg" != "" ]; then
+    echo "The following warnings could be ignored, and the generated crds work well:"
+    echo $msg | awk '{print "Warning:",$0}'   
+fi
+
+# rename files, copy files
+mkdir -p ${crdOutputs}/devices
+mkdir -p ${crdOutputs}/reliablesyncs
+
+for entry in `ls /tmp/crds/*.yaml`; do
+    crdName=$(echo ${entry} | cut -d'.' -f3 | cut -d'_' -f2)
+
+    if [ "$crdName" == "devices" ] || [ "$crdName" == "devicemodels" ]; then
+        # remove the last element if it is 's'
+        if [ "${crdName: -1}" == "s" ]; then
+          crdName="${crdName:$i:-1}"
+        fi
+        cp -v ${entry} ${crdOutputs}/devices/devices_${devicesVersion}_${crdName}.yaml 
+    elif [ "$crdName" == "clusterobjectsyncs" ]; then
+        cp -v ${entry} ${crdOutputs}/reliablesyncs/cluster_objectsync_${reliablesyncsVersion}.yaml
+    elif [ "$crdName" == "objectsyncs" ]; then
+        cp -v ${entry} ${crdOutputs}/reliablesyncs/objectsync_${reliablesyncsVersion}.yaml
+    else
+        # other cases would not handle
+        continue
+    fi
+done
+
+# clean
+rm -rf /tmp/crds
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
Add a shell script to generate crds,  and has Integrated in makefile. 
Developers can use a couple of parameters , such as crdVersions,crdOutputs,devicesVersion,reliablesyncsVersion, to generate the corresponding version of crds.

/kind feature

**What this PR does / why we need it**:
As a supplementary script to generate crds.


**Special notes for your reviewer**:

Help infos:
```
# generate crds.
#
# Args:
#     crdVersions, default: v1
#     crdOutputs, default: build/crd
#     devicesVersion, default: v1alpha2
#     reliablesyncsVersion, default: v1alpha1
#
# Example:
#     make generate 
```

The script have warnings for the map values, but it could be ignored, the generated crds works well.
```
hack/generate-crds.sh --crdVersions=v1beta1 --crdOutputs=build/crds --devicesVersion=v1alpha2 --reliablesyncsVersion=v1alpha1 || true
The following warnings could be ignored, and the generated crds works well:
Warning: /root/go/src/github.com/kubeedge/cloud/pkg/apis/devices/v1alpha2/device_instance_types.go:379:33: map values must be a named type, not *ast.InterfaceType
'/tmp/crds/devices.kubeedge.io_devicemodels.yaml' -> 'build/crds/devices/devices_v1alpha2_devicemodel.yaml'
'/tmp/crds/devices.kubeedge.io_devices.yaml' -> 'build/crds/devices/devices_v1alpha2_device.yaml'
'/tmp/crds/reliablesyncs.kubeedge.io_clusterobjectsyncs.yaml' -> 'build/crds/reliablesyncs/cluster_objectsync_v1alpha1.yaml'
'/tmp/crds/reliablesyncs.kubeedge.io_objectsyncs.yaml' -> 'build/crds/reliablesyncs/objectsync_v1alpha1.yaml
```
/cc @fisherxu 
