### PR TITLE
rebuild build-tools image totally

### DIFF
--- a/build/docker/build-tools/make-build-tools.sh
+++ b/build/docker/build-tools/make-build-tools.sh
@@ -17,7 +17,7 @@ done
 
 if [ "$PUSH_TAG" = 'push' ]; then
   echo "push edgecore image"
-  manifestCreateCmd="docker manifest create --amend $REPOSITORY:latest"
+  manifestCreateCmd="docker manifest create $REPOSITORY:latest"
   for arch in "${ARCHS[@]}" ; do
     REPOSITORY_ARCH="$REPOSITORY"-"$arch"
     if [ "$arch" = "amd64" ]; then
@@ -31,7 +31,7 @@ if [ "$PUSH_TAG" = 'push' ]; then
   echo "command: $manifestCreateCmd"
   doCreate="$($manifestCreateCmd)"
   echo "$doCreate"
-  docker manifest push "$REPOSITORY":latest
+  docker manifest push --purge "$REPOSITORY":latest
 else
   echo "image save in local"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
rebuild kubeedge/build-tools images totally, or maybe new updates cannot be built into the image
by commands `docker manifest push --help` , `docker manifest create --help`
```
--purge      Remove the local manifest list after push
--amend      Amend an existing manifest list
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
