### PR TITLE
move edgehub moduleName to common module package

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application.go
+++ b/cloud/pkg/dynamiccontroller/application/application.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller/messagelayer"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
-	"github.com/kubeedge/kubeedge/edge/pkg/edgehub"
+	edgemodule "github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	metaserverconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/config"
 	"github.com/kubeedge/kubeedge/pkg/metaserver"
 )
@@ -328,7 +328,7 @@ func (a *Agent) doApply(app *Application) {
 	app.Status = InApplying
 	msg := model.NewMessage("").SetRoute(MetaServerSource, modules.DynamicControllerModuleGroup).FillBody(app)
 	msg.SetResourceOperation("null", "null")
-	resp, err := beehiveContext.SendSync(edgehub.ModuleNameEdgeHub, *msg, 10*time.Second)
+	resp, err := beehiveContext.SendSync(edgemodule.EdgeHubModuleName, *msg, 10*time.Second)
 	if err != nil {
 		app.Status = Failed
 		app.Reason = fmt.Sprintf("failed to access cloud Application center: %v", err)

--- a/edge/pkg/common/modules/names.go
+++ b/edge/pkg/common/modules/names.go
@@ -11,4 +11,6 @@ const (
 	EdgeStreamModuleName = "edgestream"
 	// DeviceTwinModuleName name
 	DeviceTwinModuleName = "twin"
+	// EdgeHubModuleName name
+	EdgeHubModuleName = "websocket"
 )

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -47,7 +47,6 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/edged/apis"
 	"github.com/kubeedge/kubeedge/edge/pkg/edged/config"
-	"github.com/kubeedge/kubeedge/edge/pkg/edgehub"
 	"github.com/kubeedge/kubeedge/pkg/util"
 )
 
@@ -387,8 +386,8 @@ func (e *edged) registerNode() error {
 	resource := fmt.Sprintf("%s/%s/%s", e.namespace, model.ResourceTypeNodeStatus, e.nodeName)
 	nodeInfoMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.InsertOperation, node)
 	var res model.Message
-	if _, ok := core.GetModules()[edgehub.ModuleNameEdgeHub]; ok {
-		res, err = beehiveContext.SendSync(edgehub.ModuleNameEdgeHub, *nodeInfoMsg, syncMsgRespTimeout)
+	if _, ok := core.GetModules()[modules.EdgeHubModuleName]; ok {
+		res, err = beehiveContext.SendSync(modules.EdgeHubModuleName, *nodeInfoMsg, syncMsgRespTimeout)
 	} else {
 		res, err = beehiveContext.SendSync(EdgeController, *nodeInfoMsg, syncMsgRespTimeout)
 	}

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -15,11 +15,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1"
 )
 
-//define edgehub module name
-const (
-	ModuleNameEdgeHub = "websocket"
-)
-
 var HasTLSTunnelCerts = make(chan bool, 1)
 
 //EdgeHub defines edgehub object structure
@@ -46,7 +41,7 @@ func Register(eh *v1alpha1.EdgeHub, nodeName string) {
 
 //Name returns the name of EdgeHub module
 func (eh *EdgeHub) Name() string {
-	return ModuleNameEdgeHub
+	return modules.EdgeHubModuleName
 }
 
 //Group returns EdgeHub group

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -117,7 +117,7 @@ func (eh *EdgeHub) routeToCloud() {
 			return
 		default:
 		}
-		message, err := beehiveContext.Receive(ModuleNameEdgeHub)
+		message, err := beehiveContext.Receive(modules.EdgeHubModuleName)
 		if err != nil {
 			klog.Errorf("failed to receive message from edge: %v", err)
 			time.Sleep(time.Second)
@@ -143,7 +143,7 @@ func (eh *EdgeHub) keepalive() {
 		default:
 		}
 		msg := model.NewMessage("").
-			BuildRouter(ModuleNameEdgeHub, "resource", "node", messagepkg.OperationKeepalive).
+			BuildRouter(modules.EdgeHubModuleName, "resource", "node", messagepkg.OperationKeepalive).
 			FillBody("ping")
 
 		// post message to cloud hub

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -77,21 +77,21 @@ func TestDispatch(t *testing.T) {
 		{
 			name:          "dispatch with valid input",
 			hub:           &EdgeHub{},
-			message:       model.NewMessage("").BuildRouter(ModuleNameEdgeHub, module.TwinGroup, "", ""),
+			message:       model.NewMessage("").BuildRouter(module.EdgeHubModuleName, module.TwinGroup, "", ""),
 			expectedError: nil,
 			isResponse:    false,
 		},
 		{
 			name:          "Error Case in dispatch",
 			hub:           &EdgeHub{},
-			message:       model.NewMessage("test").BuildRouter(ModuleNameEdgeHub, module.EdgedGroup, "", ""),
+			message:       model.NewMessage("test").BuildRouter(module.EdgeHubModuleName, module.EdgedGroup, "", ""),
 			expectedError: fmt.Errorf("msg_group not found"),
 			isResponse:    true,
 		},
 		{
 			name:          "Response Case in dispatch",
 			hub:           &EdgeHub{},
-			message:       model.NewMessage("test").BuildRouter(ModuleNameEdgeHub, module.TwinGroup, "", ""),
+			message:       model.NewMessage("test").BuildRouter(module.EdgeHubModuleName, module.TwinGroup, "", ""),
 			expectedError: nil,
 			isResponse:    true,
 		},
@@ -133,8 +133,8 @@ func TestRouteToEdge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockAdapter.EXPECT().Receive().Return(*model.NewMessage("test").BuildRouter(ModuleNameEdgeHub, module.EdgedGroup, "", ""), nil).Times(tt.receiveTimes)
-			mockAdapter.EXPECT().Receive().Return(*model.NewMessage("test").BuildRouter(ModuleNameEdgeHub, module.TwinGroup, "", ""), nil).Times(tt.receiveTimes)
+			mockAdapter.EXPECT().Receive().Return(*model.NewMessage("test").BuildRouter(module.EdgeHubModuleName, module.EdgedGroup, "", ""), nil).Times(tt.receiveTimes)
+			mockAdapter.EXPECT().Receive().Return(*model.NewMessage("test").BuildRouter(module.EdgeHubModuleName, module.TwinGroup, "", ""), nil).Times(tt.receiveTimes)
 			mockAdapter.EXPECT().Receive().Return(*model.NewMessage(""), errors.New("Connection Refused")).Times(1)
 			go tt.hub.routeToEdge()
 			stop := <-tt.hub.reconnectChan
@@ -229,9 +229,9 @@ func TestRouteToCloud(t *testing.T) {
 			go tt.hub.routeToCloud()
 			time.Sleep(2 * time.Second)
 			core.Register(&EdgeHub{})
-			beehiveContext.AddModule(ModuleNameEdgeHub)
+			beehiveContext.AddModule(module.EdgeHubModuleName)
 			msg := model.NewMessage("").BuildHeader("test_id", "", 1)
-			beehiveContext.Send(ModuleNameEdgeHub, *msg)
+			beehiveContext.Send(module.EdgeHubModuleName, *msg)
 			stopChan := <-tt.hub.reconnectChan
 			if stopChan != struct{}{} {
 				t.Errorf("Error in route to cloud")


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
edgehub moduleName is defined in edgehub module, move it to common module package. just consistent with other modules.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
