### PR TITLE
fix the edgecore channelfull problem when edge node is offline for a …

### DIFF
--- a/edge/pkg/edgehub/common/cacheutil/cache.go
+++ b/edge/pkg/edgehub/common/cacheutil/cache.go
@@ -1,0 +1,82 @@
+package cacheutil
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"k8s.io/klog/v2"
+)
+
+type edgeHub interface {
+	SendCacheToCloud(message model.Message) error
+}
+
+type EdgeCache struct {
+	cacheStore map[string]*model.Message
+	cacheIndex []string
+	enabled    bool
+	edgeHub    edgeHub
+	mu         sync.Mutex
+}
+
+func NewMetaCache(eh edgeHub) *EdgeCache {
+	return &EdgeCache{
+		cacheStore: map[string]*model.Message{},
+		cacheIndex: []string{},
+		enabled:    false,
+		edgeHub:    eh,
+	}
+}
+
+func (ec *EdgeCache) SaveToCache(m *model.Message) error {
+	ec.mu.Lock()
+	hash := fmt.Sprintf("%s-%s-%s", m.GetResource(), m.GetOperation(), m.GetSource())
+	ec.cacheStore[hash] = m
+	ec.sortIndex(hash)
+	ec.mu.Unlock()
+	return nil
+}
+func (ec *EdgeCache) CacheToCloud() error {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	klog.Infof("start sending cache to cloud")
+	for len(ec.cacheIndex) > 0 {
+		name := ec.cacheIndex[0]
+		err := ec.edgeHub.SendCacheToCloud(*ec.cacheStore[name])
+		if err != nil {
+			return err
+		}
+		klog.Infof("successfully send cache %s to cloud", name)
+		ec.cacheIndex = ec.cacheIndex[1:]
+		delete(ec.cacheStore, name)
+	}
+	klog.Infof("finished sending cache to cloud")
+	return nil
+}
+func (ec *EdgeCache) GetCache() map[string]*model.Message {
+	return ec.cacheStore
+}
+func (ec *EdgeCache) SetEnabled(enable bool) {
+	ec.enabled = enable
+}
+func (ec *EdgeCache) IsEnabled() bool {
+	return ec.enabled
+}
+func (ec *EdgeCache) sortIndex(hash string) {
+	klog.V(4).Infof("ec cacheIndex: %v", ec.cacheIndex)
+	for index, item := range ec.cacheIndex {
+		if item == hash {
+			if (index + 1) != len(ec.cacheIndex) {
+				copy(ec.cacheIndex[index:], ec.cacheIndex[index+1:])
+				ec.cacheIndex[len(ec.cacheIndex)-1] = hash
+			}
+			return
+		}
+	}
+	ec.cacheIndex = append(ec.cacheIndex, hash)
+
+}
+func (ec *EdgeCache) CleanIndex() {
+	ec.cacheIndex = ec.cacheIndex[0:0]
+}

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -60,6 +60,7 @@ func (eh *EdgeHub) Enable() bool {
 func (eh *EdgeHub) Start() {
 	eh.certManager = certificate.NewCertManager(config.Config.EdgeHub, config.Config.NodeName)
 	eh.certManager.Start()
+	eh.initCache()
 
 	HasTLSTunnelCerts <- true
 	close(HasTLSTunnelCerts)
@@ -83,12 +84,14 @@ func (eh *EdgeHub) Start() {
 
 		err = eh.chClient.Init()
 		if err != nil {
+			eh.enableCache()
 			klog.Errorf("connection failed: %v, will reconnect after %s", err, waitTime.String())
 			time.Sleep(waitTime)
 			continue
 		}
 		// execute hook func after connect
 		eh.pubConnectInfo(true)
+		eh.disableCache()
 		go eh.routeToEdge()
 		go eh.routeToCloud()
 		go eh.keepalive()

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -12,8 +12,8 @@ import (
 	messagepkg "github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/clients"
-	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/common/msghandler"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/common/cacheutil"
+	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/common/msghandler"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 )
 
@@ -184,7 +184,7 @@ func (eh *EdgeHub) enableCache() {
 				}
 				return
 			}
-			message, err := beehiveContext.Receive(ModuleNameEdgeHub)
+			message, err := beehiveContext.Receive(modules.EdgeHubModuleName)
 			if err != nil {
 				klog.Errorf("failed to receive message from edge: %v", err)
 				time.Sleep(time.Second)


### PR DESCRIPTION
Signed-off-by: linc101 <gollink@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When edgenode is offline ,metaserver and devicecontroller will continously send msg to edgehub through beehive which will cause channel full warning when the message piles up to 5000. We added a cache mechanism to merge duplicate messages, so that the message count will barely hit the limit.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
