### PR TITLE
Automated cherry pick of #3136 origin release 1.8

### DIFF
--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstream
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -26,10 +27,12 @@ import (
 	"strings"
 
 	"github.com/emicklei/go-restful"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudstream/config"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream/flushwriter"
 )
@@ -106,7 +109,23 @@ func (s *StreamServer) getContainerLogs(r *restful.Request, w *restful.Response)
 		}
 	}()
 
-	sessionKey := strings.Split(r.Request.Host, ":")[0]
+	// extract pod namespace and pod name from request
+	meta := strings.Split(r.Request.URL.Path, "/")
+	namespaceName := meta[2]
+	podName := meta[3]
+
+	kubeClient := client.GetKubeClient()
+	if kubeClient == nil {
+		klog.Fatalf("cannot get kube client\n")
+		return
+	}
+
+	pod, err := kubeClient.CoreV1().Pods(namespaceName).Get(context.Background(), podName, v1.GetOptions{})
+	if err != nil {
+		klog.Errorf("get pod %s/%s failed: %v\n", namespaceName, podName, err)
+		return
+	}
+	sessionKey := pod.Spec.NodeName
 	session, ok := s.tunnel.getSession(sessionKey)
 	if !ok {
 		err = fmt.Errorf("Can not find %v session ", sessionKey)


### PR DESCRIPTION
Using the IP address of the node the pod is running on for identifying the session.

Signed-off-by: Armin Schlegel <armin.schlegel@gmx.de>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
Currently the session key is idenfitied by the IP address of the node. However this breaks if there are two nodes with the same IP address, e.g. two different LANs with nodes connected who share the same IP address by accident. This PR changes the session key to the nodes name the pod is running on. This way cloudcore can address the correct node when trying to read the logs. The current behavior can fail if it addresses a node by IP which does not have the pod running.

