### PR TITLE
do not maintain nodestatus in localcache

### DIFF
--- a/cloud/pkg/edgecontroller/manager/location.go
+++ b/cloud/pkg/edgecontroller/manager/location.go
@@ -10,7 +10,7 @@ import (
 
 // LocationCache cache the map of node, pod, configmap, secret
 type LocationCache struct {
-	// EdgeNodes is a map, key is nodeName, value is Status
+	// EdgeNodes is a set, key is nodeName
 	EdgeNodes sync.Map
 	// configMapNode is a map, key is namespace/configMapName, value is nodeName
 	configMapNode sync.Map
@@ -130,16 +130,9 @@ func (lc *LocationCache) IsEdgeNode(nodeName string) bool {
 	return ok
 }
 
-//
-func (lc *LocationCache) GetNodeStatus(nodeName string) (string, bool) {
-	value, ok := lc.EdgeNodes.Load(nodeName)
-	status, ok := value.(string)
-	return status, ok
-}
-
 // UpdateEdgeNode is to maintain edge nodes name upto-date by querying kubernetes client
-func (lc *LocationCache) UpdateEdgeNode(nodeName string, status string) {
-	lc.EdgeNodes.Store(nodeName, status)
+func (lc *LocationCache) UpdateEdgeNode(nodeName string) {
+	lc.EdgeNodes.Store(nodeName, struct{}{})
 }
 
 // DeleteConfigMap from cache

--- a/cloud/pkg/edgecontroller/manager/location_test.go
+++ b/cloud/pkg/edgecontroller/manager/location_test.go
@@ -244,53 +244,6 @@ func TestIsEdgeNode(t *testing.T) {
 	}
 }
 
-// TestGetNodeStatus is function to test GetNodeStatus
-func TestGetNodeStatus(t *testing.T) {
-	nodeOK := nodes[0]
-	nodeUnknown := nodes[1]
-	locationCache := LocationCache{}
-	locationCache.EdgeNodes.Store(nodeOK, commonconst.MessageSuccessfulContent)
-	locationCache.EdgeNodes.Store(nodeUnknown, "Unknown")
-
-	tests := []struct {
-		name     string
-		lc       *LocationCache
-		nodeName string
-		want     string
-		exist    bool
-	}{
-		{
-			name:     "TestGetNodeStatus() Case: Node status is OK",
-			lc:       &locationCache,
-			nodeName: nodeOK,
-			want:     commonconst.MessageSuccessfulContent,
-			exist:    true,
-		},
-		{
-			name:     "TestGetNodeStatus() Case: Node status is Unknown",
-			lc:       &locationCache,
-			nodeName: nodeUnknown,
-			want:     "Unknown",
-			exist:    true,
-		},
-		{
-			name:     "TestGetNodeStatus() Case: Node not exist",
-			lc:       &locationCache,
-			nodeName: "notExistNode",
-			want:     "",
-			exist:    false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got, exist := test.lc.GetNodeStatus(test.nodeName); !reflect.DeepEqual(got, test.want) || !reflect.DeepEqual(exist, test.exist) {
-				t.Errorf("Manager.TestGetNodeStatus() case failed: gotStatus = %v,gotExist = %v, wantStatus = %v.  wantExist: %v", got, exist, test.want, test.exist)
-			}
-		})
-	}
-}
-
 // TestUpdateEdgeNode is function to test UpdateEdgeNode
 func TestUpdateEdgeNode(t *testing.T) {
 	locationCache := LocationCache{}
@@ -300,25 +253,25 @@ func TestUpdateEdgeNode(t *testing.T) {
 	tests := []struct {
 		name string
 		lc   *LocationCache
-		want string
+		want bool
 	}{
 		{
 			name: "TestUpdateEdgeNode() Case: Node status update to OK",
 			lc:   &locationCache,
-			want: commonconst.MessageSuccessfulContent,
+			want: true,
 		},
 		{
 			name: "TestUpdateEdgeNode() Case: Node status update to Unknown",
 			lc:   &locationCache,
-			want: "Unknown",
+			want: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.lc.UpdateEdgeNode(nodeName, test.want)
-			if got, _ := test.lc.EdgeNodes.Load(nodeName); !reflect.DeepEqual(got, test.want) {
-				t.Errorf("Manager.TestUpdateEdgeNode() case failed: got = %v, want = %v.", got, test.want)
+			test.lc.UpdateEdgeNode(nodeName)
+			if _, ok := test.lc.EdgeNodes.Load(nodeName); !ok {
+				t.Errorf("Manager.TestUpdateEdgeNode() case failed: got = %v, want = %v.", ok, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
The nodestatus stored in localcache was used for sending service/endpoints. Because the edgemesh has been decoupled from edgecore, it seems that no one will use the nodestatus stored in localcache anymore. So we had better to remove it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
