### PR TITLE
add device state update topic constant

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/common.go
+++ b/edge/pkg/devicetwin/dtcommon/common.go
@@ -49,6 +49,8 @@ const (
 	DeviceETUpdatedSuffix = "/updated"
 	// DeviceETStateUpdateSuffix the topic suffix for device state update event
 	DeviceETStateUpdateSuffix = "/state/update"
+	// DeviceETStateUpdateResultSuffix the topic suffix for device state update result event
+	DeviceETStateUpdateResultSuffix = "/state/update/result"
 	// DeviceETStateGetSuffix the topic suffix for device state get event
 	DeviceETStateGetSuffix = "/state/get"
 

--- a/edge/pkg/devicetwin/dtmanager/device.go
+++ b/edge/pkg/devicetwin/dtmanager/device.go
@@ -116,7 +116,7 @@ func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg in
 	if err != nil {
 		return err
 	}
-	topic := dtcommon.DeviceETPrefix + device.ID + dtcommon.DeviceETStateUpdateSuffix + "/result"
+	topic := dtcommon.DeviceETPrefix + device.ID + dtcommon.DeviceETStateUpdateResultSuffix
 	context.Send(device.ID,
 		dtcommon.SendToEdge,
 		dtcommon.CommModule,

--- a/edge/test/integration/device/device_test.go
+++ b/edge/test/integration/device/device_test.go
@@ -68,7 +68,7 @@ var Client MQTT.Client
 
 func SubMessageReceived(client MQTT.Client, message MQTT.Message) {
 	var deviceState DeviceUpdates
-	topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateSuffix + "/result"
+	topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateResultSuffix
 	if message.Topic() == topic {
 		devicePayload := (message.Payload())
 		err := json.Unmarshal(devicePayload, &deviceState)
@@ -198,7 +198,7 @@ var _ = Describe("Event Bus Testing", func() {
 			}
 			Expect(TokenClient.Error()).NotTo(HaveOccurred())
 			devicetopic := dtcommon.MemETPrefix + ctx.Cfg.NodeID + dtcommon.MemETUpdateSuffix
-			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateSuffix + "/result"
+			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateResultSuffix
 			Token := Client.Subscribe(devicetopic, 0, DeviceSubscribed)
 			if Token.Wait() && TokenClient.Error() != nil {
 				common.Fatalf("Subscribe to Topic  Failed  %s, %s", TokenClient.Error(), topic)
@@ -219,7 +219,7 @@ var _ = Describe("Event Bus Testing", func() {
 		It("TC_TEST_EBUS_6: change the device status to online from eventbus", func() {
 			var message DeviceUpdate
 			message.State = "online"
-			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateSuffix + "/result"
+			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateResultSuffix
 			body, err := json.Marshal(message)
 			if err != nil {
 				common.Fatalf("Marshal failed %v", err)
@@ -248,7 +248,7 @@ var _ = Describe("Event Bus Testing", func() {
 		It("TC_TEST_EBUS_7: change the device status to unknown from eventbus", func() {
 			var message DeviceUpdate
 			message.State = "unknown"
-			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateSuffix + "/result"
+			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateResultSuffix
 			body, err := json.Marshal(message)
 			if err != nil {
 				common.Fatalf("Marshal failed %v", err)
@@ -276,7 +276,7 @@ var _ = Describe("Event Bus Testing", func() {
 		It("TC_TEST_EBUS_8: change the device status to offline from eventbus", func() {
 			var message DeviceUpdate
 			message.State = "offline"
-			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateSuffix + "/result"
+			topic := dtcommon.DeviceETPrefix + DeviceIDN + dtcommon.DeviceETStateUpdateResultSuffix
 			body, err := json.Marshal(message)
 			if err != nil {
 				common.Fatalf("Marshal failed %v", err)


### PR DESCRIPTION
Signed-off-by: TianTianBigWang <zilong.wang@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
add constant for device status update event topic, like twin update event topic
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
