### PR TITLE
Fix local-up exit without error msg

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -19,10 +19,6 @@
 # KubeEdge Authors:
 # To Get Detail Version Info for KubeEdge Project
 
-set -o errexit
-set -o nounset
-set -o pipefail
-
 YES="y"
 NO="n"
 


### PR DESCRIPTION
Signed-off-by: fisherxu <xufei40@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
If the kubectl is not installed, the local-up will exit, the message as below:
```
Cleaning up...
Running kind: [kind delete cluster --name test]
Deleting cluster "test" ...
go detail version: go version go1.16 linux/amd64
go version: 1.16
checking kubectl
Cleaning up...
Running kind: [kind delete cluster --name test]
Deleting cluster "test" ...
```
The kubectl error msg is not printed. Because in golang.sh source the set -x, so check kubectl will exit.

Just remove the set-x  in golang.sh, hack-local-up.sh will set it.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
