### PR TITLE
csidriver: handle topology constraints

### DIFF
--- a/cloud/cmd/csidriver/app/options/options.go
+++ b/cloud/cmd/csidriver/app/options/options.go
@@ -24,9 +24,10 @@ import (
 type CSIDriverOptions struct {
 	Endpoint         string
 	DriverName       string
-	NodeID           string
 	KubeEdgeEndpoint string
 	Version          string
+	StatePath        string
+	TopologyKey      string
 }
 
 // NewCSIDriverOptions returns options object
@@ -39,7 +40,8 @@ func (o *CSIDriverOptions) Flags() (fss cliflag.NamedFlagSets) {
 	fs := fss.FlagSet("csidriver")
 	fs.StringVar(&o.Endpoint, "endpoint", "unix:///csi/csi.sock", "CSI endpoint")
 	fs.StringVar(&o.DriverName, "drivername", "csidriver", "name of the driver")
-	fs.StringVar(&o.NodeID, "nodeid", "", "node id determines which node will be used to create/delete volumes")
+	fs.StringVar(&o.StatePath, "state-path", "/kubeedge/csidriver", "path to the state storage")
+	fs.StringVar(&o.TopologyKey, "topology-key", "csi.kubeedge.io/nodeid", "topology key to use when considering accessibility requirements. The topology value must be the kubeedge node name which is used for routing CSI requests. The topology key must be defined")
 	fs.StringVar(&o.KubeEdgeEndpoint, "kubeedge-endpoint", "unix:///kubeedge/kubeedge.sock", "kubeedge endpoint")
 	fs.StringVar(&o.Version, "version", "dev", "version")
 	return

--- a/cloud/pkg/csidriver/controllerserver.go
+++ b/cloud/pkg/csidriver/controllerserver.go
@@ -17,374 +17,201 @@ limitations under the License.
 package csidriver
 
 import (
-	"encoding/base64"
-	"encoding/json"
-	"errors"
+	"fmt"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/google/uuid"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/csidriver/state"
 	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 type controllerServer struct {
 	caps             []*csi.ControllerServiceCapability
-	nodeID           string
+	sendFn           KubeEdgeSendFn
 	kubeEdgeEndpoint string
+	inFlight         *inFlight
+	store            *state.Store
+	topologyKey      string
 }
 
+type KubeEdgeSendFn func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error
+
 // newControllerServer creates controller server
-func newControllerServer(nodeID, kubeEdgeEndpoint string) *controllerServer {
+func newControllerServer(kubeEdgeEndpoint string, store *state.Store, topologyKey string) *controllerServer {
 	return &controllerServer{
 		caps: getControllerServiceCapabilities(
 			[]csi.ControllerServiceCapability_RPC_Type{
 				csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 				csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
 			}),
-		nodeID:           nodeID,
+		sendFn:           sendToKubeEdge,
 		kubeEdgeEndpoint: kubeEdgeEndpoint,
+		topologyKey:      topologyKey,
+		inFlight:         newInFlight(),
+		store:            store,
 	}
 }
 
 // CreateVolume issues create volume func
 func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
-	// Check arguments
-	if len(req.GetName()) == 0 {
+	volName := req.GetName()
+	if len(volName) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Name missing in request")
 	}
 	caps := req.GetVolumeCapabilities()
 	if caps == nil {
 		return nil, status.Error(codes.InvalidArgument, "Volume Capabilities missing in request")
 	}
+	klog.V(4).Infof("create volume request id=%s req=%#v", volName, req)
 
-	volumeID := uuid.New().String()
-
-	// Build message struct
-	resource, err := buildResource(cs.nodeID,
-		DefaultNamespace,
-		constants.CSIResourceTypeVolume,
-		volumeID)
-	if err != nil {
-		klog.Errorf("build message resource failed with error: %s", err)
-		return nil, err
+	if ok := cs.inFlight.Insert(volName); !ok {
+		return nil, status.Errorf(codes.Aborted, "request already inflight for %s", volName)
 	}
+	defer cs.inFlight.Delete(volName)
 
-	m := jsonpb.Marshaler{}
-	js, err := m.MarshalToString(req)
+	edgeNode, err := pickEdgeNode(req.GetAccessibilityRequirements(), cs.topologyKey)
 	if err != nil {
-		klog.Errorf("failed to marshal to string with error: %s", err)
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, "Can not pick edge node based on accessibility requirements")
 	}
-	klog.V(4).Infof("create volume marshal to string: %s", js)
-	msg := model.NewMessage("").
-		BuildRouter(DefaultReceiveModuleName, GroupResource, resource, constants.CSIOperationTypeCreateVolume).
-		FillBody(js)
-
-	// Marshal message
-	reqData, err := json.Marshal(msg)
-	if err != nil {
-		klog.Errorf("marshal request failed with error: %v", err)
-		return nil, err
-	}
+	klog.V(4).Infof("picked edge node: %s", edgeNode)
 
 	// Send message to KubeEdge
-	resdata, err := sendToKubeEdge(string(reqData), cs.kubeEdgeEndpoint)
+	res := &csi.CreateVolumeResponse{}
+	err = cs.sendFn(req, edgeNode, volName, constants.CSIOperationTypeCreateVolume, res, cs.kubeEdgeEndpoint)
 	if err != nil {
 		klog.Errorf("send to kubeedge failed with error: %v", err)
 		return nil, err
 	}
 
-	// Unmarshal message
-	result, err := extractMessage(resdata)
+	err = cs.store.Update(res.Volume.VolumeId, edgeNode)
 	if err != nil {
-		klog.Errorf("unmarshal response failed with error: %v", err)
-		return nil, err
+		return nil, status.Error(codes.Internal, "unable to update state")
 	}
 
-	klog.V(4).Infof("create volume result: %v", result)
-	data := result.GetContent().(string)
-
-	if result.GetOperation() == model.ResponseErrorOperation {
-		klog.Errorf("create volume with error: %s", data)
-		return nil, errors.New(data)
-	}
-
-	decodeBytes, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		klog.Errorf("create volume decode with error: %v", err)
-		return nil, err
-	}
-
-	response := &csi.CreateVolumeResponse{}
-	err = json.Unmarshal(decodeBytes, response)
-	if err != nil {
-		klog.Errorf("create volume unmarshal with error: %v", err)
-		return nil, err
-	}
-	klog.V(4).Infof("create volume response: %v", response)
-
+	klog.V(4).Infof("create volume response: %#v", res)
 	createVolumeResponse := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      response.Volume.VolumeId,
+			VolumeId:      res.Volume.VolumeId,
 			CapacityBytes: req.GetCapacityRange().GetRequiredBytes(),
-			VolumeContext: req.GetParameters(),
 		},
 	}
 	if req.GetVolumeContentSource() != nil {
 		createVolumeResponse.Volume.ContentSource = req.GetVolumeContentSource()
 	}
+	klog.V(4).Infof("returning volume response: %#v", createVolumeResponse)
 	return createVolumeResponse, nil
+}
+
+func pickEdgeNode(requirement *csi.TopologyRequirement, topoKey string) (string, error) {
+	klog.Info("topology requirements: %#v", requirement)
+	if requirement == nil {
+		return "", fmt.Errorf("missing topology requirements")
+	}
+	for _, topology := range requirement.GetPreferred() {
+		node, exists := findTopoKey(topology.GetSegments(), topoKey)
+		if exists {
+			return node, nil
+		}
+	}
+	for _, topology := range requirement.GetRequisite() {
+		node, exists := findTopoKey(topology.GetSegments(), topoKey)
+		if exists {
+			return node, nil
+		}
+	}
+	return "", fmt.Errorf("could not find matching node")
+}
+
+func findTopoKey(segments map[string]string, topoKey string) (string, bool) {
+	node, exists := segments[topoKey]
+	if exists {
+		return node, true
+	}
+	return "", false
 }
 
 // DeleteVolume issues delete volume func
 func (cs *controllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
-	// Check arguments
-	if len(req.GetVolumeId()) == 0 {
+	volumeID := req.GetVolumeId()
+	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID missing in request")
 	}
-
-	// Build message struct
-	resource, err := buildResource(cs.nodeID,
-		DefaultNamespace,
-		constants.CSIResourceTypeVolume,
-		req.GetVolumeId())
+	edgeName, err := cs.store.Get(volumeID)
 	if err != nil {
-		klog.Errorf("build message resource failed with error: %s", err)
-		return nil, err
+		return nil, status.Error(codes.Internal, "unable to get state")
 	}
-
-	m := jsonpb.Marshaler{}
-	js, err := m.MarshalToString(req)
-	if err != nil {
-		klog.Errorf("failed to marshal to string with error: %s", err)
-		return nil, err
-	}
-	klog.V(4).Infof("delete volume marshal to string: %s", js)
-	msg := model.NewMessage("").
-		BuildRouter(DefaultReceiveModuleName, GroupResource, resource, constants.CSIOperationTypeDeleteVolume).
-		FillBody(js)
-
-	// Marshal message
-	reqData, err := json.Marshal(msg)
-	if err != nil {
-		klog.Errorf("marshal request failed with error: %v", err)
-		return nil, err
-	}
-
-	// Send message to KubeEdge
-	resdata, err := sendToKubeEdge(string(reqData), cs.kubeEdgeEndpoint)
+	klog.V(4).Infof("delete volume %s from %s", volumeID, edgeName)
+	res := &csi.DeleteVolumeResponse{}
+	err = cs.sendFn(req, edgeName, volumeID, constants.CSIOperationTypeDeleteVolume, res, cs.kubeEdgeEndpoint)
 	if err != nil {
 		klog.Errorf("send to kubeedge failed with error: %v", err)
 		return nil, err
 	}
-
-	// Unmarshal message
-	result, err := extractMessage(resdata)
+	err = cs.store.Delete(volumeID)
 	if err != nil {
-		klog.Errorf("unmarshal response failed with error: %v", err)
-		return nil, err
+		return nil, status.Error(codes.Internal, fmt.Sprintf("unable to update state: %s", err))
 	}
-
-	klog.V(4).Infof("delete volume result: %v", result)
-	data := result.GetContent().(string)
-
-	if msg.GetOperation() == model.ResponseErrorOperation {
-		klog.Errorf("delete volume with error: %s", data)
-		return nil, errors.New(data)
-	}
-
-	decodeBytes, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		klog.Errorf("delete volume decode with error: %v", err)
-		return nil, err
-	}
-
-	deleteVolumeResponse := &csi.DeleteVolumeResponse{}
-	err = json.Unmarshal(decodeBytes, deleteVolumeResponse)
-	if err != nil {
-		klog.Errorf("delete volume unmarshal with error: %v", err)
-		return nil, err
-	}
-	klog.V(4).Infof("delete volume response: %v", deleteVolumeResponse)
-	return deleteVolumeResponse, nil
+	klog.V(4).Infof("delete volume response: %v", res)
+	return res, nil
 }
 
 // ControllerPublishVolume issues controller publish volume func
 func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	instanceID := req.GetNodeId()
 	volumeID := req.GetVolumeId()
