### PR TITLE
fix residual terminating pods problem after edge node reconnected

### DIFF
--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -470,11 +470,8 @@ func (mh *MessageHandle) MessageWriteLoop(info *model.HubInfo, stopServe chan Ex
 		if err != nil {
 			klog.Errorf("Failed to send event to node: %s, affected event: %s, err: %s",
 				info.NodeID, dumpMessageMetadata(copyMsg), err.Error())
+			nodeQueue.Done(key)
 			nodeQueue.Add(key.(string))
-			if strings.Contains(err.Error(), "use of closed network connection") {
-				mh.nodeConns.Delete(info.NodeID)
-				continue
-			}
 			time.Sleep(time.Second * 2)
 		}
 


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
fix residual terminating pods problem after edge node reconnected

1. As the function describe said at L150 https://github.com/kubernetes/client-go/blob/master/util/workqueue/queue.go
You must call Done with item when you have finished processing it.
Otherwise, the key will always exists in processing set and can't process by nodeQueue.Get() again. 

2. Delete the `nodeConn` concurrently will also cause terminating pods that can't be deleted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3736

**Special notes for your reviewer**:
cc @fisherxu 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
