### PR TITLE
using lateset codes to do keadm_e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ keadm_e2e:
 	@echo "KEADM_E2E_HELP_INFO"
 else
 keadm_e2e:
+	hack/make-rules/release.sh kubeedge
 	tests/e2e/scripts/keadm_e2e.sh
 endif
 

--- a/tests/e2e/scripts/keadm_e2e.sh
+++ b/tests/e2e/scripts/keadm_e2e.sh
@@ -32,6 +32,7 @@ function cleanup() {
 }
 
 function build_keadm() {
+  cd $KUBEEDGE_ROOT
   make all WHAT=keadm
   cd $E2E_DIR
   ginkgo build -r keadm/
@@ -50,15 +51,13 @@ function prepare_cluster() {
 }
 
 function start_kubeedge() {
+  local KUBEEDGE_VERSION="$@"
+
   sudo mkdir -p /var/lib/kubeedge
-  sudo mkdir -p /etc/kubeedge
   cd $KUBEEDGE_ROOT
   export KUBECONFIG=$HOME/.kube/config
 
-  sudo cp _output/release/${VERSION}/kubeedge-${VERSION}-linux-amd64.tar.gz _output/release/${VERSION}/checksum_kubeedge-${VERSION}-linux-amd64.tar.gz.txt /etc/kubeedge
-
-  kubeedge_version=${VERSION: 1}
-  sudo -E _output/local/bin/keadm init --kube-config=$KUBECONFIG --advertise-address=127.0.0.1 --kubeedge-version=${kubeedge_version}
+  sudo -E _output/local/bin/keadm init --kube-config=$KUBECONFIG --advertise-address=127.0.0.1 --kubeedge-version=${KUBEEDGE_VERSION}
   export MASTER_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' test-control-plane`
 
   # ensure tokensecret is generated
@@ -69,7 +68,7 @@ function start_kubeedge() {
 
   export TOKEN=$(sudo _output/local/bin/keadm gettoken --kube-config=$KUBECONFIG)
   sudo systemctl set-environment CHECK_EDGECORE_ENVIRONMENT="false"
-  sudo -E CHECK_EDGECORE_ENVIRONMENT="false" _output/local/bin/keadm join --token=$TOKEN --cloudcore-ipport=127.0.0.1:10000 --edgenode-name=edge-node --kubeedge-version=${kubeedge_version}
+  sudo -E CHECK_EDGECORE_ENVIRONMENT="false" _output/local/bin/keadm join --token=$TOKEN --cloudcore-ipport=127.0.0.1:10000 --edgenode-name=edge-node --kubeedge-version=${KUBEEDGE_VERSION}
 
   #Pre-configurations required for running the suite.
   #Any new config addition required corresponding code changes.
@@ -112,13 +111,14 @@ function run_test() {
       exit 1
   else
       echo "Integration suite successfully passed all the tests !!"
-      exit 0
   fi
 }
 
 set -Ee
 trap cleanup EXIT
 trap cleanup ERR
+
+echo -e "\nUsing latest commit code to do keadm_e2e test..."
 
 echo -e "\nBuilding keadm..."
 build_keadm
@@ -128,8 +128,31 @@ export KUBECONFIG=$HOME/.kube/config
 echo -e "\nPreparing cluster..."
 prepare_cluster
 
+kubeedge_version=${VERSION: 1}
+#if we use the local release version compiled with the latest codes, we need to copy release file and checksum file.
+sudo mkdir -p /etc/kubeedge
+
+sudo cp ${KUBEEDGE_ROOT}/_output/release/${VERSION}/kubeedge-${VERSION}-linux-amd64.tar.gz ${KUBEEDGE_ROOT}/_output/release/${VERSION}/checksum_kubeedge-${VERSION}-linux-amd64.tar.gz.txt /etc/kubeedge
+
+echo -e "\nStarting kubeedge..." ${kubeedge_version}
+start_kubeedge ${kubeedge_version}
+
+echo -e "\nRunning test..."
+run_test
+
+# clean the before test
+cleanup
+
+echo -e "\nUsing latest official release version to do keadm_e2e test..."
+
+echo -e "\nBuilding keadm..."
+build_keadm
+
+echo -e "\nPreparing cluster..."
+prepare_cluster
+
 echo -e "\nStarting kubeedge..."
-start_kubeedge
+start_kubeedge ""
 
 echo -e "\nRunning test..."
 run_test

--- a/tests/e2e/scripts/keadm_e2e.sh
+++ b/tests/e2e/scripts/keadm_e2e.sh
@@ -18,11 +18,17 @@ KUBEEDGE_ROOT=$PWD
 WORKDIR=$(dirname $0)
 E2E_DIR=$(realpath $(dirname $0)/..)
 
+debugflag="-test.v -ginkgo.v"
+source "${KUBEEDGE_ROOT}/hack/lib/golang.sh"
+kubeedge::version::get_version_info
+VERSION=${GIT_VERSION}
+
 function cleanup() {
   sudo pkill edgecore || true
   sudo pkill cloudcore || true
   kind delete cluster --name test
   sudo rm -rf /var/log/kubeedge /etc/kubeedge /etc/systemd/system/edgecore.service $E2E_DIR/keadm/keadm.test $E2E_DIR/config.json
+  sudo rm -rf ${KUBEEDGE_ROOT}/_output/release/${VERSION}/
 }
 
 function build_keadm() {
@@ -45,10 +51,14 @@ function prepare_cluster() {
 
 function start_kubeedge() {
   sudo mkdir -p /var/lib/kubeedge
+  sudo mkdir -p /etc/kubeedge
   cd $KUBEEDGE_ROOT
   export KUBECONFIG=$HOME/.kube/config
 
-  sudo -E _output/local/bin/keadm init --kube-config=$KUBECONFIG --advertise-address=127.0.0.1
+  sudo cp _output/release/${VERSION}/kubeedge-${VERSION}-linux-amd64.tar.gz _output/release/${VERSION}/checksum_kubeedge-${VERSION}-linux-amd64.tar.gz.txt /etc/kubeedge
+
+  kubeedge_version=${VERSION: 1}
+  sudo -E _output/local/bin/keadm init --kube-config=$KUBECONFIG --advertise-address=127.0.0.1 --kubeedge-version=${kubeedge_version}
   export MASTER_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' test-control-plane`
 
   # ensure tokensecret is generated
@@ -59,7 +69,7 @@ function start_kubeedge() {
 
   export TOKEN=$(sudo _output/local/bin/keadm gettoken --kube-config=$KUBECONFIG)
   sudo systemctl set-environment CHECK_EDGECORE_ENVIRONMENT="false"
-  sudo -E CHECK_EDGECORE_ENVIRONMENT="false" _output/local/bin/keadm join --token=$TOKEN --cloudcore-ipport=127.0.0.1:10000 --edgenode-name=edge-node
+  sudo -E CHECK_EDGECORE_ENVIRONMENT="false" _output/local/bin/keadm join --token=$TOKEN --cloudcore-ipport=127.0.0.1:10000 --edgenode-name=edge-node --kubeedge-version=${kubeedge_version}
 
   #Pre-configurations required for running the suite.
   #Any new config addition required corresponding code changes.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
before we use the official release version to do keadm_e2e, that's not right, that's using last release version kubeedge to do e2e test.
we should use the latest codes to build a new release, and then with it do keadm_e2e test
/hold waiting for https://github.com/kubeedge/kubeedge/pull/3467
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
