### PR TITLE
fix/edged and edge controller: make customsiz labels available when restart …

### DIFF
--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -92,6 +92,8 @@ func (e *edged) initialNode() (*v1.Node, error) {
 		node.Labels[k] = v
 	}
 
+	e.labels = node.Labels
+
 	if node.Annotations == nil {
 		node.Annotations = make(map[string]string)
 	}


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
update the labels field in edgecore's file and synchronize the labels to cloud when restart edgecore 
Which issue(s) this PR fixes:

Fixes #
#2764