### PR TITLE
add bind-address config option and remove address in websocket/quic/https

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -44,7 +44,12 @@ func StartHTTPServer() {
 	router.HandleFunc(constants.DefaultCertURL, edgeCoreClientCert).Methods(http.MethodGet)
 	router.HandleFunc(constants.DefaultCAURL, getCA).Methods(http.MethodGet)
 
-	addr := fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.HTTPS.Port)
+	var addr string
+	if hubconfig.Config.BindAddress != "" {
+		addr = fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.HTTPS.Port)
+	} else {
+		addr = fmt.Sprintf("%s:%d", hubconfig.Config.HTTPS.Address, hubconfig.Config.HTTPS.Port)
+	}
 
 	cert, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: hubconfig.Config.Cert}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: hubconfig.Config.Key}))
 

--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -44,7 +44,7 @@ func StartHTTPServer() {
 	router.HandleFunc(constants.DefaultCertURL, edgeCoreClientCert).Methods(http.MethodGet)
 	router.HandleFunc(constants.DefaultCAURL, getCA).Methods(http.MethodGet)
 
-	addr := fmt.Sprintf("%s:%d", hubconfig.Config.HTTPS.Address, hubconfig.Config.HTTPS.Port)
+	addr := fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.HTTPS.Port)
 
 	cert, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: hubconfig.Config.Cert}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: hubconfig.Config.Key}))
 

--- a/cloud/pkg/cloudhub/servers/server.go
+++ b/cloud/pkg/cloudhub/servers/server.go
@@ -53,13 +53,19 @@ func createTLSConfig(ca, cert, key []byte) tls.Config {
 
 func startWebsocketServer() {
 	tlsConfig := createTLSConfig(hubconfig.Config.Ca, hubconfig.Config.Cert, hubconfig.Config.Key)
+	var addr string
+	if hubconfig.Config.BindAddress != "" {
+		addr = fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.WebSocket.Port)
+	} else {
+		addr = fmt.Sprintf("%s:%d", hubconfig.Config.WebSocket.Address, hubconfig.Config.WebSocket.Port)
+	}
 
 	svc := server.Server{
 		Type:       api.ProtocolTypeWS,
 		TLSConfig:  &tlsConfig,
 		AutoRoute:  true,
 		ConnNotify: handler.CloudhubHandler.OnRegister,
-		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.WebSocket.Port),
+		Addr:       addr,
 		ExOpts:     api.WSServerOption{Path: "/"},
 	}
 	klog.Infof("Starting cloudhub %s server", api.ProtocolTypeWS)
@@ -68,13 +74,19 @@ func startWebsocketServer() {
 
 func startQuicServer() {
 	tlsConfig := createTLSConfig(hubconfig.Config.Ca, hubconfig.Config.Cert, hubconfig.Config.Key)
+	var addr string
+	if hubconfig.Config.BindAddress != "" {
+		addr = fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.WebSocket.Port)
+	} else {
+		addr = fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.Quic.Port)
+	}
 
 	svc := server.Server{
 		Type:       api.ProtocolTypeQuic,
 		TLSConfig:  &tlsConfig,
 		AutoRoute:  true,
 		ConnNotify: handler.CloudhubHandler.OnRegister,
-		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.Quic.Port),
+		Addr:       addr,
 		ExOpts:     api.QuicServerOption{MaxIncomingStreams: int(hubconfig.Config.Quic.MaxIncomingStreams)},
 	}
 

--- a/cloud/pkg/cloudhub/servers/server.go
+++ b/cloud/pkg/cloudhub/servers/server.go
@@ -53,12 +53,13 @@ func createTLSConfig(ca, cert, key []byte) tls.Config {
 
 func startWebsocketServer() {
 	tlsConfig := createTLSConfig(hubconfig.Config.Ca, hubconfig.Config.Cert, hubconfig.Config.Key)
+
 	svc := server.Server{
 		Type:       api.ProtocolTypeWS,
 		TLSConfig:  &tlsConfig,
 		AutoRoute:  true,
 		ConnNotify: handler.CloudhubHandler.OnRegister,
-		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.WebSocket.Address, hubconfig.Config.WebSocket.Port),
+		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.WebSocket.Port),
 		ExOpts:     api.WSServerOption{Path: "/"},
 	}
 	klog.Infof("Starting cloudhub %s server", api.ProtocolTypeWS)
