### PR TITLE
Automated cherry pick of #3553: verify go version when call build.sh script

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,7 +73,9 @@ jobs:
 
       - run: make crossbuild
 
-      - run: make crossbuild GOARM=GOARM7
+      - run: make crossbuild ARM_VERSION=GOARM7
+
+      - run: make crossbuild WHAT=cloudcore ARM_VERSION=GOARM8
 
   basic_test:
     runs-on: ubuntu-18.04

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(HELP),y)
 all: clean
 	@echo "$$ALL_HELP_INFO"
 else
-all: clean 
+all: 
 	KUBEEDGE_OUTPUT_SUBPATH=$(OUT_DIR) hack/make-rules/build.sh $(WHAT)
 endif
 
@@ -367,7 +367,7 @@ define RELEASE_HELP_INFO
 #   make release
 #   make release HELP=y
 #   make release WHAT=kubeedge
-#   make release WHAT=kubeedge GOARM=GOARM7
+#   make release WHAT=kubeedge ARM_VERSION=GOARM7
 #
 endef
 .PHONY: release
@@ -376,5 +376,5 @@ release:
 	@echo "$$RELEASE_HELP_INFO"
 else
 release:
-	hack/make-rules/release.sh $(WHAT) $(GOARM)
+	hack/make-rules/release.sh $(WHAT) $(ARM_VERSION)
 endif

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(HELP),y)
 all: clean
 	@echo "$$ALL_HELP_INFO"
 else
-all: verify-golang
+all: clean 
 	KUBEEDGE_OUTPUT_SUBPATH=$(OUT_DIR) hack/make-rules/build.sh $(WHAT)
 endif
 
@@ -158,15 +158,15 @@ define CROSSBUILD_HELP_INFO
 #   WHAT: Component names to be lint check. support: $(CROSSBUILD_COMPONENTS)
 #         If not specified, "everything" will be cross build.
 #
-# GOARM: go arm value, now support:$(GOARM_VALUES)
-#        If not specified ,default use GOARM=GOARM8
+# ARM_VERSION: go arm value, now support:$(GOARM_VALUES)
+#        If not specified, build binary for ARMv8 by default.
 #
 #
 # Example:
 #   make crossbuild
 #   make crossbuild HELP=y
 #   make crossbuild WHAT=edgecore
-#   make crossbuild WHAT=edgecore GOARM=GOARM7
+#   make crossbuild WHAT=edgecore ARM_VERSION=GOARM7
 #
 endef
 .PHONY: crossbuild
@@ -174,8 +174,8 @@ ifeq ($(HELP),y)
 crossbuild:
 	@echo "$$CROSSBUILD_HELP_INFO"
 else
-crossbuild: clean
-	hack/make-rules/crossbuild.sh $(WHAT) $(GOARM)
+crossbuild: 
+	hack/make-rules/crossbuild.sh $(WHAT) $(ARM_VERSION)
 endif
 
 CRD_VERSIONS=v1
@@ -227,7 +227,7 @@ ifeq ($(HELP),y)
 smallbuild:
 	@echo "$$SMALLBUILD_HELP_INFO"
 else
-smallbuild: clean
+smallbuild: 
 	hack/make-rules/smallbuild.sh $(WHAT)
 endif
 

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -26,6 +26,27 @@ set -o pipefail
 YES="y"
 NO="n"
 
