### PR TITLE
fix:Secret can't send to edge in SecretKeyRef #3328

### DIFF
--- a/edge/pkg/edged/edged_pods.go
+++ b/edge/pkg/edged/edged_pods.go
@@ -668,6 +668,7 @@ func (e *edged) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container, p
 	// 3.  Add remaining service environment vars
 	var (
 		configMaps  = make(map[string]*v1.ConfigMap)
+		secrets     = make(map[string]*v1.Secret)
 		tmpEnv      = make(map[string]string)
 		mappingFunc = expansion.MappingFuncFor(tmpEnv)
 	)
@@ -710,6 +711,42 @@ func (e *edged) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container, p
 			if len(invalidKeys) > 0 {
 				sort.Strings(invalidKeys)
 				klog.Errorf("keys [%s] from the EnvFrom configMap %s/%s were skipped since they are considered invalid environment variable names", strings.Join(invalidKeys, ", "), pod.Namespace, name)
+			}
+		case envFrom.SecretRef != nil:
+			sc := envFrom.SecretRef
+			name := sc.Name
+			secret, ok := secrets[name]
+			if !ok {
+				if e.kubeClient == nil {
+					return result, fmt.Errorf("couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
+				}
+				optional := sc.Optional != nil && *sc.Optional
+				// K8s secretClient can't be used to obtain secret here, it's empty.
+				secret, err = e.metaClient.Secrets(pod.Namespace).Get(name)
+				if err != nil {
+					if apierrors.IsNotFound(err) && optional {
+						// ignore error when marked optional
+						continue
+					}
+					return result, err
+				}
+				secrets[name] = secret
+			}
+
+			invalidKeys := []string{}
+			for k, v := range secret.Data {
+				if len(envFrom.Prefix) > 0 {
+					k = envFrom.Prefix + k
+				}
+				if errMsgs := utilvalidation.IsEnvVarName(k); len(errMsgs) != 0 {
+					invalidKeys = append(invalidKeys, k)
+					continue
+				}
+				tmpEnv[k] = string(v)
+			}
+			if len(invalidKeys) > 0 {
+				sort.Strings(invalidKeys)
+				klog.Errorf("keys [%s] from the EnvFrom secret %s/%s were skipped since they are considered invalid environment variable names", strings.Join(invalidKeys, ", "), pod.Namespace, name)
 			}
 		}
 	}
@@ -754,6 +791,35 @@ func (e *edged) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container, p
 					}
 					return result, fmt.Errorf("couldn't find key %v in ConfigMap %v/%v", key, pod.Namespace, name)
 				}
+			case envVar.ValueFrom.SecretKeyRef != nil:
+				sc := envVar.ValueFrom.SecretKeyRef
+				name := sc.Name
+				key := sc.Key
+				optional := sc.Optional != nil && *sc.Optional
+				secret, ok := secrets[name]
+				if !ok {
+					if e.kubeClient == nil {
+						return result, fmt.Errorf("couldn't get secret %v/%v, no kubeClient defined", pod.Namespace, name)
+					}
+					// K8s secretClient can't be used to obtain secret here, it's empty.
+					secret, err = e.metaClient.Secrets(pod.Namespace).Get(name)
+					if err != nil {
+						if apierrors.IsNotFound(err) && optional {
+							// ignore error when marked optional
+							continue
+						}
+						return result, err
+					}
+					secrets[name] = secret
+				}
+				runtimeValBytes, ok := secret.Data[key]
+				if !ok {
+					if optional {
+						continue
+					}
+					return result, fmt.Errorf("couldn't find key %v in Secret %v/%v", key, pod.Namespace, name)
+				}
+				runtimeVal = string(runtimeValBytes)
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
This PR fixed a bug about _secret can't send to edge in SecretKeyRef #3328_. When we use secret through environment variables, the environment variables in docker cannot get the secret value.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # Secret can't send to edge in SecretKeyRef #3328

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
