### PR TITLE
fix "keadm get nodes -A"  printing namespaces while nodes without namespaces actually

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/get.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get.go
@@ -180,7 +180,7 @@ func (g *GetOptions) Run(args []string) error {
 		}
 	}
 
-	if g.AllNamespace {
+	if g.AllNamespace && resType != "nodes" && resType != "node" {
 		if err := g.PrintFlags.EnsureWithNamespace(); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When  excute “keadm get nodes/node -A/--all-namespaces ”，keadm may not print the namespace with null while in original k8s，the resource of node does not have any namespaces.
before:
![image](https://user-images.githubusercontent.com/53475708/142988288-bbf8f7a5-3bb9-4d59-baa3-c0bc67e8437f.png)
after this PR, not print NAMESPACE column anymore:
![image](https://user-images.githubusercontent.com/53475708/142988385-91340ef1-ec69-4990-a0c5-e05eb807f52c.png)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3345

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
