### PR TITLE
replace go get with go install

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Install dependences
         run: |
-          command -v ginkgo || go get github.com/onsi/ginkgo/ginkgo
+          command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@latest
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -124,8 +124,8 @@ jobs:
 
       - name: Install dependences
         run: |
-          command -v ginkgo || go get github.com/onsi/ginkgo/ginkgo
-          go get sigs.k8s.io/kind@v0.11.1
+          command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@latest
+          go install sigs.k8s.io/kind@v0.11.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
       - name: Checkout code
@@ -154,8 +154,8 @@ jobs:
 
       - name: Install dependences
         run: |
-          command -v ginkgo || go get github.com/onsi/ginkgo/ginkgo
-          go get sigs.k8s.io/kind@v0.11.1
+          command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@latest
+          go install sigs.k8s.io/kind@v0.11.1
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
           export RELEASE_VERSION=$(wget -qO - https://kubeedge.io/latestversion | cat)
           sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/checksum_kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz.txt

--- a/edge/test/integration/scripts/execute.sh
+++ b/edge/test/integration/scripts/execute.sh
@@ -30,7 +30,7 @@ function do_preparation() {
   sudo mkdir -p /var/lib/kubeedge
 
   which ginkgo &>/dev/null || {
-    go get github.com/onsi/ginkgo/ginkgo
+    go install github.com/onsi/ginkgo/ginkgo@latest
     sudo cp $GOPATH/bin/ginkgo /usr/bin/
   }
 

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -32,7 +32,7 @@ function check_kind {
   command -v kind >/dev/null 2>&1
   if [[ $? -ne 0 ]]; then
     echo "installing kind ."
-    GO111MODULE="on" go get sigs.k8s.io/kind@v0.11.1
+    GO111MODULE="on" go install sigs.k8s.io/kind@v0.11.1
     if [[ $? -ne 0 ]]; then
       echo "kind installed failed, exiting."
       exit 1

--- a/tests/e2e/scripts/execute.sh
+++ b/tests/e2e/scripts/execute.sh
@@ -23,7 +23,7 @@ curpath=$PWD
 echo $PWD
 
 which ginkgo &> /dev/null || (
-    go get github.com/onsi/ginkgo/ginkgo
+    go install github.com/onsi/ginkgo/ginkgo@latest
     sudo cp $GOPATH/bin/ginkgo /usr/local/bin/
 )
 

--- a/tests/performance/scripts/jenkins.sh
+++ b/tests/performance/scripts/jenkins.sh
@@ -36,7 +36,7 @@ sudo rm -rf $PWD/loadtest/loadtest.test
 sudo rm -rf $PWD/nodedensity/nodedensity.test
 sudo rm -rf $PWD/hubtest/hubtest.test
 
-go get github.com/onsi/ginkgo/ginkgo
+go install github.com/onsi/ginkgo/ginkgo@latest
 sudo cp $GOPATH/bin/ginkgo /usr/bin/
 # Specify the module name to compile in below command
 bash -x $PWD/scripts/compileperf.sh $1


### PR DESCRIPTION
Signed-off-by: gy95 <guoyao17@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead.
ref: https://golang.org/doc/go-get-install-deprecation
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
