### PR TITLE
fix remove os.Exit in updateNodeKubeletEndpoint

### DIFF
--- a/edge/pkg/edgestream/tunnel.go
+++ b/edge/pkg/edgestream/tunnel.go
@@ -165,6 +165,10 @@ func (s *TunnelSession) Serve() error {
 			return err
 		}
 
+		if mess.MessageType == stream.MessageTypeCloseConnect {
+			return fmt.Errorf("close tunnel stream connection, error:%s", string(mess.Data))
+		}
+
 		if mess.MessageType < stream.MessageTypeData {
 			go s.ServeConnection(mess)
 		}

--- a/pkg/stream/message.go
+++ b/pkg/stream/message.go
@@ -33,6 +33,7 @@ const (
 	MessageTypeMetricConnect
 	MessageTypeData
 	MessageTypeRemoveConnect
+	MessageTypeCloseConnect
 )
 
 func (m MessageType) String() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
If a edgenode registration fails, the node resource does not exist in the k8s cluster. When the edgestream of this node is connected to cloudstream (10004), it will updateNodeKubeletEndpoint, which will trigger os.Exit in this function, causing cloudcore to hang up, which will affect the connection status of other nodes


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
