### PR TITLE
do not create objectsync for msg which has no namespace

### DIFF
--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -524,6 +524,9 @@ func (mh *MessageHandle) send(hi hubio.CloudHubIO, info *model.HubInfo, msg *bee
 func (mh *MessageHandle) saveSuccessPoint(msg *beehiveModel.Message, info *model.HubInfo, nodeStore cache.Store) {
 	if msg.GetGroup() == edgeconst.GroupResource {
 		resourceNamespace, _ := edgemessagelayer.GetNamespace(*msg)
+		if resourceNamespace == "" {
+			return
+		}
 		resourceName, _ := edgemessagelayer.GetResourceName(*msg)
 		resourceType, _ := edgemessagelayer.GetResourceType(*msg)
 		resourceUID, err := channelq.GetMessageUID(*msg)


### PR DESCRIPTION
Signed-off-by: chenchunxiu <chenchunxiu_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
if msg has no namespace,  create/get/delete objectSync occurs because of no namespace

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note

```
