### PR TITLE
Update keadm-scope.md

### DIFF
--- a/docs/proposals/keadm-scope.md
+++ b/docs/proposals/keadm-scope.md
@@ -205,7 +205,7 @@ Flags:
         * docker (currently 18.06.0ce3-0~ubuntu) and check if service is up
         * kubelet, kubeadm & kubectl (latest version)
         * openssl (latest available in OS repos)
-    3. Generate certificates using openssl and save the certs in a predefined static path.
+    3. Generate certificates using openssl and save the certs in cloud secret, or in a predefined static path (versions < 1.3).
     It will also compress the folder and display on the terminal so that user can pick it up and transfer it to edge node (VM/host) manually.
     4. It will update the certificate information in `controller.yaml`
     5. Start `keadm init`.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
Update obsolete information in `keadm-scope.md`.

**Which issue(s) this PR fixes**:
https://github.com/kubeedge/kubeedge/issues/1744
XJangel commented on 27 May 2020
In KubeEdge 1.3, the certificate won't be saved locally. They will be in the secret cloudcoresecret and casecret of kubeedge namespace.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
