### PR TITLE
fix LastTransitionTime update

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -481,10 +481,6 @@ func (uc *UpstreamController) updateNodeStatus() {
 					if time.Since(nodeStatusRequest.Status.Conditions[i].LastHeartbeatTime.Time) > time.Duration(uc.config.NodeUpdateFrequency)*time.Second {
 						nodeStatusRequest.Status.Conditions[i].LastHeartbeatTime = metaV1.NewTime(time.Now())
 					}
-
-					if time.Since(nodeStatusRequest.Status.Conditions[i].LastTransitionTime.Time) > time.Duration(uc.config.NodeUpdateFrequency)*time.Second {
-						nodeStatusRequest.Status.Conditions[i].LastTransitionTime = metaV1.NewTime(time.Now())
-					}
 				}
 
 				if getNode.Annotations == nil {

--- a/edge/pkg/edged/edged_status.go
+++ b/edge/pkg/edged/edged_status.go
@@ -441,6 +441,9 @@ func (e *edged) updateNodeStatus() error {
 	if err != nil {
 		klog.Errorf("update node failed, error: %v", err)
 	}
+	e.setInitNode(&v1.Node{
+		Status: *nodeStatus.Status.DeepCopy(),
+	})
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug




**What this PR does / why we need it**:
KE will not update LastTransitionTime when the status of edgenode is unchanged. 
![Screenshot_20211015_180112](https://user-images.githubusercontent.com/32788286/137470259-b76a03bd-adc4-485f-a079-3ab772f2eb10.png)

Two changes are introdueced: 
1. update initNode status each successful `syncNodeStatus`
2. prevent edgecontroller from modifying the `LastTransitionTime`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3234 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
