### PR TITLE
Still allowed delete rule when source not exist

### DIFF
--- a/cloud/pkg/router/rule/rule.go
+++ b/cloud/pkg/router/rule/rule.go
@@ -147,14 +147,16 @@ func delRule(namespace, name string) {
 	rule := v.(*routerv1.Rule)
 
 	source, err := getSourceOfRule(rule)
-	if err != nil {
-		klog.Error(err)
-		return
+	// if source not exist, skip UnregisterListener
+	if err == nil {
+		klog.V(4).Infof("delRule: source of rule:%s exist, do UnregisterListener", rule.Spec.Source)
+		source.UnregisterListener()
+	} else {
+		klog.Warningf("delRule: source of rule:%s not exist, unnecessary do UnregisterListener:%v", rule.Spec.Source, err)
 	}
-	source.UnregisterListener()
 
 	rules.Delete(ruleKey)
-	klog.Infof("delete rule success: %s", ruleKey)
+	klog.V(4).Infof("delete rule success: %s", ruleKey)
 }
 
 func getSourceOfRule(rule *routerv1.Rule) (provider.Source, error) {


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
When router module monitor the rule delete event, if through getSourceOfRule method not get the source of the rule, we should skip UnregisterListener stage.
But the operation which delete rule from cache named "rules" shoud be allowed.

Does this PR introduce a user-facing change?:
NONE