-
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume Volume ID must be provided")
 	}
-
-	if len(instanceID) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume Instance ID must be provided")
+	edgeName := req.GetNodeId()
+	if edgeName == "" {
+		return nil, status.Error(codes.InvalidArgument, "ControllerPublishVolume Node ID must be provided")
 	}
-
-	// Build message struct
-	resource, err := buildResource(cs.nodeID,
-		DefaultNamespace,
-		constants.CSIResourceTypeVolume,
-		volumeID)
-	if err != nil {
-		klog.Errorf("build message resource failed with error: %s", err)
-		return nil, err
-	}
-
-	m := jsonpb.Marshaler{}
-	js, err := m.MarshalToString(req)
-	if err != nil {
-		klog.Errorf("failed to marshal to string with error: %s", err)
-		return nil, err
-	}
-	klog.V(4).Infof("controller publish volume marshal to string: %s", js)
-	msg := model.NewMessage("").
-		BuildRouter(DefaultReceiveModuleName, GroupResource, resource, constants.CSIOperationTypeControllerPublishVolume).
-		FillBody(js)
-
-	// Marshal message
-	reqData, err := json.Marshal(msg)
-	if err != nil {
-		klog.Errorf("marshal request failed with error: %v", err)
-		return nil, err
-	}
-
-	// Send message to KubeEdge
-	resdata, err := sendToKubeEdge(string(reqData), cs.kubeEdgeEndpoint)
+	klog.V(4).Infof("publish volume %s on %s", volumeID, edgeName)
+	res := &csi.ControllerPublishVolumeResponse{}
+	err := cs.sendFn(req, edgeName, volumeID, constants.CSIOperationTypeControllerPublishVolume, res, cs.kubeEdgeEndpoint)
 	if err != nil {
 		klog.Errorf("send to kubeedge failed with error: %v", err)
 		return nil, err
 	}
