### PR TITLE
Automated cherry pick of #3605: fix memory leak in edgesite kube-api

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
@@ -182,6 +182,7 @@ func (s *imitator) Watch(ctx context.Context, key string, rev uint64) <-chan wat
 	go func() {
 		<-ctx.Done()
 		wh.Stop()
+		close(wch)
 	}()
 	return wch
 }


### PR DESCRIPTION
Cherry pick of #3605 on release-1.9.

#3605: fix memory leak in edgesite kube-api

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.