### PR TITLE
beehive: fixes SendSync channel allocation behaviour

### DIFF
--- a/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
@@ -121,14 +121,6 @@ func (ctx *ChannelContext) SendSync(module string, message model.Message, timeou
 		return model.Message{}, fmt.Errorf("bad request module name(%s)", module)
 	}
 
-	sendTimer := time.NewTimer(timeout)
-	select {
-	case reqChannel <- message:
-	case <-sendTimer.C:
-		return model.Message{}, errors.New("timeout to send message")
-	}
-	sendTimer.Stop()
-
 	// new anonymous channel for response
 	anonChan := make(chan model.Message)
 	anonName := getAnonChannelName(message.GetID())
@@ -142,14 +134,18 @@ func (ctx *ChannelContext) SendSync(module string, message model.Message, timeou
 		ctx.anonChsLock.Unlock()
 	}()
 
+	select {
+	case reqChannel <- message:
+	case <-time.After(timeout):
+		return model.Message{}, errors.New("timeout to send message")
+	}
+
 	var resp model.Message
-	respTimer := time.NewTimer(time.Until(deadline))
 	select {
 	case resp = <-anonChan:
-	case <-respTimer.C:
+	case <-time.After(time.Until(deadline)):
 		return model.Message{}, errors.New("timeout to get response")
 	}
-	respTimer.Stop()
 
 	return resp, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

The Beehive Channel implementation for SendSync sends the message first
and then allocates the anonymous channel to receive the response. If it
so happens that the responding module is able to send response before
the channel is allocated then it won't find the channel in the map.

This results in the SendResp function just printing a log and move
forward. But the SendSync function will get stuck until the Timeout is
reached. This will lead to the caller Module not receiving the message
at all.

This commit fixes this by pre-allocating the channel and saving in the
map before it sends the request message.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3016 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