-
-	// Unmarshal message
-	result, err := extractMessage(resdata)
-	if err != nil {
-		klog.Errorf("unmarshal response failed with error: %v", err)
-		return nil, err
-	}
-
-	klog.V(4).Infof("controller publish volume result: %v", result)
-	data := result.GetContent().(string)
-
-	if msg.GetOperation() == model.ResponseErrorOperation {
-		klog.Errorf("controller publish volume with error: %s", data)
-		return nil, errors.New(data)
-	}
-
-	decodeBytes, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		klog.Errorf("controller publish volume decode with error: %v", err)
-		return nil, err
-	}
-
-	controllerPublishVolumeResponse := &csi.ControllerPublishVolumeResponse{}
-	err = json.Unmarshal(decodeBytes, controllerPublishVolumeResponse)
-	if err != nil {
-		klog.Errorf("controller publish volume unmarshal with error: %v", err)
-		return nil, err
-	}
-	klog.V(4).Infof("controller publish volume response: %v", controllerPublishVolumeResponse)
-	return controllerPublishVolumeResponse, nil
+	klog.V(4).Infof("controller publish volume response: %v", res)
+	return res, nil
 }
 
 // ControllerUnpublishVolume issues controller unpublish volume func
 func (cs *controllerServer) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	instanceID := req.GetNodeId()
 	volumeID := req.GetVolumeId()
-
 	if len(volumeID) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "ControllerUnpublishVolume Volume ID must be provided")
 	}
-
-	if len(instanceID) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "ControllerUnpublishVolume Instance ID must be provided")
+	edgeName := req.GetNodeId()
+	if edgeName == "" {
+		return nil, status.Error(codes.InvalidArgument, "ControllerUnpublishVolume Node ID must be provided")
 	}
-
-	// Build message struct
-	resource, err := buildResource(cs.nodeID,
-		DefaultNamespace,
-		constants.CSIResourceTypeVolume,
-		volumeID)
-	if err != nil {
-		klog.Errorf("Build message resource failed with error: %s", err)
-		return nil, err
-	}
-
-	m := jsonpb.Marshaler{}
-	js, err := m.MarshalToString(req)
-	if err != nil {
-		klog.Errorf("failed to marshal to string with error: %s", err)
-		return nil, err
-	}
-	klog.V(4).Infof("controller Unpublish Volume marshal to string: %s", js)
-	msg := model.NewMessage("").
-		BuildRouter(DefaultReceiveModuleName, GroupResource, resource, constants.CSIOperationTypeControllerUnpublishVolume).
-		FillBody(js)
-
-	// Marshal message
-	reqData, err := json.Marshal(msg)
-	if err != nil {
-		klog.Errorf("marshal request failed with error: %v", err)
-		return nil, err
-	}
-
-	// Send message to KubeEdge
-	resdata, err := sendToKubeEdge(string(reqData), cs.kubeEdgeEndpoint)
+	klog.V(4).Infof("unpublish volume %s on %s", volumeID, edgeName)
+	res := &csi.ControllerUnpublishVolumeResponse{}
+	err := cs.sendFn(req, edgeName, volumeID, constants.CSIOperationTypeControllerUnpublishVolume, res, cs.kubeEdgeEndpoint)
 	if err != nil {
 		klog.Errorf("send to kubeedge failed with error: %v", err)
 		return nil, err
 	}
