### PR TITLE
make metaserver.addrs configurable

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application_test.go
+++ b/cloud/pkg/dynamiccontroller/application/application_test.go
@@ -25,7 +25,7 @@ func TestApplicationGC(t *testing.T) {
 			requestInfo := &apirequest.RequestInfo{
 				IsResourceRequest: true,
 				Verb:              "GET",
-				Path:              "http://127.0.0.1:10550/api/v1/nodes",
+				Path:              "http://" + metaserverconfig.Config.Addr + "/api/v1/nodes",
 				APIPrefix:         "api",
 				APIGroup:          "",
 				APIVersion:        "v1",

--- a/edge/pkg/metamanager/metaserver/config/config.go
+++ b/edge/pkg/metamanager/metaserver/config/config.go
@@ -19,6 +19,7 @@ func InitConfigure(c *v1alpha1.MetaServer) {
 	once.Do(func() {
 		Config.Enable = c.Enable
 		Config.Debug = c.Debug
+		Config.Addr = c.Addr
 		// so edgehub must register before metamanager
 		Config.NodeName = edgehubconfig.Config.NodeName
 	})

--- a/edge/pkg/metamanager/metaserver/server.go
+++ b/edge/pkg/metamanager/metaserver/server.go
@@ -18,13 +18,9 @@ import (
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	"k8s.io/klog/v2"
 
+	metaserverconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/serializer"
-)
-
-const (
-	// TODO: make addrs configurable
-	Httpaddr = "127.0.0.1:10550"
 )
 
 // MetaServer is simplification of server.GenericAPIServer
@@ -51,11 +47,11 @@ func (ls *MetaServer) Start(stopChan <-chan struct{}) {
 	h := ls.BuildBasicHandler()
 	h = BuildHandlerChain(h, ls)
 	s := http.Server{
-		Addr:    Httpaddr,
+		Addr:    metaserverconfig.Config.Addr,
 		Handler: h,
 	}
 	utilruntime.HandleError(s.ListenAndServe())
-	klog.Infof("[metaserver]start to listen and server at %v", Httpaddr)
+	klog.Infof("[metaserver]start to listen and server at %v", metaserverconfig.Config.Addr)
 	<-stopChan
 }
 

--- a/edge/test/integration/metaserver/metaserver_test.go
+++ b/edge/test/integration/metaserver/metaserver_test.go
@@ -6,6 +6,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	metaserverconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/config"
 )
 
 var _ = Describe("Test MetaServer", func() {

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -139,6 +139,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				MetaServer: &MetaServer{
 					Enable: false,
 					Debug:  false,
+					Addr:   "127.0.0.1:10550",
 				},
 			},
 			ServiceBus: &ServiceBus{

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -385,6 +385,9 @@ type MetaManager struct {
 type MetaServer struct {
 	Enable bool `json:"enable"`
 	Debug  bool `json:"debug"`
+	// Addr indicates metaServer address
+	// default "127.0.0.1:10550"
+	Addr string `json:"addr"`
 }
 
 // ServiceBus indicates the ServiceBus module config

--- a/tests/integration/metaserver/access_test.go
+++ b/tests/integration/metaserver/access_test.go
@@ -10,12 +10,12 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver"
+	metaserverconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/config"
 )
 
 func TestGet(t *testing.T) {
 	kubeclient, err := kubernetes.NewForConfig(&rest.Config{
-		Host: "http://" + metaserver.Httpaddr,
+		Host: "http://" + metaserverconfig.Config.Addr,
 	})
 	if err != nil {
 		t.Fatalf("failed to new a kubeclient for testing")
@@ -29,7 +29,7 @@ func TestGet(t *testing.T) {
 
 func TestService(t *testing.T) {
 	kubeclient, err := kubernetes.NewForConfig(&rest.Config{
-		Host: "http://" + metaserver.Httpaddr,
+		Host: "http://" + metaserverconfig.Config.Addr,
 	})
 	if err != nil {
 		t.Fatalf("failed to get kubeclient, %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This pr allows us to configure the MetaServer.address in edgecore.yaml(default is 127.0.0.1:10550), which will greatly improve flexibility.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
make sure metaserver.enable = true 
