### PR TITLE
fix: change the resourceType of msg issued by synccontroller

### DIFF
--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -138,7 +138,7 @@ func GetMessageAPIVersion(msg *beehiveModel.Message) string {
 func GetMessageResourceType(msg *beehiveModel.Message) string {
 	obj, ok := msg.Content.(runtime.Object)
 	if ok {
-		return UnsafeKindToResource(obj.GetObjectKind().GroupVersionKind().Kind)
+		return obj.GetObjectKind().GroupVersionKind().Kind
 	}
 	return ""
 }

--- a/pkg/metaserver/util/util_test.go
+++ b/pkg/metaserver/util/util_test.go
@@ -76,7 +76,7 @@ func TestGetMessageResourceType(t *testing.T) {
 						},
 					},
 				}},
-			want: UnsafeKindToResource("Pod"),
+			want: "Pod",
 		},
 		{
 			name: "TestGetMessageResourceType(): Case 2: Content other",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In order to fix the problem #2833, I unified the resource types of the msg issued by the `DynamicController` into a singular form(pod), but I found that this problem still occurs in the edgecore log. 
As a result of analysis, I found that I ignored the msg issued by `SyncController` , the resourceType of this part is taken from `objectsync.Spec.ObjectKind`
https://github.com/kubeedge/kubeedge/blob/29b840d4777b3cee51b791e9dc604eb55b979765/cloud/pkg/synccontroller/objectsync.go#L52-L56
and when `objectsync` is created in `cloudhub`, the assignment of the `objectsync.Spec.ObjectKind` field is plural(pods)
https://github.com/kubeedge/kubeedge/blob/29b840d4777b3cee51b791e9dc604eb55b979765/cloud/pkg/cloudhub/handler/messagehandler.go#L553-L569

https://github.com/kubeedge/kubeedge/blob/29b840d4777b3cee51b791e9dc604eb55b979765/pkg/metaserver/util/util.go#L137-L144

so this pr unifies the resType of msg issued by `SyncController` into a singular form.
after doing this, since the `edged` processing queue is de-duplicated, the same message will not be processed repeatedly, so there is no impact. There may be things that have not been considered, welcome to review :)

**Which issue(s) this PR fixes**:
Fixes #2833

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
none