### PR TITLE
make the namespace optional

### DIFF
--- a/build/cloud/01-namespace.yaml
+++ b/build/cloud/01-namespace.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kubeedge
+  name: kubeedge-system
   labels:
     k8s-app: kubeedge

--- a/build/cloud/02-serviceaccount.yaml
+++ b/build/cloud/02-serviceaccount.yaml
@@ -5,4 +5,4 @@ metadata:
     k8s-app: kubeedge
     kubeedge: cloudcore
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system

--- a/build/cloud/04-clusterrolebinding.yaml
+++ b/build/cloud/04-clusterrolebinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system

--- a/build/cloud/05-configmap.yaml
+++ b/build/cloud/05-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system
   labels:
     k8s-app: kubeedge
     kubeedge: cloudcore

--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     k8s-app: kubeedge
     kubeedge: cloudcore
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system
 spec:
   selector:
     matchLabels:

--- a/build/cloud/08-service.yaml.example
+++ b/build/cloud/08-service.yaml.example
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system
   labels:
     k8s-app: kubeedge
     kubeedge: cloudcore

--- a/build/cloud/ha/01-ha-prepare.yaml
+++ b/build/cloud/ha/01-ha-prepare.yaml
@@ -14,7 +14,7 @@ metadata:
     k8s-app: kubeedge
     kubeedge: cloudcore
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,7 +71,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cloudcore
-    namespace: kubeedge
+    namespace: kubeedge-system
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/build/cloud/ha/02-ha-configmap.yaml.example
+++ b/build/cloud/ha/02-ha-configmap.yaml.example
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system
   labels:
     k8s-app: kubeedge
     kubeedge: cloudcore

--- a/build/cloud/ha/03-ha-deployment.yaml.example
+++ b/build/cloud/ha/03-ha-deployment.yaml.example
@@ -5,7 +5,7 @@ metadata:
     k8s-app: kubeedge
     kubeedge: cloudcore
   name: cloudcore
-  namespace: kubeedge
+  namespace: kubeedge-system
 spec:
   replicas: 2
   selector:

--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -73,6 +73,8 @@ kubernetes controller which manages devices so that the device metadata/status d
 				klog.Exit(err)
 			}
 
+			constants.SystemNamespaceInit(config.GetNamespace())
+
 			// To help debugging, immediately log version
 			klog.Infof("Version: %+v", version.Get())
 			client.InitKubeEdgeClient(config.KubeAPIConfig)

--- a/cloud/cmd/iptablesmanager/app/server.go
+++ b/cloud/cmd/iptablesmanager/app/server.go
@@ -57,6 +57,9 @@ func NewIptablesManagerCommand() *cobra.Command {
 				Burst:       constants.DefaultKubeBurst,
 				KubeConfig:  opts.KubeConfig,
 			}
+
+			// init namespace
+			constants.SystemNamespaceInit(os.Getenv(constants.NamespaceEnvKey))
 			go iptables.NewIptablesManager(kubeAPIConfig, opts.ForwardPort).Run(ctx)
 
 			c := make(chan os.Signal, 1)

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -15,9 +16,9 @@ const (
 	NodeName = "NodeName"
 
 	ProjectName = "KubeEdge"
+	SystemName  = "kubeedge-system"
 
-	SystemName      = "kubeedge"
-	SystemNamespace = SystemName
+	NamespaceEnvKey = "NAMESPACE"
 )
 
 // Resources
@@ -146,3 +147,20 @@ const (
 	// MessageSuccessfulContent is the successful content value of Message struct
 	MessageSuccessfulContent string = "OK"
 )
+
+var (
+	SystemNamespace = SystemName
+
+	once sync.Once
+)
+
+func SystemNamespaceInit(ns string) {
+	once.Do(
+		func() {
+			if ns == "" {
+				return
+			}
+			SystemNamespace = ns
+		},
+	)
+}

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -111,7 +111,7 @@ function start_cloudcore {
   # ensure tokensecret is generated
   while true; do
       sleep 3
-      kubectl get secret -nkubeedge| grep -q tokensecret && break
+      kubectl get secret -nkubeedge-system| grep -q tokensecret && break
   done
 }
 
@@ -121,7 +121,7 @@ function start_edgecore {
   ${EDGE_BIN} --defaultconfig >  ${EDGE_CONFIGFILE}
 
   sed -i '/edgeStream:/{n;s/false/true/;}' ${EDGE_CONFIGFILE}
-  token=`kubectl get secret -nkubeedge tokensecret -o=jsonpath='{.data.tokendata}' | base64 -d`
+  token=`kubectl get secret -nkubeedge-system tokensecret -o=jsonpath='{.data.tokendata}' | base64 -d`
 
   sed -i -e "s|token: .*|token: ${token}|g" \
       -e "s|hostnameOverride: .*|hostnameOverride: edge-node|g" \

--- a/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/gettoken.go
@@ -66,8 +66,13 @@ func queryToken(namespace string, name string, kubeConfigPath string) ([]byte, e
 		return nil, err
 	}
 	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), name, metaV1.GetOptions{})
