### PR TITLE
Automated cherry pick of #3570: fix lots of duplicate logs "Failed to get obj" in

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -8,8 +8,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
@@ -31,15 +33,24 @@ func (sctl *SyncController) manageObject(sync *v1alpha1.ObjectSync) {
 	}
 	resource := util.UnsafeKindToResource(sync.Spec.ObjectKind)
 	gvr := gv.WithResource(resource)
-
+	nodeName := getNodeName(sync.Name)
+	resourceType := strings.ToLower(sync.Spec.ObjectKind)
 	//ret, err := informers.GetInformersManager().GetDynamicSharedInformerFactory().ForResource(gvr).Lister().ByNamespace(sync.Namespace).Get(sync.Spec.ObjectName)
 	ret, err := sctl.kubeclient.Resource(gvr).Namespace(sync.Namespace).Get(context.TODO(), sync.Spec.ObjectName, metav1.GetOptions{})
-	if err != nil || ret == nil {
+	if apierrors.IsNotFound(err) {
+		// trigger the delete event
+		klog.V(4).Infof("%s: %s has been deleted in K8s, send the delete event to edge in sync loop", resourceType, sync.Spec.ObjectName)
+		newObject := &unstructured.Unstructured{}
+		newObject.SetNamespace(sync.Namespace)
+		newObject.SetName(sync.Spec.ObjectName)
+		newObject.SetUID(types.UID(getObjectUID(sync.Name)))
+		msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.DeleteOperation, newObject)
+		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
+		return
+	} else if err != nil || ret == nil {
 		klog.Errorf("failed to get obj(gvr:%v,namespace:%v,name:%v), %v", gvr, sync.Namespace, sync.Spec.ObjectName, err)
 		return
 	}
-
-	nodeName := getNodeName(sync.Name)
 
 	object, err = meta.Accessor(ret)
 	if err != nil {
@@ -54,7 +65,7 @@ func (sctl *SyncController) manageObject(sync *v1alpha1.ObjectSync) {
 		}, sync.Spec.ObjectName)
 	}
 
-	sendEvents(err, nodeName, sync, strings.ToLower(sync.Spec.ObjectKind), object.GetResourceVersion(), object)
+	sendEvents(err, nodeName, sync, resourceType, object.GetResourceVersion(), object)
 }
 
 func sendEvents(err error, nodeName string, sync *v1alpha1.ObjectSync, resourceType string,


### PR DESCRIPTION
Cherry pick of #3570 on release-1.9.

#3570: fix lots of duplicate logs "Failed to get obj" in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.