+kubeedge::golang::verify_golang_version() {
+  echo "go detail version: $(go version)"
+
+  goversion=$(go version |awk -F ' ' '{printf $3}' |sed 's/go//g')
+
+  echo "go version: $goversion"
+
+  X=$(echo $goversion|awk -F '.' '{printf $1}')
+  Y=$(echo $goversion|awk -F '.' '{printf $2}')
+
+  if [ $X -lt 1 ] ; then
+	  echo "go major version must >= 1, now is $X"
+	  exit 1
+  fi
+
+  if [ $Y -lt 16 ] ; then
+	  echo "go minor version must >= 16, now is $Y"
+	  exit 1
+  fi
+}
+
 kubeedge::version::get_version_info() {
 
   GIT_COMMIT=$(git rev-parse "HEAD^{commit}" 2>/dev/null)
@@ -290,7 +311,7 @@ kubeedge::golang::cross_build_place_binaries() {
 
   mkdir -p ${KUBEEDGE_OUTPUT_BINPATH}
   for bin in ${binaries[@]}; do
-    echo "cross buildding $bin GOARM${goarm}"
+    echo "cross building $bin GOARM${goarm}"
     local name="${bin##*/}"
     if [ "${goarm}" == "8" ]; then
       set -x

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -176,6 +176,7 @@ ALL_BINARIES_AND_TARGETS=(
   edgesite-agent:edgesite/cmd/edgesite-agent
   edgesite-server:edgesite/cmd/edgesite-server
   csidriver:cloud/cmd/csidriver
+  iptablesmanager:cloud/cmd/iptablesmanager
 )
 
 kubeedge::golang::get_target_by_binary() {
@@ -241,22 +242,6 @@ kubeedge::golang::build_binaries() {
 
 }
 
-
-KUBEEDGE_ALL_CROSS_BINARIES=(
-edgecore
-)
-
-kubeedge::golang::is_cross_build_binary() {
-  local key=$1
-  for bin in "${KUBEEDGE_ALL_CROSS_BINARIES[@]}" ; do
-    if [ "${bin}" == "${key}" ]; then
-      echo ${YES}
-      return
-    fi
-  done
-  echo ${NO}
-}
-
 KUBEEDGE_ALL_CROSS_GOARMS=(
 8
 7
@@ -284,18 +269,12 @@ kubeedge::golang::cross_build_place_binaries() {
         # Assume arguments starting with a dash are flags to pass to go.
         goarm="${arg##*GOARM}"
       else
-        if [ "$(kubeedge::golang::is_cross_build_binary ${arg})" == "${NO}" ]; then
-          echo "${arg} does not support cross build"
-          exit 1
-        fi
         targets+=("$(kubeedge::golang::get_target_by_binary $arg)")
       fi
   done
 
   if [[ ${#targets[@]} -eq 0 ]]; then
-    for bin in ${KUBEEDGE_ALL_CROSS_BINARIES[@]}; do
-        targets+=("$(kubeedge::golang::get_target_by_binary $bin)")
-    done
+    targets+=("${KUBEEDGE_ALL_TARGETS[@]}")
   fi
 
   if [ "$(kubeedge::golang::is_supported_goarm ${goarm})" == "${NO}" ]; then
@@ -315,6 +294,7 @@ kubeedge::golang::cross_build_place_binaries() {
     local name="${bin##*/}"
     if [ "${goarm}" == "8" ]; then
       set -x
+      GOARM="" # need to clear the value since golang compiler doesn't allow this env when building the binary for ARMv8.
       GOARCH=arm64 GOOS="linux" CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -ldflags "$ldflags" $bin
       set +x
     elif [ "${goarm}" == "7" ]; then
@@ -474,3 +454,4 @@ kubeedge::golang::run_test() {
     go test ${testdirs[@]}
   fi
 }
+

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -77,25 +77,6 @@ function install_golangci-lint {
     export PATH=$PATH:$GOPATH/bin
 }
 
-verify_go_version(){
-  if [[ -z "$(command -v go)" ]]; then
-    echo "Can't find 'go' in PATH, please fix and retry.
-See http://golang.org/doc/install for installation instructions."
-    exit 1
-  fi
-
-  local go_version
-  IFS=" " read -ra go_version <<< "$(go version)"
-  local minimum_go_version
-  minimum_go_version=go1.12.1
-  if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
-    echo "Detected go version: ${go_version[*]}.
-Kubernetes requires ${minimum_go_version} or greater.
-Please install ${minimum_go_version} or later."
-    exit 1
-  fi
-}
-
 verify_docker_installed(){
   # verify the docker installed
   command -v docker >/dev/null || {

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -26,9 +26,9 @@ fi
 export CLUSTER_CONTEXT="--name ${CLUSTER_NAME}"
 
 function check_prerequisites {
+  kubeedge::golang::verify_golang_version
   check_kubectl
   check_kind
-  verify_go_version
   verify_docker_installed
 }
 
@@ -191,6 +191,7 @@ function generate_streamserver_cert {
 
 cleanup
 
+source "${KUBEEDGE_ROOT}/hack/lib/golang.sh"
 source "${KUBEEDGE_ROOT}/hack/lib/install.sh"
 
 check_prerequisites

--- a/hack/make-rules/build.sh
+++ b/hack/make-rules/build.sh
@@ -23,4 +23,5 @@ set -o pipefail
 KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${KUBEEDGE_ROOT}/hack/lib/init.sh"
 
+kubeedge::golang::verify_golang_version
 kubeedge::golang::build_binaries "$@"

--- a/hack/make-rules/clean.sh
+++ b/hack/make-rules/clean.sh
@@ -33,5 +33,6 @@ kubeedge::clean::bin(){
   rm -rf $KUBEEDGE_OUTPUT_BINPATH/*
 }
 
+kubeedge::golang::verify_golang_version
 kubeedge::clean::cache
 kubeedge::clean::bin

--- a/hack/make-rules/crossbuild.sh
+++ b/hack/make-rules/crossbuild.sh
@@ -23,4 +23,5 @@ set -o pipefail
 KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${KUBEEDGE_ROOT}/hack/lib/init.sh"
 
+kubeedge::golang::verify_golang_version
 kubeedge::golang::cross_build_place_binaries "$@"

--- a/hack/make-rules/release.sh
+++ b/hack/make-rules/release.sh
@@ -57,7 +57,7 @@ function release() {
         if [ "${ARCH}" == "amd64" ]; then
           hack/make-rules/build.sh edgesite-server edgesite-agent
         else
-          hack/make-rules/crossbuild.sh edgesite-server edgesite-agent ${GOARM}
+          hack/make-rules/crossbuild.sh edgesite-server edgesite-agent ${ARM_VERSION}
         fi
 
         build_edgesite_release $VERSION $ARCH
@@ -66,7 +66,7 @@ function release() {
         if [ "${ARCH}" == "amd64" ]; then
           hack/make-rules/build.sh keadm
         else
-          hack/make-rules/crossbuild.sh keadm ${GOARM}
+          hack/make-rules/crossbuild.sh keadm ${ARM_VERSION}
         fi
 
         build_keadm_release $VERSION $ARCH
@@ -75,7 +75,7 @@ function release() {
         if [ "${ARCH}" == "amd64" ]; then
           hack/make-rules/build.sh cloudcore admission edgecore csidriver iptablesmanager
         else
-          hack/make-rules/crossbuild.sh cloudcore admission edgecore csidriver iptablesmanager ${GOARM}
+          hack/make-rules/crossbuild.sh cloudcore admission edgecore csidriver iptablesmanager ${ARM_VERSION}
         fi
 
         build_kubeedge_release $VERSION $ARCH

--- a/hack/make-rules/smallbuild.sh
+++ b/hack/make-rules/smallbuild.sh
@@ -23,4 +23,5 @@ set -o pipefail
 KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "${KUBEEDGE_ROOT}/hack/lib/init.sh"
 
+kubeedge::golang::verify_golang_version
 kubeedge::golang::small_build_place_binaries "$@"

--- a/hack/verify-golang.sh
+++ b/hack/verify-golang.sh
@@ -20,24 +20,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# The root of the build/dist directory
-KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+KUBEEDGE_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/..
 
-echo "go detail version: $(go version)"
+source "${KUBEEDGE_ROOT}/hack/lib/golang.sh"
 
-goversion=$(go version |awk -F ' ' '{printf $3}' |sed 's/go//g')
+kubeedge::golang::verify_golang_version
 
-echo "go version: $goversion"
-
-X=$(echo $goversion|awk -F '.' '{printf $1}')
-Y=$(echo $goversion|awk -F '.' '{printf $2}')
-
-if [ $X -lt 1 ] ; then
-	echo "go major version must >= 1, now is $X"
-	exit 1
-fi
-
-if [ $Y -lt 15 ] ; then
-	echo "go minor version must >= 15, now is $Y"
-	exit 1
-fi


### PR DESCRIPTION
Cherry pick of #3553 on release-1.9.

#3553: verify go version when call build.sh script

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.