### PR TITLE
fix target kubeletendpoint port in metrics request,the edgecore kubel…

### DIFF
--- a/cloud/pkg/cloudstream/containermetrics_connection.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
+	"strconv"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog/v2"
 
+	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
@@ -74,9 +75,8 @@ func (ms *ContainerMetricsConnection) SendConnection() (stream.EdgedConnection, 
 		URL:    *ms.r.Request.URL,
 		Header: ms.r.Request.Header,
 	}
-	targetPort := strings.Split(ms.r.Request.Host, ":")[1]
 	connector.URL.Scheme = httpScheme
-	connector.URL.Host = net.JoinHostPort(defaultServerHost, targetPort)
+	connector.URL.Host = net.JoinHostPort(defaultServerHost, strconv.Itoa(constants.ServerPort))
 	m, err := connector.CreateConnectMessage()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
…etedgepoint should be stable of 10350,not the cloudside kubeletenpoint port of node

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
when user want to use promethus to pull metric from edged. The pull request will request the kubeletendpoint port of edged.
But in active-active mode of cloudcore, the kubeletendpoint port of the node is defferent from the real port of edged(10350).
In the code, when stream do the request from cloudside to the edgeside ,the tagert port is  not the real port of edged. Just fix this.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2996 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