@@ -67,12 +68,13 @@ func startWebsocketServer() {
 
 func startQuicServer() {
 	tlsConfig := createTLSConfig(hubconfig.Config.Ca, hubconfig.Config.Cert, hubconfig.Config.Key)
+
 	svc := server.Server{
 		Type:       api.ProtocolTypeQuic,
 		TLSConfig:  &tlsConfig,
 		AutoRoute:  true,
 		ConnNotify: handler.CloudhubHandler.OnRegister,
-		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.Quic.Address, hubconfig.Config.Quic.Port),
+		Addr:       fmt.Sprintf("%s:%d", hubconfig.Config.BindAddress, hubconfig.Config.Quic.Port),
 		ExOpts:     api.QuicServerOption{MaxIncomingStreams: int(hubconfig.Config.Quic.MaxIncomingStreams)},
 	}
 

--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -95,6 +95,9 @@ func addJoinOtherFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 	cmd.Flags().StringVar(&initOpts.AdvertiseAddress, types.AdvertiseAddress, initOpts.AdvertiseAddress,
 		"Use this key to set IPs in cloudcore's certificate SubAltNames field. eg: 10.10.102.78,10.10.102.79")
 
+	cmd.Flags().StringVar(&initOpts.BindAddress, types.BindAddress, initOpts.BindAddress,
+		"Use this key to set IP in cloudcore's bind-address as mqtt/websocket/https IP address field. eg: 0.0.0.0")
+
 	cmd.Flags().StringVar(&initOpts.DNS, types.DomainName, initOpts.DNS,
 		"Use this key to set domain names in cloudcore's certificate SubAltNames field. eg: www.cloudcore.cn,www.kubeedge.cn")
 
@@ -136,6 +139,7 @@ func Add2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string
 	toolList["Cloud"] = &util.KubeCloudInstTool{
 		Common:           common,
 		AdvertiseAddress: initOptions.AdvertiseAddress,
+		BindAddress:      initOptions.BindAddress,
 		DNSName:          initOptions.DNS,
 		TarballPath:      initOptions.TarballPath,
 	}

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -61,6 +61,8 @@ const (
 
 	AdvertiseAddress = "advertise-address"
 
+	BindAddress = "bind-address"
+
 	TokenSecretName = "tokensecret"
 
 	TokenDataName = "tokendata"

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -26,6 +26,7 @@ type InitOptions struct {
 	KubeConfig       string
 	Master           string
 	AdvertiseAddress string
+	BindAddress      string
 	DNS              string
 	TarballPath      string
 }

--- a/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/cloudinstaller.go
@@ -15,6 +15,7 @@ import (
 type KubeCloudInstTool struct {
 	Common
 	AdvertiseAddress string
+	BindAddress      string
 	DNSName          string
 	TarballPath      string
 }
@@ -52,6 +53,10 @@ func (cu *KubeCloudInstTool) InstallTools() error {
 
 	if cu.AdvertiseAddress != "" {
 		cloudCoreConfig.Modules.CloudHub.AdvertiseAddress = strings.Split(cu.AdvertiseAddress, ",")
+	}
+
+	if cu.BindAddress != "" {
+		cloudCoreConfig.Modules.CloudHub.BindAddress = cu.BindAddress
 	}
 
 	if cu.DNSName != "" {

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -72,13 +72,13 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				},
 				WebSocket: &CloudHubWebSocket{
 					Enable:  true,
-					Address: "0.0.0.0",
 					Port:    10000,
+					Address: "0.0.0.0",
 				},
 				HTTPS: &CloudHubHTTPS{
 					Enable:  true,
-					Address: "0.0.0.0",
 					Port:    10002,
+					Address: "0.0.0.0",
 				},
 			},
 			EdgeController: &EdgeController{
@@ -205,13 +205,13 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 				},
 				WebSocket: &CloudHubWebSocket{
 					Enable:  true,
-					Address: "0.0.0.0",
 					Port:    10000,
+					Address: "0.0.0.0",
 				},
 				HTTPS: &CloudHubHTTPS{
 					Enable:  true,
-					Address: "0.0.0.0",
 					Port:    10002,
+					Address: "0.0.0.0",
 				},
 			},
 			Router: &Router{

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -62,6 +62,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				TokenRefreshDuration:    12,
 				Quic: &CloudHubQUIC{
 					Enable:             false,
+					Address:            "0.0.0.0",
 					Port:               10001,
 					MaxIncomingStreams: 10000,
 				},
@@ -70,12 +71,14 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					Address: "unix:///var/lib/kubeedge/kubeedge.sock",
 				},
 				WebSocket: &CloudHubWebSocket{
-					Enable: true,
-					Port:   10000,
+					Enable:  true,
+					Address: "0.0.0.0",
+					Port:    10000,
 				},
 				HTTPS: &CloudHubHTTPS{
-					Enable: true,
-					Port:   10002,
+					Enable:  true,
+					Address: "0.0.0.0",
+					Port:    10002,
 				},
 			},
 			EdgeController: &EdgeController{
@@ -201,12 +204,14 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 					Address: "unix:///var/lib/kubeedge/kubeedge.sock",
 				},
 				WebSocket: &CloudHubWebSocket{
-					Enable: true,
-					Port:   10000,
+					Enable:  true,
+					Address: "0.0.0.0",
+					Port:    10000,
 				},
 				HTTPS: &CloudHubHTTPS{
-					Enable: true,
-					Port:   10002,
+					Enable:  true,
+					Address: "0.0.0.0",
+					Port:    10002,
 				},
 			},
 			Router: &Router{

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -56,12 +56,12 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				TLSPrivateKeyFile:       constants.DefaultKeyFile,
 				WriteTimeout:            30,
 				AdvertiseAddress:        []string{advertiseAddress.String()},
+				BindAddress:             "0.0.0.0",
 				DNSNames:                []string{""},
 				EdgeCertSigningDuration: 365,
 				TokenRefreshDuration:    12,
 				Quic: &CloudHubQUIC{
 					Enable:             false,
-					Address:            "0.0.0.0",
 					Port:               10001,
 					MaxIncomingStreams: 10000,
 				},
@@ -70,14 +70,12 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					Address: "unix:///var/lib/kubeedge/kubeedge.sock",
 				},
 				WebSocket: &CloudHubWebSocket{
-					Enable:  true,
-					Port:    10000,
-					Address: "0.0.0.0",
+					Enable: true,
+					Port:   10000,
 				},
 				HTTPS: &CloudHubHTTPS{
-					Enable:  true,
-					Port:    10002,
-					Address: "0.0.0.0",
+					Enable: true,
+					Port:   10002,
 				},
 			},
 			EdgeController: &EdgeController{
@@ -197,19 +195,18 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 				TLSCertFile:       constants.DefaultCertFile,
 				TLSPrivateKeyFile: constants.DefaultKeyFile,
 				AdvertiseAddress:  []string{advertiseAddress.String()},
+				BindAddress:       "0.0.0.0",
 				UnixSocket: &CloudHubUnixSocket{
 					Enable:  true,
 					Address: "unix:///var/lib/kubeedge/kubeedge.sock",
 				},
 				WebSocket: &CloudHubWebSocket{
-					Enable:  true,
-					Port:    10000,
-					Address: "0.0.0.0",
+					Enable: true,
+					Port:   10000,
 				},
 				HTTPS: &CloudHubHTTPS{
-					Enable:  true,
-					Port:    10002,
-					Address: "0.0.0.0",
+					Enable: true,
+					Port:   10002,
 				},
 			},
 			Router: &Router{

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -129,6 +129,9 @@ type CloudHub struct {
 	HTTPS *CloudHubHTTPS `json:"https,omitempty"`
 	// AdvertiseAddress sets the IP address for the cloudcore to advertise.
 	AdvertiseAddress []string `json:"advertiseAddress,omitempty"`
+	// BindAddress sets the IP address for WebSocket, Quic, and HTTPS addresses.
+	// default "0.0.0.0"
+	BindAddress string `json:"bindAddress,omitempty"`
 	// DNSNames sets the DNSNames for CloudCore.
 	DNSNames []string `json:"dnsNames,omitempty"`
 	// EdgeCertSigningDuration indicates the validity period of edge certificate
@@ -144,9 +147,6 @@ type CloudHubQUIC struct {
 	// Enable indicates whether enable quic protocol
 	// default false
 	Enable bool `json:"enable"`
-	// Address set server ip address
-	// default 0.0.0.0
-	Address string `json:"address,omitempty"`
 	// Port set open port for quic server
 	// default 10001
 	Port uint32 `json:"port,omitempty"`
@@ -170,9 +170,6 @@ type CloudHubWebSocket struct {
 	// Enable indicates whether enable websocket protocol
 	// default true
 	Enable bool `json:"enable"`
-	// Address indicates server ip address
-	// default 0.0.0.0
-	Address string `json:"address,omitempty"`
 	// Port indicates the open port for websocket server
 	// default 10000
 	Port uint32 `json:"port,omitempty"`
@@ -183,9 +180,6 @@ type CloudHubHTTPS struct {
 	// Enable indicates whether enable Https protocol
 	// default true
 	Enable bool `json:"enable"`
-	// Address indicates server ip address
-	// default 0.0.0.0
-	Address string `json:"address,omitempty"`
 	// Port indicates the open port for HTTPS server
 	// default 10002
 	Port uint32 `json:"port,omitempty"`

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -147,6 +147,10 @@ type CloudHubQUIC struct {
 	// Enable indicates whether enable quic protocol
 	// default false
 	Enable bool `json:"enable"`
+	// Address set server ip address
+	// default 0.0.0.0
+	//TODO: remove this field at v1.13, be replaced by CloudHub.BindAddress
+	Address string `json:"address,omitempty"`
 	// Port set open port for quic server
 	// default 10001
 	Port uint32 `json:"port,omitempty"`
@@ -170,6 +174,10 @@ type CloudHubWebSocket struct {
 	// Enable indicates whether enable websocket protocol
 	// default true
 	Enable bool `json:"enable"`
+	// Address indicates server ip address
+	// default 0.0.0.0
+	//TODO: remove this field at v1.13, be replaced by CloudHub.BindAddress
+	Address string `json:"address,omitempty"`
 	// Port indicates the open port for websocket server
 	// default 10000
 	Port uint32 `json:"port,omitempty"`
@@ -180,6 +188,10 @@ type CloudHubHTTPS struct {
 	// Enable indicates whether enable Https protocol
 	// default true
 	Enable bool `json:"enable"`
+	// Address indicates server ip address
+	// default 0.0.0.0
+	//TODO: remove this field at v1.13, be replaced by CloudHub.BindAddress
+	Address string `json:"address,omitempty"`
 	// Port indicates the open port for HTTPS server
 	// default 10002
 	Port uint32 `json:"port,omitempty"`

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
@@ -68,18 +68,17 @@ func ValidateModuleCloudHub(c v1alpha1.CloudHub) field.ErrorList {
 		}
 	}
 	if len(validAddress) > 0 {
-		for _, m := range validAddress {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.BindAddress, m))
-		}
-	}
-	if len(validWSAddress) > 0 {
-		for _, m := range validWSAddress {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.WebSocket.Address, m))
-		}
-	}
-	if len(validQAddress) > 0 {
-		for _, m := range validQAddress {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.Quic.Address, m))
+		if len(validWSAddress) > 0 || len(validQAddress) > 0 {
+			for _, m := range validWSAddress {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.WebSocket.Address, m))
+			}
+			for _, m := range validQAddress {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.Quic.Address, m))
+			}
+		} else {
+			for _, m := range validAddress {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.BindAddress, m))
+			}
 		}
 	}
 

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
@@ -53,6 +53,8 @@ func ValidateModuleCloudHub(c v1alpha1.CloudHub) field.ErrorList {
 	validHTTPSPort := utilvalidation.IsValidPortNum(int(c.HTTPS.Port))
 	validWPort := utilvalidation.IsValidPortNum(int(c.WebSocket.Port))
 	validAddress := utilvalidation.IsValidIP(c.BindAddress)
+	validWSAddress := utilvalidation.IsValidIP(c.WebSocket.Address)
+	validQAddress := utilvalidation.IsValidIP(c.Quic.Address)
 	validQPort := utilvalidation.IsValidPortNum(int(c.Quic.Port))
 
 	if len(validHTTPSPort) > 0 {
@@ -70,6 +72,17 @@ func ValidateModuleCloudHub(c v1alpha1.CloudHub) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.BindAddress, m))
 		}
 	}
