### PR TITLE
replace deprecated package io/ioutil with packages io and os

### DIFF
--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -83,7 +83,7 @@ func Run(opt *options.AdmissionOptions) {
 	controller.Client = cli
 	controller.CrdClient = vcli
 
-	caBundle, err := ioutil.ReadFile(opt.CaCertFile)
+	caBundle, err := os.ReadFile(opt.CaCertFile)
 	if err != nil {
 		klog.Exitf("Unable to read cacert file: %v\n", err)
 	}

--- a/cloud/pkg/admissioncontroller/common.go
+++ b/cloud/pkg/admissioncontroller/common.go
@@ -3,7 +3,7 @@ package admissioncontroller
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -66,7 +66,7 @@ type hookFunc func(admissionv1beta1.AdmissionReview) *admissionv1beta1.Admission
 func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 	var body []byte
 	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
+		if data, err := io.ReadAll(r.Body); err == nil {
 			body = data
 		}
 	}

--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"k8s.io/client-go/tools/cache"
@@ -36,14 +36,14 @@ func InitConfigure(hub *v1alpha1.CloudHub) {
 			CloudHub: *hub,
 		}
 
-		ca, err := ioutil.ReadFile(hub.TLSCAFile)
+		ca, err := os.ReadFile(hub.TLSCAFile)
 		if err == nil {
 			block, _ := pem.Decode(ca)
 			ca = block.Bytes
 			klog.Info("Succeed in loading CA certificate from local directory")
 		}
 
