### PR TITLE
buildx on x86

### DIFF
--- a/hack/make-rules/crossbuildimage.sh
+++ b/hack/make-rules/crossbuildimage.sh
@@ -82,6 +82,11 @@ function build_multi_arch_images() {
     DOCKERFILE_PATH="$(get_dockerfile_by_target ${arg})"
 
     set -x
+    
+    # If there's any issues when using buildx, can refer to the issue below
+    # https://github.com/docker/buildx/issues/495
+    # https://github.com/multiarch/qemu-user-static/issues/100
+    # docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
     docker buildx build --build-arg GO_LDFLAGS="${GO_LDFLAGS}" -t ${IMAGE_REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG} -f ${DOCKERFILE_PATH} --platform linux/amd64,linux/arm64,linux/arm/v7 --push .
     set +x
   done


### PR DESCRIPTION
Signed-off-by: zhu733756 <zhu733756@kubesphere.io>

supports buildx on x86

release-note:
```release-note
None
```
