### PR TITLE
Automated cherry pick of #3486: update k8s version to v1.21.8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -126,7 +126,7 @@ jobs:
         run: |
           command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@latest
           go install sigs.k8s.io/kind@v0.11.1
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.4/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -156,7 +156,7 @@ jobs:
         run: |
           command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@latest
           go install sigs.k8s.io/kind@v0.11.1
-          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.3/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.4/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
           export RELEASE_VERSION=$(wget -qO - https://kubeedge.io/latestversion | cat)
           sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/checksum_kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz.txt
           sudo wget -qP /etc/kubeedge https://github.com/kubeedge/kubeedge/releases/download/${RELEASE_VERSION}/kubeedge-${RELEASE_VERSION}-linux-amd64.tar.gz

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -62,7 +62,7 @@ const (
 	DefaultVolumeStatsAggPeriod        = time.Minute
 	DefaultTunnelPort                  = 10004
 
-	CurrentSupportK8sVersion = "v1.19.3"
+	CurrentSupportK8sVersion = "v1.21.4"
 
 	// MetaManager
 	DefaultPodStatusSyncInterval = 60


### PR DESCRIPTION
Cherry pick of #3486 on release-1.9.

#3486: update k8s version to v1.21.8

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.