### PR TITLE
Fix: resType does not match

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/listener.go
+++ b/cloud/pkg/dynamiccontroller/application/listener.go
@@ -1,6 +1,8 @@
 package application
 
 import (
+	"strings"
+
 	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,6 +15,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/constants"
 	v2 "github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/v2"
+	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
 )
 
 type SelectorListener struct {
@@ -54,7 +57,9 @@ func (l *SelectorListener) sendObj(event watch.Event, messageLayer messagelayer.
 	if namespace == "" {
 		namespace = v2.NullNamespace
 	}
-	resource, err := messagelayer.BuildResource(l.nodeName, namespace, l.gvr.Resource, accessor.GetName())
+	kind := util.UnsafeResourceToKind(l.gvr.Resource)
+	resourceType := strings.ToLower(kind)
+	resource, err := messagelayer.BuildResource(l.nodeName, namespace, resourceType, accessor.GetName())
 	if err != nil {
 		klog.Warningf("built message resource failed with error: %s", err)
 		return

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -161,6 +161,11 @@ const (
 	redirectContainerStream = false
 	// ResolvConfDefault gives the default dns resolv configration file
 	ResolvConfDefault = "/etc/resolv.conf"
+
+	ResourceTypePods       = "pods"
+	ResourceTypeSecrets    = "secrets"
+	ResourceTypeConfigMaps = "configmaps"
+	CSIResourceTypeVolumes = "volumes"
 )
 
 // podReady holds the initPodReady flag and its lock
@@ -1128,7 +1133,7 @@ func (e *edged) syncPod() {
 		}
 		klog.Infof("result content is %s", result.Content)
 		switch resType {
-		case model.ResourceTypePod:
+		case model.ResourceTypePod, ResourceTypePods:
 			if op == model.ResponseOperation && resID == "" && result.GetSource() == metamanager.MetaManagerModuleName {
 				err := e.handlePodListFromMetaManager(content)
 				if err != nil {
@@ -1150,7 +1155,7 @@ func (e *edged) syncPod() {
 					continue
 				}
 			}
-		case model.ResourceTypeConfigmap:
+		case model.ResourceTypeConfigmap, ResourceTypeConfigMaps:
 			if op != model.ResponseOperation {
 				err := e.handleConfigMap(op, content)
 				if err != nil {
@@ -1160,7 +1165,7 @@ func (e *edged) syncPod() {
 				klog.Infof("skip to handle configMap with type response")
 				continue
 			}
-		case model.ResourceTypeSecret:
+		case model.ResourceTypeSecret, ResourceTypeSecrets:
 			if op != model.ResponseOperation {
 				err := e.handleSecret(op, content)
 				if err != nil {
@@ -1170,7 +1175,7 @@ func (e *edged) syncPod() {
 				klog.Infof("skip to handle secret with type response")
 				continue
 			}
-		case constants.CSIResourceTypeVolume:
+		case constants.CSIResourceTypeVolume, CSIResourceTypeVolumes:
 			klog.Infof("volume operation type: %s", op)
 			res, err := e.handleVolume(op, content)
 			if err != nil {

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -161,11 +161,6 @@ const (
 	redirectContainerStream = false
 	// ResolvConfDefault gives the default dns resolv configration file
 	ResolvConfDefault = "/etc/resolv.conf"
-
-	ResourceTypePods       = "pods"
-	ResourceTypeSecrets    = "secrets"
-	ResourceTypeConfigMaps = "configmaps"
-	CSIResourceTypeVolumes = "volumes"
 )
 
 // podReady holds the initPodReady flag and its lock
@@ -1133,7 +1128,7 @@ func (e *edged) syncPod() {
 		}
 		klog.Infof("result content is %s", result.Content)
 		switch resType {
-		case model.ResourceTypePod, ResourceTypePods:
+		case model.ResourceTypePod:
 			if op == model.ResponseOperation && resID == "" && result.GetSource() == metamanager.MetaManagerModuleName {
 				err := e.handlePodListFromMetaManager(content)
 				if err != nil {
@@ -1155,7 +1150,7 @@ func (e *edged) syncPod() {
 					continue
 				}
 			}
-		case model.ResourceTypeConfigmap, ResourceTypeConfigMaps:
+		case model.ResourceTypeConfigmap:
 			if op != model.ResponseOperation {
 				err := e.handleConfigMap(op, content)
 				if err != nil {
@@ -1165,7 +1160,7 @@ func (e *edged) syncPod() {
 				klog.Infof("skip to handle configMap with type response")
 				continue
 			}
-		case model.ResourceTypeSecret, ResourceTypeSecrets:
+		case model.ResourceTypeSecret:
 			if op != model.ResponseOperation {
 				err := e.handleSecret(op, content)
 				if err != nil {
@@ -1175,7 +1170,7 @@ func (e *edged) syncPod() {
 				klog.Infof("skip to handle secret with type response")
 				continue
 			}
-		case constants.CSIResourceTypeVolume, CSIResourceTypeVolumes:
+		case constants.CSIResourceTypeVolume:
 			klog.Infof("volume operation type: %s", op)
 			res, err := e.handleVolume(op, content)
 			if err != nil {

--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -50,9 +50,13 @@ func UnsafeResourceToKind(r string) string {
 		return r
 	}
 	unusualResourceToKind := map[string]string{
-		"endpoints": "Endpoints",
-		"nodes":     "Node",
-		"services":  "Service",
+		"endpoints":                    "Endpoints",
+		"nodes":                        "Node",
+		"services":                     "Service",
+		"podstatus":                    "PodStatus",
+		"nodestatus":                   "NodeStatus",
+		"customresourcedefinitions":    "CustomResourceDefinition",
+		"customresourcedefinitionlist": "CustomResourceDefinitionList",
 	}
 	if v, isUnusual := unusualResourceToKind[r]; isUnusual {
 		return v
@@ -74,7 +78,11 @@ func UnsafeKindToResource(k string) string {
 		return k
 	}
 	unusualKindToResource := map[string]string{
-		"Endpoints": "endpoints",
+		"Endpoints":                    "endpoints",
+		"PodStatus":                    "podstatus",
+		"NodeStatus":                   "nodestatus",
+		"CustomResourceDefinition":     "customresourcedefinitions",
+		"CustomResourceDefinitionList": "customresourcedefinitionlist",
 	}
 	if v, isUnusual := unusualKindToResource[k]; isUnusual {
 		return v


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When running `edgecore` normally, I will always see such an error:
```
E1111 17:25:26.918430 4131180 edged.go:1181] resType is not pod or configmap or secret or volume: esType is pods
```
it can be pods or secrets or configmaps or volumes


The reason for this problem is probably that the resource of msg from `edgeController` is in singular form(pod), but the resource of msg from `dynamicController` is in plural form(pods), but it has not been considered by `edged.syncPod()`. 
This problem is explained in #2833 and tried to resolved in #2836. But I don’t know why it was not merged...

**Which issue(s) this PR fixes**:
Fixes #2833

**Special notes for your reviewer**:
Because the queue for Edged processing is deduplicated, it doesn’t matter if send the same msg twice.

**Does this PR introduce a user-facing change?**:
none