-
-	// Unmarshal message
-	result, err := extractMessage(resdata)
-	if err != nil {
-		klog.Errorf("unmarshal response failed with error: %v", err)
-		return nil, err
-	}
-
-	klog.V(4).Infof("controller Unpublish Volume result: %v", result)
-	data := result.GetContent().(string)
-
-	if msg.GetOperation() == model.ResponseErrorOperation {
-		klog.Errorf("controller Unpublish Volume with error: %s", data)
-		return nil, errors.New(data)
-	}
-
-	decodeBytes, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		klog.Errorf("controller Unpublish Volume decode with error: %v", err)
-		return nil, err
-	}
-
-	controllerUnpublishVolumeResponse := &csi.ControllerUnpublishVolumeResponse{}
-	err = json.Unmarshal(decodeBytes, controllerUnpublishVolumeResponse)
-	if err != nil {
-		klog.Errorf("controller Unpublish Volume unmarshal with error: %v", err)
-		return nil, err
-	}
-	klog.V(4).Infof("controller Unpublish Volume response: %v", controllerUnpublishVolumeResponse)
-	return controllerUnpublishVolumeResponse, nil
+	klog.V(4).Infof("controller Unpublish Volume response: %v", res)
+	return res, nil
 }
 
 func (cs *controllerServer) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
-	// Check arguments
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID cannot be empty")
 	}
 	if len(req.VolumeCapabilities) == 0 {
-		return nil, status.Error(codes.InvalidArgument, req.VolumeId)
+		return nil, status.Error(codes.InvalidArgument, "Volume Capabilities can not be empty")
 	}
 
 	for _, cap := range req.GetVolumeCapabilities() {
 		if cap.GetMount() == nil && cap.GetBlock() == nil {
-			return nil, status.Error(codes.InvalidArgument, "cannot have both mount and block access type be undefined")
+			return nil, status.Error(codes.InvalidArgument, "Cannot have both mount and block access type be undefined")
 		}
 	}
 

