### PR TITLE
syncPod method add message content type choice in edged.go

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -1121,10 +1121,18 @@ func (e *edged) syncPod() {
 		}
 		op := result.GetOperation()
 
-		content, err := result.GetContentData()
-		if err != nil {
-			klog.Errorf("get message content data failed: %v", err)
-			continue
+		var content []byte
+		switch result.Content.(type) {
+		case []byte:
+			content = result.GetContent().([]byte)
+		case string:
+			content = []byte(result.GetContent().(string))
+		default:
+			content, err = json.Marshal(result.Content)
+			if err != nil {
+				klog.Errorf("marshal message content failed: %v", err)
+				continue
+			}
 		}
 		klog.Infof("result content is %s", result.Content)
 		switch resType {


### PR DESCRIPTION
Signed-off-by: lvchenggang lvchenggang_yewu@cmss.chinamobile.com

What type of PR is this?
/kind feature

What this PR does / why we need it:
syncPod method add message  content type choice in edged.go.
the message content type probably more than one []byte type, if the message come from cloudhub udsserver, then the type is string.
We need to consider this situation.

Does this PR introduce a user-facing change?:
NONE