### PR TITLE
devicetwin: ValidateValue supports checking integer

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/util.go
+++ b/edge/pkg/devicetwin/dtcommon/util.go
@@ -15,10 +15,10 @@ func ValidateValue(valueType string, value string) error {
 		return nil
 	case "string":
 		return nil
-	case "int":
+	case "int", "integer":
 		_, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			return errors.New("the value is not int")
+			return errors.New("the value is not int or integer")
 		}
 		return nil
 	case "float":

--- a/edge/pkg/devicetwin/dtcommon/util_test.go
+++ b/edge/pkg/devicetwin/dtcommon/util_test.go
@@ -49,7 +49,7 @@ func TestValidateValue(t *testing.T) {
 		name:      "ValidateValueIntErrorCase",
 		valueType: "int",
 		value:     "test",
-		wantErr:   errors.New("the value is not int"),
+		wantErr:   errors.New("the value is not int or integer"),
 	}, {
 		// float error
 		name:      "ValidateValueFloatErrorCase",

--- a/edge/pkg/devicetwin/dtmanager/twin_test.go
+++ b/edge/pkg/devicetwin/dtmanager/twin_test.go
@@ -1013,7 +1013,7 @@ func TestDealTwinCompare(t *testing.T) {
 				Metadata: &dttype.TypeMetadata{Type: typeInt},
 			},
 			dealType: RestDealType,
-			err:      errors.New("the value is not int"),
+			err:      errors.New("the value is not int or integer"),
 		},
 		{
 			name:         "TestDealTwinCompare(): Case 3: expectedOk is true; dealVersion() returns false",
@@ -1246,7 +1246,7 @@ func TestDealTwinAdd(t *testing.T) {
 				ActualVersion:   &dttype.TwinVersion{},
 			},
 			dealType: RestDealType,
-			err:      errors.New("the value is not int"),
+			err:      errors.New("the value is not int or integer"),
 		},
 		{
 			name: "TestDealTwinAdd(): Case 6: msgTwin.Actual is not nil; ValidateValue() returns error; dealType=1",
@@ -1438,7 +1438,7 @@ func TestDealMsgTwin(t *testing.T) {
 				Result:     result,
 				SyncResult: syncResultDevice,
 				Document:   documentDevice,
-				Err:        errors.New("the value is not int"),
+				Err:        errors.New("the value is not int or integer"),
 			},
 		},
 		{


### PR DESCRIPTION
device-yaml files still use integer rather than int, so make it flexible

Signed-off-by: longguang.yue <yuelg@chinaunicom.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign @rohitsardesai83

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