--- a/cloud/pkg/csidriver/controllerserver_test.go
+++ b/cloud/pkg/csidriver/controllerserver_test.go
@@ -1,0 +1,480 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package csidriver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubeedge/kubeedge/cloud/pkg/csidriver/state"
+)
+
+func TestCSICreateVolume(t *testing.T) {
+	RegisterTestingT(t)
+	topoKey := "csi.example.io/topokey"
+	errBoom := errors.New("boom")
+	tbl := []struct {
+		name   string
+		sendFn KubeEdgeSendFn
+		req    *csi.CreateVolumeRequest
+		res    *csi.CreateVolumeResponse
+		err    string
+	}{
+		{
+			name: "err missing volume name",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return nil
+			},
+			req: &csi.CreateVolumeRequest{},
+			err: "rpc error: code = InvalidArgument desc = Name missing in request",
+		},
+		{
+			name: "err missing volume capabilities",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return nil
+			},
+			req: &csi.CreateVolumeRequest{
+				Name: "foo",
+			},
+			err: "rpc error: code = InvalidArgument desc = Volume Capabilities missing in request",
+		},
+		{
+			name: "kubeedge send error",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return errBoom
+			},
+			err: errBoom.Error(),
+			req: &csi.CreateVolumeRequest{
+				Name:               "foo",
+				VolumeCapabilities: []*csi.VolumeCapability{},
+				AccessibilityRequirements: &csi.TopologyRequirement{
+					Requisite: []*csi.Topology{
+						{
+							Segments: map[string]string{
+								topoKey: "im here so it won't error early",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "successful response",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				rq := req.(*csi.CreateVolumeRequest)
+				rs := res.(*csi.CreateVolumeResponse)
+
+				Expect(rq.Name).To(Equal("foo"))
+				Expect(nodeID).To(Equal("my-edge-node-xyz"))
+				Expect(rq.CapacityRange.RequiredBytes).To(BeEquivalentTo(10))
+
+				*rs = csi.CreateVolumeResponse{
+					Volume: &csi.Volume{
+						VolumeId: "1234",
+					},
+				}
+				return nil
+			},
+			req: &csi.CreateVolumeRequest{
+				Name: "foo",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 10,
+					LimitBytes:    20,
+				},
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Volume{
+						Volume: &csi.VolumeContentSource_VolumeSource{
+							VolumeId: "example",
+						},
+					},
+				},
+				AccessibilityRequirements: &csi.TopologyRequirement{
+					Requisite: []*csi.Topology{
+						{
+							Segments: map[string]string{
+								topoKey: "my-edge-node-xyz",
+							},
+						},
+					},
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{},
+			},
+			res: &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					VolumeId:      "1234",
+					CapacityBytes: 10,
+					ContentSource: &csi.VolumeContentSource{
+						Type: &csi.VolumeContentSource_Volume{
+							Volume: &csi.VolumeContentSource_VolumeSource{
+								VolumeId: "example",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	td, err := os.MkdirTemp("", "")
+	Expect(err).ToNot(HaveOccurred())
+	store, err := state.New(td)
+	Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		os.RemoveAll(td)
+	}()
+	for _, row := range tbl {
+		t.Run(row.name, func(t *testing.T) {
+			cs := newControllerServer("foo", store, topoKey)
+			cs.sendFn = row.sendFn
+			res, err := cs.CreateVolume(context.Background(), row.req)
+			if row.err != "" {
+				Expect(err).To(MatchError(row.err))
+				Expect(res).To(BeNil())
+			} else {
+				Expect(err).To(BeNil())
+				Expect(res).To(Equal(row.res))
+			}
+		})
+	}
+}
+
+func TestCSIDeleteVolume(t *testing.T) {
+	RegisterTestingT(t)
+	errBoom := errors.New("boom")
+	tbl := []struct {
+		name   string
+		sendFn KubeEdgeSendFn
+		req    *csi.DeleteVolumeRequest
+		res    *csi.DeleteVolumeResponse
+		err    string
+	}{
+		{
+			name: "err missing volume id",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return nil
+			},
+			req: &csi.DeleteVolumeRequest{},
+			err: "rpc error: code = InvalidArgument desc = Volume ID missing in request",
+		},
+		{
+			name: "kubeedge send error",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return errBoom
+			},
+			err: errBoom.Error(),
+			req: &csi.DeleteVolumeRequest{
+				VolumeId: "foo",
+			},
+		},
+		{
+			name: "successful response",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				rq := req.(*csi.DeleteVolumeRequest)
+				rs := res.(*csi.DeleteVolumeResponse)
+
+				Expect(rq.VolumeId).To(Equal("foo"))
+				*rs = csi.DeleteVolumeResponse{}
+				return nil
+			},
+			req: &csi.DeleteVolumeRequest{
+				VolumeId: "foo",
+			},
+			res: &csi.DeleteVolumeResponse{},
+		},
+	}
+
+	td, err := os.MkdirTemp("", "")
+	Expect(err).ToNot(HaveOccurred())
+	store, err := state.New(td)
+	Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		os.RemoveAll(td)
+	}()
+
+	for _, row := range tbl {
+		t.Run(row.name, func(t *testing.T) {
+			cs := newControllerServer("foo", store, "")
+			cs.sendFn = row.sendFn
+
+			// prepare state so we can delete it
+			err := store.Update(row.req.VolumeId, "node-1234")
+			Expect(err).ToNot(HaveOccurred())
+
+			res, err := cs.DeleteVolume(context.Background(), row.req)
+			if row.err != "" {
+				Expect(err).To(MatchError(row.err))
+				Expect(res).To(BeNil())
+			} else {
+				Expect(err).To(BeNil())
+				Expect(res).To(Equal(row.res))
+				// should be deleted now
+				_, err = store.Get(row.req.VolumeId)
+				Expect(err).To(MatchError(state.ErrNotExist))
+			}
+		})
+	}
+}
+
+func TestCSIPublishVolume(t *testing.T) {
+	RegisterTestingT(t)
+	errBoom := errors.New("boom")
+	tbl := []struct {
+		name   string
+		sendFn KubeEdgeSendFn
+		req    *csi.ControllerPublishVolumeRequest
+		res    *csi.ControllerPublishVolumeResponse
+		err    string
+	}{
+		{
+			name: "err missing volume id",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return nil
+			},
+			req: &csi.ControllerPublishVolumeRequest{
+				NodeId: "foo",
+			},
+			err: "rpc error: code = InvalidArgument desc = ControllerPublishVolume Volume ID must be provided",
+		},
+		{
+			name: "err missing node id",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return nil
+			},
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId: "foo",
+			},
+			err: "rpc error: code = InvalidArgument desc = ControllerPublishVolume Node ID must be provided",
+		},
+		{
+			name: "kubeedge send error",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return errBoom
+			},
+			err: errBoom.Error(),
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId: "foo",
+				NodeId:   "bar",
+			},
+		},
+		{
+			name: "successful response",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				rq := req.(*csi.ControllerPublishVolumeRequest)
+				rs := res.(*csi.ControllerPublishVolumeResponse)
+
+				Expect(rq.VolumeId).To(Equal("foo"))
+				Expect(rq.NodeId).To(Equal("bar"))
+				*rs = csi.ControllerPublishVolumeResponse{
+					PublishContext: map[string]string{
+						"foo": "example",
+					},
+				}
+				return nil
+			},
+			req: &csi.ControllerPublishVolumeRequest{
+				VolumeId: "foo",
+				NodeId:   "bar",
+			},
+			res: &csi.ControllerPublishVolumeResponse{
+				PublishContext: map[string]string{
+					"foo": "example",
+				},
+			},
+		},
+	}
+
+	for _, row := range tbl {
+		t.Run(row.name, func(t *testing.T) {
+			cs := newControllerServer("foo", nil, "")
+			cs.sendFn = row.sendFn
+			res, err := cs.ControllerPublishVolume(context.Background(), row.req)
+			if row.err != "" {
+				Expect(err).To(MatchError(row.err))
+				Expect(res).To(BeNil())
+			} else {
+				Expect(err).To(BeNil())
+				Expect(res).To(Equal(row.res))
+			}
+		})
+	}
+}
+
+func TestCSIUnpublishVolume(t *testing.T) {
+	RegisterTestingT(t)
+	errBoom := errors.New("boom")
+	tbl := []struct {
+		name   string
+		sendFn KubeEdgeSendFn
+		req    *csi.ControllerUnpublishVolumeRequest
+		res    *csi.ControllerUnpublishVolumeResponse
+		err    string
+	}{
+		{
+			name: "err missing volume id",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return nil
+			},
+			req: &csi.ControllerUnpublishVolumeRequest{
+				NodeId: "foo",
+			},
+			err: "rpc error: code = InvalidArgument desc = ControllerUnpublishVolume Volume ID must be provided",
+		},
+		{
+			name: "err missing node id",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return nil
+			},
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: "foo",
+			},
+			err: "rpc error: code = InvalidArgument desc = ControllerUnpublishVolume Node ID must be provided",
+		},
+		{
+			name: "kubeedge send error",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				return errBoom
+			},
+			err: errBoom.Error(),
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: "foo",
+				NodeId:   "bar",
+			},
+		},
+		{
+			name: "successful response",
+			sendFn: func(req interface{}, nodeID, volumeID, csiOp string, res interface{}, kubeEdgeEndpoint string) error {
+				rq := req.(*csi.ControllerUnpublishVolumeRequest)
+				rs := res.(*csi.ControllerUnpublishVolumeResponse)
+
+				Expect(rq.VolumeId).To(Equal("foo"))
+				Expect(rq.NodeId).To(Equal("bar"))
+				*rs = csi.ControllerUnpublishVolumeResponse{}
+				return nil
+			},
+			req: &csi.ControllerUnpublishVolumeRequest{
+				VolumeId: "foo",
+				NodeId:   "bar",
+			},
+			res: &csi.ControllerUnpublishVolumeResponse{},
+		},
+	}
+
+	for _, row := range tbl {
+		t.Run(row.name, func(t *testing.T) {
+			cs := newControllerServer("foo", nil, "")
+			cs.sendFn = row.sendFn
+			res, err := cs.ControllerUnpublishVolume(context.Background(), row.req)
+			if row.err != "" {
+				Expect(err).To(MatchError(row.err))
+				Expect(res).To(BeNil())
+			} else {
+				Expect(err).To(BeNil())
+				Expect(res).To(Equal(row.res))
+			}
+		})
+	}
+}
+
+func TestCSIValidateVolumeCapabilities(t *testing.T) {
+	RegisterTestingT(t)
+	tbl := []struct {
+		name string
+		req  *csi.ValidateVolumeCapabilitiesRequest
+		res  *csi.ValidateVolumeCapabilitiesResponse
+		err  string
+	}{
+		{
+			name: "err missing volume id",
+
+			req: &csi.ValidateVolumeCapabilitiesRequest{},
+			err: "rpc error: code = InvalidArgument desc = Volume ID cannot be empty",
+		},
+		{
+			name: "err missing node id",
+			req: &csi.ValidateVolumeCapabilitiesRequest{
+				VolumeId: "foo",
+			},
+			err: "rpc error: code = InvalidArgument desc = Volume Capabilities can not be empty",
+		},
+		{
+			name: "err missing access type",
+			req: &csi.ValidateVolumeCapabilitiesRequest{
+				VolumeId: "foo",
+				VolumeContext: map[string]string{
+					"foo": "example",
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{},
+				},
+			},
+			err: "rpc error: code = InvalidArgument desc = Cannot have both mount and block access type be undefined",
+		},
+		{
+			name: "successful response",
+			req: &csi.ValidateVolumeCapabilitiesRequest{
+				VolumeId: "foo",
+				VolumeContext: map[string]string{
+					"foo": "example",
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+						},
+					},
+				},
+			},
+			res: &csi.ValidateVolumeCapabilitiesResponse{
+				Confirmed: &csi.ValidateVolumeCapabilitiesResponse_Confirmed{
+					VolumeContext: map[string]string{
+						"foo": "example",
+					},
+					VolumeCapabilities: []*csi.VolumeCapability{
+						{
+							AccessType: &csi.VolumeCapability_Mount{
+								Mount: &csi.VolumeCapability_MountVolume{},
+							},
+							AccessMode: &csi.VolumeCapability_AccessMode{
+								Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, row := range tbl {
+		t.Run(row.name, func(t *testing.T) {
+			cs := newControllerServer("foo", nil, "")
+			res, err := cs.ValidateVolumeCapabilities(context.Background(), row.req)
+			if row.err != "" {
+				Expect(err).To(MatchError(row.err))
+				Expect(res).To(BeNil())
+			} else {
+				Expect(err).To(BeNil())
+				Expect(res).To(Equal(row.res))
+			}
+		})
+	}
+}

--- a/cloud/pkg/csidriver/identityserver.go
+++ b/cloud/pkg/csidriver/identityserver.go
@@ -69,6 +69,13 @@ func (ids *identityServer) GetPluginCapabilities(ctx context.Context, req *csi.G
 					},
 				},
 			},
+			{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
+					},
+				},
+			},
 		},
 	}, nil
 }

