### PR TITLE
change kubeletEndpoint port when cloudstream conneted

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -127,10 +127,10 @@ kubernetes controller which manages devices so that the device metadata/status d
 // registerModules register all the modules started in cloudcore
 func registerModules(c *v1alpha1.CloudCoreConfig) {
 	cloudhub.Register(c.Modules.CloudHub)
-	edgecontroller.Register(c.Modules.EdgeController, c.CommonConfig)
+	edgecontroller.Register(c.Modules.EdgeController)
 	devicecontroller.Register(c.Modules.DeviceController)
 	synccontroller.Register(c.Modules.SyncController)
-	cloudstream.Register(c.Modules.CloudStream)
+	cloudstream.Register(c.Modules.CloudStream, c.CommonConfig)
 	router.Register(c.Modules.Router)
 	dynamiccontroller.Register(c.Modules.DynamicController)
 }

--- a/cloud/pkg/cloudstream/cloudstream.go
+++ b/cloud/pkg/cloudstream/cloudstream.go
@@ -26,17 +26,21 @@ import (
 
 type cloudStream struct {
 	enable bool
+
+	tunnelPort int
 }
 
-func newCloudStream(enable bool) *cloudStream {
+func newCloudStream(enable bool, tunnelPort int) *cloudStream {
 	return &cloudStream{
 		enable: enable,
+
+		tunnelPort: tunnelPort,
 	}
 }
 
-func Register(controller *v1alpha1.CloudStream) {
+func Register(controller *v1alpha1.CloudStream, commonConfig *v1alpha1.CommonConfig) {
 	config.InitConfigure(controller)
-	core.Register(newCloudStream(controller.Enable))
+	core.Register(newCloudStream(controller.Enable, commonConfig.TunnelPort))
 }
 
 func (s *cloudStream) Name() string {
@@ -51,7 +55,7 @@ func (s *cloudStream) Start() {
 	// TODO: Will improve in the future
 	ok := <-cloudhub.DoneTLSTunnelCerts
 	if ok {
-		ts := newTunnelServer()
+		ts := newTunnelServer(s.tunnelPort)
 
 		// start new tunnel server
 		go ts.Start()

--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -93,8 +93,6 @@ type UpstreamController struct {
 
 	config v1alpha1.EdgeController
 
-	TunnelPort int
-
 	// message channel
 	nodeStatusChan            chan model.Message
 	podStatusChan             chan model.Message
@@ -392,7 +390,6 @@ func (uc *UpstreamController) updatePodStatus() {
 // createNode create new edge node to kubernetes
 func (uc *UpstreamController) createNode(name string, node *v1.Node) (*v1.Node, error) {
 	node.Name = name
-	node.Status.DaemonEndpoints.KubeletEndpoint.Port = int32(uc.TunnelPort)
 	return uc.kubeClient.CoreV1().Nodes().Create(context.Background(), node, metaV1.CreateOptions{})
 }
 
@@ -508,10 +505,9 @@ func (uc *UpstreamController) updateNodeStatus() {
 				// Keep the same "VolumesAttached" attribute with upstream,
 				// since this value is maintained by kube-controller-manager.
 				nodeStatusRequest.Status.VolumesAttached = getNode.Status.VolumesAttached
+				nodeStatusRequest.Status.DaemonEndpoints.KubeletEndpoint.Port = getNode.Status.DaemonEndpoints.KubeletEndpoint.Port
 
 				getNode.Status = nodeStatusRequest.Status
-
-				getNode.Status.DaemonEndpoints.KubeletEndpoint.Port = int32(uc.TunnelPort)
 
 				node, err := uc.kubeClient.CoreV1().Nodes().UpdateStatus(context.Background(), getNode, metaV1.UpdateOptions{})
 				if err != nil {

--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -505,7 +505,9 @@ func (uc *UpstreamController) updateNodeStatus() {
 				// Keep the same "VolumesAttached" attribute with upstream,
 				// since this value is maintained by kube-controller-manager.
 				nodeStatusRequest.Status.VolumesAttached = getNode.Status.VolumesAttached
-				nodeStatusRequest.Status.DaemonEndpoints.KubeletEndpoint.Port = getNode.Status.DaemonEndpoints.KubeletEndpoint.Port
+				if getNode.Status.DaemonEndpoints.KubeletEndpoint.Port != 0 {
+					nodeStatusRequest.Status.DaemonEndpoints.KubeletEndpoint.Port = getNode.Status.DaemonEndpoints.KubeletEndpoint.Port
+				}
 
 				getNode.Status = nodeStatusRequest.Status
 

--- a/cloud/pkg/edgecontroller/edgecontroller.go
+++ b/cloud/pkg/edgecontroller/edgecontroller.go
@@ -17,7 +17,7 @@ type EdgeController struct {
 	downstream *controller.DownstreamController
 }
 
-func newEdgeController(config *v1alpha1.EdgeController, tunnelPort int) *EdgeController {
+func newEdgeController(config *v1alpha1.EdgeController) *EdgeController {
 	ec := &EdgeController{config: *config}
 	if !ec.Enable() {
 		return ec
@@ -27,7 +27,6 @@ func newEdgeController(config *v1alpha1.EdgeController, tunnelPort int) *EdgeCon
 	if err != nil {
 		klog.Exitf("new upstream controller failed with error: %s", err)
 	}
-	ec.upstream.TunnelPort = tunnelPort
 
 	ec.downstream, err = controller.NewDownstreamController(config, informers.GetInformersManager().GetK8sInformerFactory(), informers.GetInformersManager(), informers.GetInformersManager().GetCRDInformerFactory())
 	if err != nil {
@@ -36,8 +35,8 @@ func newEdgeController(config *v1alpha1.EdgeController, tunnelPort int) *EdgeCon
 	return ec
 }
 
-func Register(ec *v1alpha1.EdgeController, commonConfig *v1alpha1.CommonConfig) {
-	core.Register(newEdgeController(ec, commonConfig.TunnelPort))
+func Register(ec *v1alpha1.EdgeController) {
+	core.Register(newEdgeController(ec))
 }
 
 // Name of controller


### PR DESCRIPTION
Signed-off-by: chenchunxiu <chenchunxiu_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If cloudcore is multi-active (cloudcore1, cloudcore2, cloudcore3) and LB is used.
In bellowing case, kubectl exec/logs failed.

LB forward connection of cloudhub (from edge-node-01) to cloudcore1.    --- cloudhub port 10000
LB forward connection of cloudstream (from edge-node-01) to cloudcore2. --- cloudstream port 10004 

So, we should change kubeletEndpoint when cloudstrem conneted, not cloudhub connected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note

```
