### PR TITLE
replace github.com/pkg/errors with Go native error

### DIFF
--- a/edge/pkg/edgehub/common/certutil/certfile.go
+++ b/edge/pkg/edgehub/common/certutil/certfile.go
@@ -4,8 +4,8 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 
-	"github.com/pkg/errors"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 )
@@ -25,15 +25,15 @@ func WriteKeyAndCert(keyFile string, certFile string, key crypto.Signer, cert *x
 // WriteKey stores the given key at the given location
 func WriteKey(pkiPath string, key crypto.Signer) error {
 	if key == nil {
-		return errors.New("private key cannot be nil when writing to file")
+		return fmt.Errorf("private key cannot be nil when writing to file")
 	}
 
 	encoded, err := keyutil.MarshalPrivateKeyToPEM(key)
 	if err != nil {
-		return errors.Wrapf(err, "unable to marshal private key to PEM")
+		return fmt.Errorf("unable to marshal private key to PEM: %w", err)
 	}
 	if err := keyutil.WriteKey(pkiPath, encoded); err != nil {
-		return errors.Wrapf(err, "unable to write private key to file %s", pkiPath)
+		return fmt.Errorf("unable to write private key to file %s: %w", pkiPath, err)
 	}
 
 	return nil
@@ -42,11 +42,11 @@ func WriteKey(pkiPath string, key crypto.Signer) error {
 // WriteCert stores the given certificate at the given location
 func WriteCert(certPath string, cert *x509.Certificate) error {
 	if cert == nil {
-		return errors.New("certificate cannot be nil when writing to file")
+		return fmt.Errorf("certificate cannot be nil when writing to file")
 	}
 
 	if err := certutil.WriteCert(certPath, EncodeCertPEM(cert)); err != nil {
-		return errors.Wrapf(err, "unable to write certificate to file %s", certPath)
+		return fmt.Errorf("unable to write certificate to file %s: %w", certPath, err)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.8.1
 	github.com/paypal/gatt v0.0.0-20151011220935-4ae819d591cf
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/shirou/gopsutil v2.20.9+incompatible
 	github.com/spf13/cobra v1.1.1

--- a/keadm/cmd/keadm/app/cmd/version.go
+++ b/keadm/cmd/keadm/app/cmd/version.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
@@ -62,7 +61,7 @@ func RunVersion(out io.Writer, cmd *cobra.Command) error {
 		}
 		fmt.Fprintln(out, string(y))
 	default:
-		return errors.Errorf("invalid output format: %s", of)
+		return fmt.Errorf("invalid output format: %s", of)
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -523,7 +523,6 @@ github.com/paypal/gatt/xpc
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
stop using `github.com/pkg/errors`, replaced by Go native error. just as https://github.com/kubernetes/kubernetes/issues/103043
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
