### PR TITLE
devicetwin: ValidateValue supports integer check, just like int

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/util.go
+++ b/edge/pkg/devicetwin/dtcommon/util.go
@@ -15,7 +15,7 @@ func ValidateValue(valueType string, value string) error {
 		return nil
 	case "string":
 		return nil
-	case "int":
+	case "int", "integer":
 		_, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return errors.New("the value is not int")


### PR DESCRIPTION
many device-yaml  files still use integer rather than int, so this patch makes it flexible

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
