### PR TITLE
fix bug: incorrect storage of some crds

### DIFF
--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -70,7 +70,7 @@ func UnsafeResourceToKind(r string) string {
 }
 
 func UnsafeKindToResource(k string) string {
-	if len(k) == 0 {
+	if len(k) == 0 || len(k) == 1 {
 		return k
 	}
 	unusualKindToResource := map[string]string{
@@ -84,6 +84,10 @@ func UnsafeKindToResource(k string) string {
 	case "s":
 		return r + "es"
 	case "y":
+		if string(r[len(r)-2]) == "a" || string(r[len(r)-2]) == "e" || string(r[len(r)-2]) == "i" ||
+			string(r[len(r)-2]) == "o" || string(r[len(r)-2]) == "u" {
+			return r + "s"
+		}
 		return strings.TrimSuffix(r, "y") + "ies"
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Some crds like gateway，its plural form is gateways instead of gatewaies，causing wrong value stored in the database meta_v2

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
https://github.com/kubeedge/edgemesh/issues/7
https://github.com/kubeedge/edgemesh/issues/8

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
