### PR TITLE
cloudhub: prevent dropping volume messages

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -159,7 +159,8 @@ func isListResource(msg *beehiveModel.Message) bool {
 	if strings.Contains(msgResource, beehiveModel.ResourceTypePodlist) ||
 		strings.Contains(msgResource, "membership") ||
 		strings.Contains(msgResource, "twin/cloud_updated") ||
-		strings.Contains(msgResource, beehiveModel.ResourceTypeServiceAccountToken) {
+		strings.Contains(msgResource, beehiveModel.ResourceTypeServiceAccountToken) ||
+		isVolumeOperation(msg.GetOperation()) {
 		return true
 	}
 
@@ -185,6 +186,13 @@ func isListResource(msg *beehiveModel.Message) bool {
 	}
 
 	return false
+}
+
+func isVolumeOperation(op string) bool {
+	return op == commonconst.CSIOperationTypeCreateVolume ||
+		op == commonconst.CSIOperationTypeDeleteVolume ||
+		op == commonconst.CSIOperationTypeControllerPublishVolume ||
+		op == commonconst.CSIOperationTypeControllerUnpublishVolume
 }
 
 func isDeleteMessage(msg *beehiveModel.Message) bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Volume-related messages are being dropped from cloudcore at the moment. I.e. no CreateVolume/DeleteVolume calls are forwarded to the edge nodes.

**Which issue(s) this PR fixes**:
Relates to #3336

**Special notes for your reviewer**:
This is a first PR of a series. I have a lot of csi-related changes in flight. I try to split them into smaller chunks.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