--- a/cloud/pkg/csidriver/inflight.go
+++ b/cloud/pkg/csidriver/inflight.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package csidriver
+
+import (
+	"sync"
+)
+
+type inFlight struct {
+	mux    *sync.Mutex
+	lookup map[string]bool
+}
+
+func newInFlight() *inFlight {
+	return &inFlight{
+		mux:    &sync.Mutex{},
+		lookup: map[string]bool{},
+	}
+}
+
+func (i *inFlight) Insert(key string) bool {
+	i.mux.Lock()
+	defer i.mux.Unlock()
+	if _, ok := i.lookup[key]; ok {
+		return false
+	}
+	i.lookup[key] = true
+	return true
+}
+
+func (i *inFlight) Delete(key string) {
+	i.mux.Lock()
+	defer i.mux.Unlock()
+	delete(i.lookup, key)
+}

--- a/cloud/pkg/csidriver/inflight_test.go
+++ b/cloud/pkg/csidriver/inflight_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package csidriver
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestInflight(t *testing.T) {
+	RegisterTestingT(t)
+	i := newInFlight()
+
+	ok := i.Insert("foo")
+	Expect(ok).To(BeTrue())
+
+	ok = i.Insert("foo")
+	Expect(ok).To(BeFalse())
+
+	i.Delete("foo")
+	ok = i.Insert("foo")
+	Expect(ok).To(BeTrue())
+}

