### PR TITLE
avoid print goroutine stack trace when component start failed

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -58,19 +58,19 @@ kubernetes controller which manages devices so that the device metadata/status d
 			flag.PrintFlags(cmd.Flags())
 
 			if errs := opts.Validate(); len(errs) > 0 {
-				klog.Fatal(util.SpliceErrors(errs))
+				klog.Exit(util.SpliceErrors(errs))
 			}
 
 			config, err := opts.Config()
 			if err != nil {
-				klog.Fatal(err)
+				klog.Exit(err)
 			}
 			if errs := validation.ValidateCloudCoreConfiguration(config); len(errs) > 0 {
-				klog.Fatal(util.SpliceErrors(errs.ToAggregate().Errors()))
+				klog.Exit(util.SpliceErrors(errs.ToAggregate().Errors()))
 			}
 
 			if err := features.DefaultMutableFeatureGate.SetFromMap(config.FeatureGates); err != nil {
-				klog.Fatal(err)
+				klog.Exit(err)
 			}
 
 			// To help debugging, immediately log version

--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -68,16 +68,16 @@ func Run(opt *options.AdmissionOptions) {
 	klog.V(4).Infof("AdmissionOptions: %+v", *opt)
 	restConfig, err := clientcmd.BuildConfigFromFlags(opt.Master, opt.Kubeconfig)
 	if err != nil {
-		klog.Fatal(err)
+		klog.Exit(err)
 	}
 
 	cli, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		klog.Fatalf("Create kube client failed with error: %v", err)
+		klog.Exitf("Create kube client failed with error: %v", err)
 	}
 	vcli, err := versioned.NewForConfig(restConfig)
 	if err != nil {
-		klog.Fatalf("Create versioned client failed with error: %v", err)
+		klog.Exitf("Create versioned client failed with error: %v", err)
 	}
 
 	controller.Client = cli
@@ -85,13 +85,13 @@ func Run(opt *options.AdmissionOptions) {
 
 	caBundle, err := ioutil.ReadFile(opt.CaCertFile)
 	if err != nil {
-		klog.Fatalf("Unable to read cacert file: %v\n", err)
+		klog.Exitf("Unable to read cacert file: %v\n", err)
 	}
 
 	//TODO: read somewhere to get what's kind of webhook is enabled, register those webhook only.
 	err = controller.registerWebhooks(opt, caBundle)
 	if err != nil {
-		klog.Fatalf("Failed to register the webhook with error: %v", err)
+		klog.Exitf("Failed to register the webhook with error: %v", err)
 	}
 
 	http.HandleFunc("/devicemodels", serveDeviceModel)
@@ -105,7 +105,7 @@ func Run(opt *options.AdmissionOptions) {
 	}
 
 	if err := server.ListenAndServeTLS("", ""); err != nil {
-		klog.Fatalf("Start server failed with error: %v", err)
+		klog.Exitf("Start server failed with error: %v", err)
 	}
 }
 
@@ -116,7 +116,7 @@ func configTLS(opt *options.AdmissionOptions, restConfig *restclient.Config) *tl
 	if len(opt.CertFile) != 0 && len(opt.KeyFile) != 0 {
 		sCert, err := tls.LoadX509KeyPair(opt.CertFile, opt.KeyFile)
 		if err != nil {
-			klog.Fatal(err)
+			klog.Exit(err)
 		}
 
 		return &tls.Config{
@@ -127,7 +127,7 @@ func configTLS(opt *options.AdmissionOptions, restConfig *restclient.Config) *tl
 	if len(restConfig.CertData) != 0 && len(restConfig.KeyData) != 0 {
 		sCert, err := tls.X509KeyPair(restConfig.CertData, restConfig.KeyData)
 		if err != nil {
-			klog.Fatal(err)
+			klog.Exit(err)
 		}
 
 		return &tls.Config{
@@ -135,7 +135,7 @@ func configTLS(opt *options.AdmissionOptions, restConfig *restclient.Config) *tl
 		}
 	}
 
-	klog.Fatal("tls: failed to find any tls config data")
+	klog.Exit("tls: failed to find any tls config data")
 	return &tls.Config{}
 }
 

--- a/cloud/pkg/admissioncontroller/common.go
+++ b/cloud/pkg/admissioncontroller/common.go
@@ -74,7 +74,7 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 	// verify the content type is accurate
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
-		klog.Fatalf("contentType=%s, expect application/json", contentType)
+		klog.Exitf("contentType=%s, expect application/json", contentType)
 		return
 	}
 
