### PR TITLE
added iptables to Dockerfile and made cloudcore privileged

### DIFF
--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -19,40 +19,41 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - name: cloudcore
-        image: kubeedge/cloudcore:v1.3.1
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 10000
-          name: cloudhub
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 200m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 512Mi
-        volumeMounts:
-        - name: conf
-          mountPath: /etc/kubeedge/config
-        - name: certs
-          mountPath: /etc/kubeedge
-        - name: sock
-          mountPath: /var/lib/kubeedge
+        - name: cloudcore
+          image: kubeedge/cloudcore:v1.3.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 10000
+              name: cloudhub
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 200m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/kubeedge/config
+            - name: certs
+              mountPath: /etc/kubeedge
+            - name: sock
+              mountPath: /var/lib/kubeedge
+          securityContext:
+            privileged: true
       restartPolicy: Always
       serviceAccount: cloudcore
       serviceAccountName: cloudcore
       volumes:
-      - name: conf
-        configMap:
-          name: cloudcore
-      - name: certs
-        hostPath:
-          path: /etc/kubeedge
-          type: DirectoryOrCreate
-      - name: sock
-        hostPath:
-          path: /var/lib/kubeedge
-          type: DirectoryOrCreate
-
+        - name: conf
+          configMap:
+            name: cloudcore
+        - name: certs
+          hostPath:
+            path: /etc/kubeedge
+            type: DirectoryOrCreate
+        - name: sock
+          hostPath:
+            path: /var/lib/kubeedge
+            type: DirectoryOrCreate

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -5,11 +5,15 @@ ARG GO_LDFLAGS
 COPY . /go/src/github.com/kubeedge/kubeedge
 
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/cloudcore -ldflags "$GO_LDFLAGS -w -s" \
-github.com/kubeedge/kubeedge/cloud/cmd/cloudcore
+    github.com/kubeedge/kubeedge/cloud/cmd/cloudcore
 
 
 FROM alpine:3.11
 
 COPY --from=builder /usr/local/bin/cloudcore /usr/local/bin/cloudcore
+
+RUN apk add --update-cache \
+    iptables \
+    && rm -rf /var/cache/apk/*
 
 ENTRYPOINT ["cloudcore"]

--- a/build/cloud/ha/03-ha-deployment.yaml.example
+++ b/build/cloud/ha/03-ha-deployment.yaml.example
@@ -43,6 +43,8 @@ spec:
         - name: cloudcore
           image: kubeedge/cloudcore:{tag}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
           ports:
             - containerPort: 10000
               name: cloudhub


### PR DESCRIPTION
Signed-off-by: Armin Schlegel <armin.schlegel@gmx.de>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds iptables to the cloudcore docker image and enables the cloudcore container privileged to modify the nodes iptables.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3128

**Special notes for your reviewer**:
no

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
