### PR TITLE
support multi architecture image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,27 @@ image:
 	hack/make-rules/image.sh $(WHAT)
 endif
 
+define CROSS_IMAGE_HELP_INFO
+# Use Buildx to build multi-architecture docker images.
+#
+# Args:
+#   WHAT: component names to build. support: $(BINARIES)
+#         If not specified, "everything" will be built.
+#
+# Example:
+#   make crossbuildimage
+#   make crossbuildimage HELP=y
+#   make crossbuildimage WHAT=cloudcore
+endef
+.PHONY: crossbuildimage
+ifeq ($(HELP),y)
+crossbuildimage:
+	@echo "CROSS_IMAGE_HELP_INFO"
+else
+crossbuildimage:
+	hack/make-rules/crossbuildimage.sh $(WHAT)
+endif
+
 define INSTALL_HELP_INFO
 # install
 #

--- a/hack/make-rules/crossbuildimage.sh
+++ b/hack/make-rules/crossbuildimage.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+###
+#Copyright 2021 The KubeEdge Authors.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+###
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+IMAGE_TAG=$(git describe --tags)
+GO_LDFLAGS="$(${KUBEEDGE_ROOT}/hack/make-rules/version.sh)"
+IMAGE_REPO_NAME="kubeedge"
+
+ALL_IMAGES_AND_TARGETS=(
+  #{target}:{IMAGE_NAME}:{DOCKERFILE_PATH}
+  cloudcore:cloudcore:build/cloud/Dockerfile
+  admission:admission:build/admission/Dockerfile
+  edgecore:edgecore:build/edge/Dockerfile
+  edgesite-agent:edgesite-agent:build/edgesite/agent-build.Dockerfile
+  edgesite-server:edgesite-server:build/edgesite/server-build.Dockerfile
+  csidriver:csidriver:build/csidriver/Dockerfile
+  iptablesmanager:iptables-manager:build/iptablesmanager/Dockerfile
+)
+
+function get_imagename_by_target() {
+  local key=$1
+  for bt in "${ALL_IMAGES_AND_TARGETS[@]}" ; do
+    local binary="${bt%%:*}"
+    if [ "${binary}" == "${key}" ]; then
+      local name_path="${bt#*:}"
+      echo "${name_path%%:*}"
+      return
+    fi
+  done
+  echo "can not find image name: $key"
+  exit 1
+}
+
+function get_dockerfile_by_target() {
+  local key=$1
+  for bt in "${ALL_IMAGES_AND_TARGETS[@]}" ; do
+    local binary="${bt%%:*}"
+    if [ "${binary}" == "${key}" ]; then
+      local name_path="${bt#*:}"
+      echo "${name_path#*:}"
+      return
+    fi
+  done
+  echo "can not find dockerfile for: $key"
+  exit 1
+}
+
+function build_multi_arch_images() {
+  local -a targets=()
+
+  for arg in "$@"; do
+    targets+=("${arg}")
+  done
+
+  if [[ ${#targets[@]} -eq 0 ]]; then
+     for bt in "${ALL_IMAGES_AND_TARGETS[@]}" ; do
+       targets+=("${bt%%:*}")
+     done
+  fi
+
+  for arg in "${targets[@]}"; do
+    IMAGE_NAME="$(get_imagename_by_target ${arg})"
+    DOCKERFILE_PATH="$(get_dockerfile_by_target ${arg})"
+
+    set -x
+    docker buildx build --build-arg GO_LDFLAGS="${GO_LDFLAGS}" -t ${IMAGE_REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG} -f ${DOCKERFILE_PATH} --platform linux/amd64,linux/arm64,linux/arm/v7 --push .
+    set +x
+  done
+}
+
+#use Docker Buildx to build multi-arch docker images
+#How to enable Docker Buildx:
+#please follow this to open Buildx function: https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408
+# buildx will push the image to registry, so we need to login registry first and use `-t` flag to set image tag specifically.
+build_multi_arch_images "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
support multi architecture image build
use Buildx to build multi arch images: this holds all arch images into one.
But we need to open docker buildx function first: this is not easy and need many steps, I follow this blog https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408 to enable buildx
And buildx will directly push built images to the registry, but not store them locally, so we need an image repo to hold the images.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
