### PR TITLE
Refactor computing the SHA512 checksum to go instead of bash

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -32,54 +32,52 @@ import (
 
 var PrivateDownloadServiceFile = downloadServiceFile
 
-func TestManagedKubernetesVersion(t *testing.T) {
-	vers := version.Info{Minor: "17"}
-	t.Run("test with minor version of 17", func(t *testing.T) {
-		err := checkKubernetesVersion(&vers)
-		if err != nil {
-			t.Fatalf("checked errored with: %s\n", err)
-		}
-	})
+func TestCheckKubernetesVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     *version.Info
+		expectError bool
+	}{
+		{
+			name: "Supported version",
+			version: &version.Info{
+				Major: "1",
+				Minor: "11",
+			},
+			expectError: false,
+		},
+		{
+			name: "Badly formatted version",
+			version: &version.Info{
+				Major: "1",
+				Minor: "a",
+			},
+			expectError: true,
+		},
+		{
+			name: "Old version",
+			version: &version.Info{
+				Major: "1",
+				Minor: "3",
+			},
+			expectError: true,
+		},
+	}
 
-	vers.Minor = "17+"
-	t.Run("test with minor version of 17+", func(t *testing.T) {
-		err := checkKubernetesVersion(&vers)
-		if err != nil {
-			t.Fatalf("checked errored with: %s\n", err)
-		}
-	})
-
-	vers.Minor = "100"
-	t.Run("test with minor version of 100", func(t *testing.T) {
-		err := checkKubernetesVersion(&vers)
-		if err != nil {
-			t.Fatalf("checked errored with: %s\n", err)
-		}
-	})
-
-	vers.Minor = "100+"
-	t.Run("test with minor version of 100+", func(t *testing.T) {
-		err := checkKubernetesVersion(&vers)
-		if err != nil {
-			t.Fatalf("checked errored with: %s\n", err)
-		}
-	})
-
-	vers.Minor = "3"
-	t.Run("test with minor version of 3", func(t *testing.T) {
-		err := checkKubernetesVersion(&vers)
-		if err == nil {
-			t.Fatalf("check should return an error and didn't")
-		}
-	})
-
-	vers.Minor = "3+"
-	t.Run("test with minor version of 3+", func(t *testing.T) {
-		err := checkKubernetesVersion(&vers)
-		if err == nil {
-			t.Fatalf("check should return an error and didn't")
-		}
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkKubernetesVersion(test.version)
+			if test.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got %v", err)
+				}
+			}
+		})
+	}
 }
 
 func TestPrivateDownloadServiceFile(t *testing.T) {

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -192,3 +192,37 @@ func TestFileExists(t *testing.T) {
 		t.Fatalf("file %v should not exist", notExistFile)
 	}
 }
+
+func TestComputeSHA512Checksum(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "a",
+			expected: "1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpfile, err := ioutil.TempFile("", test.name)
+			if err != nil {
+				t.Errorf("Unable to create temp file: %v", err)
+			}
+
+			defer tmpfile.Close()
+			if _, err := tmpfile.Write([]byte(test.name)); err != nil {
+				t.Errorf("Unable to write to temp file: %v", err)
+			}
+
+			actual, err := computeSHA512Checksum(tmpfile.Name())
+			if err != nil {
+				t.Errorf("Unable to compute checksum: %v", err)
+			}
+			if actual != test.expected {
+				t.Errorf("expected %s, got %s", test.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test

**What this PR does / why we need it**:
Refactors untestable bash --> testable Go

**Which issue(s) this PR fixes**:
Work on #3138

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