@@ -86,7 +86,7 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 
 	deserializer := codecs.UniversalDeserializer()
 	if _, _, err := deserializer.Decode(body, nil, &requestedAdmissionReview); err != nil {
-		klog.Fatalf("decode failed with error: %v", err)
+		klog.Exitf("decode failed with error: %v", err)
 		responseAdmissionReview.Response = toAdmissionResponse(err)
 	} else {
 		responseAdmissionReview.Response = hook(requestedAdmissionReview)
@@ -98,9 +98,9 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 
 	respBytes, err := json.Marshal(responseAdmissionReview)
 	if err != nil {
-		klog.Fatalf("cannot marshal to a valid response %v", err)
+		klog.Exitf("cannot marshal to a valid response %v", err)
 	}
 	if _, err := w.Write(respBytes); err != nil {
-		klog.Fatalf("cannot write response %v", err)
+		klog.Exitf("cannot write response %v", err)
 	}
 }

--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -71,7 +71,7 @@ func (a *cloudHub) Start() {
 	// check whether the certificates exist in the local directory,
 	// and then check whether certificates exist in the secret, generate if they don't exist
 	if err := httpserver.PrepareAllCerts(); err != nil {
-		klog.Fatal(err)
+		klog.Exit(err)
 	}
 	// TODO: Will improve in the future
 	DoneTLSTunnelCerts <- true
@@ -79,7 +79,7 @@ func (a *cloudHub) Start() {
 
 	// generate Token
 	if err := httpserver.GenerateToken(); err != nil {
-		klog.Fatal(err)
+		klog.Exit(err)
 	}
 
 	// HttpServer mainly used to issue certificates for the edge

--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -29,7 +29,7 @@ type Configure struct {
 func InitConfigure(hub *v1alpha1.CloudHub) {
 	once.Do(func() {
 		if len(hub.AdvertiseAddress) == 0 {
-			klog.Fatal("AdvertiseAddress must be specified!")
+			klog.Exit("AdvertiseAddress must be specified!")
 		}
 
 		Config = Configure{
@@ -54,7 +54,7 @@ func InitConfigure(hub *v1alpha1.CloudHub) {
 			Config.Ca = ca
 			Config.CaKey = caKey
 		} else if !(ca == nil && caKey == nil) {
-			klog.Fatal("Both of ca and caKey should be specified!")
+			klog.Exit("Both of ca and caKey should be specified!")
 		}
 
 		cert, err := ioutil.ReadFile(hub.TLSCertFile)
@@ -74,7 +74,7 @@ func InitConfigure(hub *v1alpha1.CloudHub) {
 			Config.Cert = cert
 			Config.Key = key
 		} else if !(cert == nil && key == nil) {
-			klog.Fatal("Both of cert and key should be specified!")
+			klog.Exit("Both of cert and key should be specified!")
 		}
 	})
 }

--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -49,7 +49,7 @@ func StartHTTPServer() {
 	cert, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: hubconfig.Config.Cert}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: hubconfig.Config.Key}))
 
 	if err != nil {
-		klog.Fatal(err)
+		klog.Exit(err)
 	}
 
 	server := &http.Server{
@@ -60,7 +60,7 @@ func StartHTTPServer() {
 			ClientAuth:   tls.RequestClientCert,
 		},
 	}
-	klog.Fatal(server.ListenAndServeTLS("", ""))
+	klog.Exit(server.ListenAndServeTLS("", ""))
 }
 
 // getCA returns the caCertDER

