### PR TITLE
DeviceTwin: optimize device state's judgement code

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/device.go
+++ b/edge/pkg/devicetwin/dtmanager/device.go
@@ -86,7 +86,12 @@ func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg in
 	if !ok {
 		return nil, nil
 	}
-	if strings.Compare("online", updatedDevice.State) != 0 && strings.Compare("offline", updatedDevice.State) != 0 && strings.Compare("unknown", updatedDevice.State) != 0 {
+
+	// state refers to definition in mappers-go/pkg/common/const.go
+	state := strings.ToLower(updatedDevice.State)
+	switch state {
+	case "online", "offline", "ok", "unknown", "disconnected":
+	default:
 		return nil, nil
 	}
 	lastOnline := time.Now().Format("2006-01-02 15:04:05")
@@ -113,7 +118,7 @@ func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg in
 		dtcommon.CommModule,
 		context.BuildModelMessage(modules.BusGroup, "", topic, messagepkg.OperationPublish, payload))
 
-	msgResource := "device/" + device.ID + "/state"
+	msgResource := "device/" + device.ID + dtcommon.DeviceETStateUpdateSuffix
 	context.Send(deviceID,
 		dtcommon.SendToCloud,
 		dtcommon.CommModule,


### PR DESCRIPTION
1. optimize device state's judgement code
2. enable to pass "disconnected" and "ok" state to cloudcore

Signed-off-by: longguang.yue <yuelg@chinaunicom.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/assign rohitsardesai83

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
