### PR TITLE
Automated cherry pick of #3010: fix target kubeletendpoint port in metrics request,the

### DIFF
--- a/cloud/pkg/cloudstream/containermetrics_connection.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
+	"strconv"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog/v2"
 
+	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
@@ -74,9 +75,8 @@ func (ms *ContainerMetricsConnection) SendConnection() (stream.EdgedConnection, 
 		URL:    *ms.r.Request.URL,
 		Header: ms.r.Request.Header,
 	}
-	targetPort := strings.Split(ms.r.Request.Host, ":")[1]
 	connector.URL.Scheme = httpScheme
-	connector.URL.Host = net.JoinHostPort(defaultServerHost, targetPort)
+	connector.URL.Host = net.JoinHostPort(defaultServerHost, strconv.Itoa(constants.ServerPort))
 	m, err := connector.CreateConnectMessage()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry pick of #3010 on release-1.8.

#3010: fix target kubeletendpoint port in metrics request,the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.