--- a/cloud/pkg/csidriver/state/store.go
+++ b/cloud/pkg/csidriver/state/store.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type Store struct {
+	basePath string
+
+	mux   *sync.RWMutex
+	state *State
+}
+
+type State struct {
+	// store which volume id belongs to which edgenode
+	// this is needed for correct routing
+	Volumes map[string]string `json:"volumes"`
+}
+
+const (
+	stateFileName = "volumes.json"
+)
+
+var ErrNotExist = errors.New("volume does not exist")
+
+func New(basePath string) (*Store, error) {
+	s := &Store{
+		basePath: basePath,
+		mux:      &sync.RWMutex{},
+		state: &State{
+			Volumes: map[string]string{},
+		},
+	}
+
+	if err := os.MkdirAll(basePath, 0750); err != nil {
+		return nil, fmt.Errorf("failed to create base state path: %v", err)
+	}
+
+	return s, s.recover()
+}
+
+func (s *Store) recover() error {
+	data, err := ioutil.ReadFile(filepath.Join(s.basePath, stateFileName))
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return fmt.Errorf("error reading state: %v", err)
+	}
+	if err := json.Unmarshal(data, &s.state); err != nil {
+		return fmt.Errorf("error decoding state file: %v", err)
+	}
+	return nil
+}
+
+func (s *Store) save() error {
+	data, err := json.Marshal(&s.state)
+	if err != nil {
+		return fmt.Errorf("error encoding state: %v", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(s.basePath, stateFileName), data, 0600); err != nil {
+		return fmt.Errorf("error writing state file: %v", err)
+	}
+	return nil
+}
+
+func (s *Store) Get(volumeID string) (string, error) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
+	nodeID, ok := s.state.Volumes[volumeID]
+	if !ok {
+		return "", ErrNotExist
+	}
+	return nodeID, nil
+}
+
+func (s *Store) Update(volumeID, nodeID string) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	s.state.Volumes[volumeID] = nodeID
+	return s.save()
+}
+
+func (s *Store) Delete(volumeID string) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	delete(s.state.Volumes, volumeID)
+	return s.save()
+}

--- a/cloud/pkg/csidriver/state/store_test.go
+++ b/cloud/pkg/csidriver/state/store_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStore(t *testing.T) {
+	RegisterTestingT(t)
+
+	td, err := os.MkdirTemp("", "")
+	Expect(err).ToNot(HaveOccurred())
+	s, err := New(td)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = s.Update("pvc-76fabc8a7", "node-1")
+	Expect(err).ToNot(HaveOccurred())
+
+	nodeID, err := s.Get("pvc-76fabc8a7")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(nodeID).To(Equal("node-1"))
+
+	err = s.Delete("pvc-76fabc8a7")
+	Expect(err).ToNot(HaveOccurred())
+	_, err = s.Get("pvc-76fabc8a7")
+	Expect(err).To(MatchError(ErrNotExist))
+}
+
+func TestRecover(t *testing.T) {
+	RegisterTestingT(t)
+	stateToRestore := `{
+		"volumes": {
+			"pvc-76fabc8a7": "node-1"
+		}
+	  }`
+	td, err := os.MkdirTemp("", "")
+	Expect(err).ToNot(HaveOccurred())
+	err = os.WriteFile(filepath.Join(td, "volumes.json"), []byte(stateToRestore), os.ModePerm)
+	Expect(err).ToNot(HaveOccurred())
+
+	s, err := New(td)
+	Expect(err).ToNot(HaveOccurred())
+	nodeID, err := s.Get("pvc-76fabc8a7")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(nodeID).To(Equal("node-1"))
+}

