### PR TITLE
Automated cherry pick of #3177: perf: cloudcore ecertificate application restful api supports

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -180,8 +181,19 @@ func signEdgeCert(w http.ResponseWriter, r *http.Request) {
 		klog.Errorf("fail to ParseCertificateRequest of edgenode: %s! error:%v", r.Header.Get(constants.NodeName), err)
 		return
 	}
-	subject := csr.Subject
-	clientCertDER, err := signCerts(subject, csr.PublicKey)
+	usagesStr := r.Header.Get("ExtKeyUsages")
+	var usages []x509.ExtKeyUsage
+	if usagesStr == "" {
+		usages = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+	} else {
+		err := json.Unmarshal([]byte(usagesStr), &usages)
+		if err != nil {
+			klog.Errorf("unmarshal http header ExtKeyUsages fail, err: %v", err)
+			return
+		}
+	}
+	klog.V(4).Infof("receive sign crt request, ExtKeyUsages: %v", usages)
+	clientCertDER, err := signCerts(csr.Subject, csr.PublicKey, usages)
 	if err != nil {
 		klog.Errorf("fail to signCerts for edgenode:%s! error:%v", r.Header.Get(constants.NodeName), err)
 		return
@@ -193,11 +205,11 @@ func signEdgeCert(w http.ResponseWriter, r *http.Request) {
 }
 
 // signCerts will create a certificate for EdgeCore
-func signCerts(subInfo pkix.Name, pbKey crypto.PublicKey) ([]byte, error) {
+func signCerts(subInfo pkix.Name, pbKey crypto.PublicKey, usages []x509.ExtKeyUsage) ([]byte, error) {
 	cfgs := &certutil.Config{
 		CommonName:   subInfo.CommonName,
 		Organization: subInfo.Organization,
-		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Usages:       usages,
 	}
 	clientKey := pbKey
 


### PR DESCRIPTION
Cherry pick of #3177 on release-1.8.

#3177: perf: cloudcore ecertificate application restful api supports

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.