### PR TITLE
Extend the stale timeout for prs and issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -23,8 +23,8 @@ exemptAssignees: false
 staleLabel: lifecycle/stale
 
 pull:
-  daysUntilClose: 60
-  daysUntilStale: 90
+  daysUntilClose: 90
+  daysUntilStale: 365
   markComment: >
     Hello 👋 Looks like there was no activity on this amazing PR for last 90 days.
 
@@ -36,8 +36,8 @@ pull:
     Closing for now as there was no activity for last 60 days after marked as stale, let us know if you need this to be reopened! 🤗
 
 issues:
-  daysUntilClose: 60
-  daysUntilStale: 90
+  daysUntilClose: 90
+  daysUntilStale: 365
   markComment: >
     Hello 👋 Looks like there was no activity on this issue for last 90 days.
 
@@ -49,4 +49,4 @@ issues:
     Closing for now as there was no activity for last 60 days after marked as stale, let us know if you need this to be reopened! 🤗
 
 # Limit the number of actions per hour, from 1-30. Default is 30
-limitPerRun: 30
+limitPerRun: 5


### PR DESCRIPTION
Signed-off-by: fisherxu <xufei40@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Now we have lots of prs and issues which haven't been fixed before staled and closed,  so extend the stale timeout for them.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
