### PR TITLE
Pod running on edge node has invalid serviceaccount token

### DIFF
--- a/edge/pkg/edged/volume_host.go
+++ b/edge/pkg/edged/volume_host.go
@@ -158,7 +158,9 @@ func (evh *edgedVolumeHost) GetSecretFunc() func(namespace, name string) (*api.S
 func (evh *edgedVolumeHost) GetVolumeDevicePluginDir(pluginName string) string { return "" }
 
 func (evh *edgedVolumeHost) DeleteServiceAccountTokenFunc() func(podUID types.UID) {
-	return func(types.UID) {}
+	return func(podUID types.UID) {
+		evh.edge.metaClient.ServiceAccountToken().DeleteServiceAccountToken(podUID)
+	}
 }
 
 func (evh *edgedVolumeHost) GetEventRecorder() recordtools.EventRecorder {

--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -3,13 +3,17 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao"
 )
 
 // ServiceAccountTokenGetter is interface to get client service account token
@@ -20,11 +24,14 @@ type ServiceAccountTokenGetter interface {
 // ServiceAccountTokenInterface is interface for client service account token
 type ServiceAccountTokenInterface interface {
 	GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
+	DeleteServiceAccountToken(podUID types.UID)
 }
 
 type serviceAccountToken struct {
 	send SendInterface
 }
+
+const maxTTL = 24 * time.Hour
 
 func newServiceAccountToken(s SendInterface) *serviceAccountToken {
 	return &serviceAccountToken{
@@ -32,8 +39,82 @@ func newServiceAccountToken(s SendInterface) *serviceAccountToken {
 	}
 }
 
-func (c *serviceAccountToken) GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-	resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypeServiceAccountToken, name)
+func (c *serviceAccountToken) DeleteServiceAccountToken(podUID types.UID) {
+	svcAccounts, err := dao.QueryAllMeta("type", model.ResourceTypeServiceAccountToken)
+	if err != nil {
+		klog.Errorf("query meta failed: %v", err)
+		return
+	}
+	for _, sa := range *svcAccounts {
+		var tr authenticationv1.TokenRequest
+		err = json.Unmarshal([]byte(sa.Value), &tr)
+		if err != nil {
+			klog.Errorf("unmarshal resource %s token request failed: %v", sa.Key, err)
+			continue
+		}
+		if podUID == tr.Spec.BoundObjectRef.UID {
+			err := dao.DeleteMetaByKey(sa.Key)
+			if err != nil {
+				klog.Errorf("delete meta %s failed: %v", sa.Key, err)
+				return
+			}
+		}
+	}
+}
+
+// requiresRefresh returns true if the token is older than 80% of its total
+// ttl, or if the token is older than 24 hours.
+func requiresRefresh(tr *authenticationv1.TokenRequest) bool {
+	if tr.Spec.ExpirationSeconds == nil {
+		cpy := tr.DeepCopy()
+		cpy.Status.Token = ""
+		klog.Errorf("expiration seconds was nil for tr: %#v", cpy)
+		return false
+	}
+	now := time.Now()
+	exp := tr.Status.ExpirationTimestamp.Time
+	iat := exp.Add(-1 * time.Duration(*tr.Spec.ExpirationSeconds) * time.Second)
+
+	if now.After(iat.Add(maxTTL)) {
+		return true
+	}
+	// Require a refresh if within 20% of the TTL from the expiration time.
+	if now.After(exp.Add(-1 * time.Duration((*tr.Spec.ExpirationSeconds*20)/100) * time.Second)) {
+		return true
+	}
+	return false
+}
+
+func getTokenLocally(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+	resKey := metamanager.KeyFunc(name, namespace, tr)
+	metas, err := dao.QueryMeta("key", resKey)
+	if err != nil {
+		klog.Errorf("query meta %s failed: %v", resKey, err)
+		return nil, err
+	}
+	if len(*metas) != 1 {
+		klog.Errorf("query meta %s length error", resKey)
+		return nil, fmt.Errorf("query meta %s length error", resKey)
+	}
+	var tokenRequest authenticationv1.TokenRequest
+	err = json.Unmarshal([]byte((*metas)[0]), &tokenRequest)
+	if err != nil {
+		klog.Errorf("unmarshal resource %s token request failed: %v", resKey, err)
+		return nil, err
+	}
+	if requiresRefresh(&tokenRequest) {
+		err := dao.DeleteMetaByKey(resKey)
+		if err != nil {
+			klog.Errorf("delete meta %s failed: %v", resKey, err)
+			return nil, err
+		}
+		klog.Errorf("resource %s token expired", resKey)
+		return nil, fmt.Errorf("resource %s token expired", resKey)
+	}
+	return &tokenRequest, nil
+}
+
+func getTokenRemotely(resource string, tr *authenticationv1.TokenRequest, c *serviceAccountToken) (*authenticationv1.TokenRequest, error) {
 	tokenMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, tr)
 	msg, err := c.send.SendSync(tokenMsg)
 	if err != nil {
@@ -51,6 +132,15 @@ func (c *serviceAccountToken) GetServiceAccountToken(namespace string, name stri
 		return handleServiceAccountTokenFromMetaDB(content)
 	}
 	return handleServiceAccountTokenFromMetaManager(content)
+}
+
+func (c *serviceAccountToken) GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+	tokenReq, err := getTokenLocally(name, namespace, tr)
+	if err != nil {
+		resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypeServiceAccountToken, name)
+		return getTokenRemotely(resource, tr, c)
+	}
+	return tokenReq, nil
 }
 
 func handleServiceAccountTokenFromMetaDB(content []byte) (*authenticationv1.TokenRequest, error) {


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
We currently only create one serviceaccount token for one namespace in the edge node, it was saved in DB with primary KEY format `<namespace>/<restype></serviceaccount name>`, so all pods in one node use the same one serviceaccount token (which belongs to the first pod created in the edge node). It will authenticate failed after the first pod was deleted.
cc @fisherxu @kevin-wangzefeng 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3798

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
