### PR TITLE
support k8s v1.21.X

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Install dependences
         run: |
           command -v ginkgo || go get github.com/onsi/ginkgo/ginkgo
-          go get sigs.k8s.io/kind@v0.9.0
+          go get sigs.k8s.io/kind@v0.11.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
       - name: Checkout code
@@ -155,7 +155,7 @@ jobs:
       - name: Install dependences
         run: |
           command -v ginkgo || go get github.com/onsi/ginkgo/ginkgo
-          go get sigs.k8s.io/kind@v0.9.0
+          go get sigs.k8s.io/kind@v0.11.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
           export RELEASE_VERSION=$(wget -qO - https://kubeedge.io/latestversion | cat)
           sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/checksum_kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz.txt

--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -158,7 +158,7 @@ func isListResource(msg *beehiveModel.Message) bool {
 	if strings.Contains(msgResource, beehiveModel.ResourceTypePodlist) ||
 		strings.Contains(msgResource, "membership") ||
 		strings.Contains(msgResource, "twin/cloud_updated") ||
-		strings.Contains(msgResource, commonconst.ResourceTypeServiceAccount) {
+		strings.Contains(msgResource, beehiveModel.ResourceTypeServiceAccountToken) {
 		return true
 	}
 

--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -157,7 +157,8 @@ func isListResource(msg *beehiveModel.Message) bool {
 	msgResource := msg.GetResource()
 	if strings.Contains(msgResource, beehiveModel.ResourceTypePodlist) ||
 		strings.Contains(msgResource, "membership") ||
-		strings.Contains(msgResource, "twin/cloud_updated") {
+		strings.Contains(msgResource, "twin/cloud_updated") ||
+		strings.Contains(msgResource, commonconst.ResourceTypeServiceAccount) {
 		return true
 	}
 

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -106,7 +106,7 @@ const (
 	DefaultQueryNodeBuffer                  = 1024
 	DefaultUpdateNodeBuffer                 = 1024
 	DefaultDeletePodBuffer                  = 1024
-	DefaultServiceAccountBuffer             = 1024
+	DefaultServiceAccountTokenBuffer        = 1024
 
 	DefaultPodEventBuffer           = 1
 	DefaultConfigMapEventBuffer     = 1
@@ -142,7 +142,4 @@ const (
 	// ServerPort is the default port for the edgecore server on each host machine.
 	// May be overridden by a flag at startup in the future.
 	ServerPort = 10350
-
-	ResourceTypeServiceAccount     = "serviceaccount"
-	OperationTypeGetServiceAccount = "getserviceaccount"
 )

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -92,6 +92,7 @@ const (
 	DefaultUpdateNodeWorkers                 = 4
 	DefaultDeletePodWorkers                  = 4
 	DefaultUpdateRuleStatusWorkers           = 4
+	DefaultServiceAccountTokenWorkers        = 4
 
 	DefaultUpdatePodStatusBuffer            = 1024
 	DefaultUpdateNodeStatusBuffer           = 1024
@@ -105,6 +106,7 @@ const (
 	DefaultQueryNodeBuffer                  = 1024
 	DefaultUpdateNodeBuffer                 = 1024
 	DefaultDeletePodBuffer                  = 1024
+	DefaultServiceAccountBuffer             = 1024
 
 	DefaultPodEventBuffer           = 1
 	DefaultConfigMapEventBuffer     = 1
@@ -140,4 +142,7 @@ const (
 	// ServerPort is the default port for the edgecore server on each host machine.
 	// May be overridden by a flag at startup in the future.
 	ServerPort = 10350
+
+	ResourceTypeServiceAccount     = "serviceaccount"
+	OperationTypeGetServiceAccount = "getserviceaccount"
 )

--- a/edge/pkg/edged/volume_host.go
+++ b/edge/pkg/edged/volume_host.go
@@ -170,7 +170,7 @@ func (evh *edgedVolumeHost) GetPodsDir() string {
 
 func (evh *edgedVolumeHost) GetServiceAccountTokenFunc() func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
 	return func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-		return evh.edge.metaClient.ServiceAccounts().GetServiceAccountToken(namespace, name, tr)
+		return evh.edge.metaClient.ServiceAccountToken().GetServiceAccountToken(namespace, name, tr)
 	}
 }
 

--- a/edge/pkg/edged/volume_host.go
+++ b/edge/pkg/edged/volume_host.go
@@ -169,8 +169,8 @@ func (evh *edgedVolumeHost) GetPodsDir() string {
 }
 
 func (evh *edgedVolumeHost) GetServiceAccountTokenFunc() func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-	return func(_, _ string, _ *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-		return nil, fmt.Errorf("GetServiceAccountToken unsupported")
+	return func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+		return evh.edge.metaClient.ServiceAccounts().GetServiceAccountToken(namespace, name, tr)
 	}
 }
 

--- a/edge/pkg/metamanager/client/metaclient.go
+++ b/edge/pkg/metamanager/client/metaclient.go
@@ -24,6 +24,7 @@ type CoreInterface interface {
 	NodesGetter
 	NodeStatusGetter
 	SecretsGetter
+	ServiceAccountsGetter
 	PersistentVolumesGetter
 	PersistentVolumeClaimsGetter
 	VolumeAttachmentsGetter
@@ -51,6 +52,10 @@ func (m *metaClient) NodeStatus(namespace string) NodeStatusInterface {
 
 func (m *metaClient) Secrets(namespace string) SecretsInterface {
 	return newSecrets(namespace, m.send)
+}
+
+func (m *metaClient) ServiceAccounts() ServiceAccountsInterface {
+	return newServiceAccounts(m.send)
 }
 
 func (m *metaClient) PodStatus(namespace string) PodStatusInterface {

--- a/edge/pkg/metamanager/client/metaclient.go
+++ b/edge/pkg/metamanager/client/metaclient.go
@@ -24,7 +24,7 @@ type CoreInterface interface {
 	NodesGetter
 	NodeStatusGetter
 	SecretsGetter
-	ServiceAccountsGetter
+	ServiceAccountTokenGetter
 	PersistentVolumesGetter
 	PersistentVolumeClaimsGetter
 	VolumeAttachmentsGetter
@@ -54,8 +54,8 @@ func (m *metaClient) Secrets(namespace string) SecretsInterface {
 	return newSecrets(namespace, m.send)
 }
 
-func (m *metaClient) ServiceAccounts() ServiceAccountsInterface {
-	return newServiceAccounts(m.send)
+func (m *metaClient) ServiceAccountToken() ServiceAccountTokenInterface {
+	return newServiceAccountToken(m.send)
 }
 
 func (m *metaClient) PodStatus(namespace string) PodStatusInterface {

--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+)
+
+// ServiceAccountsGetter is interface to get client service accounts
+type ServiceAccountsGetter interface {
+	ServiceAccounts() ServiceAccountsInterface
+}
+
+// ServiceAccountsInterface is interface for client service account token
+type ServiceAccountsInterface interface {
+	GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
+}
+
+type serviceAccounts struct {
+	send SendInterface
+}
+
+func newServiceAccounts(s SendInterface) *serviceAccounts {
+	return &serviceAccounts{
+		send: s,
+	}
+}
+
+func (c *serviceAccounts) GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+	resource := fmt.Sprintf("%s/%s/%s", namespace, constants.ResourceTypeServiceAccount, name)
+	tokenMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, constants.OperationTypeGetServiceAccount, tr)
+	msg, err := c.send.SendSync(tokenMsg)
+	if err != nil {
+		klog.Errorf("get service account token failed, err: %v", err)
+		return nil, fmt.Errorf("get service account token failed, err: %v", err)
+	}
+
+	var content []byte
+	switch msg.Content.(type) {
+	case []byte:
+		content = msg.GetContent().([]byte)
+	default:
+		content, err = json.Marshal(msg.GetContent())
+		if err != nil {
+			klog.Errorf("marshal message to serviceaccount token failed, err: %v", err)
+			return nil, fmt.Errorf("marshal message to serviceaccount token failed, err: %v", err)
+		}
+	}
+
+	return handleServiceAccount(content)
+}
+
+func handleServiceAccount(content []byte) (*authenticationv1.TokenRequest, error) {
+	var serviceAccount authenticationv1.TokenRequest
+	err := json.Unmarshal(content, &serviceAccount)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal message to service account failed, err: %v", err)
+	}
+	return &serviceAccount, nil
+}

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -466,6 +466,29 @@ func (m *metaManager) processVolume(message model.Message) {
 	klog.Infof("process volume send to cloud resp[%+v]", resp)
 }
 
+func (m *metaManager) processServiceAccount(message model.Message) {
+	opration := message.GetOperation()
+	switch opration {
+	case constants.OperationTypeGetServiceAccount:
+		originalID := message.GetID()
+		message.UpdateID()
+
+		// send model msg to cloud
+		resp, err := beehiveContext.SendSync(
+			string(metaManagerConfig.Config.ContextSendModule),
+			message,
+			time.Duration(metaManagerConfig.Config.RemoteQueryTimeout)*time.Second)
+		if err != nil {
+			klog.Errorf("send request for service account to cloud failed, err is %v", err)
+			return
+		}
+		resp.BuildHeader(resp.GetID(), originalID, resp.GetTimestamp())
+		sendToEdged(&resp, message.IsSync())
+	default:
+		klog.Warningf("not supported serviceaccount token operation: %v", opration)
+	}
+}
+
 func (m *metaManager) process(message model.Message) {
 	operation := message.GetOperation()
 	switch operation {
@@ -492,6 +515,10 @@ func (m *metaManager) process(message model.Message) {
 		constants.CSIOperationTypeControllerPublishVolume,
 		constants.CSIOperationTypeControllerUnpublishVolume:
 		m.processVolume(message)
+	case constants.OperationTypeGetServiceAccount:
+		m.processServiceAccount(message)
+	default:
+		klog.Errorf("metamanager not supported operation: %v", operation)
 	}
 }
 

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -32,7 +32,7 @@ function check_kind {
   command -v kind >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
     echo "installing kind ."
-    GO111MODULE="on" go get sigs.k8s.io/kind@v0.9.0
+    GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.0
     if [[ $? -ne 0 ]]; then
       echo "kind installed failed, exiting."
       exit 1

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -32,7 +32,7 @@ function check_kind {
   command -v kind >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
     echo "installing kind ."
-    GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.0
+    GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
     if [[ $? -ne 0 ]]; then
       echo "kind installed failed, exiting."
       exit 1

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -103,6 +103,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					QueryNode:                  constants.DefaultQueryNodeBuffer,
 					UpdateNode:                 constants.DefaultUpdateNodeBuffer,
 					DeletePod:                  constants.DefaultDeletePodBuffer,
+					ServiceAccount:             constants.DefaultServiceAccountBuffer,
 				},
 				Context: &ControllerContext{
 					SendModule:       metaconfig.ModuleNameCloudHub,
@@ -124,6 +125,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					UpdateNodeWorkers:                 constants.DefaultUpdateNodeWorkers,
 					DeletePodWorkers:                  constants.DefaultDeletePodWorkers,
 					UpdateRuleStatusWorkers:           constants.DefaultUpdateRuleStatusWorkers,
+					ServiceAccountTokenWorkers:        constants.DefaultServiceAccountTokenWorkers,
 				},
 			},
 			DeviceController: &DeviceController{

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -103,7 +103,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					QueryNode:                  constants.DefaultQueryNodeBuffer,
 					UpdateNode:                 constants.DefaultUpdateNodeBuffer,
 					DeletePod:                  constants.DefaultDeletePodBuffer,
-					ServiceAccount:             constants.DefaultServiceAccountBuffer,
+					ServiceAccountToken:        constants.DefaultServiceAccountTokenBuffer,
 				},
 				Context: &ControllerContext{
 					SendModule:       metaconfig.ModuleNameCloudHub,

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -265,7 +265,7 @@ type EdgeControllerBuffer struct {
 	DeletePod int32 `json:"deletePod,omitempty"`
 	// ServiceAccount indicates the buffer of service account token
 	// default 1024
-	ServiceAccount int32 `json:"serviceaccount,omitempty"`
+	ServiceAccountToken int32 `json:"serviceAccountToken,omitempty"`
 }
 
 // ControllerContext indicates the message layer context for all controllers

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -263,6 +263,9 @@ type EdgeControllerBuffer struct {
 	// DeletePod indicates the buffer of delete pod message from edge
 	// default 1024
 	DeletePod int32 `json:"deletePod,omitempty"`
+	// ServiceAccount indicates the buffer of service account token
+	// default 1024
+	ServiceAccount int32 `json:"serviceaccount,omitempty"`
 }
 
 // ControllerContext indicates the message layer context for all controllers
@@ -318,6 +321,9 @@ type EdgeControllerLoad struct {
 	// UpdateRuleStatusWorkers indicates the load of update rule status
 	// default 4
 	UpdateRuleStatusWorkers int32 `json:"UpdateRuleStatusWorkers,omitempty"`
+	// ServiceAccountTokenWorkers indicates the load of service account token
+	// default 4
+	ServiceAccountTokenWorkers int32 `json:"ServiceAccountTokenWorkers,omitempty"`
 }
 
 // DeviceController indicates the device controller

--- a/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
@@ -75,7 +75,7 @@ func NewDefaultEdgeSiteConfig() *EdgeSiteConfig {
 					QueryNode:                  constants.DefaultQueryNodeBuffer,
 					UpdateNode:                 constants.DefaultUpdateNodeBuffer,
 					DeletePod:                  constants.DefaultDeletePodBuffer,
-					ServiceAccount:             constants.DefaultServiceAccountBuffer,
+					ServiceAccountToken:        constants.DefaultServiceAccountTokenBuffer,
 				},
 				Context: &cloudcoreconfig.ControllerContext{
 					SendModule:     metaconfig.ModuleNameMetaManager,

--- a/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgesite/v1alpha1/default.go
@@ -75,6 +75,7 @@ func NewDefaultEdgeSiteConfig() *EdgeSiteConfig {
 					QueryNode:                  constants.DefaultQueryNodeBuffer,
 					UpdateNode:                 constants.DefaultUpdateNodeBuffer,
 					DeletePod:                  constants.DefaultDeletePodBuffer,
+					ServiceAccount:             constants.DefaultServiceAccountBuffer,
 				},
 				Context: &cloudcoreconfig.ControllerContext{
 					SendModule:     metaconfig.ModuleNameMetaManager,
@@ -95,6 +96,7 @@ func NewDefaultEdgeSiteConfig() *EdgeSiteConfig {
 					UpdateNodeWorkers:                 constants.DefaultUpdateNodeWorkers,
 					DeletePodWorkers:                  constants.DefaultDeletePodWorkers,
 					UpdateRuleStatusWorkers:           constants.DefaultUpdateRuleStatusWorkers,
+					ServiceAccountTokenWorkers:        constants.DefaultServiceAccountTokenWorkers,
 				},
 			},
 			Edged: &edgecoreconfig.Edged{

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
@@ -17,16 +17,17 @@ const (
 	ResponseOperation      = "response"
 	ResponseErrorOperation = "error"
 
-	ResourceTypePod          = "pod"
-	ResourceTypeConfigmap    = "configmap"
-	ResourceTypeSecret       = "secret"
-	ResourceTypeNode         = "node"
-	ResourceTypePodlist      = "podlist"
-	ResourceTypePodStatus    = "podstatus"
-	ResourceTypeNodeStatus   = "nodestatus"
-	ResourceTypeRule         = "rule"
-	ResourceTypeRuleEndpoint = "ruleendpoint"
-	ResourceTypeRuleStatus   = "rulestatus"
+	ResourceTypePod                 = "pod"
+	ResourceTypeConfigmap           = "configmap"
+	ResourceTypeServiceAccountToken = "serviceaccounttoken"
+	ResourceTypeSecret              = "secret"
+	ResourceTypeNode                = "node"
+	ResourceTypePodlist             = "podlist"
+	ResourceTypePodStatus           = "podstatus"
+	ResourceTypeNodeStatus          = "nodestatus"
+	ResourceTypeRule                = "rule"
+	ResourceTypeRuleEndpoint        = "ruleendpoint"
+	ResourceTypeRuleStatus          = "rulestatus"
 )
 
 // Message struct


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
To support k8s v1.21.X
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3002

**Special notes for your reviewer**:
when kubeedge running in the k8s v1.21.X environment, pod cannot run successfully. And the edgecore logs error: `GetServiceAccountToken unsupported`, so we should implement the function `func (evh *edgedVolumeHost) GetServiceAccountTokenFunc()` https://github.com/kubeedge/kubeedge/blob/597c2b4bf33f59009390e3d6f6fed3b03226225d/edge/pkg/edged/volume_host.go#L171-L175

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
