### PR TITLE
Automated cherry pick of #3723: support armhf

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependences
         run: |
           sudo apt-get update
-          sudo apt-get install -y upx-ucl gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabi libc6-dev-armel-cross
+          sudo apt-get install -y upx-ucl gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabihf
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/build/docker/build-tools/build-tools.dockerfile
+++ b/build/docker/build-tools/build-tools.dockerfile
@@ -4,7 +4,7 @@ ARG ARCH=amd64
 RUN apt-get update && apt-get install -y wget \
     vim git make gcc upx-ucl 
 
-RUN if [ "${ARCH}" = "amd64" ]; then apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabi libc6-dev-armel-cross ; fi
+RUN if [ "${ARCH}" = "amd64" ]; then apt-get install -y gcc-aarch64-linux-gnu libc6-dev-arm64-cross gcc-arm-linux-gnueabihf ; fi
  
 RUN apt-get autoremove -y &&\
     apt-get clean &&\

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -300,7 +300,7 @@ kubeedge::golang::cross_build_place_binaries() {
       set +x
     elif [ "${goarm}" == "7" ]; then
       set -x
-      GOARCH=arm GOOS="linux" GOARM=${goarm} CGO_ENABLED=1 CC=arm-linux-gnueabi-gcc go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -ldflags "$ldflags" $bin
+      GOARCH=arm GOOS="linux" GOARM=${goarm} CGO_ENABLED=1 CC=arm-linux-gnueabihf-gcc go build -o ${KUBEEDGE_OUTPUT_BINPATH}/${name} -ldflags "$ldflags" $bin
       set +x
     fi
   done


### PR DESCRIPTION
Cherry pick of #3723 on release-1.10.

#3723: support armhf

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.