### PR TITLE
perf: cloudcore certificate application restful api supports certificate usages

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -180,8 +181,19 @@ func signEdgeCert(w http.ResponseWriter, r *http.Request) {
 		klog.Errorf("fail to ParseCertificateRequest of edgenode: %s! error:%v", r.Header.Get(constants.NodeName), err)
 		return
 	}
-	subject := csr.Subject
-	clientCertDER, err := signCerts(subject, csr.PublicKey)
+	usagesStr := r.Header.Get("ExtKeyUsages")
+	var usages []x509.ExtKeyUsage
+	if usagesStr == "" {
+		usages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	} else {
+		err := json.Unmarshal([]byte(usagesStr), &usages)
+		if err != nil {
+			klog.Errorf("unmarshal http header ExtKeyUsages fail, err: %v", err)
+			return
+		}
+	}
+	klog.V(4).Infof("receive sign crt request, ExtKeyUsages: %v", usages)
+	clientCertDER, err := signCerts(csr.Subject, csr.PublicKey, usages)
 	if err != nil {
 		klog.Errorf("fail to signCerts for edgenode:%s! error:%v", r.Header.Get(constants.NodeName), err)
 		return
@@ -193,11 +205,11 @@ func signEdgeCert(w http.ResponseWriter, r *http.Request) {
 }
 
 // signCerts will create a certificate for EdgeCore
-func signCerts(subInfo pkix.Name, pbKey crypto.PublicKey) ([]byte, error) {
+func signCerts(subInfo pkix.Name, pbKey crypto.PublicKey, usages []x509.ExtKeyUsage) ([]byte, error) {
 	cfgs := &certutil.Config{
 		CommonName:   subInfo.CommonName,
 		Organization: subInfo.Organization,
-		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Usages:       usages,
 	}
 	clientKey := pbKey
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
The certificate usages signed by the current cloudcore certificate application restful api are all x509.ExtKeyUsageClientAuth. By adding the certificate usage parameter, the clients (such as edgemesh-server and edgemesh-agent) are allowed to apply for different usages of certificates.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
When users upgrade kubeedge versions, if edgecore is the new restful api version, they need ensure that the cloudcore is also the new restful api version
```release-note

```
