### PR TITLE
fix help message when white noise issue occurs

### DIFF
--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -61,7 +61,7 @@ kubeedge::lint::check() {
     fi
 
     [[ $(git diff --name-only) ]] && {
-      echo "Some files have white noise issue, please run \`make lint\` to slove this issue"
+      echo "Some files have white noise issue, please run \`make lint\` to solve and \`git status\` to find and fix this issue"
       return 1
     }
     set -o pipefail


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When ci lint or `make lint` command checks white noise, the suggestion message should suggest using `git status` or `git diff` to find the reason, but not using `make lint` command. Or, developers or who first encounters whitenoise,  don't know how to fix this problem.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
