### PR TITLE
Add missing resource permissions to cloudcore ClusterRole

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -7,13 +7,13 @@ metadata:
     kubeedge: cloudcore
 rules:
 - apiGroups: [""]
-  resources: ["nodes", "nodes/status", "configmaps", "pods", "pods/status", "secrets", "endpoints", "services","persistentvolumes","persistentvolumeclaims"]
+  resources: ["nodes", "nodes/status", "serviceaccounts/token", "configmaps", "pods", "pods/status", "secrets", "endpoints", "services", "persistentvolumes", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update"]
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "create"]
 - apiGroups: [""]
-  resources: ["pods/status"]
+  resources: ["nodes", "pods/status"]
   verbs: ["patch"]
 - apiGroups: [""]
   resources: ["pods"]
@@ -33,3 +33,6 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]

--- a/build/cloud/ha/01-ha-prepare.yaml
+++ b/build/cloud/ha/01-ha-prepare.yaml
@@ -26,13 +26,13 @@ metadata:
     kubeedge: cloudcore
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "nodes/status", "configmaps", "pods", "pods/status", "secrets", "endpoints", "services","persistentvolumes","persistentvolumeclaims"]
+    resources: ["nodes", "nodes/status", "serviceaccounts/token", "configmaps", "pods", "pods/status", "secrets", "endpoints", "services", "persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "create", "update"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "create"]
   - apiGroups: [""]
-    resources: ["pods/status"]
+    resources: ["nodes", "pods/status"]
     verbs: ["patch"]
   - apiGroups: [""]
     resources: ["pods"]
@@ -52,6 +52,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.istio.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/build/helm/cloudcore/templates/rbac_cloudcore.yaml
+++ b/build/helm/cloudcore/templates/rbac_cloudcore.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- end }}
 rules:
 - apiGroups: [""]
-  resources: ["nodes",  "nodes/status", "serviceaccounts/token", "configmaps", "pods", "pods/status", "secrets", "endpoints", "services","persistentvolumes","persistentvolumeclaims"]
+  resources: ["nodes", "nodes/status", "serviceaccounts/token", "configmaps", "pods", "pods/status", "secrets", "endpoints", "services", "persistentvolumes", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update"]
 - apiGroups: [""]
   resources: ["namespaces"]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add missing resource serviceaccounts/token to cloudcore ClusterRole.

**Which issue(s) this PR fixes**:
Fixes #3319

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```