### PR TITLE
Remove gopath in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ DESTDIR?=
 USR_DIR?=/usr/local
 INSTALL_DIR?=${DESTDIR}${USR_DIR}
 INSTALL_BIN_DIR?=${INSTALL_DIR}/bin
-GOPATH?=$(shell go env GOPATH)
 
 # make all builds both cloud and edge binaries
 

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -148,7 +148,7 @@ kubeedge::golang::binaries_from_targets() {
 
 kubeedge::check::env() {
   errors=()
-  if [ -z $GOPATH ]; then
+  if [ -z $(go env GOPATH) ]; then
     errors+="GOPATH environment value not set"
   fi
 


### PR DESCRIPTION
Signed-off-by: fisherxu <xufei40@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When building with container, the stdout will still print the log:
```
hack/make-rules/build_with_container.sh hack/make-rules/build.sh cloudcore
make: go: Command not found
+ docker run --rm -u 0:998 --init --sig-proxy=false -e XDG_CACHE_HOME=/tmp/.cache -v /root/codes/src/github.com/kubeedge/kubeedge:/kubeedge -w /kubeedge kubeedge/build-tools hack/make-rules/build.sh cloudcore
```

`make: go: Command not found` should not be printed. GOPATH is not used now.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
