### PR TITLE
sync the response message unconditionally

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -100,9 +100,10 @@ func (q *ChannelMessageQueue) addMessageToQueue(nodeID string, msg *beehiveModel
 		return
 	}
 
-	item, exist, _ := nodeStore.GetByKey(messageKey)
-
-	if !isDeleteMessage(msg) {
+	//if the operation is delete, force to sync the resource message
+	//if the operation is response, force to sync the resource message, since the edgecore requests it
+	if !isDeleteMessage(msg) && msg.GetOperation() != beehiveModel.ResponseOperation {
+		item, exist, _ := nodeStore.GetByKey(messageKey)
 		// If the message doesn't exist in the store, then compare it with
 		// the version stored in the database
 		if !exist {


### PR DESCRIPTION
if the operation is response, force to sync the resource message, since the edgecore requests it


**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
In case that the edgecore with the same node name is re-installed or moved to another edge node, it can't find imagePullSecrets or configMaps in local metamanager and also failed to get response from cloudcore.
If edgecore request a resouce from cloudcore, which means the resource doesn't exist in local metamanager, cloudcore has to sync the response resource down to edge.


**Which issue(s) this PR fixes**:
#2967


**Does this PR introduce a user-facing change?**:
NONE