--- a/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
@@ -93,7 +93,7 @@ func GenerateToken() error {
 			<-t.C
 			refreshedCaHashToken := refreshToken()
 			if err := CreateTokenSecret([]byte(refreshedCaHashToken)); err != nil {
-				klog.Fatalf("failed to create the ca token for edgecore register, err: %v", err)
+				klog.Exitf("failed to create the ca token for edgecore register, err: %v", err)
 			}
 		}
 	}()

--- a/cloud/pkg/cloudhub/servers/server.go
+++ b/cloud/pkg/cloudhub/servers/server.go
@@ -62,7 +62,7 @@ func startWebsocketServer() {
 		ExOpts:     api.WSServerOption{Path: "/"},
 	}
 	klog.Infof("Starting cloudhub %s server", api.ProtocolTypeWS)
-	klog.Fatal(svc.ListenAndServeTLS("", ""))
+	klog.Exit(svc.ListenAndServeTLS("", ""))
 }
 
 func startQuicServer() {
@@ -77,5 +77,5 @@ func startQuicServer() {
 	}
 
 	klog.Infof("Starting cloudhub %s server", api.ProtocolTypeQuic)
-	klog.Fatal(svc.ListenAndServeTLS("", ""))
+	klog.Exit(svc.ListenAndServeTLS("", ""))
 }

--- a/cloud/pkg/cloudhub/servers/udsserver/server.go
+++ b/cloud/pkg/cloudhub/servers/udsserver/server.go
@@ -43,7 +43,7 @@ func StartServer(address string) {
 
 	klog.Info("start unix domain socket server")
 	if err := uds.StartServer(); err != nil {
-		klog.Fatalf("failed to start uds server: %v", err)
+		klog.Exitf("failed to start uds server: %v", err)
 		return
 	}
 }

--- a/cloud/pkg/cloudstream/config/config.go
+++ b/cloud/pkg/cloudstream/config/config.go
@@ -67,7 +67,7 @@ func InitConfigure(stream *v1alpha1.CloudStream) {
 			Config.Cert = cert
 			Config.Key = key
 		} else if !(cert == nil && key == nil) {
-			klog.Fatal("Both of tunnelCert and key should be specified!")
+			klog.Exit("Both of tunnelCert and key should be specified!")
 		}
 	})
 }

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -116,7 +116,7 @@ func (s *StreamServer) getContainerLogs(r *restful.Request, w *restful.Response)
 
 	kubeClient := client.GetKubeClient()
 	if kubeClient == nil {
-		klog.Fatalf("cannot get kube client\n")
+		klog.Exitf("cannot get kube client\n")
 		return
 	}
 
