### PR TITLE
fix: use path.Join(..) to set resource string

### DIFF
--- a/cloud/pkg/cloudhub/common/model/types.go
+++ b/cloud/pkg/cloudhub/common/model/types.go
@@ -4,7 +4,7 @@ import (
 
 	// Mapping value of json to struct member
 	_ "encoding/json"
-	"fmt"
+	"path"
 	"strings"
 
 	"github.com/kubeedge/beehive/pkg/core/model"
@@ -72,14 +72,15 @@ type HubInfo struct {
 
 // NewResource constructs a resource field using resource type and ID
 func NewResource(resType, resID string, info *HubInfo) string {
-	var prefix string
+	paths := make([]string, 0, 4)
 	if info != nil {
-		prefix = fmt.Sprintf("%s/%s/", model.ResourceTypeNode, info.NodeID)
+		paths = append(paths, model.ResourceTypeNode, info.NodeID)
 	}
-	if resID == "" {
-		return fmt.Sprintf("%s%s", prefix, resType)
+	paths = append(paths, resType)
+	if resID != "" {
+		paths = append(paths, resID)
 	}
-	return fmt.Sprintf("%s%s/%s", prefix, resType, resID)
+	return path.Join(paths...)
 }
 
 // IsNodeStopped indicates if the node is stopped or running

--- a/cloud/pkg/cloudhub/common/model/types_test.go
+++ b/cloud/pkg/cloudhub/common/model/types_test.go
@@ -66,6 +66,13 @@ func TestNewResource(t *testing.T) {
 			info:    &HubInfo{ProjectID: "Project1", NodeID: "Node1"},
 			str:     "node/Node1/node/res1",
 		},
+		{
+			name:    "TestNewResource(): Case 3: info is nil",
+			resType: ResNode,
+			resID:   "res1",
+			info:    nil,
+			str:     "node/res1",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: WillardHu <wei.hu@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug
/kind test

**What this PR does / why we need it**:

Make the code better for performance and readability, and add unit test case when `HubInfo` is nil.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
