### PR TITLE
fix propagating signals on docker build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,9 @@ on:
     tags:
   pull_request:
 
+env:
+  CONTAINER_RUN_OPTIONS: " "
+
 jobs:
   lint:
     runs-on: ubuntu-18.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ go:
   - 1.16
 
 env:
-  - HOME=/home/travis
+  - HOME=/home/travis CONTAINER_RUN_OPTIONS=" "
 
 cache:
   directories:

--- a/hack/make-rules/build_with_container.sh
+++ b/hack/make-rules/build_with_container.sh
@@ -24,11 +24,12 @@ KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 MOUNTPATH="${MOUNTPATH:-/kubeedge}"
 KUBEEDGE_BUILD_IMAGE=${KUBEEDGE_BUILD_IMAGE:-"kubeedge/build-tools"}
 DOCKER_GID="${DOCKER_GID:-$(grep '^docker:' /etc/group | cut -f3 -d:)}"
+CONTAINER_RUN_OPTIONS="${CONTAINER_RUN_OPTIONS:--it}"
 
 echo "start building inside container"
-docker run --rm -u "${UID}:${DOCKER_GID}" \
+docker run --rm ${CONTAINER_RUN_OPTIONS} -u "${UID}:${DOCKER_GID}" \
     --init \
-    --sig-proxy=false \
+    --sig-proxy=true \
     -e XDG_CACHE_HOME=/tmp/.cache \
     -v ${KUBEEDGE_ROOT}:${MOUNTPATH} \
     -w ${MOUNTPATH} ${KUBEEDGE_BUILD_IMAGE} "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When Docker recieves SIGTERM, it forwards the signal to the container and then exits immediately. It does not wait for the container to die, it just assumes it will.
this patch will fix the shell terminal appears to have stopped the container progress, but `docker ps`  still display the container is still running.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
