### PR TITLE
support labelselector for metaserver

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -71,9 +72,8 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ob
 	return nil
 }
 
-//TODO: implement it
 func (s *store) GetToList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
-	panic("GetToList implement me")
+	return s.List(ctx, key, opts, listObj)
 }
 
 func (s *store) List(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
@@ -103,6 +103,15 @@ func (s *store) List(ctx context.Context, key string, opts storage.ListOptions, 
 
 		labelSet := labels.Set(unstrObj.GetLabels())
 		if !opts.Predicate.Label.Matches(labelSet) {
+			continue
+		}
+
+		// only support metadata.name & metadata.namespace
+		fieldSet := fields.Set{
+			"metadata.name":      unstrObj.GetName(),
+			"metadata.namespace": unstrObj.GetNamespace(),
+		}
+		if !opts.Predicate.Field.Matches(fieldSet) {
 			continue
 		}
 

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
@@ -99,6 +100,18 @@ func (s *store) List(ctx context.Context, key string, opts storage.ListOptions, 
 		if err != nil {
 			return err
 		}
+
+		if !opts.Predicate.Label.Empty() {
+			tmpObjLabels := unstrObj.GetLabels()
+			if tmpObjLabels == nil {
+				continue
+			}
+			var objLabels = (labels.Set)(tmpObjLabels)
+			if !opts.Predicate.Label.Matches(objLabels) {
+				continue
+			}
+		}
+
 		unstrList.Items = append(unstrList.Items, unstrObj)
 	}
 	rv := strconv.FormatUint(resp.Revision, 10)

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -101,15 +101,9 @@ func (s *store) List(ctx context.Context, key string, opts storage.ListOptions, 
 			return err
 		}
 
-		if !opts.Predicate.Label.Empty() {
-			tmpObjLabels := unstrObj.GetLabels()
-			if tmpObjLabels == nil {
-				continue
-			}
-			var objLabels = (labels.Set)(tmpObjLabels)
-			if !opts.Predicate.Label.Matches(objLabels) {
-				continue
-			}
+		labelSet := labels.Set(unstrObj.GetLabels())
+		if !opts.Predicate.Label.Matches(labelSet) {
+			continue
 		}
 
 		unstrList.Items = append(unstrList.Items, unstrObj)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
If the network of edge-node is ok, we send /list request with labelSelector, it works ok.
If edge-node is offline, metaserver does not support labelSelector filter, and the full amount of data will be returned.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: