### PR TITLE
remove duplicate SessionHostNameOverride constant

### DIFF
--- a/cloud/pkg/cloudstream/tunnelserver.go
+++ b/cloud/pkg/cloudstream/tunnelserver.go
@@ -95,10 +95,6 @@ func (s *TunnelServer) getNodeIP(node string) (string, bool) {
 
 func (s *TunnelServer) connect(r *restful.Request, w *restful.Response) {
 	hostNameOverride := r.HeaderParameter(stream.SessionKeyHostNameOverride)
-	if hostNameOverride == "" {
-		// TODO: Fix SessionHostNameOverride typo, remove this in v1.7.x
-		hostNameOverride = r.HeaderParameter(stream.SessionKeyHostNameOverrideOld)
-	}
 	internalIP := r.HeaderParameter(stream.SessionKeyInternalIP)
 	if internalIP == "" {
 		internalIP = strings.Split(r.Request.RemoteAddr, ":")[0]

--- a/edge/pkg/edgestream/edgestream.go
+++ b/edge/pkg/edgestream/edgestream.go
@@ -109,9 +109,6 @@ func (e *edgestream) TLSClientConnect(url url.URL, tlsConfig *tls.Config) error 
 	header.Add(stream.SessionKeyHostNameOverride, e.hostnameOverride)
 	header.Add(stream.SessionKeyInternalIP, e.nodeIP)
 
-	// TODO: Fix SessionHostNameOverride typo, remove this in v1.7.x
-	header.Add(stream.SessionKeyHostNameOverrideOld, e.hostnameOverride)
-
 	con, _, err := dial.Dial(url.String(), header)
 	if err != nil {
 		klog.Errorf("dial %v error %v", url.String(), err)

--- a/pkg/stream/constants.go
+++ b/pkg/stream/constants.go
@@ -3,7 +3,4 @@ package stream
 const (
 	SessionKeyHostNameOverride = "SessionHostNameOverride"
 	SessionKeyInternalIP       = "SessionInternalIP"
-
-	// TODO: Fix SessionHostNameOverride typo, remove this in v1.7.x
-	SessionKeyHostNameOverrideOld = "SessionHostNameOverride"
 )


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
remove duplicate `"SessionHostNameOverride"` string literal definitions
this is introduced by PR https://github.com/kubeedge/kubeedge/pull/2744 to be compatible with older versions
and this wrong typo is fixed in PR https://github.com/kubeedge/kubeedge/pull/3066
So now we could remove this
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
