### PR TITLE
replace deprecated Dial with DialContext

### DIFF
--- a/cloud/pkg/router/utils/http/http.go
+++ b/cloud/pkg/router/utils/http/http.go
@@ -29,10 +29,10 @@ var (
 // NewHTTPClient create new client
 func NewHTTPClient() *http.Client {
 	transport := &http.Transport{
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   connectTimeout,
 			KeepAlive: keepaliveTimeout,
-		}).Dial,
+		}).DialContext,
 		MaxIdleConnsPerHost:   maxIdleConnectionsPerHost,
 		ResponseHeaderTimeout: responseReadTimeout,
 		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},

--- a/edge/pkg/edgehub/common/http/http.go
+++ b/edge/pkg/edgehub/common/http/http.go
@@ -29,10 +29,10 @@ var (
 // NewHTTPClient create new client
 func NewHTTPClient() *http.Client {
 	transport := &http.Transport{
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   connectTimeout,
 			KeepAlive: keepaliveTimeout,
-		}).Dial,
+		}).DialContext,
 		MaxIdleConnsPerHost:   maxIdleConnectionsPerHost,
 		ResponseHeaderTimeout: responseReadTimeout,
 		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
http Transport `Dial` is deprecated, replace it with recommanded `DialContext`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
