### PR TITLE
add reviewer ttlv to devicetwin and devicecontroller

### DIFF
--- a/cloud/pkg/devicecontroller/OWNERS
+++ b/cloud/pkg/devicecontroller/OWNERS
@@ -11,3 +11,4 @@ reviewers:
   - kevin-wangzefeng
   - rohitsardesai83
   - subpathdev
+  - ttlv

--- a/edge/pkg/devicetwin/OWNERS
+++ b/edge/pkg/devicetwin/OWNERS
@@ -6,3 +6,4 @@ reviewers:
   - Iceber
   - sids-b
   - subpathdev
+  - ttlv


### PR DESCRIPTION
What type of PR is this?

What this PR does / why we need it:
add ttlv to devicetwin devicecontroller mapper module reviewer.

PRs authored:
https://github.com/kubeedge/mappers-go/pulls?q=pr+author%3Attlv+
https://github.com/kubeedge/kubeedge/pulls?q=+is%3Apr+author%3Attlv
reviews:
https://github.com/kubeedge/kubeedge/pulls?q=is%3Apr+reviewed-by%3Attlv+
https://github.com/kubeedge/mappers-go/pulls?q=is%3Apr+reviewed-by%3Attlv+
Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?: