### PR TITLE
devicecontroller: fix dataProperty misplaced

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -377,8 +377,14 @@ func addDeviceInstanceAndProtocol(device *v1alpha2.Device, deviceProfile *types.
 	}
 
 	deviceInstance.Twins = device.Status.Twins
-	deviceInstance.DataProperties = device.Spec.Data.DataProperties
-	deviceInstance.DataTopic = device.Spec.Data.DataTopic
+
+	// add dataProperties and dataTopic
+	if len(device.Spec.Data.DataProperties) > 0 || len(device.Spec.Data.DataTopic) > 0 {
+		deviceInstance.Data = &v1alpha2.DeviceData{
+			DataProperties: device.Spec.Data.DataProperties,
+			DataTopic:      device.Spec.Data.DataTopic,
+		}
+	}
 
 	addPropertyVisitorsToDeviceInstance(device, deviceInstance)
 
@@ -561,10 +567,14 @@ func (dc *DownstreamController) updateConfigMap(device *v1alpha2.Device) {
 				addPropertyVisitorsToDeviceInstance(device, devInst)
 				// update twins
 				devInst.Twins = device.Status.Twins
-				// update data
-				devInst.DataProperties = device.Spec.Data.DataProperties
-				// update data topic
-				devInst.DataTopic = device.Spec.Data.DataTopic
+
+				// update data and data topic
+				if len(device.Spec.Data.DataProperties) > 0 || len(device.Spec.Data.DataTopic) > 0 {
+					devInst.Data = &v1alpha2.DeviceData{
+						DataProperties: device.Spec.Data.DataProperties,
+						DataTopic:      device.Spec.Data.DataTopic,
+					}
+				}
 				// update protocol
 				devInst.Protocol = deviceProtocol.Name
 				break

--- a/cloud/pkg/devicecontroller/types/deviceprofile.go
+++ b/cloud/pkg/devicecontroller/types/deviceprofile.go
@@ -28,14 +28,10 @@ type DeviceInstance struct {
 	// Optional: A passive device won't have twin properties and this list could be empty.
 	// +optional
 	Twins []v1alpha2.Twin `json:"twins,omitempty"`
-	// A list of data properties, which are not required to be processed by edgecore
+	// Data section describe a list of time-series properties which should be processed
+	// on edge node.
 	// +optional
-	DataProperties []v1alpha2.DataProperty `json:"dataProperties,omitempty"`
-	// Topic used by mapper, all data collected from dataProperties
-	// should be published to this topic,
-	// the default value is $ke/events/device/+/data/update
-	// +optional
-	DataTopic string `json:"dataTopic,omitempty"`
+	Data *v1alpha2.DeviceData `json:"data,omitempty"`
 	// PropertyVisitors is list of all PropertyVisitors in DeviceModels
 	PropertyVisitors []*PropertyVisitor `json:"propertyVisitors,omitempty"`
 }

--- a/tests/e2e/utils/device.go
+++ b/tests/e2e/utils/device.go
@@ -1549,15 +1549,17 @@ func UpdatedConfigMapModbusForDataAndTwins(nodeSelector string) v12.ConfigMap {
 					},
 				},
 			},
-			DataProperties: []v1alpha2.DataProperty{
-				{
-					PropertyName: "temperature",
-					Metadata: map[string]string{
-						"type": "string",
+			Data: &v1alpha2.DeviceData{
+				DataProperties: []v1alpha2.DataProperty{
+					{
+						PropertyName: "temperature",
+						Metadata: map[string]string{
+							"type": "string",
+						},
 					},
 				},
+				DataTopic: "$ke/events/+/device/customized/update",
 			},
-			DataTopic:        "$ke/events/+/device/customized/update",
 			PropertyVisitors: propertyVisitors,
 		},
 	}


### PR DESCRIPTION
add data section in device-profile-config-<edgenode> configmap, then
mappers-go can parse dataProperty successfully


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cannot get data property with default mappers such as modbus.

**Which issue(s) this PR fixes**:
Fixes #3063

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
