### PR TITLE
fix unlock in addDevice of membership

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/membership.go
+++ b/edge/pkg/devicetwin/dtmanager/membership.go
@@ -241,7 +241,6 @@ func addDevice(context *dtcontext.DTContext, toAdd []dttype.Device, baseMessage 
 		result, err := dttype.MarshalMembershipUpdate(addDeviceResult)
 		if err != nil {
 			klog.Errorf("add device %s failed, marshal membership err: %s", device.ID, err)
-			continue
 		} else {
 			context.Send("",
 				dtcommon.SendToEdge,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
a lock was in line 195-197:
> ```go
>if delta {
>	context.Lock(device.ID)
>}
> ```
unlock was in line 251-253:
> ```go
>if delta {
>	context.Unlock(device.ID)
>}
> ```
PR #3348 add log err if convert membership failed , if we use "continue" in line 244 before unlock, it may cause not relase lock as mentioned, so here we should remove it.

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
