### PR TITLE
fix: use `path.Join` replace `fmt.Sprintf` to set the path value

### DIFF
--- a/cloud/pkg/router/provider/eventbus/eventbus.go
+++ b/cloud/pkg/router/provider/eventbus/eventbus.go
@@ -3,6 +3,7 @@ package eventbus
 import (
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -60,9 +61,9 @@ func (factory *eventbusFactory) GetSource(ep *v1.RuleEndpoint, sourceResource ma
 }
 
 func (eb *EventBus) RegisterListener(handle listener.Handle) error {
-	listener.MessageHandlerInstance.AddListener(fmt.Sprintf("%s/node/%s/%s/%s", "bus", eb.nodeName, eb.namespace, eb.subTopic), handle)
+	listener.MessageHandlerInstance.AddListener(path.Join("bus/node", eb.nodeName, eb.namespace, eb.subTopic), handle)
 	msg := model.NewMessage("")
-	msg.SetResourceOperation(fmt.Sprintf("node/%s/%s/%s", eb.nodeName, eb.namespace, eb.subTopic), "subscribe")
+	msg.SetResourceOperation(path.Join("node", eb.nodeName, eb.namespace, eb.subTopic), "subscribe")
 	msg.SetRoute("router_eventbus", modules.UserGroup)
 	beehiveContext.Send(modules.CloudHubModuleName, *msg)
 	return nil
@@ -70,10 +71,10 @@ func (eb *EventBus) RegisterListener(handle listener.Handle) error {
 
 func (eb *EventBus) UnregisterListener() {
 	msg := model.NewMessage("")
-	msg.SetResourceOperation(fmt.Sprintf("node/%s/%s/%s", eb.nodeName, eb.namespace, eb.subTopic), "unsubscribe")
+	msg.SetResourceOperation(path.Join("node", eb.nodeName, eb.namespace, eb.subTopic), "unsubscribe")
 	msg.SetRoute("router_eventbus", modules.UserGroup)
 	beehiveContext.Send(modules.CloudHubModuleName, *msg)
-	listener.MessageHandlerInstance.RemoveListener(fmt.Sprintf("%s/node/%s/%s/%s", "bus", eb.nodeName, eb.namespace, eb.subTopic))
+	listener.MessageHandlerInstance.RemoveListener(path.Join("bus/node", eb.nodeName, eb.namespace, eb.subTopic))
 }
 
 func (factory *eventbusFactory) GetTarget(ep *v1.RuleEndpoint, targetResource map[string]string) provider.Target {

--- a/cloud/pkg/router/provider/eventbus/eventbus_test.go
+++ b/cloud/pkg/router/provider/eventbus/eventbus_test.go
@@ -1,0 +1,22 @@
+package eventbus
+
+import (
+	"fmt"
+	"path"
+	"testing"
+)
+
+func TestPathJoin(t *testing.T) {
+	var s1, s2 string
+	s1 = fmt.Sprintf("%s/node/%s/%s/%s", "bus", "nodeName", "namespace", "subTopic")
+	s2 = path.Join("bus/node", "nodeName", "namespace", "subTopic")
+	if s1 != s2 {
+		t.Fatalf("expected: %s, actual: %s", s1, s2)
+	}
+
+	s1 = fmt.Sprintf("node/%s/%s/%s", "nodeName", "namespace", "subTopic")
+	s2 = path.Join("node", "nodeName", "namespace", "subTopic")
+	if s1 != s2 {
+		t.Fatalf("expected: %s, actual: %s", s1, s2)
+	}
+}


### PR DESCRIPTION
Signed-off-by: WillardHu <wei.hu@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind bug

**What this PR does / why we need it**:

Better performance and readability

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
