### PR TITLE
Remove dependency on os/exec and curl in favor of net/http

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -166,15 +166,22 @@ func RunningModule() (types.ModuleRunning, error) {
 
 // GetLatestVersion return the latest non-prerelease, non-draft version of kubeedge in releases
 func GetLatestVersion() (string, error) {
-	//Download the tar from repo
-	versionURL := "curl -k " + latestReleaseVersionURL
-	cmd := exec.Command("sh", "-c", versionURL)
-	latestReleaseData, err := cmd.Output()
+	// curl https://kubeedge.io/latestversion
+	resp, err := http.Get(latestReleaseVersionURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to get latest version from %s: %v", latestReleaseVersionURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get latest version from %s, expected %d, got status code: %d", latestReleaseVersionURL, http.StatusOK, resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
-
-	return string(latestReleaseData), nil
+	return string(body), nil
 }
 
 // BuildConfig builds config from flags

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -22,7 +22,6 @@ import (
 	"crypto/sha512"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -177,7 +176,7 @@ func GetLatestVersion() (string, error) {
 		return "", fmt.Errorf("failed to get latest version from %s, expected %d, got status code: %d", latestReleaseVersionURL, http.StatusOK, resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -477,7 +476,7 @@ func checkSum(filename, checksumFilename string, version semver.Version, tarball
 
 	if _, err := os.Stat(checksumFilepath); err == nil {
 		fmt.Printf("Expected or Default checksum file %s is already downloaded. \n", checksumFilename)
-		content, err := ioutil.ReadFile(checksumFilepath)
+		content, err := os.ReadFile(checksumFilepath)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes a dependency on curl being installed and the insecure check (-k/--insecure) flag to mitigate the risk of man-in-the-middle attacks.

**Which issue(s) this PR fixes**:
Fixes #3385

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
