### PR TITLE
fix/reliable-message-delivery: ObjectSync must be created when the resource first sends to CloudHub

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -132,7 +132,7 @@ func (q *ChannelMessageQueue) addMessageToQueue(nodeID string, msg *beehiveModel
 						Name: objectSyncName,
 					},
 					Spec: v1alpha1.ObjectSyncSpec{
-						ObjectAPIVersion: util.GetMessageAPIVerison(msg),
+						ObjectAPIVersion: util.GetMessageAPIVersion(msg),
 						ObjectKind:       util.GetMessageResourceType(msg),
 						ObjectName:       resourceName,
 					},

--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -1,10 +1,12 @@
 package channelq
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -13,14 +15,18 @@ import (
 
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	beehiveModel "github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/apis/reliablesyncs/v1alpha1"
+	crdClientset "github.com/kubeedge/kubeedge/cloud/pkg/client/clientset/versioned"
 	reliablesyncslisters "github.com/kubeedge/kubeedge/cloud/pkg/client/listers/reliablesyncs/v1alpha1"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller/application"
 	edgeconst "github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/constants"
 	edgemessagelayer "github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/synccontroller"
 	commonconst "github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
 )
 
 // ChannelMessageQueue is the channel implementation of MessageQueue
@@ -33,6 +39,8 @@ type ChannelMessageQueue struct {
 
 	objectSyncLister        reliablesyncslisters.ObjectSyncLister
 	clusterObjectSyncLister reliablesyncslisters.ClusterObjectSyncLister
+
+	crdClient crdClientset.Interface
 }
 
 // NewChannelMessageQueue initializes a new ChannelMessageQueue
@@ -40,6 +48,7 @@ func NewChannelMessageQueue(objectSyncLister reliablesyncslisters.ObjectSyncList
 	return &ChannelMessageQueue{
 		objectSyncLister:        objectSyncLister,
 		clusterObjectSyncLister: clusterObjectSyncLister,
+		crdClient:               client.GetCRDClient(),
 	}
 }
 
@@ -108,14 +117,36 @@ func (q *ChannelMessageQueue) addMessageToQueue(nodeID string, msg *beehiveModel
 		// the version stored in the database
 		if !exist {
 			resourceNamespace, _ := edgemessagelayer.GetNamespace(*msg)
+			resourceName, _ := edgemessagelayer.GetResourceName(*msg)
 			resourceUID, err := GetMessageUID(*msg)
+			objectSyncName := synccontroller.BuildObjectSyncName(nodeID, resourceUID)
 			if err != nil {
 				klog.Errorf("fail to get message UID for message: %s", msg.Header.ID)
 				return
 			}
-			objectSync, err := q.objectSyncLister.ObjectSyncs(resourceNamespace).Get(synccontroller.BuildObjectSyncName(nodeID, resourceUID))
+			objectSync, err := q.objectSyncLister.ObjectSyncs(resourceNamespace).Get(objectSyncName)
 			if err == nil && objectSync.Status.ObjectResourceVersion != "" && synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) <= 0 {
 				return
+			} else if err != nil && apierrors.IsNotFound(err) {
+				objectSync := &v1alpha1.ObjectSync{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: objectSyncName,
+					},
+					Spec: v1alpha1.ObjectSyncSpec{
+						ObjectAPIVersion: util.GetMessageAPIVerison(msg),
+						ObjectKind:       util.GetMessageResourceType(msg),
+						ObjectName:       resourceName,
+					},
+				}
+				objectSyncStatus, err := q.crdClient.ReliablesyncsV1alpha1().ObjectSyncs(resourceNamespace).Create(context.Background(), objectSync, metav1.CreateOptions{})
+				if err != nil {
+					klog.Errorf("Failed to create objectSync: %s, err: %v", objectSyncName, err)
+					return
+				}
+				objectSyncStatus.Status.ObjectResourceVersion = "0"
+				if _, err := q.crdClient.ReliablesyncsV1alpha1().ObjectSyncs(resourceNamespace).UpdateStatus(context.Background(), objectSyncStatus, metav1.UpdateOptions{}); err != nil {
+					klog.Errorf("Failed to update objectSync: %s, err: %v", objectSyncName, err)
+				}
 			}
 		}
 

--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers/httpserver"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers/udsserver"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/informers"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
@@ -33,7 +34,7 @@ func newCloudHub(enable bool) *cloudHub {
 	// declare used informer
 	clusterObjectSyncInformer := crdFactory.Reliablesyncs().V1alpha1().ClusterObjectSyncs()
 	objectSyncInformer := crdFactory.Reliablesyncs().V1alpha1().ObjectSyncs()
-	messageq := channelq.NewChannelMessageQueue(objectSyncInformer.Lister(), clusterObjectSyncInformer.Lister())
+	messageq := channelq.NewChannelMessageQueue(objectSyncInformer.Lister(), clusterObjectSyncInformer.Lister(), client.GetCRDClient())
 	ch := &cloudHub{
 		enable:   enable,
 		messageq: messageq,

--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -471,6 +471,10 @@ func (mh *MessageHandle) MessageWriteLoop(info *model.HubInfo, stopServe chan Ex
 			klog.Errorf("Failed to send event to node: %s, affected event: %s, err: %s",
 				info.NodeID, dumpMessageMetadata(copyMsg), err.Error())
 			nodeQueue.Add(key.(string))
+			if strings.Contains(err.Error(), "use of closed network connection") {
+				mh.nodeConns.Delete(info.NodeID)
+				continue
+			}
 			time.Sleep(time.Second * 2)
 		}
 

--- a/cloud/pkg/synccontroller/createfailedobject.go
+++ b/cloud/pkg/synccontroller/createfailedobject.go
@@ -1,7 +1,0 @@
-package synccontroller
-
-// TODO: Compare the objects in K8s with the objects that have been persisted to the edge,
-// If the objects fail to persisted to the edge for the first time, it will be recreated here.
-func (sctl *SyncController) manageCreateFailedObject() {
-
-}

--- a/cloud/pkg/synccontroller/synccontroller.go
+++ b/cloud/pkg/synccontroller/synccontroller.go
@@ -117,8 +117,6 @@ func (sctl *SyncController) reconcile() {
 		klog.Errorf("Failed to list all the ObjectSyncs: %v", err)
 	}
 	sctl.manageObjectSync(allObjectSyncs)
-
-	sctl.manageCreateFailedObject()
 }
 
 // Compare the cluster scope objects that have been persisted to the edge with the cluster scope objects in K8s,


### PR DESCRIPTION
…source first sends to CloudHub

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When the resource message arrives at CloudHub for the first time, check whether there is a corresponding ObjectSync. If not, create an ObjectSync with zero `ObjectResourceVersion` to trigger the SyncController.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3243

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE