### PR TITLE
remove not-used callback func return value: interface{}

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/communicate_test.go
+++ b/edge/pkg/devicetwin/dtmanager/communicate_test.go
@@ -209,7 +209,7 @@ func TestDealSendToCloud(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := dealSendToCloud(test.context, test.resource, test.msg)
+			err := dealSendToCloud(test.context, test.resource, test.msg)
 			if !reflect.DeepEqual(err, test.wantErr) {
 				t.Errorf("dealSendToCloud() error = %v, wantErr %v", err, test.wantErr)
 				return
@@ -261,7 +261,7 @@ func TestDealLifeCycle(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := dealLifeCycle(test.context, test.resource, test.msg)
+			err := dealLifeCycle(test.context, test.resource, test.msg)
 			if !reflect.DeepEqual(err, test.wantErr) {
 				t.Errorf("dealLifeCycle() error = %v, wantErr %v", err, test.wantErr)
 			}
@@ -295,7 +295,7 @@ func TestDealConfirm(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := dealConfirm(test.context, test.resource, test.msg)
+			err := dealConfirm(test.context, test.resource, test.msg)
 			if !reflect.DeepEqual(err, test.wantErr) {
 				t.Errorf("dealConfirm() error = %v, wantErr %v", err, test.wantErr)
 				return

--- a/edge/pkg/devicetwin/dtmanager/device_test.go
+++ b/edge/pkg/devicetwin/dtmanager/device_test.go
@@ -39,9 +39,9 @@ import (
 var called bool
 
 //testAction is a dummy function for testing Start
-func testAction(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {
+func testAction(context *dtcontext.DTContext, resource string, msg interface{}) error {
 	called = true
-	return called, errors.New("Called the dummy function for testing")
+	return errors.New("Called the dummy function for testing")
 }
 
 // TestDeviceStartAction is function to test Start() when value is passed in ReceiverChan.
@@ -187,7 +187,6 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 		context  *dtcontext.DTContext
 		resource string
 		msg      interface{}
-		want     interface{}
 		wantErr  error
 		// filterReturn is the return of mock interface querySeterMock's filter function
 		filterReturn orm.QuerySeter
@@ -204,7 +203,6 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 			context:  dtContexts,
 			resource: "DeviceA",
 			msg:      "",
-			want:     nil,
 			wantErr:  errors.New("msg not Message type"),
 		},
 		{
@@ -212,7 +210,6 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 			context:  dtContexts,
 			resource: "DeviceB",
 			msg:      &model.Message{Content: bytesEmptyDevUpdate},
-			want:     nil,
 			wantErr:  nil,
 		},
 		{
@@ -220,7 +217,6 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 			context:  dtContexts,
 			resource: "DeviceC",
 			msg:      &model.Message{Content: bytesEmptyDevUpdate},
-			want:     nil,
 			wantErr:  nil,
 		},
 		{
@@ -228,7 +224,6 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 			context:  dtContexts,
 			resource: "DeviceD",
 			msg:      &model.Message{Content: bytesEmptyDevUpdate},
-			want:     nil,
 			wantErr:  nil,
 		},
 		{
@@ -236,7 +231,6 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 			context:          dtContexts,
 			resource:         "DeviceD",
 			msg:              &model.Message{Content: bytesDevUpdate},
-			want:             nil,
 			wantErr:          nil,
 			filterReturn:     querySeterMock,
 			updateReturnInt:  int64(1),
@@ -250,13 +244,10 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 			querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(test.times)
 			querySeterMock.EXPECT().Update(gomock.Any()).Return(test.updateReturnInt, test.updateReturnErr).Times(test.times)
 			ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(test.times)
-			got, err := dealDeviceStateUpdate(test.context, test.resource, test.msg)
+			err := dealDeviceStateUpdate(test.context, test.resource, test.msg)
 			if !reflect.DeepEqual(err, test.wantErr) {
 				t.Errorf("dealDeviceStateUpdate() error = %v, wantErr %v", err, test.wantErr)
 				return
-			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("dealDeviceStateUpdate() = %v, want %v", got, test.want)
 			}
 		})
 	}
@@ -277,7 +268,6 @@ func TestDealUpdateDeviceAttr(t *testing.T) {
 		context  *dtcontext.DTContext
 		resource string
 		msg      interface{}
-		want     interface{}
 		wantErr  error
 	}{
 		{
@@ -285,7 +275,6 @@ func TestDealUpdateDeviceAttr(t *testing.T) {
 			context:  dtContexts,
 			resource: "Device",
 			msg:      "",
-			want:     nil,
 			wantErr:  errors.New("msg not Message type"),
 		},
 		{
@@ -293,19 +282,15 @@ func TestDealUpdateDeviceAttr(t *testing.T) {
 			context:  dtContexts,
 			resource: "DeviceA",
 			msg:      &msg,
-			want:     nil,
 			wantErr:  nil,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := dealDeviceAttrUpdate(test.context, test.resource, test.msg)
+			err := dealDeviceAttrUpdate(test.context, test.resource, test.msg)
 			if !reflect.DeepEqual(err, test.wantErr) {
 				t.Errorf("dealUpdateDeviceAttr() error = %v, wantErr %v", err, test.wantErr)
 				return
-			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("dealUpdateDeviceAttr() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/edge/pkg/devicetwin/dtmanager/dtworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dtworker.go
@@ -16,4 +16,4 @@ type Worker struct {
 }
 
 //CallBack for deal
-type CallBack func(*dtcontext.DTContext, string, interface{}) (interface{}, error)
+type CallBack func(*dtcontext.DTContext, string, interface{}) error

--- a/edge/pkg/devicetwin/dtmanager/membership.go
+++ b/edge/pkg/devicetwin/dtmanager/membership.go
@@ -40,7 +40,7 @@ func (mw MemWorker) Start() {
 			}
 			if dtMsg, isDTMessage := msg.(*dttype.DTMessage); isDTMessage {
 				if fn, exist := memActionCallBack[dtMsg.Action]; exist {
-					_, err := fn(mw.DTContexts, dtMsg.Identity, dtMsg.Msg)
+					err := fn(mw.DTContexts, dtMsg.Identity, dtMsg.Msg)
 					if err != nil {
 						klog.Errorf("MemModule deal %s event failed: %v", dtMsg.Action, err)
 					}
@@ -83,22 +83,22 @@ func getRemoveList(context *dtcontext.DTContext, devices []dttype.Device) []dtty
 	})
 	return toRemove
 }
-func dealMembershipDetail(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {
+func dealMembershipDetail(context *dtcontext.DTContext, resource string, msg interface{}) error {
 	klog.Info("Deal node detail info")
 	message, ok := msg.(*model.Message)
 	if !ok {
-		return nil, errors.New("msg not Message type")
+		return errors.New("msg not Message type")
 	}
 
 	contentData, ok := message.Content.([]byte)
 	if !ok {
-		return nil, errors.New("assertion failed")
+		return errors.New("assertion failed")
 	}
 
 	devices, err := dttype.UnmarshalMembershipDetail(contentData)
 	if err != nil {
 		klog.Errorf("Unmarshal membership info failed , err: %#v", err)
-		return nil, err
+		return err
 	}
 
 	baseMessage := dttype.BaseMessage{EventID: devices.EventID}
@@ -113,25 +113,25 @@ func dealMembershipDetail(context *dtcontext.DTContext, resource string, msg int
 		removeDevice(context, toRemove, baseMessage, isDelta)
 	}
 	klog.Info("Deal node detail info successful")
-	return nil, nil
+	return nil
 }
 
-func dealMembershipUpdate(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {
+func dealMembershipUpdate(context *dtcontext.DTContext, resource string, msg interface{}) error {
 	klog.Infof("Membership event")
 	message, ok := msg.(*model.Message)
 	if !ok {
-		return nil, errors.New("msg not Message type")
+		return errors.New("msg not Message type")
 	}
 
 	contentData, ok := message.Content.([]byte)
 	if !ok {
-		return nil, errors.New("assertion failed")
+		return errors.New("assertion failed")
 	}
 
 	updateEdgeGroups, err := dttype.UnmarshalMembershipUpdate(contentData)
 	if err != nil {
 		klog.Errorf("Unmarshal membership info failed , err: %#v", err)
-		return nil, err
+		return err
 	}
 
 	baseMessage := dttype.BaseMessage{EventID: updateEdgeGroups.EventID}
@@ -143,23 +143,23 @@ func dealMembershipUpdate(context *dtcontext.DTContext, resource string, msg int
 		// delete device
 		removeDevice(context, updateEdgeGroups.RemoveDevices, baseMessage, false)
 	}
-	return nil, nil
+	return nil
 }
 
-func dealMembershipGet(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {
+func dealMembershipGet(context *dtcontext.DTContext, resource string, msg interface{}) error {
 	klog.Infof("MEMBERSHIP EVENT")
 	message, ok := msg.(*model.Message)
 	if !ok {
-		return nil, errors.New("msg not Message type")
+		return errors.New("msg not Message type")
 	}
 
 	contentData, ok := message.Content.([]byte)
 	if !ok {
-		return nil, errors.New("assertion failed")
+		return errors.New("assertion failed")
 	}
 
 	dealMembershipGetInner(context, contentData)
-	return nil, nil
+	return nil
 }
 
 // addDevice add device to the edge group

--- a/edge/pkg/devicetwin/dtmanager/membership_test.go
+++ b/edge/pkg/devicetwin/dtmanager/membership_test.go
@@ -72,9 +72,8 @@ func TestDealMembershipDetailInvalidEmptyMessage(t *testing.T) {
 		DeviceList: &sync.Map{},
 		GroupID:    "1",
 	}
-	value, err := dealMembershipDetail(dtc, "t", "invalid")
+	err := dealMembershipDetail(dtc, "t", "invalid")
 	assert.Error(t, err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipDetailInvalidMsg(t *testing.T) {
@@ -87,10 +86,9 @@ func TestDealMembershipDetailInvalidMsg(t *testing.T) {
 		Content: "invalidmsg",
 	}
 
-	value, err := dealMembershipDetail(dtc, "t", m)
+	err := dealMembershipDetail(dtc, "t", m)
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("assertion failed"), err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipDetailInvalidContent(t *testing.T) {
@@ -104,9 +102,8 @@ func TestDealMembershipDetailInvalidContent(t *testing.T) {
 		Content: cnt,
 	}
 
-	value, err := dealMembershipDetail(dtc, "t", m)
+	err := dealMembershipDetail(dtc, "t", m)
 	assert.Error(t, err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipDetailValid(t *testing.T) {
@@ -122,9 +119,8 @@ func TestDealMembershipDetailValid(t *testing.T) {
 	var m = &model.Message{
 		Content: content,
 	}
-	value, err := dealMembershipDetail(dtc, "t", m)
+	err := dealMembershipDetail(dtc, "t", m)
 	assert.NoError(t, err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipUpdateEmptyMessage(t *testing.T) {
@@ -132,10 +128,9 @@ func TestDealMembershipUpdateEmptyMessage(t *testing.T) {
 		DeviceList: &sync.Map{},
 		GroupID:    "1",
 	}
-	value, err := dealMembershipDetail(dtc, "t", "invalid")
+	err := dealMembershipDetail(dtc, "t", "invalid")
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("msg not Message type"), err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipUpdateInvalidMsg(t *testing.T) {
@@ -148,10 +143,9 @@ func TestDealMembershipUpdateInvalidMsg(t *testing.T) {
 		Content: "invalidmessage",
 	}
 
-	value, err := dealMembershipUpdate(dtc, "t", m)
+	err := dealMembershipUpdate(dtc, "t", m)
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("assertion failed"), err)
-	assert.Equal(t, nil, value)
 }
 func TestDealMembershipUpdateInvalidContent(t *testing.T) {
 	dtc := &dtcontext.DTContext{
@@ -165,9 +159,8 @@ func TestDealMembershipUpdateInvalidContent(t *testing.T) {
 		Content: cnt,
 	}
 
-	value, err := dealMembershipUpdate(dtc, "t", m)
+	err := dealMembershipUpdate(dtc, "t", m)
 	assert.Error(t, err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipUpdateValidAddedDevice(t *testing.T) {
@@ -205,9 +198,8 @@ func TestDealMembershipUpdateValidAddedDevice(t *testing.T) {
 	var m = &model.Message{
 		Content: content,
 	}
-	value, err := dealMembershipUpdate(dtc, "t", m)
+	err := dealMembershipUpdate(dtc, "t", m)
 	assert.NoError(t, err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipUpdateValidRemovedDevice(t *testing.T) {
@@ -234,9 +226,8 @@ func TestDealMembershipUpdateValidRemovedDevice(t *testing.T) {
 	var m = &model.Message{
 		Content: content,
 	}
-	value, err := dealMembershipUpdate(dtc, "t", m)
+	err := dealMembershipUpdate(dtc, "t", m)
 	assert.NoError(t, err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipGetEmptyMsg(t *testing.T) {
@@ -244,10 +235,9 @@ func TestDealMembershipGetEmptyMsg(t *testing.T) {
 		DeviceList: &sync.Map{},
 		GroupID:    "1",
 	}
-	value, err := dealMembershipGet(dtc, "t", "invalid")
+	err := dealMembershipGet(dtc, "t", "invalid")
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("msg not Message type"), err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipGetInvalidMsg(t *testing.T) {
@@ -260,10 +250,9 @@ func TestDealMembershipGetInvalidMsg(t *testing.T) {
 		Content: "hello",
 	}
 
-	value, err := dealMembershipGet(dtc, "t", m)
+	err := dealMembershipGet(dtc, "t", m)
 	assert.Error(t, err)
 	assert.Equal(t, errors.New("assertion failed"), err)
-	assert.Equal(t, nil, value)
 }
 
 func TestDealMembershipGetValid(t *testing.T) {
@@ -290,7 +279,7 @@ func TestDealMembershipGetValid(t *testing.T) {
 	var m = &model.Message{
 		Content: content,
 	}
-	_, err := dealMembershipGet(dtc, "t", m)
+	err := dealMembershipGet(dtc, "t", m)
 	assert.NoError(t, err)
 }
 

--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -59,7 +59,7 @@ func (tw TwinWorker) Start() {
 			}
 			if dtMsg, isDTMessage := msg.(*dttype.DTMessage); isDTMessage {
 				if fn, exist := twinActionCallBack[dtMsg.Action]; exist {
-					_, err := fn(tw.DTContexts, dtMsg.Identity, dtMsg.Msg)
+					err := fn(tw.DTContexts, dtMsg.Identity, dtMsg.Msg)
 					if err != nil {
 						klog.Errorf("TwinModule deal %s event failed", dtMsg.Action)
 					}
@@ -88,23 +88,23 @@ func initTwinActionCallBack() {
 	})
 }
 
-func dealTwinSync(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {
+func dealTwinSync(context *dtcontext.DTContext, resource string, msg interface{}) error {
 	klog.Infof("Twin Sync EVENT")
 	message, ok := msg.(*model.Message)
 	if !ok {
-		return nil, errors.New("msg not Message type")
+		return errors.New("msg not Message type")
 	}
 	result := []byte("")
 	content, ok := message.Content.([]byte)
 	if !ok {
-		return nil, errors.New("invalid message content")
+		return errors.New("invalid message content")
 	}
 
 	msgTwin, err := dttype.UnmarshalDeviceTwinUpdate(content)
 	if err != nil {
 		klog.Errorf("Unmarshal update request body failed, err: %#v", err)
 		dealUpdateResult(context, "", "", dtcommon.BadRequestCode, errors.New("Unmarshal update request body failed, Please check the request"), result)
-		return nil, err
+		return err
 	}
 
 	klog.Infof("Begin to update twin of the device %s", resource)
@@ -113,41 +113,41 @@ func dealTwinSync(context *dtcontext.DTContext, resource string, msg interface{}
 	DealDeviceTwin(context, resource, eventID, msgTwin.Twin, SyncDealType)
 	context.Unlock(resource)
 	//todo send ack
-	return nil, nil
+	return nil
 }
 
-func dealTwinGet(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {
+func dealTwinGet(context *dtcontext.DTContext, resource string, msg interface{}) error {
 	klog.Infof("Twin Get EVENT")
 	message, ok := msg.(*model.Message)
 	if !ok {
-		return nil, errors.New("msg not Message type")
+		return errors.New("msg not Message type")
 	}
 
 	content, ok := message.Content.([]byte)
 	if !ok {
-		return nil, errors.New("invalid message content")
+		return errors.New("invalid message content")
 	}
 
 	DealGetTwin(context, resource, content)
-	return nil, nil
+	return nil
 }
 
-func dealTwinUpdate(context *dtcontext.DTContext, resource string, msg interface{}) (interface{}, error) {
+func dealTwinUpdate(context *dtcontext.DTContext, resource string, msg interface{}) error {
 	klog.Infof("Twin Update EVENT")
 	message, ok := msg.(*model.Message)
 	if !ok {
-		return nil, errors.New("msg not Message type")
+		return errors.New("msg not Message type")
 	}
 
 	content, ok := message.Content.([]byte)
 	if !ok {
-		return nil, errors.New("invalid message content")
+		return errors.New("invalid message content")
 	}
 
 	context.Lock(resource)
 	Updated(context, resource, content)
 	context.Unlock(resource)
-	return nil, nil
+	return nil
 }
 
 // Updated update the snapshot

--- a/edge/pkg/devicetwin/dtmanager/twin_test.go
+++ b/edge/pkg/devicetwin/dtmanager/twin_test.go
@@ -278,7 +278,7 @@ func TestDealTwinSync(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := dealTwinSync(test.context, test.resource, test.msg); !reflect.DeepEqual(err, test.err) {
+			if err := dealTwinSync(test.context, test.resource, test.msg); !reflect.DeepEqual(err, test.err) {
 				t.Errorf("DTManager.TestDealTwinSync() case failed: got = %v, Want = %v", err, test.err)
 			}
 		})
@@ -328,7 +328,7 @@ func TestDealTwinGet(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := dealTwinGet(test.context, test.resource, test.msg); !reflect.DeepEqual(err, test.err) {
+			if err := dealTwinGet(test.context, test.resource, test.msg); !reflect.DeepEqual(err, test.err) {
 				t.Errorf("DTManager.TestDealTwinGet() case failed: got = %v, Want = %v", err, test.err)
 			}
 		})
@@ -379,7 +379,7 @@ func TestDealTwinUpdate(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := dealTwinUpdate(test.context, test.resource, test.msg); !reflect.DeepEqual(err, test.err) {
+			if err := dealTwinUpdate(test.context, test.resource, test.msg); !reflect.DeepEqual(err, test.err) {
 				t.Errorf("DTManager.TestDealTwinUpdate() case failed: got = %v, Want = %v", err, test.err)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
func ·Callback` return value `interface{}` is never used, so we can remove it 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
