### PR TITLE
Handling node/*/membership/detail

### DIFF
--- a/cloud/pkg/devicecontroller/constants/service.go
+++ b/cloud/pkg/devicecontroller/constants/service.go
@@ -2,12 +2,13 @@ package constants
 
 // Service level constants
 const (
-	ResourceNodeIDIndex         = 1
-	ResourceDeviceIndex         = 2
-	ResourceDeviceIDIndex       = 3
-	ResourceNode                = "node"
-	ResourceDevice              = "device"
-	ResourceTypeTwinEdgeUpdated = "twin/edge_updated"
+	ResourceNodeIDIndex          = 1
+	ResourceDeviceIndex          = 2
+	ResourceDeviceIDIndex        = 3
+	ResourceNode                 = "node"
+	ResourceDevice               = "device"
+	ResourceTypeTwinEdgeUpdated  = "twin/edge_updated"
+	ResourceTypeMembershipDetail = "membership/detail"
 
 	// Group
 	GroupTwin = "twin"

--- a/cloud/pkg/devicecontroller/controller/upstream.go
+++ b/cloud/pkg/devicecontroller/controller/upstream.go
@@ -97,6 +97,7 @@ func (uc *UpstreamController) dispatchMessage() {
 		switch resourceType {
 		case constants.ResourceTypeTwinEdgeUpdated:
 			uc.deviceStatusChan <- msg
+		case constants.ResourceTypeMembershipDetail:
 		default:
 			klog.Warningf("Message: %s, with resource type: %s not intended for device controller", msg.GetID(), resourceType)
 		}

--- a/cloud/pkg/devicecontroller/messagelayer/util.go
+++ b/cloud/pkg/devicecontroller/messagelayer/util.go
@@ -36,8 +36,11 @@ func GetDeviceID(resource string) (string, error) {
 func GetResourceType(resource string) (string, error) {
 	if strings.Contains(resource, deviceconstants.ResourceTypeTwinEdgeUpdated) {
 		return deviceconstants.ResourceTypeTwinEdgeUpdated, nil
+	} else if strings.Contains(resource, deviceconstants.ResourceTypeMembershipDetail) {
+		return deviceconstants.ResourceTypeMembershipDetail, nil
 	}
-	return "", errors.New("unknown resource")
+
+	return "", fmt.Errorf("unknown resource, found: %s", resource)
 }
 
 // GetNodeID from "beehive/pkg/core/model".Message.Router.Resource

--- a/cloud/pkg/devicecontroller/messagelayer/util_test.go
+++ b/cloud/pkg/devicecontroller/messagelayer/util_test.go
@@ -151,11 +151,19 @@ func TestGetResourceType(t *testing.T) {
 		wantErr error
 	}{
 		{
-			"TestGetNodeID() Case 1: success",
+			"TestGetResourceType ResourceTypeTwinEdgeUpdated: success",
 			args{
 				resource: fmt.Sprintf("node/%s/%s", "nid", deviceconstants.ResourceTypeTwinEdgeUpdated),
 			},
 			deviceconstants.ResourceTypeTwinEdgeUpdated,
+			nil,
+		},
+		{
+			"TestGetResourceType() ResourceTypeMembershipDetail: success",
+			args{
+				resource: deviceconstants.ResourceTypeMembershipDetail,
+			},
+			deviceconstants.ResourceTypeMembershipDetail,
 			nil,
 		},
 		{
@@ -164,7 +172,7 @@ func TestGetResourceType(t *testing.T) {
 				resource: "",
 			},
 			"",
-			fmt.Errorf("unknown resource"),
+			fmt.Errorf("unknown resource, found: %s", ""),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
A lot of warnings are generated by the devicecontroller/controller/upstream.go where the resource type cannot be identified. Most of these messages are of the resource type node/*/membersip/detail. These resource type will not generate a warning any more.