### PR TITLE
add e2e test for edge autonomy

### DIFF
--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -198,6 +198,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 	})
 
 	Context("Test Edge Autonomy", func() {
+		var podName string
 		BeforeEach(func() {
 			// Get current test description
 			testDescription = CurrentGinkgoTestDescription()
@@ -220,8 +221,9 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 
 			script := path.Join(gopath, "src/github.com/kubeedge/kubeedge/tests/e2e/scripts/autonomy.sh")
 			utils.Infof("autonomy scripts path is %v", script)
+			shellCommand := script + " " + podName
 
-			cmd := exec.Command("/bin/bash", "-c", script)
+			cmd := exec.Command("/bin/bash", "-c", shellCommand)
 			output, err := cmd.Output()
 			utils.Infof("autonomy.sh exec output is\n%s", string(output))
 			if err != nil {
@@ -232,7 +234,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 
 		It("E2E_POD_AUTONOMY_1: Create a pod and check the pod is coming up correctly, but don't delete it.", func() {
 			//Generate the random string and assign as podName
-			podName := "autonomy-" + utils.GetRandomString(5)
+			podName = "autonomy-" + utils.GetRandomString(5)
 			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
 
 			CreatePodTest(nodeName, podName, ctx, pod)

--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -194,4 +194,27 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
 		})
 	})
+
+	Context("Test Edge Autonomy", func() {
+		BeforeEach(func() {
+			// Get current test description
+			testDescription = CurrentGinkgoTestDescription()
+			// Start test timer
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testDescription.TestText)
+		})
+		AfterEach(func() {
+			// End test timer
+			testTimer.End()
+			// Print result
+			testTimer.PrintResult()
+		})
+
+		It("E2E_POD_AUTONOMY_1: Create a pod and check the pod is coming up correctly, but don't delete it.", func() {
+			//Generate the random string and assign as podName
+			podName := "autonomy-" + utils.GetRandomString(5)
+			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
+
+			CreatePodTest(nodeName, podName, ctx, pod)
+		})
+	})
 })