@@ -288,7 +288,7 @@ func (s *StreamServer) Start() {
 	pool := x509.NewCertPool()
 	data, err := ioutil.ReadFile(config.Config.TLSStreamCAFile)
 	if err != nil {
-		klog.Fatalf("Read tls stream ca file error %v", err)
+		klog.Exitf("Read tls stream ca file error %v", err)
 		return
 	}
 	pool.AppendCertsFromPEM(data)
@@ -305,7 +305,7 @@ func (s *StreamServer) Start() {
 	klog.Infof("Prepare to start stream server ...")
 	err = streamServer.ListenAndServeTLS(config.Config.TLSStreamCertFile, config.Config.TLSStreamPrivateKeyFile)
 	if err != nil {
-		klog.Fatalf("Start stream server error %v\n", err)
+		klog.Exitf("Start stream server error %v\n", err)
 		return
 	}
 }

--- a/cloud/pkg/cloudstream/tunnelserver.go
+++ b/cloud/pkg/cloudstream/tunnelserver.go
@@ -165,7 +165,7 @@ func (s *TunnelServer) Start() {
 	klog.Infof("Prepare to start tunnel server ...")
 	err = tunnelServer.ListenAndServeTLS("", "")
 	if err != nil {
-		klog.Fatalf("Start tunnelServer error %v\n", err)
+		klog.Exitf("Start tunnelServer error %v\n", err)
 		return
 	}
 }

--- a/cloud/pkg/devicecontroller/devicecontroller.go
+++ b/cloud/pkg/devicecontroller/devicecontroller.go
@@ -26,11 +26,11 @@ func newDeviceController(enable bool) *DeviceController {
 	}
 	downstream, err := controller.NewDownstreamController(informers.GetInformersManager().GetCRDInformerFactory())
 	if err != nil {
-		klog.Fatalf("New downstream controller failed with error: %s", err)
+		klog.Exitf("New downstream controller failed with error: %s", err)
 	}
 	upstream, err := controller.NewUpstreamController(downstream)
 	if err != nil {
-		klog.Fatalf("new upstream controller failed with error: %s", err)
+		klog.Exitf("new upstream controller failed with error: %s", err)
 	}
 	return &DeviceController{
 		downstream: downstream,
@@ -62,12 +62,12 @@ func (dc *DeviceController) Enable() bool {
 // Start controller
 func (dc *DeviceController) Start() {
 	if err := dc.downstream.Start(); err != nil {
-		klog.Fatalf("start downstream failed with error: %s", err)
+		klog.Exitf("start downstream failed with error: %s", err)
 	}
 	// wait for downstream controller to start and load deviceModels and devices
 	// TODO think about sync
 	time.Sleep(1 * time.Second)
 	if err := dc.upstream.Start(); err != nil {
-		klog.Fatalf("start upstream failed with error: %s", err)
+		klog.Exitf("start upstream failed with error: %s", err)
 	}
 }

--- a/cloud/pkg/dynamiccontroller/application/eventhandler.go
+++ b/cloud/pkg/dynamiccontroller/application/eventhandler.go
@@ -113,7 +113,7 @@ func NewCommonResourceEventHandler(gvr schema.GroupVersionResource, informerFact
 	klog.Infof("[metaserver/resourceEventHandler] handler(%v) init, wait for informer starting...", gvr)
 	for gvr, cacheSync := range informerFactory.WaitForCacheSync(beehiveContext.Done()) {
 		if !cacheSync {
-			klog.Fatalf("unable to sync caches for: %s", gvr.String())
+			klog.Exitf("unable to sync caches for: %s", gvr.String())
 		}
 	}
 	handler.informer = informer

--- a/cloud/pkg/dynamiccontroller/dynamiccontroller.go
+++ b/cloud/pkg/dynamiccontroller/dynamiccontroller.go
@@ -63,7 +63,7 @@ func (dctl *DynamicController) Start() {
 	dctl.dynamicSharedInformerFactory.Start(beehiveContext.Done())
 	for gvr, cacheSync := range dctl.dynamicSharedInformerFactory.WaitForCacheSync(beehiveContext.Done()) {
 		if !cacheSync {
-			klog.Fatalf("unable to sync caches for: %s", gvr.String())
+			klog.Exitf("unable to sync caches for: %s", gvr.String())
 		}
 	}
 

--- a/cloud/pkg/edgecontroller/edgecontroller.go
+++ b/cloud/pkg/edgecontroller/edgecontroller.go
@@ -25,13 +25,13 @@ func newEdgeController(config *v1alpha1.EdgeController, tunnelPort int) *EdgeCon
 	var err error
 	ec.upstream, err = controller.NewUpstreamController(config, informers.GetInformersManager().GetK8sInformerFactory())
 	if err != nil {
-		klog.Fatalf("new upstream controller failed with error: %s", err)
+		klog.Exitf("new upstream controller failed with error: %s", err)
 	}
 	ec.upstream.TunnelPort = tunnelPort
 
 	ec.downstream, err = controller.NewDownstreamController(config, informers.GetInformersManager().GetK8sInformerFactory(), informers.GetInformersManager(), informers.GetInformersManager().GetCRDInformerFactory())
 	if err != nil {
-		klog.Fatalf("new downstream controller failed with error: %s", err)
+		klog.Exitf("new downstream controller failed with error: %s", err)
 	}
 	return ec
 }
@@ -58,10 +58,10 @@ func (ec *EdgeController) Enable() bool {
 // Start controller
 func (ec *EdgeController) Start() {
 	if err := ec.upstream.Start(); err != nil {
-		klog.Fatalf("start upstream failed with error: %s", err)
+		klog.Exitf("start upstream failed with error: %s", err)
 	}
 
 	if err := ec.downstream.Start(); err != nil {
-		klog.Fatalf("start downstream failed with error: %s", err)
+		klog.Exitf("start downstream failed with error: %s", err)
 	}
 }

--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -56,19 +56,19 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 			flag.PrintFlags(cmd.Flags())
 
 			if errs := opts.Validate(); len(errs) > 0 {
-				klog.Fatal(util.SpliceErrors(errs))
+				klog.Exit(util.SpliceErrors(errs))
 			}
 
 			config, err := opts.Config()
 			if err != nil {
-				klog.Fatal(err)
+				klog.Exit(err)
 			}
 			if errs := validation.ValidateEdgeCoreConfiguration(config); len(errs) > 0 {
-				klog.Fatal(util.SpliceErrors(errs.ToAggregate().Errors()))
+				klog.Exit(util.SpliceErrors(errs.ToAggregate().Errors()))
 			}
 
 			if err := features.DefaultMutableFeatureGate.SetFromMap(config.FeatureGates); err != nil {
-				klog.Fatal(err)
+				klog.Exit(err)
 			}
 
 			// To help debugging, immediately log version
@@ -83,7 +83,7 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 			if checkEnv != "false" {
 				// Check running environment before run edge core
 				if err := environmentCheck(); err != nil {
-					klog.Fatal(fmt.Errorf("failed to check the running environment: %v", err))
+					klog.Exit(fmt.Errorf("failed to check the running environment: %v", err))
 				}
 			}
 

--- a/edge/pkg/common/dbm/db.go
+++ b/edge/pkg/common/dbm/db.go
@@ -18,13 +18,13 @@ var once sync.Once
 func InitDBConfig(driverName, dbName, dataSource string) {
 	once.Do(func() {
 		if err := orm.RegisterDriver(driverName, orm.DRSqlite); err != nil {
-			klog.Fatalf("Failed to register driver: %v", err)
+			klog.Exitf("Failed to register driver: %v", err)
 		}
 		if err := orm.RegisterDataBase(
 			dbName,
 			driverName,
 			dataSource); err != nil {
-			klog.Fatalf("Failed to register db: %v", err)
+			klog.Exitf("Failed to register db: %v", err)
 		}
 		// sync database schema
 		if err := orm.RunSyncdb(dbName, false, true); err != nil {

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -783,7 +783,7 @@ func (e *edged) initializeModules() error {
 		if err := e.cadvisor.Start(); err != nil {
 			// Fail kubelet and rely on the babysitter to retry starting kubelet.
 			// TODO(random-liu): Add backoff logic in the babysitter
-			klog.Fatalf("Failed to start cAdvisor %v", err)
+			klog.Exitf("Failed to start cAdvisor %v", err)
 		}
 
 		// trigger on-demand stats collection once so that we have capacity information for ephemeral storage.

--- a/edge/pkg/edged/server/server.go
+++ b/edge/pkg/edged/server/server.go
@@ -45,5 +45,5 @@ func (s *Server) ListenAndServe(host server.HostInterface, resourceAnalyzer stat
 		Handler:        &handler,
 		MaxHeaderBytes: 1 << 20,
 	}
-	klog.Fatal(server.ListenAndServe())
+	klog.Exit(server.ListenAndServe())
 }

--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -90,7 +90,7 @@ func (cm *CertManager) Start() {
 	if err != nil {
 		err = cm.applyCerts()
 		if err != nil {
-			klog.Fatalf("Error: %v", err)
+			klog.Exitf("Error: %v", err)
 		}
 	}
 	if cm.RotateCertificates {

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -73,7 +73,7 @@ func (eh *EdgeHub) Start() {
 		}
 		err := eh.initial()
 		if err != nil {
-			klog.Fatalf("failed to init controller: %v", err)
+			klog.Exitf("failed to init controller: %v", err)
 			return
 		}
 

--- a/edge/pkg/edgestream/edgestream.go
+++ b/edge/pkg/edgestream/edgestream.go
@@ -77,7 +77,7 @@ func (e *edgestream) Start() {
 	if ok {
 		cert, err := tls.LoadX509KeyPair(config.Config.TLSTunnelCertFile, config.Config.TLSTunnelPrivateKeyFile)
 		if err != nil {
-			klog.Fatalf("Failed to load x509 key pair: %v", err)
+			klog.Exitf("Failed to load x509 key pair: %v", err)
 		}
 		tlsConfig := &tls.Config{
 			InsecureSkipVerify: true,

--- a/keadm/cmd/keadm/app/cmd/debug/get.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get.go
@@ -542,18 +542,18 @@ func SplitSelectorParameters(args string) ([]Selector, error) {
 func HumanReadablePrint(results []dao.Meta, printer printers.ResourcePrinter, out io.Writer) error {
 	res, err := ParseMetaToAPIList(results)
 	if err != nil {
-		klog.Fatal(err)
+		klog.Exit(err)
 	}
 	for _, r := range res {
 		table, err := ConvertDataToTable(r)
 		if err != nil {
-			klog.Fatal(err)
+			klog.Exit(err)
 		}
 		if err := printer.PrintObj(table, out); err != nil {
-			klog.Fatal(err)
+			klog.Exit(err)
 		}
 		if _, err := fmt.Fprintln(out); err != nil {
-			klog.Fatal(err)
+			klog.Exit(err)
 		}
 	}
 	return nil

--- a/keadm/cmd/keadm/app/cmd/version.go
+++ b/keadm/cmd/keadm/app/cmd/version.go
@@ -40,7 +40,7 @@ func RunVersion(out io.Writer, cmd *cobra.Command) error {
 	const flag = "output"
 	of, err := cmd.Flags().GetString(flag)
 	if err != nil {
-		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
+		klog.Exitf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
 	}
 
 	switch of {

--- a/keadm/cmd/keadm/keadm.go
+++ b/keadm/cmd/keadm/keadm.go
@@ -24,6 +24,6 @@ import (
 
 func main() {
 	if err := app.Run(); err != nil {
-		klog.Fatal(err)
+		klog.Exit(err)
 	}
 }

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/context/context_factory.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/context/context_factory.go
@@ -63,7 +63,7 @@ func InitContext(contextTypes []string) {
 			globalContext.moduleContext[contextType] = socketContext
 			globalContext.messageContext[contextType] = socketContext
 		default:
-			klog.Fatalf("unsupported context type: %s", contextType)
+			klog.Exitf("unsupported context type: %s", contextType)
 		}
 	}
 }

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/core.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/core.go
@@ -36,7 +36,7 @@ func StartModules() {
 				},
 			}
 		default:
-			klog.Fatalf("unsupported context type: %s", module.contextType)
+			klog.Exitf("unsupported context type: %s", module.contextType)
 		}
 
 		beehiveContext.AddModule(&m)


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
`klog.Fatal` will print error info, including a stack trace of all running goroutines, then calls os.Exit(255).
trace contains too much info, about hundreds of lines, and these trace are helpless for debug why component progress exit abnormally.
But `klog.Exit` will only print logs, and calls os.Exit(1). And dont print stack trace.
And so it's helpful and more easily for us to find the definite reason why component start failed.
So we replace log functions as below
```
klog.Fatal => klog.Exit
klog.Fatalf => klog.Exitf
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
