### PR TITLE
simply return an error

### DIFF
--- a/cloud/pkg/cloudstream/containermetrics_connection.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection.go
@@ -114,8 +114,7 @@ func (ms *ContainerMetricsConnection) Serve() error {
 			klog.Infof("%s send close message to edge successfully", ms.String())
 			return nil
 		case <-ms.EdgePeerDone():
-			err := fmt.Errorf("%s find edge peer done, so stop this connection", ms.String())
-			return err
+			return fmt.Errorf("%s find edge peer done, so stop this connection", ms.String())
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
It isn't helpful to create an error first and then return that error