--- a/cloud/pkg/csidriver/utils_test.go
+++ b/cloud/pkg/csidriver/utils_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package csidriver
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	. "github.com/onsi/gomega"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/servers/udsserver"
+	"github.com/kubeedge/kubeedge/common/constants"
+)
+
+func TestSendToKubeEdge(t *testing.T) {
+	RegisterTestingT(t)
+	addr := "unix:///tmp/udssrv-" + strconv.FormatInt(time.Now().Unix(), 10)
+	srv := udsserver.NewUnixDomainSocket(addr, udsserver.DefaultBufferSize)
+	go func() {
+		err := srv.StartServer()
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	// wait for uds server to listen
+	<-time.After(time.Second)
+
+	tbl := []struct {
+		name     string
+		handler  func(string) string
+		req      interface{}
+		nodeID   string
+		volumeID string
+		op       string
+		res      interface{}
+		err      string
+	}{
+		{
+			name: "missing parameters",
+			err:  "failed to build message resource: required parameter are not set (node id, namespace or resource type)",
+			req:  &csi.CreateVolumeRequest{},
+			res:  &csi.CreateVolumeResponse{},
+			handler: func(s string) string {
+				return ""
+			},
+		},
+		{
+			name:     "unexpected response msg",
+			req:      &csi.CreateVolumeRequest{},
+			res:      &csi.CreateVolumeResponse{},
+			volumeID: "foo",
+			nodeID:   "bar",
+			op:       constants.CSIOperationTypeCreateVolume,
+			err:      "failed to unmarshal beehive msg: invalid character 'N' looking for beginning of value",
+			handler: func(s string) string {
+				return "NOT JSON"
+			},
+		},
+		{
+			name:     "unexpected response operation",
+			req:      &csi.CreateVolumeRequest{},
+			res:      &csi.CreateVolumeResponse{},
+			volumeID: "foo",
+			nodeID:   "bar",
+			op:       constants.CSIOperationTypeCreateVolume,
+			err:      "unexpected message error: &model.Message{Header:model.MessageHeader{ID:\"\", ParentID:\"\", Timestamp:0, ResourceVersion:\"\", Sync:false, MessageType:\"\"}, Router:model.MessageRoute{Source:\"\", Destination:\"\", Group:\"\", Operation:\"error\", Resource:\"\"}, Content:\"some-content\"}",
+			handler: func(s string) string {
+				return `{"route":{"operation":"error"},"content":"some-content"}`
+			},
+		},
+		{
+			name:     "unexpected message content",
+			req:      &csi.CreateVolumeRequest{},
+			res:      &csi.CreateVolumeResponse{},
+			volumeID: "foo",
+			nodeID:   "bar",
+			op:       constants.CSIOperationTypeCreateVolume,
+			err:      "unexpected message content type: %!s(float64=1.23451234123e+11)",
+			handler: func(s string) string {
+				return `{"route":{"operation":"response"},"content": 123451234123}`
+			},
+		},
+		{
+			name:     "successful cycle",
+			volumeID: "foo",
+			nodeID:   "bar",
+			op:       constants.CSIOperationTypeCreateVolume,
+			req: &csi.CreateVolumeRequest{
+				Name: "foo",
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: 10,
+					LimitBytes:    20,
+				},
+				VolumeContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Volume{
+						Volume: &csi.VolumeContentSource_VolumeSource{
+							VolumeId: "example",
+						},
+					},
+				},
+				VolumeCapabilities: []*csi.VolumeCapability{},
+			},
+			res: &csi.CreateVolumeResponse{
+				Volume: &csi.Volume{
+					VolumeId: "1234",
+				},
+			},
+			handler: func(s string) string {
+				// check that msg was serialized correctly
+				var im model.Message
+				err := json.Unmarshal([]byte(s), &im)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(im.Content).To(Equal(`{"name":"foo","capacityRange":{"requiredBytes":"10","limitBytes":"20"},"volumeContentSource":{"volume":{"volumeId":"example"}}}`))
+				Expect(im.Router.Operation).To(Equal("createvolume"))
+				Expect(im.Router.Resource).To(Equal("node/bar/default/volume/foo"))
+
+				// this basicially simulates what edged is doing
+				// see edged.go
+				// csi res -> json -> base64 -> model -> json string
+				pbm := jsonpb.Marshaler{}
+				emb, err := pbm.MarshalToString(&csi.CreateVolumeResponse{
+					Volume: &csi.Volume{
+						VolumeId: "1234",
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				m := model.NewMessage("")
+				m.FillBody(emb)
+				b, err := json.Marshal(m)
+				Expect(err).ToNot(HaveOccurred())
+				return string(b)
+			},
+		},
+	}
+
+	for _, row := range tbl {
+		t.Run(row.name, func(t *testing.T) {
+			srv.SetContextHandler(row.handler)
+			// clone & reset response so we can check if the value
+			// was modified as expected
+			resClone := proto.Clone(row.res.(proto.Message))
+			resClone.Reset()
+			err := sendToKubeEdge(row.req, row.nodeID, row.volumeID, row.op, resClone, addr)
+			if row.err != "" {
+				Expect(err).To(MatchError(row.err))
+			} else {
+				Expect(err).To(BeNil())
+				Expect(resClone).To(Equal(row.res))
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
(1) `csidriver` in its current form supports only a single node (specified via `--node-id`). csidriver should be smarter and provision volumes for many edge nodes. There is one central problem to solve: how do we know where a request should go to?
We can do this by using `volumeBindingMode=WaitForFirstConsumer` while attaching correct labels to `Kind=Node` and configuring `Kind=CSINode` correctly.

(2) We have to store state between `CreateVolume()` and `DeleteVolume()` requests because we can neither access `VolumeContext` from `DeleteVolume()` nor is the NodeID sent with it. Hence we store it as state on the filesystem.

(3) `inflight`: as per spec we must ensure that CreateVolume() requests are rejected if a particular volume is in the process of being created.

**Which issue(s) this PR fixes**:
Fixes #3471

**Special notes for your reviewer**:
This PR makes #3343 and #3458 obsolete.
This PR is only about handling Volume requests from external-provisioner. How `Kind=CSINode` is created is part of a separate PR #3558.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
