### PR TITLE
chart: add cert domain config in helm chart

### DIFF
--- a/manifests/charts/cloudcore/README.md
+++ b/manifests/charts/cloudcore/README.md
@@ -17,6 +17,7 @@ helm upgrade --install cloudcore ./cloudcore --namespace kubeedge --create-names
 ### cloudcore
 
 - `cloudCore.modules.cloudHub.advertiseAddress`, defines the unmissable public IPs which can be accessed by edge nodes.
+- `cloudCore.modules.cloudHub.dnsNames`, defines the domain names which can be accessed by edge nodes.
 - `cloudCore.hostNetWork`, default `true`, which shares the host network, used for setting the forward iptables rules on the host.
 - `cloudCore.image.repository`, default `kubeedge`, defines the image repo.
 - `cloudCore.image.tag`, default `v1.9.1`, defines the image tag.

--- a/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
@@ -18,6 +18,10 @@ data:
         {{- range .Values.cloudCore.modules.cloudHub.advertiseAddress }}
         - {{  .  }}
         {{- end}}
+        dnsNames:
+        {{- range .Values.cloudCore.modules.cloudHub.dnsNames }}
+        - {{  .  }}
+        {{- end}}
         nodeLimit: {{ .Values.cloudCore.modules.cloudHub.nodeLimit }}
         tlsCAFile: /etc/kubeedge/ca/rootCA.crt
         tlsCertFile: /etc/kubeedge/certs/edge.crt

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -39,6 +39,8 @@ cloudCore:
       # At least a public IP Address or an IP which can be accessed by edge nodes must be provided!
       advertiseAddress:
         - ""
+      dnsNames:
+        - ""
       nodeLimit: "1000"
       websocket:
         enable: "true"


### PR DESCRIPTION
this supports edge node connecting to cloudcore with a domain name when cloudcore is deployed with a helm chart.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