--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -18,6 +18,8 @@ package deployment
 
 import (
 	"net/http"
+	"os/exec"
+	"path"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -207,6 +209,25 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			testTimer.End()
 			// Print result
 			testTimer.PrintResult()
+			// run tests/e2e/scripts/autonomy.sh to test autonomy function
+
+			gopath, err := utils.GetGOPATH()
+			if err != nil {
+				utils.Fatalf("failed to get GOPATH: %v", err)
+				return
+			}
+			utils.Infof("gopath is %s", gopath)
+
+			script := path.Join(gopath, "src/github.com/kubeedge/kubeedge/tests/e2e/scripts/autonomy.sh")
+			utils.Infof("autonomy scripts path is %v", script)
+
+			cmd := exec.Command("/bin/bash", "-c", script)
+			output, err := cmd.Output()
+			utils.Infof("autonomy.sh exec output is\n%s", string(output))
+			if err != nil {
+				utils.Fatalf("exec autonomy scripts failed: %v", err)
+				return
+			}
 		})
 
 		It("E2E_POD_AUTONOMY_1: Create a pod and check the pod is coming up correctly, but don't delete it.", func() {

--- a/tests/e2e/scripts/autonomy.sh
+++ b/tests/e2e/scripts/autonomy.sh
@@ -14,24 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workdir=`pwd`
+workdir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 cd $workdir
+echo "workdir is "$workdir
 
 rootPath=$(cd ../../.. && pwd)
-echo $rootPath
+echo "rootPath is "$rootPath
 
 source ${rootPath}/tests/e2e/scripts/util.sh
+
+podName=$1
+echo "podName is "$podName
 
 checkContainerExist() {
   echo "wait for pod restart automatically..."
   for ((integer = 1; integer <= 20; integer++))
   do
-    num=$(docker ps | grep nginx_autonomy | wc -l)
+    num=$(docker ps | grep nginx_$podName | wc -l)
     if [[ "$num" == "0" ]]; then
       sleep 10
     else
       echo "found autonomy pod restart automatically"
-      docker ps | grep nginx_autonomy
+      docker ps | grep nginx_$podName
       break
     fi
   done
@@ -59,7 +63,7 @@ start_edgecore() {
 testAutonomy() {
   # print docker progresses for user debug.
   echo "now we have autonomy test pod as follows."
-  docker ps --filter "name=nginx_autonomy"
+  docker ps --filter "name=nginx_$podName"
 
   # pkill edgecore
   kill_component "edgecore"
@@ -68,9 +72,9 @@ testAutonomy() {
   kill_component "cloudcore"
 
   # kill all docker container progresses
-  for id in $(docker ps --filter "name=nginx_autonomy" -q)
+  for id in $(docker ps --filter "name=nginx_$podName" -q)
   do
-    docker ps --filter "name=nginx_autonomy"
+    docker ps --filter "name=nginx_$podName"
     docker kill $id
   done
 
@@ -81,9 +85,9 @@ testAutonomy() {
   checkContainerExist
 
   # ensure all the related containers stopped.
-  for id in $(docker ps --filter "name=nginx_autonomy" -q)
+  for id in $(docker ps --filter "name=nginx_$podName" -q)
   do
-    docker ps --filter "name=nginx_autonomy"
+    docker ps --filter "name=nginx_$podName"
     docker kill $id
   done
 }

--- a/tests/e2e/scripts/autonomy.sh
+++ b/tests/e2e/scripts/autonomy.sh
@@ -17,10 +17,10 @@
 workdir=`pwd`
 cd $workdir
 
-curpath=$PWD
-echo $PWD
+rootPath=$(cd ../../.. && pwd)
+echo $rootPath
 
-source ${curpath}/tests/e2e/scripts/util.sh
+source ${rootPath}/tests/e2e/scripts/util.sh
 
 checkContainerExist() {
   echo "wait for pod restart automatically..."
@@ -45,8 +45,8 @@ checkContainerExist() {
 }
 
 start_edgecore() {
-  EDGE_CONFIGFILE=${curpath}/_output/local/bin/edgecore.yaml
-  EDGE_BIN=${curpath}/_output/local/bin/edgecore
+  EDGE_CONFIGFILE=${rootPath}/_output/local/bin/edgecore.yaml
+  EDGE_BIN=${rootPath}/_output/local/bin/edgecore
   EDGECORE_LOG="/tmp/edgecore.log"
 
   echo "start edgecore..."

--- a/tests/e2e/scripts/autonomy.sh
+++ b/tests/e2e/scripts/autonomy.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright 2019 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workdir=`pwd`
+cd $workdir
+
+curpath=$PWD
+echo $PWD
+
+source ${curpath}/tests/e2e/scripts/util.sh
+
+checkContainerExist() {
+  echo "wait for pod restart automatically..."
+  for ((integer = 1; integer <= 20; integer++))
+  do
+    num=$(docker ps | grep nginx_autonomy | wc -l)
+    if [[ "$num" == "0" ]]; then
+      sleep 10
+    else
+      echo "found autonomy pod restart automatically"
+      docker ps | grep nginx_autonomy
+      break
+    fi
+  done
+
+  if [[ "$num" == "0" ]];then
+    echo "Edge Autonomy test has failures, pod doesn't restart when edgecore restart. Please check !!"
+    exit 1
+  else
+    echo "Edge Autonomy test successfully passed all the tests !!"
+  fi
+}
+
+start_edgecore() {
+  EDGE_CONFIGFILE=${curpath}/_output/local/bin/edgecore.yaml
+  EDGE_BIN=${curpath}/_output/local/bin/edgecore
+  EDGECORE_LOG="/tmp/edgecore.log"
+
+  echo "start edgecore..."
+  export CHECK_EDGECORE_ENVIRONMENT="false"
+  nohup sudo -E ${EDGE_BIN} --config=${EDGE_CONFIGFILE} > "${EDGECORE_LOG}" 2>&1 &
+  EDGECORE_PID=$!
+  echo $EDGECORE_PID
+}
+
+testAutonomy() {
+  # print docker progresses for user debug.
+  echo "now we have autonomy test pod as follows."
+  docker ps --filter "name=nginx_autonomy"
+
+  # pkill edgecore
+  kill_component "edgecore"
+
+  # pkill cloudcore
+  kill_component "cloudcore"
+
+  # kill all docker container progresses
+  for id in $(docker ps --filter "name=nginx_autonomy" -q)
+  do
+    docker ps --filter "name=nginx_autonomy"
+    docker kill $id
+  done
+
+  # restart edgecore
+  start_edgecore
+
+  # check whether containers restart automatically and successfully
+  checkContainerExist
+
+  # ensure all the related containers stopped.
+  for id in $(docker ps --filter "name=nginx_autonomy" -q)
+  do
+    docker ps --filter "name=nginx_autonomy"
+    docker kill $id
+  done
+}
+
+testAutonomy

--- a/tests/e2e/scripts/execute.sh
+++ b/tests/e2e/scripts/execute.sh
@@ -22,6 +22,9 @@ cd $workdir
 curpath=$PWD
 echo $PWD
 
+rootpath=$(cd $curpath/../../.. && pwd)
+echo "root path is " + $rootpath
+
 source ${curpath}/tests/e2e/scripts/util.sh
 
 which ginkgo &> /dev/null || (
@@ -52,16 +55,6 @@ kubectl create clusterrolebinding system:anonymous --clusterrole=cluster-admin -
 :> /tmp/testcase.log
 
 bash -x ${E2E_DIR}/scripts/fast_test.sh $1
-
-#failed cases number
-fail=`grep -e "SUCCESS\!" -e "FAIL\!" /tmp/testcase.log | awk '{print $6}' | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" | awk '{sum+=$1} END {print sum}'`
-
-#test Edge Autonomy
-#only when the above are all successful, we need to test Edge Autonomy function.
-if [ "$fail" == "0" ]
-  then
-    bash ${E2E_DIR}/scripts/autonomy.sh
-fi
 
 #stop the edgecore after the test completion
 grep  -e "Running Suite" -e "SUCCESS\!" -e "FAIL\!" /tmp/testcase.log | sed -r 's/\x1B\[([0-9];)?([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g' | sed -r 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g'

--- a/tests/e2e/scripts/util.sh
+++ b/tests/e2e/scripts/util.sh
@@ -14,24 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-setuptype=$1
-
-KUBEEDGE_ROOT=$PWD
-source ${KUBEEDGE_ROOT}/tests/e2e/scripts/util.sh
-
-kill_all_components() {
-    local components="cloudcore edgecore edgesite"
-    for component in $components; do
-        kill_component "$component"
-    done
+kill_component() {
+    local component=$1
+    if pgrep "$component" &>/dev/null; then
+        # edgesite process is found, kill the process.
+        sudo pkill $component &>/dev/null
+        if [[ "$?" == "0" ]]; then
+            echo "$component is successfully killed !!"
+        else
+            echo "Failed to kill $component process !!"
+            exit 1
+        fi
+    fi
 }
-
-cleanup_files(){
-    sudo rm -rf /tmp/etc/kubeedge /tmp/var/lib/kubeedge
-    sudo rm -f tests/e2e/config.json
-    find -name "*.test" | xargs sudo rm -f
-}
-
-kill_all_components
-
-cleanup_files

--- a/tests/e2e/utils/common.go
+++ b/tests/e2e/utils/common.go
@@ -22,9 +22,11 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -1011,4 +1013,21 @@ func PublishMqtt(topic, message string) error {
 	}
 	Infof("publish topic %s message %s", topic, message)
 	return nil
+}
+
+func GetGOPATH() (string, error) {
+	cmd := exec.Command("/bin/bash", "-c", "go env GOPATH")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get GOPATH: %v", err)
+	}
+
+	gopath := strings.TrimRight(string(output), "\r\n")
+
+	goPathSlice := strings.Split(gopath, string(os.PathListSeparator))
+	if len(goPathSlice) == 0 || goPathSlice[0] == ""{
+		return build.Default.GOPATH, nil
+	}
+
+	return goPathSlice[0], nil
 }

--- a/tests/e2e/utils/common.go
+++ b/tests/e2e/utils/common.go
@@ -1025,7 +1025,7 @@ func GetGOPATH() (string, error) {
 	gopath := strings.TrimRight(string(output), "\r\n")
 
 	goPathSlice := strings.Split(gopath, string(os.PathListSeparator))
-	if len(goPathSlice) == 0 || goPathSlice[0] == ""{
+	if len(goPathSlice) == 0 || goPathSlice[0] == "" {
 		return build.Default.GOPATH, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Edge Autonomy: Ensure edge nodes run autonomously and the applications in edge run normally, when the cloud-edge network is unstable or edge is offline and restarted.
so add test for this function.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
