### PR TITLE
modify interface name to KubeEdgeCustomInformer

### DIFF
--- a/cloud/pkg/common/informers/informers.go
+++ b/cloud/pkg/common/informers/informers.go
@@ -35,7 +35,7 @@ import (
 
 type newInformer func() cache.SharedIndexInformer
 
-type KubeEdgeCustomeInformer interface {
+type KubeEdgeCustomInformer interface {
 	EdgeNode() cache.SharedIndexInformer
 }
 
@@ -43,7 +43,7 @@ type Manager interface {
 	GetK8sInformerFactory() k8sinformer.SharedInformerFactory
 	GetCRDInformerFactory() crdinformers.SharedInformerFactory
 	GetDynamicSharedInformerFactory() dynamicinformer.DynamicSharedInformerFactory
-	KubeEdgeCustomeInformer
+	KubeEdgeCustomInformer
 	Start(stopCh <-chan struct{})
 }
 

--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -624,7 +624,7 @@ func (dc *DownstreamController) initLocating() error {
 }
 
 // NewDownstreamController create a DownstreamController from config
-func NewDownstreamController(k8sInformerFactory k8sinformers.SharedInformerFactory, keInformerFactory informers.KubeEdgeCustomeInformer,
+func NewDownstreamController(k8sInformerFactory k8sinformers.SharedInformerFactory, keInformerFactory informers.KubeEdgeCustomInformer,
 	crdInformerFactory crdinformers.SharedInformerFactory) (*DownstreamController, error) {
 	lc := &manager.LocationCache{}
 


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
fix interface name spell error: remove letter `e` from name `KubeEdgeCustomeInformer `
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
