### PR TITLE
add rules to 01-ha-prepare.yaml for cloudcore ha deployment

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -30,3 +30,6 @@ rules:
 - apiGroups: ["rules.kubeedge.io"]
   resources: ["rules", "ruleendpoints", "rules/status", "ruleendpoints/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/build/cloud/ha/01-ha-prepare.yaml
+++ b/build/cloud/ha/01-ha-prepare.yaml
@@ -49,6 +49,9 @@ rules:
   - apiGroups: ["rules.kubeedge.io"]
     resources: ["rules", "ruleendpoints", "rules/status", "ruleendpoints/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/build/helm/cloudcore/templates/rbac_cloudcore.yaml
+++ b/build/helm/cloudcore/templates/rbac_cloudcore.yaml
@@ -31,6 +31,9 @@ rules:
 - apiGroups: ["rules.kubeedge.io"]
   resources: ["rules", "ruleendpoints", "rules/status", "ruleendpoints/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 apiVersion: v1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When I tried to deploy cloudcore high availability, I needed to make some `list/watch/get` requests for crd resources, but I got an error:
When I execute: `curl http://127.0.0.1:10550/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions` in edgenode
I get:
~~~
W1207 14:25:50.920859   16813 storage.go:135] [metaserver/reststorage] failed to list obj from cloud, successfully to add listener but failed to get current list, customresourcedefinitions.apiextensions.k8s.io is forbidden: User "system:serviceaccount:kubeedge:cloudcore" cannot list resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope; try local
I1207 14:25:50.920995   16813 store.go:80] get a list req, key=/apiextensions.k8s.io/v1beta1/customresourcedefinitions/null/null
I1207 14:25:50.921054   16813 imitator.go:142] apiextensions.k8s.io/v1beta1, Resource=customresourcedefinitions,,
E1207 14:25:50.921318   16813 store.go:93] <nil>
I1207 14:25:50.921336   16813 storage.go:140] [metaserver/reststorage] successfully process list req (/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions) at local
I1207 14:26:19.918482   16813 edged.go:944] worker [4] get pod addition item [kube-flannel-ds-7pcgc]
~~~

This seems to be because there is no operation authority assigned to the `customresourcedefinitions` resource of the `apiextensions.k8s.io` group, so I added relevant fields in the deployment template yaml

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
none
