### PR TITLE
fix-3489 filter pod by nodeName

### DIFF
--- a/edge/test/integration/utils/helpers/helpers.go
+++ b/edge/test/integration/utils/helpers/helpers.go
@@ -286,7 +286,7 @@ func HandleAddAndDeletePods(operation string, edgedpoint string, UID string, con
 	payload := &v1.Pod{
 		TypeMeta:   metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: UID, Namespace: metav1.NamespaceDefault, UID: types.UID(UID)},
-		Spec:       v1.PodSpec{RestartPolicy: restartPolicy, Containers: container},
+		Spec:       v1.PodSpec{RestartPolicy: restartPolicy, Containers: container, NodeName: "edge-node"},
 	}
 	respbytes, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: lyndon <huzhengyang@gridsum.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
In order to ensure that the function of edge's watch is not affected, add a function filterPodByNodeName in the edged.go to fix the issue of #3489 that the cloud application is scheduled to the edge;

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3489

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
