### PR TITLE
Bump gorilla websocket to v1.4.2 in viaduct

### DIFF
--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 func TestValidateNodeIP(t *testing.T) {
@@ -108,13 +106,6 @@ func TestGetLocalIP(t *testing.T) {
 	_, err := GetLocalIP(GetHostname())
 	if err != nil {
 		t.Errorf("get local ip failed")
-	}
-}
-
-func TestGetPodSandboxImage(t *testing.T) {
-	image := GetPodSandboxImage()
-	if image != constants.DefaultPodSandboxImage {
-		t.Errorf("get pod sandbox image failed, get %v, expected %v", image, constants.DefaultPodSandboxImage)
 	}
 }
 

--- a/staging/src/github.com/kubeedge/viaduct/go.mod
+++ b/staging/src/github.com/kubeedge/viaduct/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cheekybits/genny v0.0.0-20170328200008-9127e812e1e9 // indirect
 	github.com/golang/mock v0.0.0-20190508161146-9fa652df1129
 	github.com/golang/protobuf v1.3.1
-	github.com/gorilla/websocket v1.4.0
+	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kubeedge/beehive v0.0.0

--- a/staging/src/github.com/kubeedge/viaduct/go.sum
+++ b/staging/src/github.com/kubeedge/viaduct/go.sum
@@ -12,8 +12,8 @@ github.com/golang/mock v0.0.0-20190508161146-9fa652df1129/go.mod h1:sBzyDLLjw3U8
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47 h1:UnszMmmmm5vLwWzDjTFVIkfhvWF1NdrmChl8L2NUDCw=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=


### PR DESCRIPTION
Signed-off-by: fisherxu <xufei40@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
There's a CVE in `v1.4.0` of `github.com/gorilla/websocket`, and the CVE has been fixed in `v1.4.1`1, so bump it to `v1.4.2` to fix the CVE.

And in vendor we have updated the `github.com/gorilla/websocket` to  `v1.4.2`, ref: https://github.com/kubeedge/kubeedge/blob/master/go.mod#L24

CVE link: https://github.com/advisories/GHSA-3xh2-74w9-5vxm

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
