### PR TITLE
fix some problems of socket context

### DIFF
--- a/build/rpm/README.md
+++ b/build/rpm/README.md
@@ -78,7 +78,7 @@ This package provides:
 	│   │   └── cloudcore
 	│   └── csidriver
 	│       └── csidriver
-	├── crds	
+	├── crds
 	│   ├── devices
 	│   │   ├── devices_v1alpha1_devicemodel.yaml
 	│   │   ├── devices_v1alpha1_device.yaml

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
@@ -51,7 +51,7 @@ func NewChannelContext() *ChannelContext {
 	return channelContext
 }
 
-func GetChannelContext() *ChannelContext{
+func GetChannelContext() *ChannelContext {
 	return channelContext
 }
 

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/context/context_factory.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/context/context_factory.go
@@ -115,7 +115,7 @@ func Cleanup(module string) {
 
 // Send the message
 func Send(module string, message model.Message) {
-	messageContext, err := getMessageContextByMessageType(message.GetType())
+	messageContext, err := getMessageContext(module)
 	if err != nil {
 		return
 	}
@@ -139,7 +139,7 @@ func Receive(module string) (model.Message, error) {
 // timeout: if <= 0 using default value(30s)
 func SendSync(module string,
 	message model.Message, timeout time.Duration) (model.Message, error) {
-	messageContext, err := getMessageContextByMessageType(message.GetType())
+	messageContext, err := getMessageContext(module)
 	if err != nil {
 		return model.Message{}, err
 	}

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
@@ -236,6 +236,7 @@ func (msg *Message) Clone(message *Message) *Message {
 func (msg *Message) NewRespByMessage(message *Message, content interface{}) *Message {
 	return NewMessage(message.GetID()).SetRoute(message.GetSource(), message.GetGroup()).
 		SetResourceOperation(message.GetResource(), ResponseOperation).
+		SetType(message.GetType()).
 		FillBody(content)
 }
 

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/module.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/module.go
@@ -17,8 +17,8 @@ type Module interface {
 
 var (
 	// Modules map
-	modules           map[string]*moduleInfo
-	disabledModules   map[string]*moduleInfo
+	modules         map[string]*moduleInfo
+	disabledModules map[string]*moduleInfo
 )
 
 func init() {

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/socket/config/config.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/socket/config/config.go
@@ -11,15 +11,15 @@ import (
 
 // SocketConfig socket config
 type SocketConfig struct {
-	ModuleName    string `yaml:"module"`
-	Server        bool   `yaml:"server"`
-	Address       string `yaml:"address"`
-	SocketType    string `yaml:"sockettype,omitempty"`
-	ConnNumberMax int    `yaml:"connmax"`
-	BufferSize    int    `yaml:"buffersize,omitempty"`
-	CaRoot        string `yaml:"ca,omitempty"`
-	Cert          string `yaml:"cert,omitempty"`
-	Key           string `yaml:"key,omitempty"`
+	ModuleName    string `json:"module"`
+	Server        bool   `json:"server"`
+	Address       string `json:"address"`
+	SocketType    string `json:"sockettype,omitempty"`
+	ConnNumberMax int    `json:"connmax"`
+	BufferSize    int    `json:"buffersize,omitempty"`
+	CaRoot        string `json:"ca,omitempty"`
+	Cert          string `json:"cert,omitempty"`
+	Key           string `json:"key,omitempty"`
 }
 
 // BuildinModuleConfig buildin module config
@@ -38,7 +38,7 @@ func init() {
 		}
 	}
 
-	InitBuildinModuleConfig(filepath)
+	buildinModuleConfig = InitBuildinModuleConfig(filepath)
 }
 
 var (

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/socket/modules/socket/server.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/socket/modules/socket/server.go
@@ -182,13 +182,10 @@ func (m *SocketServer) stopServer() {
 }
 
 func IsModuleEnabled(m string) bool {
-	modules := core.GetModules()
-
-	for name, _ := range modules {
-		if m == name {
-			return true
-		}
+	_, err := config.GetClientSocketConfig(m)
+	if err != nil {
+		return false
 	}
 
-	return false
+	return true
 }

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/socket/wrapper/wrapper.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/socket/wrapper/wrapper.go
@@ -6,7 +6,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/beehive/pkg/common"
 	"github.com/kubeedge/beehive/pkg/core/socket/wrapper/reader"
 	"github.com/kubeedge/beehive/pkg/core/socket/wrapper/writer"
 )
@@ -35,14 +34,6 @@ type ConnWrapper struct {
 func NewWrapper(connType string, conn interface{}, buffSize int) Conn {
 	readerType := reader.ReaderTypeRaw
 	writerType := writer.WriterTypeRaw
-
-	switch connType {
-	case common.MsgCtxTypeUS:
-		readerType = reader.ReaderTypePackage
-		writerType = writer.WriterTypePackage
-	default:
-		klog.Warningf("connection type is %v", connType)
-	}
 
 	return &ConnWrapper{
 		conn:   conn,


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
1. socket config structure should use `json` to define, and need to assign values to the global variable `buildinModuleConfig`
2. when `StartModules`, we need to passin `MsgCtxTypeUS`, or modules that use socket way will not work well.
3. when module start, we need to use `moduleKeeper` function, to try to re-connect when socket connection offline.
4. function `IsModuleEnabled` should read from configure file to predict whether enabled, this function is only used by socket context.
5. `NewWrapper` readerType and writerType assign values bugs
6. `context_factory.go` `Send` and `SendSync` should use module name to choose contextType, but not use message type. Because when use socket way to communicate, some message type is also empty or `""`
7. `NewRespByMessage` should `SetType` also

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