-		caKey, err := ioutil.ReadFile(hub.TLSCAKeyFile)
+		caKey, err := os.ReadFile(hub.TLSCAKeyFile)
 		if err == nil {
 			block, _ := pem.Decode(caKey)
 			caKey = block.Bytes
@@ -57,13 +57,13 @@ func InitConfigure(hub *v1alpha1.CloudHub) {
 			klog.Exit("Both of ca and caKey should be specified!")
 		}
 
-		cert, err := ioutil.ReadFile(hub.TLSCertFile)
+		cert, err := os.ReadFile(hub.TLSCertFile)
 		if err == nil {
 			block, _ := pem.Decode(cert)
 			cert = block.Bytes
 			klog.Info("Succeed in loading certificate from local directory")
 		}
-		key, err := ioutil.ReadFile(hub.TLSPrivateKeyFile)
+		key, err := os.ReadFile(hub.TLSPrivateKeyFile)
 		if err == nil {
 			block, _ := pem.Decode(key)
 			key = block.Bytes

--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -170,7 +170,7 @@ func verifyAuthorization(w http.ResponseWriter, r *http.Request) bool {
 
 // signEdgeCert signs the CSR from EdgeCore
 func signEdgeCert(w http.ResponseWriter, r *http.Request) {
-	csrContent, err := ioutil.ReadAll(r.Body)
+	csrContent, err := io.ReadAll(r.Body)
 	if err != nil {
 		klog.Errorf("fail to read file when signing the cert for edgenode:%s! error:%v", r.Header.Get(constants.NodeName), err)
 		return

--- a/cloud/pkg/cloudstream/config/config.go
+++ b/cloud/pkg/cloudstream/config/config.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -42,7 +42,7 @@ func InitConfigure(stream *v1alpha1.CloudStream) {
 			CloudStream: *stream,
 		}
 
-		ca, err := ioutil.ReadFile(stream.TLSTunnelCAFile)
+		ca, err := os.ReadFile(stream.TLSTunnelCAFile)
 		if err == nil {
 			block, _ := pem.Decode(ca)
 			ca = block.Bytes
@@ -51,13 +51,13 @@ func InitConfigure(stream *v1alpha1.CloudStream) {
 			Config.Ca = ca
 		}
 
-		cert, err := ioutil.ReadFile(stream.TLSTunnelCertFile)
+		cert, err := os.ReadFile(stream.TLSTunnelCertFile)
 		if err == nil {
 			block, _ := pem.Decode(cert)
 			cert = block.Bytes
 		}
 
-		key, err := ioutil.ReadFile(stream.TLSTunnelPrivateKeyFile)
+		key, err := os.ReadFile(stream.TLSTunnelPrivateKeyFile)
 		if err == nil {
 			block, _ := pem.Decode(key)
 			key = block.Bytes

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -21,8 +21,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 
@@ -286,7 +286,7 @@ func (s *StreamServer) Start() {
 	s.installDebugHandler()
 
 	pool := x509.NewCertPool()
-	data, err := ioutil.ReadFile(config.Config.TLSStreamCAFile)
+	data, err := os.ReadFile(config.Config.TLSStreamCAFile)
 	if err != nil {
 		klog.Exitf("Read tls stream ca file error %v", err)
 		return

--- a/cloud/pkg/edgecontroller/manager/configmap_test.go
+++ b/cloud/pkg/edgecontroller/manager/configmap_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -72,12 +71,12 @@ func TestNewConfigMapManager(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/edgecontroller/manager/endpoint_test.go
+++ b/cloud/pkg/edgecontroller/manager/endpoint_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -72,12 +71,12 @@ func TestNewEndpointsManager(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/edgecontroller/manager/node_test.go
+++ b/cloud/pkg/edgecontroller/manager/node_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -65,12 +64,12 @@ func TestNewNodesManager(t *testing.T) {
 		informer cache.SharedIndexInformer
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/edgecontroller/manager/pod_test.go
+++ b/cloud/pkg/edgecontroller/manager/pod_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sync"
@@ -234,12 +233,12 @@ func TestNewPodManager(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/edgecontroller/manager/rule_test.go
+++ b/cloud/pkg/edgecontroller/manager/rule_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -72,12 +71,12 @@ func TestNewRuleManager(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/edgecontroller/manager/ruleendpoint_test.go
+++ b/cloud/pkg/edgecontroller/manager/ruleendpoint_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -72,12 +71,12 @@ func TestNewRuleEndpointManager(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/edgecontroller/manager/secret_test.go
+++ b/cloud/pkg/edgecontroller/manager/secret_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -71,12 +70,12 @@ func TestNewSecretManager(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/edgecontroller/manager/service_test.go
+++ b/cloud/pkg/edgecontroller/manager/service_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -71,12 +70,12 @@ func TestNewServiceManager(t *testing.T) {
 		},
 	}
 
-	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(tmpfile.Name())
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
 		t.Error(err)
 	}
 	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{

--- a/cloud/pkg/router/listener/http.go
+++ b/cloud/pkg/router/listener/http.go
@@ -2,7 +2,7 @@ package listener
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -125,7 +125,7 @@ func (rh *RestHandler) httpHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	aReaderCloser := http.MaxBytesReader(w, r.Body, MaxMessageBytes)
-	b, err := ioutil.ReadAll(aReaderCloser)
+	b, err := io.ReadAll(aReaderCloser)
 	if err != nil {
 		klog.Errorf("request error, write result: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
@@ -153,7 +153,7 @@ func (rh *RestHandler) httpHandler(w http.ResponseWriter, r *http.Request) {
 			klog.Errorf("response convert error, msg id: %s, reason: %v", msgID, err)
 			return
 		}
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		if err != nil {
 			klog.Errorf("response body read error, msg id: %s, reason: %v", msgID, err)
 			return

--- a/cloud/pkg/router/provider/servicebus/servicebus.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus.go
@@ -3,7 +3,7 @@ package servicebus
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"strings"
@@ -95,7 +95,7 @@ func (sb *ServiceBus) Forward(target provider.Target, data interface{}) (respons
 	klog.Infof("message is send to target successfully. msgID: %s, target: %s", message.GetID(), target.Name())
 	httpResp, ok := resp.(*http.Response)
 	if ok {
-		byteData, _ := ioutil.ReadAll(httpResp.Body)
+		byteData, _ := io.ReadAll(httpResp.Body)
 		beehiveContext.SendToGroup(modules.CloudHubModuleGroup, *message.NewRespByMessage(message, string(byteData)))
 	}
 	return resp, nil

--- a/edge/pkg/edged/edged_getters.go
+++ b/edge/pkg/edged/edged_getters.go
@@ -25,7 +25,6 @@ package edged
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -160,7 +159,7 @@ func (e *edged) getPodVolumePathListFromDisk(podUID types.UID) ([]string, error)
 		return volumes, nil
 	}
 
-	volumePluginDirs, err := ioutil.ReadDir(podVolDir)
+	volumePluginDirs, err := os.ReadDir(podVolDir)
 	if err != nil {
 		klog.Errorf("Could not read directory %s: %v", podVolDir, err)
 		return volumes, err

--- a/edge/pkg/edged/edged_pods.go
+++ b/edge/pkg/edged/edged_pods.go
@@ -32,7 +32,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -150,7 +149,7 @@ func (e *edged) GeneratePodHostNameAndDomain(pod *v1.Pod) (string, string, error
 
 // Get a list of pods that have data directories.
 func (e *edged) listPodsFromDisk() ([]types.UID, error) {
-	podInfos, err := ioutil.ReadDir(e.getPodsDir())
+	podInfos, err := os.ReadDir(e.getPodsDir())
 	if err != nil {
 		return nil, err
 	}
@@ -491,12 +490,12 @@ func ensureHostsFile(fileName, hostIP, hostName, hostDomainName string, hostAlia
 		hostsFileContent = managedHostsFileContent(hostIP, hostName, hostDomainName, hostAliases)
 	}
 
-	return ioutil.WriteFile(fileName, hostsFileContent, 0644)
+	return os.WriteFile(fileName, hostsFileContent, 0644)
 }
 
 // nodeHostsFileContent reads the content of node's hosts file.
 func nodeHostsFileContent(hostsFilePath string, hostAliases []v1.HostAlias) ([]byte, error) {
-	hostsFileContent, err := ioutil.ReadFile(hostsFilePath)
+	hostsFileContent, err := os.ReadFile(hostsFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -24,7 +24,6 @@ package edged
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -333,7 +332,7 @@ func (e *edged) setGPUInfo(nodeStatus *edgeapi.NodeStatusRequest) error {
 }
 
 func (e *edged) setMemInfo(total, allocatable v1.ResourceList) error {
-	out, err := ioutil.ReadFile("/proc/meminfo")
+	out, err := os.ReadFile("/proc/meminfo")
 	if err != nil {
 		return err
 	}

--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -12,8 +12,9 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	nethttp "net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -238,7 +239,7 @@ func (cm *CertManager) rotateCert() (bool, error) {
 
 // getCA returns the CA in pem format.
 func (cm *CertManager) getCA() ([]byte, error) {
-	return ioutil.ReadFile(cm.caFile)
+	return os.ReadFile(cm.caFile)
 }
 
 // GetCACert gets the cloudcore CA certificate
@@ -254,7 +255,7 @@ func GetCACert(url string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	caCert, err := ioutil.ReadAll(res.Body)
+	caCert, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +286,7 @@ func (cm *CertManager) GetEdgeCert(url string, capem []byte, cert tls.Certificat
 	}
 	defer res.Body.Close()
 
-	content, err := ioutil.ReadAll(res.Body)
+	content, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/edge/pkg/edgehub/clients/quicclient/quicclient.go
+++ b/edge/pkg/edgehub/clients/quicclient/quicclient.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -48,7 +48,7 @@ func (qcc *QuicClient) Init() error {
 		klog.Errorf("Failed to load x509 key pair: %v", err)
 		return fmt.Errorf("failed to load x509 key pair, error: %v", err)
 	}
-	caCrt, err := ioutil.ReadFile(qcc.config.CaFilePath)
+	caCrt, err := os.ReadFile(qcc.config.CaFilePath)
 	if err != nil {
 		klog.Errorf("Failed to load ca file: %s", err.Error())
 		return fmt.Errorf("failed to load ca file: %s", err.Error())

--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -5,8 +5,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -55,7 +55,7 @@ func (wsc *WebSocketClient) Init() error {
 		return fmt.Errorf("failed to load x509 key pair, error: %v", err)
 	}
 
-	caCert, err := ioutil.ReadFile(config.Config.TLSCAFile)
+	caCert, err := os.ReadFile(config.Config.TLSCAFile)
 	if err != nil {
 		return err
 	}

--- a/edge/pkg/edgehub/common/http/http_test.go
+++ b/edge/pkg/edgehub/common/http/http_test.go
@@ -21,8 +21,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -120,7 +120,7 @@ func TestNewHTTPClientWithCA(t *testing.T) {
 		t.Errorf("Error in generating fake certificates: %w", err)
 		return
 	}
-	capem, err := ioutil.ReadFile(CertFile)
+	capem, err := os.ReadFile(CertFile)
 	if err != nil {
 		t.Errorf("Error in loading Cert file: %w", err)
 		return

--- a/edge/pkg/eventbus/common/util/common.go
+++ b/edge/pkg/eventbus/common/util/common.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -66,7 +65,7 @@ func HubClientInit(server, clientID, username, password string) *MQTT.ClientOpti
 			return nil
 		}
 
-		caCert, err := ioutil.ReadFile(eventconfig.Config.TLS.TLSMqttCAFile)
+		caCert, err := os.ReadFile(eventconfig.Config.TLS.TLSMqttCAFile)
 		if err != nil {
 			klog.Errorf("Failed to read TLSMqttCAFile")
 			return nil

--- a/edge/pkg/metamanager/metaserver/handlerfactory/handler.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -207,13 +206,13 @@ func parseTimeout(str string) time.Duration {
 func limitedReadBody(req *http.Request, limit int64) ([]byte, error) {
 	defer req.Body.Close()
 	if limit <= 0 {
-		return ioutil.ReadAll(req.Body)
+		return io.ReadAll(req.Body)
 	}
 	lr := &io.LimitedReader{
 		R: req.Body,
 		N: limit + 1,
 	}
-	data, err := ioutil.ReadAll(lr)
+	data, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, err
 	}

--- a/edge/pkg/servicebus/servicebus.go
+++ b/edge/pkg/servicebus/servicebus.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -181,7 +181,7 @@ func processMessage(msg *beehiveModel.Message) {
 		}
 		defer resp.Body.Close()
 		resp.Body = http.MaxBytesReader(nil, resp.Body, maxBodySize)
-		resBody, err := ioutil.ReadAll(resp.Body)
+		resBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			if err.Error() == "http: request body too large" {
 				err = fmt.Errorf("response body too large")
@@ -236,7 +236,7 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		sReq := &serverRequest{}
 		sResp := &serverResponse{}
-		byteData, err := ioutil.ReadAll(req.Body)
+		byteData, err := io.ReadAll(req.Body)
 		if err != nil {
 			sResp.Code = http.StatusBadRequest
 			sResp.Msg = "can't read data from body of the http's request"

--- a/edge/test/cloudhub/stub.go
+++ b/edge/test/cloudhub/stub.go
@@ -3,7 +3,6 @@ package test
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -78,7 +77,7 @@ func (tm *stubCloudHub) serveEvent(w http.ResponseWriter, r *http.Request) {
 
 func (tm *stubCloudHub) podHandler(w http.ResponseWriter, req *http.Request) {
 	if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			klog.Errorf("read body error %v", err)
 			w.Write([]byte("read request body error"))

--- a/edge/test/integration/utils/helpers/helpers.go
+++ b/edge/test/integration/utils/helpers/helpers.go
@@ -22,7 +22,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -334,7 +333,7 @@ func GetPods(EdgedEndpoint string) (v1.PodList, error) {
 	}
 	common.Infof("%s %s %v in %v", req.Method, req.URL, resp.Status, time.Since(t))
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		common.Fatalf("HTTP Response reading has failed: %v", err)
 		return pods, nil

--- a/edge/test/integration/utils/test_setup.go
+++ b/edge/test/integration/utils/test_setup.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -28,7 +27,7 @@ func CfgToFile(c *edgecore.EdgeCoreConfig) error {
 		fmt.Printf("Marshal edgecore config to yaml error %v\n", err)
 		os.Exit(1)
 	}
-	if err := ioutil.WriteFile(EdgeCoreConfigFile, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(EdgeCoreConfigFile, data, os.ModePerm); err != nil {
 		fmt.Printf("Create edgecore config file %v error %v\n", EdgeCoreConfigFile, err)
 		os.Exit(1)
 	}
@@ -52,7 +51,7 @@ func CreateEdgeCoreConfigFile(nodeName string) error {
 		fmt.Printf("Marshal edgecore config to yaml error %v\n", err)
 		os.Exit(1)
 	}
-	if err := ioutil.WriteFile(EdgeCoreConfigFile, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(EdgeCoreConfigFile, data, os.ModePerm); err != nil {
 		fmt.Printf("Create edgecore config file %v error %v\n", EdgeCoreConfigFile, err)
 		os.Exit(1)
 	}

--- a/edge/test/test.go
+++ b/edge/test/test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -67,7 +66,7 @@ func GetPodListFromEdged(w http.ResponseWriter) error {
 	}
 	klog.Infof("%s %s %v in %v", req.Method, req.URL, resp.Status, time.Since(t))
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("HTTP Response reading has failed: %v", err)
 		return err
@@ -98,7 +97,7 @@ func (tm *testManager) podHandler(w http.ResponseWriter, req *http.Request) {
 			klog.Errorf("Get podlist from Edged has failed: %v", err)
 		}
 	} else if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			klog.Errorf("read body error %v", err)
 			w.Write([]byte("read request body error"))
@@ -134,7 +133,7 @@ func (tm *testManager) deviceHandler(w http.ResponseWriter, req *http.Request) {
 	var Content interface{}
 
 	if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			klog.Errorf("read body error %v", err)
 			w.Write([]byte("read request body error"))
@@ -163,7 +162,7 @@ func (tm *testManager) secretHandler(w http.ResponseWriter, req *http.Request) {
 	var operation string
 	var p v1.Secret
 	if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			klog.Errorf("read body error %v", err)
 			w.Write([]byte("read request body error"))
@@ -193,7 +192,7 @@ func (tm *testManager) configmapHandler(w http.ResponseWriter, req *http.Request
 	var operation string
 	var p v1.ConfigMap
 	if req.Body != nil {
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			klog.Errorf("read body error %v", err)
 			w.Write([]byte("read request body error"))

--- a/edgesite/cmd/edgesite-server/app/server.go
+++ b/edgesite/cmd/edgesite-server/app/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -220,7 +219,7 @@ func (p *Proxy) getTLSConfig(caFile, certFile, keyFile string) (*tls.Config, err
 	}
 
 	certPool := x509.NewCertPool()
-	caCert, err := ioutil.ReadFile(filepath.Clean(caFile))
+	caCert, err := os.ReadFile(filepath.Clean(caFile))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read cluster CA cert %s: %v", caFile, err)
 	}

--- a/hack/verify-golang.sh
+++ b/hack/verify-golang.sh
@@ -37,7 +37,7 @@ if [ $X -lt 1 ] ; then
 	exit 1
 fi
 
-if [ $Y -lt 15 ] ; then
-	echo "go minor version must >= 15, now is $Y"
+if [ $Y -lt 16 ] ; then
+	echo "go minor version must >= 16, now is $Y"
 	exit 1
 fi

--- a/keadm/cmd/keadm/app/cmd/common/config.go
+++ b/keadm/cmd/keadm/app/cmd/common/config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package common
 
 import (
-	"io/ioutil"
+	"os"
 
 	"sigs.k8s.io/yaml"
 )
@@ -29,5 +29,5 @@ func Write2File(path string, data interface{}) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, d, 0666)
+	return os.WriteFile(path, d, 0666)
 }

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -91,14 +90,14 @@ func TestPrivateDownloadServiceFile(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		files, _ := ioutil.ReadDir(path.Dir(serviceFilePath))
+		files, _ := os.ReadDir(path.Dir(serviceFilePath))
 		if len(files) > 1 {
 			return fmt.Errorf("download redundancy files")
 		}
 		return err
 	}
 	var clean = func(testTmpDir string) {
-		dir, err := ioutil.ReadDir(testTmpDir)
+		dir, err := os.ReadDir(testTmpDir)
 		if err != nil {
 			t.Fatalf("failed to clean test tmp dir!\n")
 		}
@@ -109,7 +108,7 @@ func TestPrivateDownloadServiceFile(t *testing.T) {
 		}
 	}
 
-	testTmpDir, err := ioutil.TempDir("", "kubeedge")
+	testTmpDir, err := os.MkdirTemp("", "kubeedge")
 	if err != nil {
 		t.Fatalf("failed to create temp dir for testing:{%s}\n", err.Error())
 	}
@@ -170,13 +169,13 @@ func TestHasSystemd(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_BadDir")
+	dir, err := os.MkdirTemp("", "TestTempFile_BadDir")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "FileExist")
+	ef, err := os.CreateTemp(dir, "FileExist")
 	if err == nil {
 		if !FileExists(ef.Name()) {
 			t.Fatalf("file %v should exist", ef.Name())
@@ -204,7 +203,7 @@ func TestComputeSHA512Checksum(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpfile, err := ioutil.TempFile("", test.name)
+			tmpfile, err := os.CreateTemp("", test.name)
 			if err != nil {
 				t.Errorf("Unable to create temp file: %v", err)
 			}

--- a/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -165,7 +164,7 @@ func installCRDs(ks *K8SInstTool) error {
 }
 
 func createKubeEdgeV1CRD(dynamicClient dynamic.Interface, crdFile string) error {
-	content, err := ioutil.ReadFile(crdFile)
+	content, err := os.ReadFile(crdFile)
 	if err != nil {
 		return fmt.Errorf("read crd yaml error: %v", err)
 	}

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
@@ -33,7 +33,7 @@ const (
 )
 
 func (c *CloudCoreConfig) Parse(filename string) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		klog.Errorf("Failed to read configfile %s: %v", filename, err)
 		return err

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package validation
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,14 +29,14 @@ import (
 )
 
 func TestValidateCloudCoreConfiguration(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_Dir")
+	dir, err := os.MkdirTemp("", "TestTempFile_Dir")
 	if err != nil {
 		t.Errorf("create temp dir error %v", err)
 		return
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "existFile")
+	ef, err := os.CreateTemp(dir, "existFile")
 	if err != nil {
 		t.Errorf("create temp file failed: %v", err)
 		return
@@ -54,14 +53,14 @@ func TestValidateCloudCoreConfiguration(t *testing.T) {
 }
 
 func TestValidateModuleCloudHub(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_Dir")
+	dir, err := os.MkdirTemp("", "TestTempFile_Dir")
 	if err != nil {
 		t.Errorf("create temp dir error %v", err)
 		return
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "existFile")
+	ef, err := os.CreateTemp(dir, "existFile")
 	if err != nil {
 		t.Errorf("create temp file failed: %v", err)
 		return
@@ -373,14 +372,14 @@ func TestValidateModuleDynamicController(t *testing.T) {
 }
 
 func TestValidateModuleCloudStream(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_Dir")
+	dir, err := os.MkdirTemp("", "TestTempFile_Dir")
 	if err != nil {
 		t.Errorf("create temp dir error %v", err)
 		return
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "existFile")
+	ef, err := os.CreateTemp(dir, "existFile")
 	if err != nil {
 		t.Errorf("create temp file failed: %v", err)
 		return
@@ -454,14 +453,14 @@ func TestValidateModuleCloudStream(t *testing.T) {
 }
 
 func TestValidateKubeAPIConfig(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_Dir")
+	dir, err := os.MkdirTemp("", "TestTempFile_Dir")
 	if err != nil {
 		t.Errorf("create temp dir error %v", err)
 		return
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "existFile")
+	ef, err := os.CreateTemp(dir, "existFile")
 	if err != nil {
 		t.Errorf("create temp file failed: %v", err)
 		return

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/helper.go
@@ -17,14 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"io/ioutil"
+	"os"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
 func (c *EdgeCoreConfig) Parse(filename string) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		klog.Errorf("Failed to read configfile %s: %v", filename, err)
 		return err

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation_test.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,14 +29,14 @@ import (
 )
 
 func TestValidateEdgeCoreConfiguration(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_Dir")
+	dir, err := os.MkdirTemp("", "TestTempFile_Dir")
 	if err != nil {
 		t.Errorf("create temp dir error %v", err)
 		return
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "existFile")
+	ef, err := os.CreateTemp(dir, "existFile")
 	if err != nil {
 		t.Errorf("create temp file failed: %v", err)
 		return
@@ -53,13 +52,13 @@ func TestValidateEdgeCoreConfiguration(t *testing.T) {
 }
 
 func TestValidateDataBase(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_BadDir")
+	dir, err := os.MkdirTemp("", "TestTempFile_BadDir")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "FileIsExist")
+	ef, err := os.CreateTemp(dir, "FileIsExist")
 	if err == nil {
 		db := v1alpha1.DataBase{
 			DataSource: ef.Name(),

--- a/pkg/apis/componentconfig/edgesite/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/edgesite/v1alpha1/helper.go
@@ -17,14 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"io/ioutil"
+	"os"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
 func (c *EdgeSiteConfig) Parse(filename string) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		klog.Errorf("Failed to read configfile %s: %v", filename, err)
 		return err

--- a/pkg/stream/message.go
+++ b/pkg/stream/message.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/klog/v2"
 )
@@ -89,7 +88,7 @@ func ReadMessageFromTunnel(r io.Reader) (*Message, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadAll(buf)
+	data, err := io.ReadAll(buf)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/validation/check_test.go
+++ b/pkg/util/validation/check_test.go
@@ -1,20 +1,19 @@
 package validation
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestFileIsExist(t *testing.T) {
-	dir, err := ioutil.TempDir("", "TestTempFile_BadDir")
+	dir, err := os.MkdirTemp("", "TestTempFile_BadDir")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 	defer os.RemoveAll(dir)
 
-	ef, err := ioutil.TempFile(dir, "CheckFileIsExist")
+	ef, err := os.CreateTemp(dir, "CheckFileIsExist")
 	if err == nil {
 		if !FileIsExist(ef.Name()) {
 			t.Fatalf("file %v should exist", ef.Name())

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/socket/config/config.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/socket/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/klog/v2"
@@ -48,7 +47,7 @@ var (
 // InitBuildinModuleConfig init buildin module config
 func InitBuildinModuleConfig(filepath string) *BuildinModuleConfig {
 	moduleConfig := BuildinModuleConfig{}
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		klog.Errorf("failed to read file %v: %v", filepath, err)
 		return nil

--- a/staging/src/github.com/kubeedge/viaduct/examples/chat/common.go
+++ b/staging/src/github.com/kubeedge/viaduct/examples/chat/common.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"k8s.io/klog/v2"
 
@@ -18,17 +18,17 @@ func GetTlsConfig(cfg *config.Config) (*tls.Config, error) {
 		return nil, fmt.Errorf("bad cert certification files")
 	}
 
-	caBytes, err := ioutil.ReadFile(cfg.CaFile)
+	caBytes, err := os.ReadFile(cfg.CaFile)
 	if err != nil {
 		klog.Errorf("failed to read ca file(%s), error: %+v", cfg.CaFile, err)
 		return nil, err
 	}
-	cerBytes, err := ioutil.ReadFile(cfg.CertFile)
+	cerBytes, err := os.ReadFile(cfg.CertFile)
 	if err != nil {
 		klog.Errorf("failed to read cert file(%s), error: %+v", cfg.CertFile, err)
 		return nil, err
 	}
-	keyBytes, err := ioutil.ReadFile(cfg.KeyFile)
+	keyBytes, err := os.ReadFile(cfg.KeyFile)
 	if err != nil {
 		klog.Errorf("failed to read key file(%s), error: %+v", cfg.KeyFile, err)
 		return nil, err

--- a/staging/src/github.com/kubeedge/viaduct/pkg/client/ws.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/client/ws.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"k8s.io/klog/v2"
 
@@ -66,7 +66,7 @@ func (c *WSClient) Connect() (conn.Connection, error) {
 	// something wrong!!
 	var respMsg string
 	if resp != nil {
-		body, errRead := ioutil.ReadAll(resp.Body)
+		body, errRead := io.ReadAll(resp.Body)
 		if errRead == nil {
 			respMsg = fmt.Sprintf("response code: %d, response body: %s", resp.StatusCode, string(body))
 		} else {

--- a/tests/e2e/utils/common.go
+++ b/tests/e2e/utils/common.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os/exec"
 	"reflect"
@@ -309,7 +308,7 @@ func GetDeployments(list *apps.DeploymentList, getDeploymentAPI string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return err
@@ -509,7 +508,7 @@ func GetServicePort(cloudName, serviceHandler string) (int32, int32) {
 	}
 	defer resp.Body.Close()
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return -1, -1
@@ -722,7 +721,7 @@ func GetDeviceModel(list *v1alpha2.DeviceModelList, getDeviceModelAPI string, ex
 		return nil, err
 	}
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return nil, err
@@ -759,7 +758,7 @@ func GetDevice(list *v1alpha2.DeviceList, getDeviceAPI string, expectedDevice *v
 		return nil, err
 	}
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return nil, err
@@ -952,14 +951,14 @@ func SendMsg(url string, message []byte, header map[string]string) (bool, int) {
 func StartEchoServer() (string, error) {
 	r := make(chan string)
 	echo := func(response http.ResponseWriter, request *http.Request) {
-		b, _ := ioutil.ReadAll(request.Body)
+		b, _ := io.ReadAll(request.Body)
 		r <- string(b)
 		if _, err := response.Write([]byte("Hello World")); err != nil {
 			Errorf("Echo server write failed. reason: %s", err.Error())
 		}
 	}
 	url := func(response http.ResponseWriter, request *http.Request) {
-		b, _ := ioutil.ReadAll(request.Body)
+		b, _ := io.ReadAll(request.Body)
 		var buff bytes.Buffer
 		buff.WriteString("Reply from server: ")
 		buff.Write(b)
@@ -1026,7 +1025,7 @@ func CallServicebus() (response string, err error) {
 	req, _ := http.NewRequest(http.MethodPost, "http://127.0.0.1:9060", payload)
 	req.Header.Add("Content-Type", "application/json")
 	resp, _ := client.Do(req)
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	err = json.Unmarshal(body, &servicebusResponse)
 	response = servicebusResponse.Body
 	return

--- a/tests/e2e/utils/node.go
+++ b/tests/e2e/utils/node.go
@@ -21,8 +21,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -121,7 +122,7 @@ func CheckNodeReadyStatus(nodehandler, nodename string) string {
 	}
 	defer resp.Body.Close()
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return nodeStatus
@@ -156,7 +157,7 @@ func HandleConfigmap(configName chan error, operation, confighandler string, IsE
 	} else {
 		file = path.Join(curpath, "../../performance/assets/01-configmap.yaml")
 	}
-	body, err := ioutil.ReadFile(file)
+	body, err := os.ReadFile(file)
 	if err == nil {
 		client := &http.Client{}
 		t := time.Now()
@@ -208,7 +209,7 @@ func GetConfigmap(apiConfigMap string) (int, []byte) {
 		Fatalf("Sending SenHttpRequest failed: %v", err)
 		return -1, nil
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	return resp.StatusCode, body
 }
@@ -268,7 +269,7 @@ func GetNodes(api string) v1.NodeList {
 	}
 	defer resp.Body.Close()
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 	}

--- a/tests/e2e/utils/pod.go
+++ b/tests/e2e/utils/pod.go
@@ -18,7 +18,7 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -51,7 +51,7 @@ func GetPods(apiserver, label string) (v1.PodList, error) {
 		return pods, nil
 	}
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return pods, nil
@@ -75,7 +75,7 @@ func GetPodState(apiserver string) (string, int) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNotFound {
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			Fatalf("HTTP Response reading has failed: %v", err)
 		}
@@ -99,7 +99,7 @@ func DeletePods(apiserver string) (string, int) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNotFound {
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			Fatalf("HTTP Response reading has failed: %v", err)
 		}

--- a/tests/e2e/utils/rule.go
+++ b/tests/e2e/utils/rule.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"time"
@@ -209,7 +208,7 @@ func newServiceBusRuleEndpoint() *rulesv1.RuleEndpoint {
 func GetRuleList(list *rulesv1.RuleList, getRuleAPI string, expectedRule *rulesv1.Rule) ([]rulesv1.Rule, error) {
 	resp, err := SendHTTPRequest(http.MethodGet, getRuleAPI)
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return nil, err
@@ -277,7 +276,7 @@ func HandleRule(operation, apiserver, UID string, sourceType, targetType rulesv1
 		return false, 0
 	}
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	Infof("%s %s %v  %v in %v", req.Method, req.URL, resp.Status, string(contents), time.Since(t))
 	return true, resp.StatusCode
 }
@@ -329,7 +328,7 @@ func HandleRuleEndpoint(operation string, apiserver string, UID string, endpoint
 func GetRuleEndpointList(list *rulesv1.RuleEndpointList, getRuleEndpointAPI string, expectedRule *rulesv1.RuleEndpoint) ([]rulesv1.RuleEndpoint, error) {
 	resp, err := SendHTTPRequest(http.MethodGet, getRuleEndpointAPI)
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return nil, err

--- a/tests/e2e/utils/test_setup.go
+++ b/tests/e2e/utils/test_setup.go
@@ -19,7 +19,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -107,7 +107,7 @@ func getSecret(master string) string {
 		Fatalf("Send HTTP Request failed: %v", err)
 	}
 	defer resp.Body.Close()
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		Fatalf("HTTP Response reading has failed: %v", err)
 		return ""
@@ -185,7 +185,7 @@ func createCloudCoreConfigFile(kubeConfigPath string) {
 		fmt.Printf("Marshal cloudcore config to yaml error %v\n", err)
 		os.Exit(1)
 	}
-	if err := ioutil.WriteFile(constants.CloudCoreConfigFile, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(constants.CloudCoreConfigFile, data, os.ModePerm); err != nil {
 		fmt.Printf("Create cloudcore config file %v error %v\n", constants.CloudCoreConfigFile, err)
 		os.Exit(1)
 	}
@@ -208,7 +208,7 @@ func createEdgeCoreConfigFile(token, nodeName string) {
 		fmt.Printf("Marshal edgecore config to yaml error %v\n", err)
 		os.Exit(1)
 	}
-	if err := ioutil.WriteFile(constants.EdgeCoreConfigFile, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(constants.EdgeCoreConfigFile, data, os.ModePerm); err != nil {
 		fmt.Printf("Create edgecore config file %v error %v\n", constants.EdgeCoreConfigFile, err)
 		os.Exit(1)
 	}
@@ -227,7 +227,7 @@ func createEdgeSiteConfigFile(kubeMaster, nodeName string) {
 		fmt.Printf("Marshal edgesite config to yaml error %v\n", err)
 		os.Exit(1)
 	}
-	if err := ioutil.WriteFile(constants.EdgeSiteConfigFile, data, os.ModePerm); err != nil {
+	if err := os.WriteFile(constants.EdgeSiteConfigFile, data, os.ModePerm); err != nil {
 		fmt.Printf("Create edgesite config file %v error %v\n", constants.EdgeSiteConfigFile, err)
 		os.Exit(1)
 	}

--- a/tests/performance/common/common.go
+++ b/tests/performance/common/common.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"os/exec"
@@ -238,7 +237,7 @@ func AddFakePod(ControllerHubURL string, pod types.FakePod) {
 	if resp != nil {
 		defer resp.Body.Close()
 
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			utils.Fatalf("HTTP Response reading has failed: %v", err)
 		}
@@ -264,7 +263,7 @@ func DeleteFakePod(ControllerHubURL string, pod types.FakePod) {
 	if resp != nil {
 		defer resp.Body.Close()
 
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			utils.Fatalf("HTTP Response reading has failed: %v", err)
 		}
@@ -288,7 +287,7 @@ func ListFakePods(ControllerHubURL string) []types.FakePod {
 	if resp != nil {
 		defer resp.Body.Close()
 
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			utils.Fatalf("HTTP Response reading has failed: %v", err)
 		}

--- a/tests/stubs/cloud/controllerstub/podmanager.go
+++ b/tests/stubs/cloud/controllerstub/podmanager.go
@@ -19,7 +19,7 @@ package controllerstub
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -118,7 +118,7 @@ func (pm *PodManager) PodHandlerFunc(w http.ResponseWriter, req *http.Request) {
 		var p types.FakePod
 		// Get request body
 		if req.Body != nil {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				klog.Errorf("Read body error %v", err)
 				if _, err := w.Write([]byte("Read request body error")); err != nil {

--- a/tests/stubs/example/main.go
+++ b/tests/stubs/example/main.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -76,7 +75,7 @@ func AddPod(pod types.FakePod) {
 	}
 	defer resp.Body.Close()
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("HTTP Response reading has failed: %v", err)
 	}
@@ -95,7 +94,7 @@ func DeletePod(pod types.FakePod) {
 	}
 	defer resp.Body.Close()
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("HTTP Response reading has failed: %v", err)
 	}
@@ -111,7 +110,7 @@ func ListPods() {
 	}
 	defer resp.Body.Close()
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		klog.Errorf("HTTP Response reading has failed: %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
package `io/ioutil` is deprecated in Go1.16, and according to the official doc(https://golang.org/doc/go1.16#ioutil), we could use definitions in `io` and `os`.
So replace all codes using `io/ioutil` with package `os` and `io`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
