### PR TITLE
Add require rule and ruleendpoint resource from api

### DIFF
--- a/cloud/pkg/router/constants/constants.go
+++ b/cloud/pkg/router/constants/constants.go
@@ -5,4 +5,7 @@ const (
 	EventbusProvider   string = "eventbus"
 	GroupResource      string = "resource"
 	ServicebusProvider string = "servicebus"
+
+	ResourceTypeRules         string = "rules"
+	ResourceTypeRuleEndpoints string = "ruleendpoints"
 )


### PR DESCRIPTION
Signed-off-by: lvchenggang lvchenggang_yewu@cmss.chinamobile.com

What type of PR is this?
/kind feature

What this PR does / why we need it:
There exist a situation when rule and ruleendpoint crd resource create after cloudcore start, the cache in router module cannot save the rule and ruleendpoint resource where k8s subsequently create.
So this patch add getResourceFromApi method to solve this problem.

Does this PR introduce a user-facing change?:
NONE