### PR TITLE
[Enhancement] add nodelease feature

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -48,6 +48,8 @@ const (
 	DefaultRemoteImageEndpoint         = "unix:///var/run/dockershim.sock"
 	DefaultPodSandboxImage             = "kubeedge/pause:3.1"
 	DefaultNodeStatusUpdateFrequency   = 10
+	DefaultNodeStatusReportFrequency   = 300
+	DefaultNodeLeaseDurationSeconds    = 40
 	DefaultImagePullProgressDeadline   = 60
 	DefaultRuntimeRequestTimeout       = 2
 	DefaultImageGCHighThreshold        = 80
@@ -94,6 +96,7 @@ const (
 	DefaultDeletePodWorkers                  = 4
 	DefaultUpdateRuleStatusWorkers           = 4
 	DefaultServiceAccountTokenWorkers        = 4
+	DefaultLeaseWorkers                      = 4
 
 	DefaultUpdatePodStatusBuffer            = 1024
 	DefaultUpdateNodeStatusBuffer           = 1024
@@ -108,6 +111,7 @@ const (
 	DefaultUpdateNodeBuffer                 = 1024
 	DefaultDeletePodBuffer                  = 1024
 	DefaultServiceAccountTokenBuffer        = 1024
+	DefaultLeaseBuffer                      = 1024
 
 	DefaultPodEventBuffer           = 1
 	DefaultConfigMapEventBuffer     = 1

--- a/edge/pkg/edged/edged_nodelease.go
+++ b/edge/pkg/edged/edged_nodelease.go
@@ -1,0 +1,135 @@
+package edged
+
+import (
+	"fmt"
+	"sort"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+
+	"github.com/kubeedge/beehive/pkg/core"
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/edged/config"
+)
+
+var baseLease coordinationv1.Lease
+
+func (e *edged) nodeStatusHasChanged(currentStatus *v1.NodeStatus) bool {
+	originalStatusCopy := e.lastReportStatus.DeepCopy()
+	currentStatusCopy := currentStatus.DeepCopy()
+
+	// compare NodeStatus.Condition
+	if len(originalStatusCopy.Conditions) != len(currentStatusCopy.Conditions) {
+		return true
+	}
+	sort.SliceStable(originalStatusCopy.Conditions, func(i, j int) bool {
+		return originalStatusCopy.Conditions[i].Type < originalStatusCopy.Conditions[j].Type
+	})
+	sort.SliceStable(currentStatusCopy.Conditions, func(i, j int) bool {
+		return currentStatusCopy.Conditions[i].Type < currentStatusCopy.Conditions[j].Type
+	})
+	emptyHeartbeatTime := metav1.Time{}
+	for i := range currentStatusCopy.Conditions {
+		// ignore difference of LastHeartbeatTime
+		originalStatusCopy.Conditions[i].LastHeartbeatTime = emptyHeartbeatTime
+		currentStatusCopy.Conditions[i].LastHeartbeatTime = emptyHeartbeatTime
+		if !apiequality.Semantic.DeepEqual(originalStatusCopy.Conditions[i], currentStatusCopy.Conditions[i]) {
+			return true
+		}
+	}
+
+	// compare other fields of NodeStatus
+	originalStatusCopy.Conditions, currentStatusCopy.Conditions = nil, nil
+	return !apiequality.Semantic.DeepEqual(originalStatusCopy, currentStatusCopy)
+}
+
+func (e *edged) newLease(base *coordinationv1.Lease) *coordinationv1.Lease {
+	var lease *coordinationv1.Lease
+	if base == nil {
+		lease = &coordinationv1.Lease{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Lease",
+				APIVersion: "coordination.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      e.nodeName,
+				Namespace: v1.NamespaceNodeLease,
+			},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       pointer.StringPtr(e.nodeName),
+				LeaseDurationSeconds: pointer.Int32(e.nodeLeaseDurationSeconds),
+			},
+		}
+	} else {
+		lease = base.DeepCopy()
+	}
+	lease.Spec.RenewTime = &metav1.MicroTime{Time: clock.RealClock{}.Now()}
+
+	return lease
+}
+
+func (e *edged) createNodeLease() error {
+	lease := e.newLease(nil)
+	if !config.Config.RegisterNode {
+		klog.V(2).Info("register-node is set to false, do not create node lease")
+		return nil
+	}
+	klog.Infof("Attempting to create node lease %s", lease.Name)
+
+	resource := fmt.Sprintf("%s/%s/%s", lease.Namespace, model.ResourceTypeLease, lease.Name)
+	nodeleaseMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.InsertOperation, lease)
+
+	var resp model.Message
+	var err error
+	if _, ok := core.GetModules()[modules.EdgeHubModuleName]; ok {
+		resp, err = beehiveContext.SendSync(modules.EdgeHubModuleName, *nodeleaseMsg, e.nodeStatusUpdateFrequency)
+	} else {
+		resp, err = beehiveContext.SendSync(EdgeController, *nodeleaseMsg, e.nodeStatusUpdateFrequency)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if resp.Content != constants.MessageSuccessfulContent {
+		return fmt.Errorf("create node lease failed, resp: %v", resp.Content)
+	}
+
+	klog.Infof("successfully create node lease %s", lease.Name)
+	e.nodeLeaseCreated = true
+	baseLease = *lease.DeepCopy()
+	return nil
+}
+
+func (e *edged) updateNodeLease() error {
+	lease := e.newLease(&baseLease)
+	err := e.metaClient.Lease(lease.Namespace).Update(lease)
+	if err != nil {
+		klog.Errorf("update node lease failed, error: %v", err)
+		return err
+	}
+	baseLease = *lease.DeepCopy()
+	return nil
+}
+
+func (e *edged) syncNodeLease() {
+	if !e.nodeLeaseCreated {
+		if err := e.createNodeLease(); err != nil {
+			klog.Errorf("create nodelease failed: %v", err)
+			return
+		}
+	}
+
+	if err := e.updateNodeLease(); err != nil {
+		klog.Errorf("unable to update nodelease: %v", err)
+	}
+}

--- a/edge/pkg/metamanager/client/configmap.go
+++ b/edge/pkg/metamanager/client/configmap.go
@@ -53,7 +53,7 @@ func (c *configMaps) Delete(name string) error {
 func (c *configMaps) Get(name string) (*api.ConfigMap, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeConfigmap, name)
 	configMapMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(configMapMsg)
+	msg, err := c.send.SendSync(configMapMsg, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get configmap from metaManager failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/lease.go
+++ b/edge/pkg/metamanager/client/lease.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"fmt"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+)
+
+var leaseClientTimeout = 10 * time.Second
+
+// TODO:
+// Find a better way to set timeout of SendSync for lease msg.
+func SetLeaseClientTimeout(timeout time.Duration) {
+	leaseClientTimeout = timeout
+}
+
+type LeaseGetter interface {
+	Lease(namespace string) LeaseInterface
+}
+
+type LeaseInterface interface {
+	Create(*coordinationv1.Lease) (*coordinationv1.Lease, error)
+	Update(*coordinationv1.Lease) error
+	Delete(name string) error
+	Get(name string) (*coordinationv1.Lease, error)
+}
+
+type leases struct {
+	namespace string
+	send      SendInterface
+}
+
+func newLeases(namespace string, s SendInterface) *leases {
+	return &leases{
+		send:      s,
+		namespace: namespace,
+	}
+}
+
+func (l *leases) Create(lease *coordinationv1.Lease) (*coordinationv1.Lease, error) {
+	return nil, fmt.Errorf("create operation of lease is not supported")
+}
+
+func (l *leases) Update(lease *coordinationv1.Lease) error {
+	resource := fmt.Sprintf("%s/%s/%s", l.namespace, model.ResourceTypeLease, lease.Name)
+	leaseMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.UpdateOperation, lease)
+	// Update should not use default timeout. In most cases, syncMsgTimeout is much longer than
+	// NodeStatusUpdateFrequency. When the heatbeat timestamp of the nodelease msg expires, stop send it to
+	// avoid influence on the subsequent update messages.
+	_, err := l.send.SendSync(leaseMsg, false, &leaseClientTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to update lease, %v", err)
+	}
+	return nil
+}
+
+func (l *leases) Delete(name string) error {
+	return fmt.Errorf("delete operation of lease is not supported")
+}
+
+func (l *leases) Get(name string) (*coordinationv1.Lease, error) {
+	return nil, fmt.Errorf("get operation of lease is not supported")
+}

--- a/edge/pkg/metamanager/client/node.go
+++ b/edge/pkg/metamanager/client/node.go
@@ -44,7 +44,7 @@ func (c *nodes) Create(cm *api.Node) (*api.Node, error) {
 func (c *nodes) Update(cm *api.Node) error {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeNode, cm.Name)
 	nodeMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.UpdateOperation, cm)
-	_, err := c.send.SendSync(nodeMsg)
+	_, err := c.send.SendSync(nodeMsg, true, nil)
 	if err != nil {
 		return fmt.Errorf("update node failed, err: %v", err)
 	}
@@ -58,7 +58,7 @@ func (c *nodes) Delete(name string) error {
 func (c *nodes) Get(name string) (*api.Node, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeNode, name)
 	nodeMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(nodeMsg)
+	msg, err := c.send.SendSync(nodeMsg, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get node failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/nodestatus.go
+++ b/edge/pkg/metamanager/client/nodestatus.go
@@ -41,7 +41,7 @@ func (c *nodeStatus) Create(ns *edgeapi.NodeStatusRequest) (*edgeapi.NodeStatusR
 func (c *nodeStatus) Update(rsName string, ns edgeapi.NodeStatusRequest) error {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeNodeStatus, rsName)
 	nodeStatusMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.UpdateOperation, ns)
-	_, err := c.send.SendSync(nodeStatusMsg)
+	_, err := c.send.SendSync(nodeStatusMsg, true, nil)
 	if err != nil {
 		return fmt.Errorf("update nodeStatus failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/persistentvolume.go
+++ b/edge/pkg/metamanager/client/persistentvolume.go
@@ -53,7 +53,7 @@ func (c *persistentvolumes) Delete(name string) error {
 func (c *persistentvolumes) Get(name string, options metav1.GetOptions) (*api.PersistentVolume, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, "persistentvolume", name)
 	pvMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(pvMsg)
+	msg, err := c.send.SendSync(pvMsg, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get persistentvolume from metaManager failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/persistentvolumeclaim.go
+++ b/edge/pkg/metamanager/client/persistentvolumeclaim.go
@@ -53,7 +53,7 @@ func (c *persistentvolumeclaims) Delete(name string) error {
 func (c *persistentvolumeclaims) Get(name string, options metav1.GetOptions) (*api.PersistentVolumeClaim, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, "persistentvolumeclaim", name)
 	pvcMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(pvcMsg)
+	msg, err := c.send.SendSync(pvcMsg, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get persistentvolumeclaim from metaManager failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/podstatus.go
+++ b/edge/pkg/metamanager/client/podstatus.go
@@ -40,7 +40,7 @@ func (c *podStatus) Create(ps *edgeapi.PodStatusRequest) (*edgeapi.PodStatusRequ
 
 func (c *podStatus) Update(rsName string, ps edgeapi.PodStatusRequest) error {
 	podStatusMsg := message.BuildMsg(commodule.MetaGroup, "", commodule.EdgedModuleName, c.namespace+"/"+model.ResourceTypePodStatus+"/"+rsName, model.UpdateOperation, ps)
-	_, err := c.send.SendSync(podStatusMsg)
+	_, err := c.send.SendSync(podStatusMsg, true, nil)
 	if err != nil {
 		return fmt.Errorf("update podstatus failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/secret.go
+++ b/edge/pkg/metamanager/client/secret.go
@@ -52,7 +52,7 @@ func (c *secrets) Delete(name string) error {
 func (c *secrets) Get(name string) (*api.Secret, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeSecret, name)
 	secretMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(secretMsg)
+	msg, err := c.send.SendSync(secretMsg, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get secret from metaManager failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -36,7 +36,7 @@ func newServiceAccountToken(s SendInterface) *serviceAccountToken {
 func (c *serviceAccountToken) GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
 	resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypeServiceAccountToken, name)
 	tokenMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, tr)
-	msg, err := c.send.SendSync(tokenMsg)
+	msg, err := c.send.SendSync(tokenMsg, true, nil)
 	if err != nil {
 		klog.Errorf("get service account token from metaManager failed, err: %v", err)
 		return nil, fmt.Errorf("get service account token from metaManager failed, err: %v", err)

--- a/edge/pkg/metamanager/client/volumeattachment.go
+++ b/edge/pkg/metamanager/client/volumeattachment.go
@@ -41,7 +41,7 @@ func newVolumeAttachments(n string, s SendInterface) *volumeattachments {
 func (c *volumeattachments) Create(va *api.VolumeAttachment) (*api.VolumeAttachment, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, "volumeattachment", va.Name)
 	vaMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.InsertOperation, va)
-	_, err := c.send.SendSync(vaMsg)
+	_, err := c.send.SendSync(vaMsg, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create VolumeAttachment failed, err: %v", err)
 	}
@@ -55,7 +55,7 @@ func (c *volumeattachments) Update(va *api.VolumeAttachment) error {
 func (c *volumeattachments) Delete(name string) error {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, "volumeattachment", name)
 	vaMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.DeleteOperation, nil)
-	_, err := c.send.SendSync(vaMsg)
+	_, err := c.send.SendSync(vaMsg, true, nil)
 	if err != nil {
 		return fmt.Errorf("delete VolumeAttachment failed, err: %v", err)
 	}
@@ -65,7 +65,7 @@ func (c *volumeattachments) Delete(name string) error {
 func (c *volumeattachments) Get(name string, options metav1.GetOptions) (*api.VolumeAttachment, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, "volumeattachment", name)
 	vaMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(vaMsg)
+	msg, err := c.send.SendSync(vaMsg, true, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get volumeattachment from metaManager failed, err: %v", err)
 	}

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -126,6 +126,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					DeletePodWorkers:                  constants.DefaultDeletePodWorkers,
 					UpdateRuleStatusWorkers:           constants.DefaultUpdateRuleStatusWorkers,
 					ServiceAccountTokenWorkers:        constants.DefaultServiceAccountTokenWorkers,
+					LeaseWorkers:                      constants.DefaultLeaseWorkers,
 				},
 			},
 			DeviceController: &DeviceController{

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -270,6 +270,9 @@ type EdgeControllerBuffer struct {
 	// ServiceAccount indicates the buffer of service account token
 	// default 1024
 	ServiceAccountToken int32 `json:"serviceAccountToken,omitempty"`
+	// Lease indicates the buffer of lease message from edge
+	// default 1024
+	Lease int32 `json:"lease,omitempty"`
 }
 
 // ControllerContext indicates the message layer context for all controllers
@@ -328,6 +331,9 @@ type EdgeControllerLoad struct {
 	// ServiceAccountTokenWorkers indicates the load of service account token
 	// default 4
 	ServiceAccountTokenWorkers int32 `json:"ServiceAccountTokenWorkers,omitempty"`
+	// LeaseWrokers indicates the load of process leases
+	// default 4
+	LeaseWorkers int32
 }
 
 // DeviceController indicates the device controller

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -52,6 +52,8 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				Annotations:                 map[string]string{},
 				Taints:                      []v1.Taint{},
 				NodeStatusUpdateFrequency:   constants.DefaultNodeStatusUpdateFrequency,
+				NodeStatusReportFrequency:   constants.DefaultNodeStatusReportFrequency,
+				NodeLeaseDurationSeconds:    constants.DefaultNodeLeaseDurationSeconds,
 				RuntimeType:                 constants.DefaultRuntimeType,
 				DockerAddress:               constants.DefaultDockerAddress,
 				RemoteRuntimeEndpoint:       constants.DefaultRemoteRuntimeEndpoint,

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -113,8 +113,21 @@ type Edged struct {
 	// Taints indicates current node taints
 	Taints []v1.Taint `json:"taints,omitempty"`
 	// NodeStatusUpdateFrequency indicates node status update frequency (second)
+	// If enable the NodeLease feature gate, it will be the node lease update frequency, and
+	// node status computation frequency.
 	// default 10
 	NodeStatusUpdateFrequency int32 `json:"nodeStatusUpdateFrequency,omitempty"`
+	// nodeStatusReportFrequency is the frequency that edged posts node status to master if node status does not change.
+	// Edged will ignore this frequency and post node status immediately if any change is detected.
+	// It is only used when node lease feature is enabled. (second)
+	// default 300
+	NodeStatusReportFrequency int32 `json:"nodeStatusReportFrequency,omitempty"`
+	// nodeLeaseDurationSeconds is the duration the edged will set on its corresponding Lease.
+	// NodeLease provides an indicator of node health by having the Kubelet create and
+	// periodically renew a lease, named after the node, in the kube-node-lease namespace.
+	// If the lease expires, the node can be considered unhealthy.
+	// The field value must be greater than 0. Default: 40
+	NodeLeaseDurationSeconds int32 `json:"nodeLeaseDurationSeconds,omitempty"`
 	// RuntimeType indicates cri runtime ,support: docker, remote
 	// default "docker"
 	RuntimeType string `json:"runtimeType,omitempty"`

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -21,6 +21,9 @@ func init() {
 const (
 	// ProcessStatusSync supports synchronization between process message channel statuses
 	ProcessStatusSync featuregate.Feature = "ProcessStatusSync"
+
+	// NodeLease allow cloudcore to use lease to report edge node heartbeats
+	NodeLease featuregate.Feature = "NodeLease"
 )
 
 // defaultFeatureGates consists of all known Kubeedge-specific feature keys.
@@ -28,4 +31,5 @@ const (
 // available throughout Kubeedge binaries.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ProcessStatusSync: {Default: false, PreRelease: featuregate.Alpha},
+	NodeLease:         {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
@@ -31,6 +31,7 @@ const (
 	ResourceTypeRule                = "rule"
 	ResourceTypeRuleEndpoint        = "ruleendpoint"
 	ResourceTypeRuleStatus          = "rulestatus"
+	ResourceTypeLease               = "lease"
 )
 
 // Message struct


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add a new feature gate NodeLease to kubeedge, users can enable the feature gate to use nodelease to update heartbeat rather than using nodeStatus, which can obviously reduce the traffic.

In #3294, I implemented this feature with adding nodelease controller in cloudcore. It seems not a good idea, because cloudcore is designed to be a component responsible for cloud-edge communication. So in this pr, I move the relative code in edgecore.

The implementation logic is similar to `syncNodeStatus`, and do not use the k8s nodelease controller. Because the logic of native nodelease controller depends deeply on the apierrors returned by the apiserver. As an example, native nodelease controller will firstly try to update nodelease, if there's `NotFound` error then it will try to create the nodelease resource. However, kubeedge has its own communication machinism which cannot return `apierrors` currently.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3086 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

This feature gate is defaultly not enabled. Users should have to manually enable `NodeLease` feature gate in the config yaml file of edgecore. And a new field `nodeLeaseUpdateFrequency` of edged is introduced, which determines the nodelease update frequency and nodestatus check frequency. Here's an example config.yaml: 
```yaml
apiVersion: edgecore.config.kubeedge.io/v1alpha1
database:
  aliasName: default
  dataSource: /tmp/var/lib/kubeedge/edgecore.db
  driverName: sqlite3
kind: EdgeCore
featureGates:
  NodeLease: true
modules:
  ...
  edged:
    nodeLeaseUpdateFrequency: 10
    nodeStatusUpdateFrequency: 60
  ...
```
With this config, edgecore will update nodelease every 10s and check nodestatus every 10s. If there's no change on nodestatus comparing with last updated nodestatus, edgecore will not send nodestatus msg to the cloudcore. If it has been 60s since last nodestatus update, edgecore will send nodestatus update msg even there's no change.
