### PR TITLE
fix incorrect use of TrimLeft or TrimRight

### DIFF
--- a/cloud/pkg/router/provider/rest/rest.go
+++ b/cloud/pkg/router/provider/rest/rest.go
@@ -109,7 +109,7 @@ func (r *Rest) Forward(target provider.Target, data interface{}) (interface{}, e
 	res := make(map[string]interface{})
 	messageID := d["messageID"].(string)
 	res["messageID"] = messageID
-	res["param"] = strings.TrimLeft(uri[3], r.Path)
+	res["param"] = strings.TrimPrefix(uri[3], r.Path)
 	res["data"] = d["data"]
 	res["nodeName"] = strings.Split(request.RequestURI, "/")[1]
 	res["header"] = request.Header
@@ -213,10 +213,10 @@ func (r *Rest) GoToTarget(data map[string]interface{}, stop chan struct{}) (inte
 func normalizeResource(resource string) string {
 	finalResource := resource
 	if strings.HasPrefix(finalResource, "/") {
-		finalResource = strings.TrimLeft(finalResource, "/")
+		finalResource = strings.TrimPrefix(finalResource, "/")
 	}
 	if strings.HasSuffix(finalResource, "/") {
-		finalResource = strings.TrimRight(finalResource, "/")
+		finalResource = strings.TrimSuffix(finalResource, "/")
 	}
 	return finalResource
 }

--- a/cloud/pkg/router/utils/path_test.go
+++ b/cloud/pkg/router/utils/path_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -41,17 +40,6 @@ func TestPathMatch(t *testing.T) {
 
 	rule = "/a/b/d"
 	AssertTrue(t, !IsMatch(rule, req), "7")
-}
-
-func normalizeResource(resource string) string {
-	finalResource := resource
-	if strings.HasPrefix(finalResource, "/") {
-		finalResource = "/" + strings.TrimLeft(finalResource, "/")
-	}
-	if strings.HasSuffix(finalResource, "/") {
-		finalResource = strings.TrimRight(finalResource, "/")
-	}
-	return finalResource
 }
 
 // AssertTrue triggers testing error if the passed-in is true.


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
1. According to the official doc, function `strings.TrimLeft` usage is as follows: 
```
// TrimLeft returns a slice of the string s with all leading
// Unicode code points contained in cutset removed.
//
// To remove a prefix, use TrimPrefix instead.
```
And i think here we should use `TrimPrefix` and `TrimSuffix` instead of `TrimLeft` and `TrimRight`

2. remove not-used function `normalizeResource` in `cloud/pkg/router/utils/path_test.go`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