+	if len(validWSAddress) > 0 {
+		for _, m := range validWSAddress {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.WebSocket.Address, m))
+		}
+	}
+	if len(validQAddress) > 0 {
+		for _, m := range validQAddress {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.Quic.Address, m))
+		}
+	}
+
 	if len(validQPort) > 0 {
 		for _, m := range validQPort {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("port"), c.Quic.Port, m))

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation.go
@@ -52,9 +52,8 @@ func ValidateModuleCloudHub(c v1alpha1.CloudHub) field.ErrorList {
 	allErrs := field.ErrorList{}
 	validHTTPSPort := utilvalidation.IsValidPortNum(int(c.HTTPS.Port))
 	validWPort := utilvalidation.IsValidPortNum(int(c.WebSocket.Port))
-	validAddress := utilvalidation.IsValidIP(c.WebSocket.Address)
+	validAddress := utilvalidation.IsValidIP(c.BindAddress)
 	validQPort := utilvalidation.IsValidPortNum(int(c.Quic.Port))
-	validQAddress := utilvalidation.IsValidIP(c.Quic.Address)
 
 	if len(validHTTPSPort) > 0 {
 		for _, m := range validHTTPSPort {
@@ -68,17 +67,12 @@ func ValidateModuleCloudHub(c v1alpha1.CloudHub) field.ErrorList {
 	}
 	if len(validAddress) > 0 {
 		for _, m := range validAddress {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.WebSocket.Address, m))
+			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.BindAddress, m))
 		}
 	}
 	if len(validQPort) > 0 {
 		for _, m := range validQPort {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("port"), c.Quic.Port, m))
