### PR TITLE
perf: cloudcore certificate application restful api supports certificate usages

### DIFF
--- a/common/types/types.go
+++ b/common/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"crypto/x509"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -25,4 +27,10 @@ type NodeStatusRequest struct {
 	UID             types.UID
 	Status          v1.NodeStatus
 	ExtendResources map[v1.ResourceName][]ExtendResource
+}
+
+// CertificateSigningRequest is message which use for certificate request from cloudcore
+type CertificateSigningRequest struct {
+	Request []byte             `json:"request"`
+	Usages  []x509.ExtKeyUsage `json:"usages"`
 }


### PR DESCRIPTION
What type of PR is this?
/kind performance

What this PR does / why we need it:
The certificate usages signed by the current cloudcore certificate application restful api are all x509.ExtKeyUsageClientAuth. By adding the certificate usage parameter, the clients (such as edgemesh-server and edgemesh-agent) are allowed to apply for different usages of certificates.

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?:

When users upgrade kubeedge versions, if edgecore is the new restful api version, they need ensure that the cloudcore is also the new restful api version