### PR TITLE
Add testing to keadm version

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cmd.go
+++ b/keadm/cmd/keadm/app/cmd/cmd.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"io"
+
 	"github.com/spf13/cobra"
 
 	cloud "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/cloud"
@@ -58,7 +60,7 @@ var (
 )
 
 // NewKubeedgeCommand returns cobra.Command to run keadm commands
-func NewKubeedgeCommand() *cobra.Command {
+func NewKubeedgeCommand(out io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:     "keadm",
 		Short:   "keadm: Bootstrap KubeEdge cluster",
@@ -70,7 +72,7 @@ func NewKubeedgeCommand() *cobra.Command {
 	cmds.AddCommand(cloud.NewCloudInit())
 	cmds.AddCommand(edge.NewEdgeJoin())
 	cmds.AddCommand(NewKubeEdgeReset())
-	cmds.AddCommand(NewCmdVersion())
+	cmds.AddCommand(newCmdVersion(out))
 	cmds.AddCommand(cloud.NewGettoken())
 	cmds.AddCommand(debug.NewEdgeDebug())
 

--- a/keadm/cmd/keadm/app/cmd/version.go
+++ b/keadm/cmd/keadm/app/cmd/version.go
@@ -3,8 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
+	"io"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -12,19 +11,14 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
-const (
-	// DefaultErrorExitCode defines exit the code for failed action generally
-	DefaultErrorExitCode = 1
-)
-
-func NewCmdVersion() *cobra.Command {
+func newCmdVersion(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print the version of keadm",
-		Run: func(cmd *cobra.Command, args []string) {
-			err := RunVersion(cmd)
-			CheckErr(err, fatal)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunVersion(out, cmd)
 		},
+		Args: cobra.NoArgs,
 	}
 	cmd.Flags().StringP("output", "o", "", "Output format; available options are 'yaml', 'json' and 'short'")
 	return cmd
@@ -32,60 +26,35 @@ func NewCmdVersion() *cobra.Command {
 
 // RunVersion provides the version information of keadm in format depending on arguments
 // specified in cobra.Command.
-func RunVersion(cmd *cobra.Command) error {
+func RunVersion(out io.Writer, cmd *cobra.Command) error {
 	v := version.Get()
 
 	const flag = "output"
 	of, err := cmd.Flags().GetString(flag)
 	if err != nil {
-		fmt.Printf("error accessing flag %s for command %s: %v\n", flag, cmd.Name(), err)
-		os.Exit(1)
+		return fmt.Errorf("error accessing flag %s for command %s", flag, cmd.Name())
 	}
 
 	switch of {
 	case "":
-		fmt.Printf("version: %#v\n", v)
+		fmt.Fprintf(out, "version: %#v\n", v)
 	case "short":
-		fmt.Printf("%s\n", v)
+		fmt.Fprintf(out, "%s\n", v)
 	case "yaml":
 		y, err := yaml.Marshal(&v)
 		if err != nil {
 			return err
 		}
-		fmt.Printf(string(y))
+		fmt.Fprintln(out, string(y))
 	case "json":
 		y, err := json.MarshalIndent(&v, "", "  ")
 		if err != nil {
 			return err
 		}
-		fmt.Printf(string(y))
+		fmt.Fprintln(out, string(y))
 	default:
 		return fmt.Errorf("invalid output format: %s", of)
 	}
 
 	return nil
-}
-
-// fatal prints the message if set and then exits.
-func fatal(msg string, code int) {
-	if len(msg) > 0 {
-		// add newline if needed
-		if !strings.HasSuffix(msg, "\n") {
-			msg += "\n"
-		}
-
-		fmt.Fprint(os.Stderr, msg)
-	}
-	os.Exit(code)
-}
-
-// CheckErr formats a given error as a string and calls the passed handleErr
-// func with that string and an exit code.
-func CheckErr(err error, handleErr func(string, int)) {
-	switch err.(type) {
-	case nil:
-		return
-	default:
-		handleErr(err.Error(), DefaultErrorExitCode)
-	}
 }

--- a/keadm/cmd/keadm/app/cmd/version_test.go
+++ b/keadm/cmd/keadm/app/cmd/version_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestNewCmdVersion(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := newCmdVersion(&buf)
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Cannot execute version command: %v", err)
+	}
+}
+
+func TestRunVersion(t *testing.T) {
+	var buf bytes.Buffer
+	iface := make(map[string]interface{})
+	flagNameOutput := "output"
+	cmd := newCmdVersion(&buf)
+
+	testCases := []struct {
+		name              string
+		flag              string
+		expectedError     bool
+		shouldBeValidYAML bool
+		shouldBeValidJSON bool
+	}{
+		{
+			name: "valid: run without flags",
+		},
+		{
+			name: "valid: run with flag 'short'",
+			flag: "short",
+		},
+		{
+			name:              "valid: run with flag 'yaml'",
+			flag:              "yaml",
+			shouldBeValidYAML: true,
+		},
+		{
+			name:              "valid: run with flag 'json'",
+			flag:              "json",
+			shouldBeValidJSON: true,
+		},
+		{
+			name:          "invalid: run with unsupported flag",
+			flag:          "unsupported-flag",
+			expectedError: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if len(tc.flag) > 0 {
+				if err = cmd.Flags().Set(flagNameOutput, tc.flag); err != nil {
+					goto error
+				}
+			}
+			buf.Reset()
+			if err = RunVersion(&buf, cmd); err != nil {
+				goto error
+			}
+			if buf.String() == "" {
+				err = errors.New("empty output")
+				goto error
+			}
+			if tc.shouldBeValidYAML {
+				err = yaml.Unmarshal(buf.Bytes(), &iface)
+			} else if tc.shouldBeValidJSON {
+				err = json.Unmarshal(buf.Bytes(), &iface)
+			}
+		error:
+			if (err != nil) != tc.expectedError {
+				t.Errorf("Test case %q: RunVersion expected error: %v, saw: %v; %v", tc.name, tc.expectedError, err != nil, err)
+			}
+		})
+	}
+}

--- a/keadm/cmd/keadm/app/keadm.go
+++ b/keadm/cmd/keadm/app/keadm.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"flag"
+	"os"
 
 	"github.com/spf13/pflag"
 
@@ -28,6 +29,6 @@ import (
 func Run() error {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
-	cmd := cmd.NewKubeedgeCommand()
+	cmd := cmd.NewKubeedgeCommand(os.Stdout)
 	return cmd.Execute()
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind test

**What this PR does / why we need it**:
Improves test coverage by testing `keadm version`, using the exact same code from testing `kubeadm version` https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/cmd/version_test.go.

**Which issue(s) this PR fixes**:
Works on #3138 

```release-note
NONE
```
