### PR TITLE
set deleteResource func param allowsOptions true

### DIFF
--- a/edge/pkg/metamanager/metaserver/handlerfactory/handler.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/handler.go
@@ -88,7 +88,7 @@ func (f *Factory) Delete() http.Handler {
 	}
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	h := handlers.DeleteResource(f.storage, false, f.scope, fakers.NewAlwaysAdmit())
+	h := handlers.DeleteResource(f.storage, true, f.scope, fakers.NewAlwaysAdmit())
 	f.handlers["delete"] = h
 	return h
 }


### PR DESCRIPTION
Signed-off-by: Shelley-BaoYue <baoyue2@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
set func deleteResource parameters `allowoptions` true, to parse `deleteOptions` from body or url

