### PR TITLE
[WIP] add nodelease feature gate

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller"
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller"
 	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller"
+	"github.com/kubeedge/kubeedge/cloud/pkg/nodeleasecontroller"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router"
 	"github.com/kubeedge/kubeedge/cloud/pkg/synccontroller"
 	"github.com/kubeedge/kubeedge/common/constants"
@@ -89,6 +90,11 @@ kubernetes controller which manages devices so that the device metadata/status d
 
 			gis := informers.GetInformersManager()
 
+			if !features.DefaultMutableFeatureGate.Enabled(features.NodeLease) {
+				// If not enable NodeLease feature gate, nodelease controller should not run.
+				config.Modules.NodeLeaseController.Enable = false
+			}
+
 			registerModules(config)
 
 			// IptablesManager manages tunnel port related iptables rules
@@ -133,6 +139,7 @@ func registerModules(c *v1alpha1.CloudCoreConfig) {
 	cloudstream.Register(c.Modules.CloudStream)
 	router.Register(c.Modules.Router)
 	dynamiccontroller.Register(c.Modules.DynamicController)
+	nodeleasecontroller.Register(c.Modules.NodeLeaseController)
 }
 
 func NegotiateTunnelPort() (*int, error) {

--- a/cloud/pkg/common/modules/modules.go
+++ b/cloud/pkg/common/modules/modules.go
@@ -16,6 +16,9 @@ const (
 	DynamicControllerModuleName  = "dynamiccontroller"
 	DynamicControllerModuleGroup = "dynamiccontroller"
 
+	NodeLeaseControllerModuleName  = "nodeleasecontroller"
+	NodeLeaseControllerModuleGroup = "nodeleasecontroller"
+
 	CloudStreamModuleName = "cloudStream"
 	CloudStreamGroupName  = "cloudStream"
 

--- a/cloud/pkg/nodeleasecontroller/nodeleasecontroller.go
+++ b/cloud/pkg/nodeleasecontroller/nodeleasecontroller.go
@@ -1,0 +1,378 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeleasecontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	coordclientset "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+
+	"github.com/kubeedge/beehive/pkg/core"
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+const (
+	// renewIntervalFraction is the fraction of lease duration to renew the lease
+	renewIntervalFraction = 0.25
+	// maxUpdateRetries is the number of retries the nodelease controller will attempt to
+	// update the nodelease after receiving the heartbeat messages from edge nodes.
+	maxUpdateRetries = 5
+	// maxBackoff is the maximum sleep time during backoff (e.g. in backoffEnsureLease)
+	maxBackoff = 7 * time.Second
+)
+
+type HeartbeatMsg struct {
+	Timestamp string
+	NodeName  string
+}
+
+type nodeHeartbeat struct {
+	updateRetryTimes int
+	HeartbeatMsg
+}
+
+// parse will parse the HeartbeatMsg to get nodeName and timestamp.
+func (n *nodeHeartbeat) parse(timeLayout string) (string, *time.Time, error) {
+	nodeName := n.NodeName
+	heartbeatTimestamp, err := time.Parse(timeLayout, string(n.Timestamp))
+	if err != nil {
+		return nodeName, nil, fmt.Errorf("failed to parse heartbeatMsg: %s, node: %s", n.Timestamp, nodeName)
+	}
+	return nodeName, &heartbeatTimestamp, nil
+}
+
+type NodeLeaseController struct {
+	enable        bool
+	client        clientset.Interface
+	leaseClient   coordclientset.LeaseInterface
+	heartbeatCh   chan *nodeHeartbeat
+	ensureRetryCh chan *nodeHeartbeat
+
+	// leaseDurationSeconds       int32
+	renewInterval       time.Duration
+	retryHeartbeatQueue workqueue.DelayingInterface
+	retryEnsureQueue    workqueue.RateLimitingInterface
+	timeLayout          string
+
+	// latestLease is a map contains the latest node lease of each edge node
+	// which nodelease controller updated or created.
+	latestLease map[string]*coordinationv1.Lease
+}
+
+func Register(c *v1alpha1.NodeLeaseController) {
+	core.Register(NewNodeLeaseController(c.Enable))
+}
+
+func (c *NodeLeaseController) Name() string {
+	return modules.NodeLeaseControllerModuleName
+}
+
+func (c *NodeLeaseController) Group() string {
+	return modules.NodeLeaseControllerModuleGroup
+}
+
+func (c *NodeLeaseController) Enable() bool {
+	return c.enable
+}
+
+// NewNodeLeaseController constructs and returns a nodelease controller
+func NewNodeLeaseController(enable bool) *NodeLeaseController {
+	client := client.GetKubeClient()
+	leaseClient := client.CoordinationV1().Leases(corev1.NamespaceNodeLease)
+	nodeLimit := v1alpha1.NewDefaultCloudCoreConfig().Modules.CloudHub.NodeLimit
+	return &NodeLeaseController{
+		enable:        enable,
+		client:        client,
+		leaseClient:   leaseClient,
+		heartbeatCh:   make(chan *nodeHeartbeat, nodeLimit),
+		ensureRetryCh: make(chan *nodeHeartbeat, nodeLimit),
+		timeLayout:    constants.DefaultTimestampLayout, // edgehub also reports its heartbeat timestamp in DefaultTimestampLayout
+		// TODO: set renewInterval according to heartbeat time
+		renewInterval:       time.Duration(renewIntervalFraction * float64(10*time.Second)),
+		retryHeartbeatQueue: workqueue.NewDelayingQueue(),
+		retryEnsureQueue:    workqueue.NewRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(100*time.Millisecond, maxBackoff)),
+		latestLease:         make(map[string]*coordinationv1.Lease),
+	}
+}
+
+// Start runs the controller
+func (c *NodeLeaseController) Start() {
+	if c.leaseClient == nil {
+		klog.Infof("node lease controller has nil lease client, will not claim or renew leases")
+		return
+	}
+
+	klog.Info("Starting NodeLease Controller")
+
+	go c.processMessage()
+	go c.sync()
+	// retry updatelease
+	go func() {
+		for {
+			retryCase, shutdown := c.retryHeartbeatQueue.Get()
+			if shutdown {
+				klog.Infof("stop retry updatelease for nodelease controller")
+				return
+			}
+			c.heartbeatCh <- retryCase.(*nodeHeartbeat)
+		}
+	}()
+
+	// retry ensurelease
+	go func() {
+		for {
+			retryCase, shutdown := c.retryEnsureQueue.Get()
+			if shutdown {
+				klog.Infof("stop retry ensurelease for nodelease controller")
+				return
+			}
+			c.ensureRetryCh <- retryCase.(*nodeHeartbeat)
+		}
+	}()
+}
+
+func (c *NodeLeaseController) processMessage() {
+	for {
+		select {
+		case <-beehiveContext.Done():
+			klog.Info("stop processMessage of nodelease controller")
+			return
+		default:
+		}
+		msg, err := beehiveContext.Receive(modules.NodeLeaseControllerModuleName)
+		if err != nil {
+			klog.Warningf("nodelease controller processMessage reveive message failed, %s", err)
+			continue
+		}
+		heartbeat := msg.GetContent().(HeartbeatMsg)
+		klog.V(4).Infof("nodelease controller get heartbeat message: %v", heartbeat)
+		c.heartbeatCh <- &nodeHeartbeat{
+			updateRetryTimes: 0,
+			HeartbeatMsg:     heartbeat,
+		}
+	}
+}
+
+func (c *NodeLeaseController) sync() {
+	for {
+		select {
+		case <-beehiveContext.Done():
+			klog.Infof("node lease controller stopped")
+			c.retryHeartbeatQueue.ShutDown()
+			c.retryEnsureQueue.ShutDown()
+			return
+
+		case nodeHeartbeat := <-c.heartbeatCh:
+			// try to update nodelease
+			nodeName, heartbeatTimestamp, err := nodeHeartbeat.parse(c.timeLayout)
+			if err != nil {
+				klog.Errorf("failed to parse heartbeat, %v, ignore the msg", err)
+				continue
+			}
+
+			// filter out nodeHearbeat which has reached its maxRetryTimes.
+			if !c.needUpdate(nodeHeartbeat) {
+				continue
+			}
+
+			latestLease, ok := c.latestLease[nodeName]
+			if ok && latestLease != nil {
+				// As long as node lease is not (or very rarely) updated by any other agent than the nodelease controller,
+				// we can optimistically assume it didn't change since our last update and try updating
+				// based on the version from that time. Thanks to it we avoid GET call and reduce load
+				// on etcd and kube-apiserver.
+				// If at some point other agents will also be frequently updating the Lease object, this
+				// can result in performance degradation, because we will end up with calling additional
+				// GET/PUT - at this point this whole "if" should be removed.
+				err := c.updateLease(nodeName, latestLease, heartbeatTimestamp)
+				if err == nil {
+					continue
+				}
+				klog.Errorf("failed to update lease using latest lease, fallback to ensure lease, err: %v", err)
+			}
+
+			c.ensureLeaseWithRetry(nodeHeartbeat)
+
+		case nodeHeartbeat := <-c.ensureRetryCh:
+			// ensureRetry workqueue has different rate from heartbeatRetry workqueue.
+			// Thus, we process it in another case.
+			c.ensureLeaseWithRetry(nodeHeartbeat)
+		}
+	}
+}
+
+// This function will ensure that the nodelease exists in APIServer and the local latestLease
+// has the same resourceVersion as the corresponding nodeLease in APIServer. When it finds
+// both conditions are satisfied, it will try to update the nodelease once. If any error occurs,
+// it will retry operations with different strategies:
+// 1. ensureLease failed: exponentially increasing waits
+// 2. updateLease failed: fixed interval waits with max retry times
+//
+// When it comes to ensureLeaseWithRetry, there're two possible cases:
+// 1) the corresponding nodelease does not exsit in APIServer
+// 2) the local lastestLease has different resourceVersion from the nodelease in APIServer, which
+// means the nodelease was changed by someone else. It's optimisticLockError and requires getting
+// the newer version of lease to proceed.
+func (c *NodeLeaseController) ensureLeaseWithRetry(heartbeatCase *nodeHeartbeat) {
+	nodeName, heartbeatTimestamp, err := heartbeatCase.parse(c.timeLayout)
+	if err != nil {
+		klog.Errorf("unknown format of nodeHeartbeat message, drop it: %v", err)
+		return
+	}
+
+	lease, created, err := c.backoffEnsureLease(nodeName, heartbeatTimestamp)
+	if err != nil {
+		klog.Errorf("sync heartbeat for node: %s failed, timestamp: %s, retry ensure at next time", nodeName, heartbeatTimestamp)
+		c.retryEnsureQueue.AddRateLimited(heartbeatCase)
+		return
+	}
+
+	// Now, we ensure that the nodelease of the node exists and make lastestLease up to date.
+	c.latestLease[nodeName] = lease
+	// we don't need to update the lease if we just created it
+	if !created && lease != nil {
+		if err := c.updateLease(nodeName, lease, heartbeatTimestamp); err != nil {
+			// Here we've ensured the nodelease and tried to update again, and finally failed.
+			// Now there's nothing we can do for it, so just retry at the next time.
+			klog.Errorf("failed to update nodelease for %s, %v, will retry after %v", nodeName, err, c.renewInterval)
+			heartbeatCase.updateRetryTimes++
+			c.retryHeartbeatQueue.AddAfter(heartbeatCase, c.renewInterval)
+			return
+		}
+	}
+}
+
+func (c *NodeLeaseController) needUpdate(updateCase *nodeHeartbeat) bool {
+	// TODO： consider that if we need to filter out expired heartbeat msg
+	return updateCase.updateRetryTimes <= maxUpdateRetries
+}
+
+// backoffEnsureLease attempts to create the lease if it does not exist.
+// Returns the lease, and true if this call created the lease,
+// false otherwise.
+func (c *NodeLeaseController) backoffEnsureLease(nodeName string, heartbeatTimestamp *time.Time) (*coordinationv1.Lease, bool, error) {
+	var (
+		lease   *coordinationv1.Lease
+		created bool
+		err     error
+	)
+
+	lease, created, err = c.ensureLease(nodeName, heartbeatTimestamp)
+	if err == nil {
+		return lease, created, nil
+	}
+
+	return lease, created, fmt.Errorf("failed to ensure node lease exists, will retry at next time, error: %v", err)
+}
+
+// ensureLease creates the lease if it does not exist. Returns the lease and
+// a bool (true if this call created the lease), or any error that occurs.
+func (c *NodeLeaseController) ensureLease(nodeName string, heartbeatTimestamp *time.Time) (*coordinationv1.Lease, bool, error) {
+	lease, err := c.leaseClient.Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// lease does not exist, create it.
+		leaseToCreate := c.newLease(nodeName, nil, heartbeatTimestamp)
+		if leaseToCreate == nil {
+			return nil, false, fmt.Errorf("failed to get new lease, ensureLease failed for node: %s", nodeName)
+		}
+
+		if len(leaseToCreate.OwnerReferences) == 0 {
+			// We want to ensure that a lease will always have OwnerReferences set.
+			// Thus, given that we weren't able to set it correctly, we simply
+			// not create it this time - we will retry in the next iteration.
+			return nil, false, nil
+		}
+		lease, err := c.leaseClient.Create(context.TODO(), leaseToCreate, metav1.CreateOptions{})
+		if err != nil {
+			return nil, false, err
+		}
+		return lease, true, nil
+	} else if err != nil {
+		// unexpected error getting lease
+		return nil, false, err
+	}
+	// lease already existed
+	return lease, false, nil
+}
+
+// updateLease attempts to update the lease
+// call this once you're sure the lease has been created
+func (c *NodeLeaseController) updateLease(nodeName string, base *coordinationv1.Lease, heartbeatTimestamp *time.Time) error {
+	lease, err := c.leaseClient.Update(context.TODO(), c.newLease(nodeName, base, heartbeatTimestamp), metav1.UpdateOptions{})
+	if err == nil {
+		c.latestLease[nodeName] = lease
+		return nil
+	}
+	klog.Errorf("failed to update node lease, error: %v", err)
+
+	return fmt.Errorf("failed %d attempts to update node lease", maxUpdateRetries)
+}
+
+// newLease constructs a new lease if base is nil, or returns a copy of base
+// with desired state asserted on the copy.
+func (c *NodeLeaseController) newLease(nodeName string, base *coordinationv1.Lease, heartbeatTimestamp *time.Time) *coordinationv1.Lease {
+	// Use the bare minimum set of fields; other fields exist for debugging/legacy,
+	// but we don't need to make node heartbeats more complicated by using them.
+	var lease *coordinationv1.Lease
+	if base == nil {
+		lease = &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodeName,
+				Namespace: corev1.NamespaceNodeLease,
+			},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: pointer.StringPtr(nodeName),
+			},
+		}
+	} else {
+		lease = base.DeepCopy()
+	}
+
+	lease.Spec.RenewTime = &metav1.MicroTime{Time: *heartbeatTimestamp}
+
+	// Setting owner reference needs node's UID.
+	if len(lease.OwnerReferences) == 0 {
+		if node, err := c.client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{}); err == nil {
+			lease.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: corev1.SchemeGroupVersion.WithKind("Node").Version,
+					Kind:       corev1.SchemeGroupVersion.WithKind("Node").Kind,
+					Name:       nodeName,
+					UID:        node.UID,
+				},
+			}
+		} else {
+			klog.Errorf("failed to get node %q when trying to set owner ref to the node lease: %v", nodeName, err)
+		}
+	}
+
+	return lease
+}

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -46,6 +46,7 @@ const (
 	DefaultRemoteImageEndpoint         = "unix:///var/run/dockershim.sock"
 	DefaultPodSandboxImage             = "kubeedge/pause:3.1"
 	DefaultNodeStatusUpdateFrequency   = 10
+	DefaultNodeStatusReportFrequency   = 60
 	DefaultImagePullProgressDeadline   = 60
 	DefaultRuntimeRequestTimeout       = 2
 	DefaultImageGCHighThreshold        = 80
@@ -63,6 +64,9 @@ const (
 	DefaultTunnelPort                  = 10004
 
 	CurrentSupportK8sVersion = "v1.19.3"
+
+	// DefaultTimestampLayout represents the heartbeat timestamp format
+	DefaultTimestampLayout = time.RFC1123Z
 
 	// MetaManager
 	DefaultPodStatusSyncInterval = 60

--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -100,6 +100,12 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 			}
 			klog.Infof("Local IP: %s", config.Modules.Edged.NodeIP)
 
+			if !features.DefaultMutableFeatureGate.Enabled(features.NodeLease) {
+				// if not enable nodelease feature gate, ignore NodeStatusReportFrequency
+				// then the edged will update node status at the frequency of NodeStatusUpdateFrequency
+				config.Modules.Edged.NodeStatusReportFrequency = 0
+			}
+
 			registerModules(config)
 			// start all modules
 			core.Run()

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -260,6 +260,13 @@ type edged struct {
 
 	// Pod killer handles pods to be killed
 	podKiller PodKiller
+
+	// nodeStatusReportFrequency is the frequency that edged posts node status.
+	nodeStatusReportFrequency time.Duration
+	// lastStatusReportTime is the time when node status was last reported.
+	lastStatusReportTime time.Time
+	// lastReportStatus is the node status reported at lastStatusReportTime
+	lastReportStatus *v1.NodeStatus
 }
 
 // Register register edged
@@ -460,6 +467,7 @@ func newEdged(enable bool) (*edged, error) {
 		metaClient:                metaClient,
 		kubeClient:                fakekube.NewSimpleClientset(metaClient),
 		nodeStatusUpdateFrequency: time.Duration(edgedconfig.Config.NodeStatusUpdateFrequency) * time.Second,
+		nodeStatusReportFrequency: time.Duration(edgedconfig.Config.NodeStatusReportFrequency) * time.Second,
 		mounter:                   mount.New(""),
 		uid:                       types.UID("38796d14-1df3-11e8-8e5a-286ed488f209"),
 		version:                   fmt.Sprintf("%s-kubeedge-%s", constants.CurrentSupportK8sVersion, version.Get()),

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -8,6 +8,7 @@ import (
 
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/common/constants"
 	connect "github.com/kubeedge/kubeedge/edge/pkg/common/cloudconnection"
 	messagepkg "github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
@@ -166,7 +167,7 @@ func (eh *EdgeHub) keepalive() {
 		}
 		msg := model.NewMessage("").
 			BuildRouter(modules.EdgeHubModuleName, "resource", "node", messagepkg.OperationKeepalive).
-			FillBody("ping")
+			FillBody(time.Now().Format(constants.DefaultTimestampLayout))
 
 		// post message to cloud hub
 		err := eh.sendToCloud(*msg)

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -150,6 +150,9 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 			DynamicController: &DynamicController{
 				Enable: false,
 			},
+			NodeLeaseController: &NodeLeaseController{
+				Enable: true,
+			},
 			CloudStream: &CloudStream{
 				Enable:                  false,
 				TLSTunnelCAFile:         constants.DefaultCAFile,

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -80,6 +80,8 @@ type Modules struct {
 	SyncController *SyncController `json:"syncController,omitempty"`
 	// DynamicController indicates DynamicController module config
 	DynamicController *DynamicController `json:"dynamicController,omitempty"`
+	// NodeLeaseController indicates NodeLeaseController module config
+	NodeLeaseController *NodeLeaseController `json:"nodeLeaseController,omitempty"`
 	// CloudStream indicates cloudstream module config
 	CloudStream *CloudStream `json:"cloudStream,omitempty"`
 	// Router indicates router module config
@@ -374,6 +376,14 @@ type SyncController struct {
 type DynamicController struct {
 	// Enable indicates whether dynamicController is enabled,
 	// if set to false (for debugging etc.), skip checking other dynamicController configs.
+	// default true
+	Enable bool `json:"enable"`
+}
+
+// NodeLeaseController indicates the nodelease controller
+type NodeLeaseController struct {
+	// Enable indicates whether nodeleaseController is enabled,
+	// if set to false (for debugging etc.), skip checking other nodeleaseController configs.
 	// default true
 	Enable bool `json:"enable"`
 }

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -52,6 +52,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				Annotations:                 map[string]string{},
 				Taints:                      []v1.Taint{},
 				NodeStatusUpdateFrequency:   constants.DefaultNodeStatusUpdateFrequency,
+				NodeStatusReportFrequency:   constants.DefaultNodeStatusReportFrequency,
 				RuntimeType:                 constants.DefaultRuntimeType,
 				DockerAddress:               constants.DefaultDockerAddress,
 				RemoteRuntimeEndpoint:       constants.DefaultRemoteRuntimeEndpoint,

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -115,6 +115,10 @@ type Edged struct {
 	// NodeStatusUpdateFrequency indicates node status update frequency (second)
 	// default 10
 	NodeStatusUpdateFrequency int32 `json:"nodeStatusUpdateFrequency,omitempty"`
+	// nodeStatusReportFrequency indicates the interval between two reports of node status
+	// to the cloud. (second)
+	// default 60
+	NodeStatusReportFrequency int32 `json:"nodeStatusReportFrequency,omitempty"`
 	// RuntimeType indicates cri runtime ,support: docker, remote
 	// default "docker"
 	RuntimeType string `json:"runtimeType,omitempty"`

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -21,6 +21,9 @@ func init() {
 const (
 	// ProcessStatusSync supports synchronization between process message channel statuses
 	ProcessStatusSync featuregate.Feature = "ProcessStatusSync"
+
+	// NodeLease allow cloudcore to use lease to report edge node heartbeats
+	NodeLease featuregate.Feature = "NodeLease"
 )
 
 // defaultFeatureGates consists of all known Kubeedge-specific feature keys.
@@ -28,4 +31,5 @@ const (
 // available throughout Kubeedge binaries.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ProcessStatusSync: {Default: false, PreRelease: featuregate.Alpha},
+	NodeLease:         {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
Add a new feature gate `NodeLease` to kubeedge, users can enable the feature gate to use nodelease to update heartbeat rather than using nodeStatus.

<!--
Add one of the following kinds:
/kind feature


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
As we can see in the #3086, kubeedge used to update heartbeat with nodeStatus which is about 1KB. The frequent transmission of the nodeStatus(deafult every 10s) can result in overload on the weak cloud-edge network. With the `NodeLease` feature gate, we can reduce the heartbeat update packet size down to 0.2KB. I demonstrated it with tcpdump catching the packets sent from edgecore to the cloudcore during 5 min. The tcpdump output is as follows. The red box represents the heartbeat message and the yellow box represents the nodestatus message.

![Screenshot_20211113_130541](https://user-images.githubusercontent.com/32788286/141607501-8683e19c-6674-49e5-b84a-57fde1d66338.png)

Also I give the changes of `lastHeartbeatTime` and lease `renewTime` during serval minutes to display their relationship.  
**lastHearbeatTime of node0**  
```bash
[root@master ~]# while true; do
> kubectl get node node0 -o=go-template --template="lastHeartTime: {{ (index .status.conditions 0).lastHeartbeatTime}}" && echo ""
> sleep 10s
> done
lastHeartTime: 2021-11-13T03:48:38Z
lastHeartTime: 2021-11-13T03:48:38Z
lastHeartTime: 2021-11-13T03:48:38Z
lastHeartTime: 2021-11-13T03:48:38Z
lastHeartTime: 2021-11-13T03:49:38Z
lastHeartTime: 2021-11-13T03:49:38Z
lastHeartTime: 2021-11-13T03:49:38Z
lastHeartTime: 2021-11-13T03:49:38Z
lastHeartTime: 2021-11-13T03:49:38Z
lastHeartTime: 2021-11-13T03:49:38Z
lastHeartTime: 2021-11-13T03:50:38Z
lastHeartTime: 2021-11-13T03:50:38Z
lastHeartTime: 2021-11-13T03:50:38Z
lastHeartTime: 2021-11-13T03:50:38Z
lastHeartTime: 2021-11-13T03:50:38Z
lastHeartTime: 2021-11-13T03:50:38Z
```   
**lease renewTime**  
```bash
[root@master ~]# while true; do
> kubectl get lease node0 -n kube-node-lease -o=go-template --template="renewTime: {{.spec.renewTime}}" && echo ""
> sleep 10s
> done
renewTime: 2021-11-13T03:53:56.000000Z
renewTime: 2021-11-13T03:54:11.000000Z
renewTime: 2021-11-13T03:54:26.000000Z
renewTime: 2021-11-13T03:54:26.000000Z
renewTime: 2021-11-13T03:54:41.000000Z
renewTime: 2021-11-13T03:54:56.000000Z
renewTime: 2021-11-13T03:54:56.000000Z
renewTime: 2021-11-13T03:55:11.000000Z
renewTime: 2021-11-13T03:55:26.000000Z
renewTime: 2021-11-13T03:55:26.000000Z
renewTime: 2021-11-13T03:55:41.000000Z
renewTime: 2021-11-13T03:55:56.000000Z
renewTime: 2021-11-13T03:55:56.000000Z
```
We can find that the renewTime of nodelease is updated every 15s (the same as default `heartbeat` of edgehub), and the `lastHeartbeatTime` changes every 1 min (can be set in the config, which I'll describe bellow).  
This because a new nodelease controller has been introduced in kubeedge, to be specified, in cloudcore. It will continuously accept heartbeat msgs from all edge nodes connecting to it and then update corresponding nodeleases. So, the interval between every two lease renewTime is the same as `heartbeat` of edgehub.  
The interval of every two lastHeartbeatTime can be set through `nodeStatusReportFrequency` of edged. The default value is 60s currently.  When the `NodeLease` feature is enabled, the previous `nodeStatusUpdateFrequency` will be like a check interval. Edged will check the node status every `nodeStatusUpdateFrequency`. If there's no change, edged will not send a nodestatus update message until reaching the `nodeStatusReportFrequency`. Otherwise, it will send the most recent nodestatus to cloudcore.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3086 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**  

Now the `NodeLease` is in its alpha version and defaultly disabled. Users can enable the `NodeLease` feature through setting `NodeLease: true` in the `featureGates` filed of cloudcore and edgecore. Give an example here:
**cloudcore.yaml**
```yaml
apiVersion: cloudcore.config.kubeedge.io/v1alpha1
commonConfig:
  tunnelPort: 10350
kind: CloudCore
kubeAPIConfig:
  burst: 200
  contentType: application/vnd.kubernetes.protobuf
  kubeConfig:
  master: ""
  qps: 100
featureGates:
  NodeLease: true
modules:
  nodeLeaseController:
    enable: true
...
```
**edgecore.yaml**
```yaml
apiVersion: edgecore.config.kubeedge.io/v1alpha1
database:
  aliasName: default
  dataSource: /tmp/var/lib/kubeedge/edgecore.db
  driverName: sqlite3
kind: EdgeCore
featureGates:
  NodeLease: true
modules:
  edgeHub:
    heartbeat: 15
    ...
  edged:
    nodeStatusReportFrequency: 60
    nodeStatusUpdateFrequency: 10
    ...
```
And run cloudcore and edgecore with `cloudcore.yaml` and `edgecore.yaml` respectively, then you can use the `NodeLease` feature.  
Note: if the `NodeLease` feature gate is not enabled, the fields of `nodeLeaseController.enable` and `edged.nodeStatusReportFrequency` will be ignored. 


/kind feature