### PR TITLE
Use armhf as default for armv7/v6

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependences
         run: |
           sudo apt-get update
-          sudo apt-get install -y upx-ucl gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabi libc6-dev-armel-cross
+          sudo apt-get install -y upx-ucl gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabihf
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/build/docker/build-tools/build-tools.dockerfile
+++ b/build/docker/build-tools/build-tools.dockerfile
@@ -4,7 +4,7 @@ ARG ARCH=amd64
 RUN apt-get update && apt-get install -y wget \
     vim git make gcc upx-ucl 
 
-RUN if [ "${ARCH}" = "amd64" ]; then apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabi libc6-dev-armel-cross ; fi
+RUN if [ "${ARCH}" = "amd64" ]; then apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabihf ; fi
  
 RUN apt-get autoremove -y &&\
     apt-get clean &&\

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -300,7 +300,7 @@ kubeedge::golang::cross_build_place_binaries() {
       set +x
     elif [ "${goarm}" == "7" ]; then
       set -x
-      GOARCH=arm GOOS="linux" GOARM=${goarm} CGO_ENABLED=1 CC=arm-linux-gnueabi-gcc go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -ldflags "$ldflags" $bin
+      GOARCH=arm GOOS="linux" GOARM=${goarm} CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -ldflags "$ldflags" $bin
       set +x
     fi
   done


### PR DESCRIPTION
Signed-off-by: fisherxu <xufei40@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Now for the armv6 and later, all support armhf, and for ubuntu since 12.04, armel will not supported.

When cross-building, arm-linux-gnueabi-gcc will build armel by default, arm-linux-gnueabihf-gcc  will build armhf by default.

And armhf has better compatibility. Armv5 or before I think it will be probably rarely used?

Ref: https://github.com/kubeedge/kubeedge/issues/3586#issuecomment-1021027805
https://github.com/golang/go/wiki/GoArm#supported-architectures  
https://github.com/golang/go/wiki/GoArm#supported-operating-systems

cc @zhu733756 @dafanshu

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubeedge/kubeedge/issues/3586#issuecomment-1021027805

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
