### PR TITLE
delete unwanted configmap label

### DIFF
--- a/build/cloud/ha/02-ha-configmap.yaml.example
+++ b/build/cloud/ha/02-ha-configmap.yaml.example
@@ -13,14 +13,6 @@ data:
     kubeAPIConfig:
       kubeConfig: ""
       master: ""
-    leaderelection:
-      LeaderElect: true
-      LeaseDuration: 15s
-      RenewDeadline: 10s
-      ResourceLock: endpointsleases
-      ResourceName: cloudcorelease
-      ResourceNamespace: kubeedge
-      RetryPeriod: 2s
     modules:
       cloudHub:
         advertiseAddress:


### PR DESCRIPTION
The leaderelection in the configuration is no longer used