### PR TITLE
Fix no prompt while executing `make all` without sed

### DIFF
--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -25,19 +25,21 @@ KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 
 if [[ "$OSTYPE" == "darwin"* ]]
 then
-    SED_CMD=`which gsed`
-    if [ -z $SED_CMD ]
+    if ! which gsed >/dev/null 2>&1
     then
         echo "Please install gnu-sed (brew install gnu-sed)"
         exit 1
+    else
+        SED_CMD=`which gsed`
     fi
 elif [[ "$OSTYPE" == "linux"* ]]
 then
-    SED_CMD=`which sed`
-    if [ -z $SED_CMD ]
+    if ! which sed >/dev/null 2>&1
     then
         echo "Please install sed"
         exit 1
+    else
+        SED_CMD=`which sed`
     fi
 else
     echo "Unsupported OS $OSTYPE"

--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -20,33 +20,36 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SED_CMD=""
-KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+function kubeedge::lint::init() {
+    SED_CMD=""
+    KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 
-if [[ "$OSTYPE" == "darwin"* ]]
-then
-    if ! which gsed >/dev/null 2>&1
+    if [[ "$OSTYPE" == "darwin"* ]]
     then
-        echo "Please install gnu-sed (brew install gnu-sed)"
-        exit 1
-    else
-        SED_CMD=`which gsed`
-    fi
-elif [[ "$OSTYPE" == "linux"* ]]
-then
-    if ! which sed >/dev/null 2>&1
+        if ! which gsed >/dev/null 2>&1
+        then
+            echo "Please install gnu-sed (brew install gnu-sed)"
+            exit 1
+        else
+            SED_CMD=`which gsed`
+        fi
+    elif [[ "$OSTYPE" == "linux"* ]]
     then
-        echo "Please install sed"
-        exit 1
+        if ! which sed >/dev/null 2>&1
+        then
+            echo "Please install sed"
+            exit 1
+        else
+            SED_CMD=`which sed`
+        fi
     else
-        SED_CMD=`which sed`
+        echo "Unsupported OS $OSTYPE"
+        exit 1
     fi
-else
-    echo "Unsupported OS $OSTYPE"
-    exit 1
-fi
+}
 
 kubeedge::lint::check() {
+    kubeedge::lint::init
     cd ${KUBEEDGE_ROOT}
     echo "start lint ..."
     set +o pipefail


### PR DESCRIPTION
Signed-off-by: zhukunshuai <jookunshuai@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

**What this PR does / why we need it**:

If sed/gnu-sed is not installed, it will not exit immediately, but will prompt that it is not installed.

![image](https://user-images.githubusercontent.com/62384022/149811330-2660f3a9-0ece-4b18-836c-63b31dec5454.png)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3562 

