### PR TITLE
Dynamiccontroller send sync message timeout configrable

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application.go
+++ b/cloud/pkg/dynamiccontroller/application/application.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller/config"
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller/messagelayer"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	edgemodule "github.com/kubeedge/kubeedge/edge/pkg/common/modules"
@@ -328,7 +329,7 @@ func (a *Agent) doApply(app *Application) {
 	app.Status = InApplying
 	msg := model.NewMessage("").SetRoute(MetaServerSource, modules.DynamicControllerModuleGroup).FillBody(app)
 	msg.SetResourceOperation("null", "null")
-	resp, err := beehiveContext.SendSync(edgemodule.EdgeHubModuleName, *msg, 10*time.Second)
+	resp, err := beehiveContext.SendSync(edgemodule.EdgeHubModuleName, *msg, time.Duration(config.Config.DynamicController.MsgTimeOut)*time.Second)
 	if err != nil {
 		app.Status = Failed
 		app.Reason = fmt.Sprintf("failed to access cloud Application center: %v", err)

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -148,7 +148,8 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				Enable: true,
 			},
 			DynamicController: &DynamicController{
-				Enable: false,
+				Enable:     false,
+				MsgTimeOut: 10,
 			},
 			CloudStream: &CloudStream{
 				Enable:                  false,

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -376,6 +376,10 @@ type DynamicController struct {
 	// if set to false (for debugging etc.), skip checking other dynamicController configs.
 	// default true
 	Enable bool `json:"enable"`
+
+	// MsgTimeOut indicates the overtime of send sync message
+	// default 10
+	MsgTimeOut int64 `json:"msgTimeOut,omitempty"`
 }
 
 // CloudSream indicates the stream controller


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
When send message to edgehub, make param timeout in dynamiccontroller configrable, then the modification will become easier.

Does this PR introduce a user-facing change?:
NONE