### PR TITLE
fix message pile up in edgecore when node is offline

### DIFF
--- a/edge/pkg/common/cloudconnection/cloudconstants.go
+++ b/edge/pkg/common/cloudconnection/cloudconstants.go
@@ -1,7 +1,33 @@
 package cloudconnection
 
-//constants for cloud connection
+import "sync"
+
+// constants for cloud connection
 const (
 	CloudConnected    = "cloud_connected"
 	CloudDisconnected = "cloud_disconnected"
 )
+
+var (
+	// isCloudConnected indicate Whether the connection was
+	// successfully established between edge and cloud
+	isCloudConnected = false
+
+	lock sync.RWMutex
+)
+
+// SetConnected set isCloudConnected value
+// true indicates edge and cloud establish connection successfully
+// false indicates edge and cloud connection interrupted.
+func SetConnected(isConnected bool) {
+	lock.Lock()
+	defer lock.Unlock()
+	isCloudConnected = isConnected
+}
+
+// IsConnected return isCloudConnected
+func IsConnected() bool {
+	lock.RLock()
+	defer lock.RUnlock()
+	return isCloudConnected
+}

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -176,7 +176,9 @@ func (eh *EdgeHub) keepalive() {
 }
 
 func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
-	// var info model.Message
+	// update connected info
+	connect.SetConnected(isConnected)
+
 	content := connect.CloudConnected
 	if !isConnected {
 		content = connect.CloudDisconnected

--- a/edge/pkg/metamanager/config/config.go
+++ b/edge/pkg/metamanager/config/config.go
@@ -10,10 +10,6 @@ import (
 var Config Configure
 var once sync.Once
 
-// Connected stands for whether it is connected
-// TODO need consider to add lock @kadisi
-var Connected = false
-
 type Configure struct {
 	v1alpha1.MetaManager
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

when node is offline  msg send error and when node is online msg is send successfully

```
E0310 21:33:02.439420 1323700 edged_status.go:441] update node failed, error: edge and cloud connection is interrupted
I0310 21:33:09.155357 1323700 edged.go:957] worker [3] get pod addition item [kube-proxy-jqvp4]
I0310 21:33:09.155385 1323700 edged.go:1025] start to consume added pod [kube-proxy-jqvp4]
I0310 21:33:09.155605 1323700 edged.go:1069] consume added pod [kube-proxy-jqvp4] successfully
I0310 21:33:09.208948 1323700 process.go:458] get a message {Header:{ID:2655245e-518a-4e52-8cc9-e63439ccef64 ParentID: Timestamp:1646919189198 ResourceVersion: Sync:true MessageType:} Router:{Source:edged Destination: Group:meta Operation:query Resource:kube-system/serviceaccounttoken/kube-proxy} Content:&TokenRequest{ObjectMeta:{      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []},Spec:TokenRequestSpec{Audiences:[],BoundObjectRef:&BoundObjectReference{Kind:Pod,APIVersion:v1,Name:kube-proxy-jqvp4,UID:30c943cd-023d-4ed7-97f5-b37b6c9852a7,},ExpirationSeconds:*3607,},Status:TokenRequestStatus{Token:,ExpirationTimestamp:0001-01-01 00:00:00 +0000 UTC,},}}
I0310 21:33:09.209172 1323700 process.go:458] get a message {Header:{ID:2073baa6-17ad-4825-8541-c0dedfcff1ae ParentID: Timestamp:1646919189198 ResourceVersion: Sync:true MessageType:} Router:{Source:edged Destination: Group:meta Operation:query Resource:kube-system/configmap/kube-proxy} Content:<nil>}
I0310 21:33:09.220205 1323700 process.go:458] get a message {Header:{ID:9381ae25-7786-4a35-8585-61ac094bf54a ParentID: Timestamp:1646919189209 ResourceVersion: Sync:true MessageType:} Router:{Source:edged Destination: Group:meta Operation:query Resource:kube-system/configmap/kube-root-ca.crt} Content:<nil>}
E0310 21:33:12.445806 1323700 edged_status.go:441] update node failed, error: edge and cloud connection is interrupted
E0310 21:33:21.006952 1323700 ws.go:77] dial websocket error(dial tcp 192.168.0.88:10000: i/o timeout), response message: 
E0310 21:33:21.006995 1323700 websocket.go:90] Init websocket connection failed dial tcp 192.168.0.88:10000: i/o timeout
E0310 21:33:22.451308 1323700 edged_status.go:441] update node failed, error: edge and cloud connection is interrupted
E0310 21:33:32.457121 1323700 edged_status.go:441] update node failed, error: edge and cloud connection is interrupted
I0310 21:33:33.159079 1323700 ws.go:45] dial wss://192.168.0.88:10000/e632aba927ea4ac2b575ec1603d56f10/edge-node/events successfully
I0310 21:33:33.159122 1323700 websocket.go:93] Websocket connect to cloud access successful
W0310 21:33:33.159205 1323700 eventbus.go:154] Action not found
I0310 21:33:33.159213 1323700 process.go:458] get a message {Header:{ID:ee073b07-9553-4759-89d9-2d9c253450f8 ParentID: Timestamp:1646919213159 ResourceVersion: Sync:false MessageType:} Router:{Source:edgehub Destination: Group:meta Operation:connect Resource:node/connection} Content:cloud_connected}
E0310 21:33:33.159242 1323700 process.go:440] metamanager not supported operation: connect
I0310 21:33:33.159243 1323700 process.go:283] DeviceTwin receive msg
I0310 21:33:33.159277 1323700 process.go:66] Send msg to the CommModule module in twin
I0310 21:33:33.159291 1323700 communicate.go:40] receive msg commModule
I0310 21:33:33.159250 1323700 process.go:458] get a message {Header:{ID:d83f14e6-4a31-4f96-a5f4-3f9944126891 ParentID: Timestamp:1646919213159 ResourceVersion: Sync:false MessageType:} Router:{Source:edgehub Destination: Group:meta Operation:connect Resource:node/connection} Content:cloud_connected}
E0310 21:33:33.159303 1323700 process.go:440] metamanager not supported operation: connect
I0310 21:33:33.159296 1323700 communicate.go:95] CONNECTED EVENT
I0310 21:33:33.159321 1323700 communicate.go:143] Request detail
I0310 21:33:42.473791 1323700 process.go:458] get a message {Header:{ID:7e0b9d7b-9d1e-42c4-962f-75e937a2a385 ParentID: Timestamp:1646919222463 ResourceVersion: Sync:true MessageType:} Router:{Source:edged Destination: Group:meta Operation:update Resource:default/nodestatus/edge-node} Content:{UID:38796d14-1df3-11e8-8e5a-286ed488f209 Status:{Capacity:map[cpu:{i:{value:8 scale:0} d:{Dec:<nil>} s:8 Format:DecimalSI} ephemeral-storage:{i:{value:105419542528 scale:0} d:{Dec:<nil>} s: Format:BinarySI} memory:{i:{value:16818110464 scale:0} d:{Dec:<nil>} s:16039Mi Format:BinarySI} pods:{i:{value:110 scale:0} d:{Dec:<nil>} s: Format:DecimalSI}] Allocatable:map[cpu:{i:{value:8 scale:0} d:{Dec:<nil>} s:8 Format:DecimalSI} ephemeral-storage:{i:{value:104345800704 scale:0} d:{Dec:<nil>} s: Format:BinarySI} memory:{i:{value:16713252864 scale:0} d:{Dec:<nil>} s: Format:BinarySI} pods:{i:{value:110 scale:0} d:{Dec:<nil>} s: Format:DecimalSI}] Phase:Running Conditions:[{Type:Ready Status:True LastHeartbeatTime:2022-03-10 21:33:42.458236021 +0800 CST m=+591.639345402 LastTransitionTime:2022-03-10 21:23:51.140907328 +0800 CST m=+0.322016710 Reason:EdgeReady Message:edge is posting ready status}] Addresses:[{Type:InternalIP Address:192.168.0.88} {Type:Hostname Address:edge-node}] DaemonEndpoints:{KubeletEndpoint:{Port:10350}} NodeInfo:{MachineID: SystemUUID: BootID: KernelVersion:4.15.0-136-generic OSImage:Ubuntu 18.04.5 LTS ContainerRuntimeVersion:docker://20.10.7 KubeletVersion:v1.22.6-kubeedge-v1.9.0-228+d3a0018384b3fc KubeProxyVersion: OperatingSystem:linux Architecture:amd64} Images:[] VolumesInUse:[] VolumesAttached:[] Config:nil} ExtendResources:map[]}}
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
