### PR TITLE
Builds are only supported for GOOS=linux, so set it explicitly

### DIFF
--- a/edge/test/integration/scripts/execute.sh
+++ b/edge/test/integration/scripts/execute.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The KubeEdge Authors.
 #

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -214,7 +214,7 @@ kubeedge::golang::build_binaries() {
     echo "building $bin"
     local name="${bin##*/}"
     set -x
-    GOOS="linux" CGO_ENABLED=1 go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -gcflags="${gogcflags:-}" -ldflags "${goldflags:-}" $bin
+    GOOS="linux" go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -gcflags="${gogcflags:-}" -ldflags "${goldflags:-}" $bin
     set +x
   done
 }

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -214,10 +214,9 @@ kubeedge::golang::build_binaries() {
     echo "building $bin"
     local name="${bin##*/}"
     set -x
-    go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -gcflags="${gogcflags:-}" -ldflags "${goldflags:-}" $bin
+    GOOS="linux" CGO_ENABLED=1 go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -gcflags="${gogcflags:-}" -ldflags "${goldflags:-}" $bin
     set +x
   done
-
 }
 
 


### PR DESCRIPTION
Signed-off-by: Michael Shen <mishen@umich.edu>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Since only target operating systems of linux are supported, so explicitly setting this will allow builds from other operating systems, like macOS to succeed. Furthermore, I noticed there was an error in the integrationtest make target.

**Which issue(s) this PR fixes**:
Related to #3322

```release-note
NONE
```