-		}
-	}
-	if len(validQAddress) > 0 {
-		for _, m := range validQAddress {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("Address"), c.Quic.Address, m))
 		}
 	}
 	if !strings.HasPrefix(strings.ToLower(c.UnixSocket.Address), "unix://") {

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
@@ -129,7 +129,7 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			name: "case4 invalid websocket addr",
 			input: v1alpha1.CloudHub{
 				Enable:      true,
-				BindAddress: "xxx.xxx.xxx.xxx",
+				BindAddress: "127.0.0.1",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},
@@ -172,7 +172,7 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			expected: field.ErrorList{field.Invalid(field.NewPath("port"), uint32(0), "must be between 1 and 65535, inclusive")},
 		},
 		{
-			name: "case6 invalid websocket addr",
+			name: "case6 invalid quic addr",
 			input: v1alpha1.CloudHub{
 				Enable:      true,
 				BindAddress: "127.0.0.1",

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
@@ -129,7 +129,7 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			name: "case4 invalid websocket addr",
 			input: v1alpha1.CloudHub{
 				Enable:      true,
-				BindAddress: "127.0.0.1",
+				BindAddress: "xxx.xxx.xxx.xxx",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},
@@ -175,7 +175,7 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			name: "case6 invalid quic addr",
 			input: v1alpha1.CloudHub{
 				Enable:      true,
-				BindAddress: "127.0.0.1",
+				BindAddress: "xxx.xxx.xxx.xxx",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
@@ -82,17 +82,16 @@ func TestValidateModuleCloudHub(t *testing.T) {
 		{
 			name: "case2 invalid https port",
 			input: v1alpha1.CloudHub{
-				Enable: true,
+				Enable:      true,
+				BindAddress: "127.0.0.1",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 0,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -104,17 +103,16 @@ func TestValidateModuleCloudHub(t *testing.T) {
 		{
 			name: "case3 invalid websocket port",
 			input: v1alpha1.CloudHub{
-				Enable: true,
+				Enable:      true,
+				BindAddress: "127.0.0.1",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port:    0,
-					Address: "127.0.0.1",
+					Port: 0,
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -124,19 +122,18 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			expected: field.ErrorList{field.Invalid(field.NewPath("port"), uint32(0), "must be between 1 and 65535, inclusive")},
 		},
 		{
-			name: "case4 invalid websocket addr",
+			name: "case4 invalid bind address",
 			input: v1alpha1.CloudHub{
-				Enable: true,
+				Enable:      true,
+				BindAddress: "xxx.xxx.xxx.xxx",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port:    10002,
-					Address: "xxx.xxx.xxx.xxx",
+					Port: 10002,
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -148,17 +145,16 @@ func TestValidateModuleCloudHub(t *testing.T) {
 		{
 			name: "case5 invalid quic port",
 			input: v1alpha1.CloudHub{
-				Enable: true,
+				Enable:      true,
+				BindAddress: "127.0.0.1",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port:    0,
-					Address: "127.0.0.1",
+					Port: 0,
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -168,41 +164,18 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			expected: field.ErrorList{field.Invalid(field.NewPath("port"), uint32(0), "must be between 1 and 65535, inclusive")},
 		},
 		{
-			name: "case6 invalid websocket addr",
+			name: "case6 invalid unixSocketAddress",
 			input: v1alpha1.CloudHub{
-				Enable: true,
+				Enable:      true,
+				BindAddress: "127.0.0.1",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port:    10002,
-					Address: "xxx.xxx.xxx.xxx",
-				},
-				UnixSocket: &v1alpha1.CloudHubUnixSocket{
-					Address: unixAddr,
-				},
-				TokenRefreshDuration: 1,
-			},
-			expected: field.ErrorList{field.Invalid(field.NewPath("Address"), "xxx.xxx.xxx.xxx", "must be a valid IP address, (e.g. 10.9.8.7)")},
-		},
-		{
-			name: "case7 invalid unixSocketAddress",
-			input: v1alpha1.CloudHub{
-				Enable: true,
-				HTTPS: &v1alpha1.CloudHubHTTPS{
-					Port: 10000,
-				},
-				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port:    10002,
-					Address: "127.0.0.1",
-				},
-				Quic: &v1alpha1.CloudHubQUIC{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: "var/lib/kubeedge/kubeedge.sock",
@@ -213,19 +186,18 @@ func TestValidateModuleCloudHub(t *testing.T) {
 				"var/lib/kubeedge/kubeedge.sock", "unixSocketAddress must has prefix unix://")},
 		},
 		{
-			name: "case8 invalid TokenRefreshDuration",
+			name: "case7 invalid TokenRefreshDuration",
 			input: v1alpha1.CloudHub{
-				Enable: true,
+				Enable:      true,
+				BindAddress: "127.0.0.1",
 				HTTPS: &v1alpha1.CloudHubHTTPS{
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port:    10002,
-					Address: "127.0.0.1",
+					Port: 10002,
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
@@ -88,10 +88,12 @@ func TestValidateModuleCloudHub(t *testing.T) {
 					Port: 0,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -109,10 +111,12 @@ func TestValidateModuleCloudHub(t *testing.T) {
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port: 0,
+					Port:    0,
+					Address: "127.0.0.1",
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -122,7 +126,7 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			expected: field.ErrorList{field.Invalid(field.NewPath("port"), uint32(0), "must be between 1 and 65535, inclusive")},
 		},
 		{
-			name: "case4 invalid bind address",
+			name: "case4 invalid websocket addr",
 			input: v1alpha1.CloudHub{
 				Enable:      true,
 				BindAddress: "xxx.xxx.xxx.xxx",
@@ -130,10 +134,12 @@ func TestValidateModuleCloudHub(t *testing.T) {
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port: 10002,
+					Port:    10002,
+					Address: "xxx.xxx.xxx.xxx",
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -151,10 +157,12 @@ func TestValidateModuleCloudHub(t *testing.T) {
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port: 0,
+					Port:    0,
+					Address: "127.0.0.1",
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -164,7 +172,7 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			expected: field.ErrorList{field.Invalid(field.NewPath("port"), uint32(0), "must be between 1 and 65535, inclusive")},
 		},
 		{
-			name: "case6 invalid unixSocketAddress",
+			name: "case6 invalid websocket addr",
 			input: v1alpha1.CloudHub{
 				Enable:      true,
 				BindAddress: "127.0.0.1",
@@ -172,10 +180,35 @@ func TestValidateModuleCloudHub(t *testing.T) {
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port: 10002,
+					Port:    10002,
+					Address: "xxx.xxx.xxx.xxx",
+				},
+				UnixSocket: &v1alpha1.CloudHubUnixSocket{
+					Address: unixAddr,
+				},
+				TokenRefreshDuration: 1,
+			},
+			expected: field.ErrorList{field.Invalid(field.NewPath("Address"), "xxx.xxx.xxx.xxx", "must be a valid IP address, (e.g. 10.9.8.7)")},
+		},
+		{
+			name: "case7 invalid unixSocketAddress",
+			input: v1alpha1.CloudHub{
+				Enable:      true,
+				BindAddress: "127.0.0.1",
+				HTTPS: &v1alpha1.CloudHubHTTPS{
+					Port: 10000,
+				},
+				WebSocket: &v1alpha1.CloudHubWebSocket{
+					Port:    10002,
+					Address: "127.0.0.1",
+				},
+				Quic: &v1alpha1.CloudHubQUIC{
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: "var/lib/kubeedge/kubeedge.sock",
@@ -186,7 +219,7 @@ func TestValidateModuleCloudHub(t *testing.T) {
 				"var/lib/kubeedge/kubeedge.sock", "unixSocketAddress must has prefix unix://")},
 		},
 		{
-			name: "case7 invalid TokenRefreshDuration",
+			name: "case8 invalid TokenRefreshDuration",
 			input: v1alpha1.CloudHub{
 				Enable:      true,
 				BindAddress: "127.0.0.1",
@@ -194,10 +227,12 @@ func TestValidateModuleCloudHub(t *testing.T) {
 					Port: 10000,
 				},
 				WebSocket: &v1alpha1.CloudHubWebSocket{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				Quic: &v1alpha1.CloudHubQUIC{
-					Port: 10002,
+					Port:    10002,
+					Address: "127.0.0.1",
 				},
 				UnixSocket: &v1alpha1.CloudHubUnixSocket{
 					Address: unixAddr,
@@ -206,6 +241,29 @@ func TestValidateModuleCloudHub(t *testing.T) {
 			},
 			expected: field.ErrorList{field.Invalid(field.NewPath("TokenRefreshDuration"),
 				time.Duration(0), "TokenRefreshDuration must be positive")},
+		},
+		{
+			name: "case9 invalid bind address",
+			input: v1alpha1.CloudHub{
+				Enable:      true,
+				BindAddress: "xxx.xxx.xxx.xxx",
+				HTTPS: &v1alpha1.CloudHubHTTPS{
+					Port: 10000,
+				},
+				WebSocket: &v1alpha1.CloudHubWebSocket{
+					Port:    10002,
+					Address: "127.0.0.1",
+				},
+				Quic: &v1alpha1.CloudHubQUIC{
+					Port:    10002,
+					Address: "127.0.0.1",
+				},
+				UnixSocket: &v1alpha1.CloudHubUnixSocket{
+					Address: unixAddr,
+				},
+				TokenRefreshDuration: 1,
+			},
+			expected: field.ErrorList{field.Invalid(field.NewPath("Address"), "xxx.xxx.xxx.xxx", "must be a valid IP address, (e.g. 10.9.8.7)")},
 		},
 	}
 

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -22,10 +22,11 @@ import (
 )
 
 // IsValidIP tests that the argument is a valid IP address.
-func IsValidIP(value string) []string {
-	if net.ParseIP(value) == nil {
+func IsValidIP(IP string) []string {
+	if net.ParseIP(IP) == nil {
 		return []string{"must be a valid IP address, (e.g. 10.9.8.7)"}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
websocket/quic/https configures of cloudhub all have address config, so combine these to one config bind-address
add bind-address config option and remove address in websocket/quic/https
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of #1642

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