+	// The kubeedge system namespace changed from kubeedge to kubeedge-system.
+	// The following is only for forward compatibility, and will be deleted in future release.
 	if err != nil {
-		return nil, err
+		secret, err = client.CoreV1().Secrets("kubeedge").Get(context.Background(), name, metaV1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return secret.Data[common.TokenDataName], nil
 }

--- a/manifests/charts/cloudcore/templates/daemonset_iptablesmanager.yaml
+++ b/manifests/charts/cloudcore/templates/daemonset_iptablesmanager.yaml
@@ -40,6 +40,11 @@ spec:
       - name: iptables-manager
         command: ['iptables-manager']
         image: {{ .Values.iptablesManager.image.repository }}:{{ .Values.iptablesManager.image.tag }}
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         imagePullPolicy: {{ .Values.iptablesManager.image.pullPolicy }}
         {{- with .Values.iptablesManager.securityContext }}
         securityContext: {{ toYaml . | nindent 10 }}

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
@@ -23,6 +23,8 @@ import (
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
+
+	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 type IptablesMgrMode string
@@ -44,6 +46,14 @@ func (c *CloudCoreConfig) Parse(filename string) error {
 		return err
 	}
 	return nil
+}
+
+func (c *CloudCoreConfig) GetNamespace() string {
+	if ns := os.Getenv(constants.NamespaceEnvKey); ns != "" {
+		return ns
+	}
+
+	return constants.SystemName
 }
 
 func (in *IptablesManager) UnmarshalJSON(data []byte) error {

--- a/tests/e2e/scripts/keadm_beta_e2e.sh
+++ b/tests/e2e/scripts/keadm_beta_e2e.sh
@@ -57,6 +57,11 @@ function build_image() {
 function start_kubeedge() {
   sudo mkdir -p /var/lib/kubeedge
   cd $KUBEEDGE_ROOT
+  export KUBECONFIG=$HOME/.kube/config
+
+  cd $HELM_DIR
+  SET_ARGS="--set cloudCore.modules.cloudHub.advertiseAddress[0]=$MASTER_IP --set cloudCore.image.tag=$IMAGE_TAG --set cloudCore.service.enable=false"
+  helm upgrade --install --wait --timeout 30s cloudcore ./cloudcore --namespace kubeedge-system --create-namespace -f ./cloudcore/values.yaml $SET_ARGS
   export MASTER_IP=`kubectl get node test-control-plane -o jsonpath={.status.addresses[0].address}`
   export KUBECONFIG=$HOME/.kube/config
   docker run --rm kubeedge/installation-package:$IMAGE_TAG cat /usr/local/bin/keadm > /usr/local/bin/keadm && chmod +x /usr/local/bin/keadm
@@ -66,7 +71,7 @@ function start_kubeedge() {
   # ensure tokensecret is generated
   while true; do
       sleep 3
-      kubectl get secret -nkubeedge 2>/dev/null | grep -q tokensecret && break
+      kubectl get secret -nkubeedge-system 2>/dev/null | grep -q tokensecret && break
   done
   
   cd $KUBEEDGE_ROOT

--- a/tests/e2e/scripts/keadm_e2e.sh
+++ b/tests/e2e/scripts/keadm_e2e.sh
@@ -63,6 +63,7 @@ function start_kubeedge() {
   # ensure tokensecret is generated
   while true; do
       sleep 3
+      kubectl get secret -nkubeedge-system 2>/dev/null | grep -q tokensecret && break
       kubectl get secret -nkubeedge 2>/dev/null | grep -q tokensecret && break
   done
 


### PR DESCRIPTION
Signed-off-by: zhu733756 <zhu733756@kubesphere.io>

Fix #3547 

## How to test
```
helm upgrade --install cloudcore ./cloudcore --namespace kubeedge001 --create-namespace -f ./cloudcore/values.yaml --set cloudCore.modules.cloudHub.advertiseAddress[0]=192.168.88.6 --set cloudCore.image.repository=zhu733756/cloudcore --set cloudCore.image.tag=v1.9.1-beta-2
```

## Screen Captures

![image](https://user-images.githubusercontent.com/38685176/149432430-2ec67f3a-45f0-4f33-b9c7-83b7c896b082.png)
