### PR TITLE
remove function getPodCondition not-used return value: index

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -343,10 +343,10 @@ func (uc *UpstreamController) updatePodStatus() {
 					status := podStatus.Status
 					oldStatus := getPod.Status
 					// Set ReadyCondition.LastTransitionTime
-					if _, readyCondition := uc.getPodCondition(&status, v1.PodReady); readyCondition != nil {
+					if readyCondition := uc.getPodCondition(&status, v1.PodReady); readyCondition != nil {
 						// Need to set LastTransitionTime.
 						lastTransitionTime := metaV1.Now()
-						_, oldReadyCondition := uc.getPodCondition(&oldStatus, v1.PodReady)
+						oldReadyCondition := uc.getPodCondition(&oldStatus, v1.PodReady)
 						if oldReadyCondition != nil && readyCondition.Status == oldReadyCondition.Status {
 							lastTransitionTime = oldReadyCondition.LastTransitionTime
 						}
@@ -354,10 +354,10 @@ func (uc *UpstreamController) updatePodStatus() {
 					}
 
 					// Set InitializedCondition.LastTransitionTime.
-					if _, initCondition := uc.getPodCondition(&status, v1.PodInitialized); initCondition != nil {
+					if initCondition := uc.getPodCondition(&status, v1.PodInitialized); initCondition != nil {
 						// Need to set LastTransitionTime.
 						lastTransitionTime := metaV1.Now()
-						_, oldInitCondition := uc.getPodCondition(&oldStatus, v1.PodInitialized)
+						oldInitCondition := uc.getPodCondition(&oldStatus, v1.PodInitialized)
 						if oldInitCondition != nil && initCondition.Status == oldInitCondition.Status {
 							lastTransitionTime = oldInitCondition.LastTransitionTime
 						}
@@ -899,17 +899,17 @@ func (uc *UpstreamController) unmarshalPodStatusMessage(msg model.Message) (ns s
 }
 
 // GetPodCondition extracts the provided condition from the given status and returns that.
-// Returns nil and -1 if the condition is not present, and the index of the located condition.
-func (uc *UpstreamController) getPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) (int, *v1.PodCondition) {
+// Returns nil if the condition is not present, or return the located condition.
+func (uc *UpstreamController) getPodCondition(status *v1.PodStatus, conditionType v1.PodConditionType) *v1.PodCondition {
 	if status == nil {
-		return -1, nil
+		return nil
 	}
 	for i := range status.Conditions {
 		if status.Conditions[i].Type == conditionType {
-			return i, &status.Conditions[i]
+			return &status.Conditions[i]
 		}
 	}
-	return -1, nil
+	return nil
 }
 
 func (uc *UpstreamController) isPodNotRunning(statuses []v1.ContainerStatus) bool {


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
function `func (uc *UpstreamController) getPodCondition` return value `index` is never used, so just remove it
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
