### PR TITLE
Automated cherry pick of #3647: update default version in keadm to v1.10

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -54,7 +54,7 @@ const (
 	RuntimeType = "runtimetype"
 
 	// DefaultKubeEdgeVersion is the default KubeEdge version
-	DefaultKubeEdgeVersion = "1.9.0"
+	DefaultKubeEdgeVersion = "1.10.0"
 
 	// Token sets the token used when edge applying for the certificate
 	Token = "token"
@@ -208,7 +208,7 @@ const (
 	ExternalIptablesMgrMode = "external"
 	InternalIptablesMgrMode = "internal"
 	EdgemeshProfileKey      = "edgemesh"
-	HelmDefaultVersion      = "v1.9.0"
+	HelmDefaultVersion      = "v1.10.0"
 )
 
 var (


### PR DESCRIPTION
Cherry pick of #3647 on release-1.10.

#3647: update default version in keadm to v1.10

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.