### PR TITLE
rpminstaller:add support for openEuler

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/rpminstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/rpminstaller.go
@@ -18,10 +18,15 @@ package util
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/blang/semver"
 
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+const (
+	openEulerVendorName = "openEuler"
 )
 
 // RpmOS struct objects shall have information of the tools version to be installed
@@ -51,13 +56,24 @@ func (r *RpmOS) InstallMQTT() error {
 		return nil
 	}
 
-	// install MQTT
-	for _, command := range []string{
+	commands := []string{
 		"yum -y install epel-release",
 		"yum -y install mosquitto",
 		"systemctl start mosquitto",
 		"systemctl enable mosquitto",
-	} {
+	}
+
+	vendorName, err := getOSVendorName()
+	if err != nil {
+		fmt.Printf("Get OS vendor name failed: %v\n", err)
+	}
+	// epel-release package does not included in openEuler
+	if vendorName == openEulerVendorName {
+		commands = commands[1:]
+	}
+
+	// install MQTT
+	for _, command := range commands {
 		cmd := NewCommand(command)
 		if err := cmd.Exec(); err != nil {
 			return err
@@ -115,4 +131,14 @@ func (r *RpmOS) IsKubeEdgeProcessRunning(proc string) (bool, error) {
 // IsProcessRunning checks if the given process is running or not
 func (r *RpmOS) IsProcessRunning(proc string) (bool, error) {
 	return isKubeEdgeProcessRunning(proc)
+}
+
+func getOSVendorName() (string, error) {
+	cmd := NewCommand("cat /etc/os-release | grep -E \"^NAME=\" | awk -F'=' '{print $2}'")
+	if err := cmd.Exec(); err != nil {
+		return "", err
+	}
+	vendor := strings.Trim(cmd.GetStdOut(), "\"")
+
+	return vendor, nil
 }


### PR DESCRIPTION
keadm will install epel-release when edge node want to join cluster,
openEuler does not provide epel-release, it's better to support keadm
join on openEuler ^.^

> openEuler is an innovative platform nurtured by community collaboration. It aims to build a unified and open OS that supports multiple processor architectures, and to advance the hardware/software application ecosystem.

Signed-off-by: CooperLi <a710905118@163.com>

