### PR TITLE
fix pod exec is not close conn when edgecore is closed

### DIFF
--- a/cloud/pkg/cloudstream/containerexec_connection.go
+++ b/cloud/pkg/cloudstream/containerexec_connection.go
@@ -123,6 +123,7 @@ func (c *ContainerExecConnection) Serve() error {
 			msg := stream.NewMessage(connector.GetMessageID(), stream.MessageTypeData, data[:n])
 			if err := c.WriteToTunnel(msg); err != nil {
 				klog.Errorf("%s failed to write to tunnel server, err: %v", c.String(), err)
+				break
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When we use the exec pod function, when edgecore fails (for example, systemctl stop edgecore), exec will hang, the command line cannot be entered, and the tcp connection between apiserver and cloudcore's 10003 port is still connected.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
