### PR TITLE
Automated cherry pick of #3815: Pods configure imagePullSecret but doesn't exist in

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -1060,10 +1060,8 @@ func (e *edged) consumePodAddition(namespacedName *types.NamespacedName) error {
 		return err
 	}
 
-	secrets, err := e.getSecretsFromMetaManager(pod)
-	if err != nil {
-		return err
-	}
+	// Fetch the pull secrets for the pod
+	secrets := e.getImagePullSecretsForPod(pod)
 
 	podUID := pod.GetUID()
 	t, ok := e.podLastSyncTime.Load(podUID)
@@ -1408,17 +1406,18 @@ func (e *edged) deletePod(obj interface{}) {
 	klog.Infof("success remove pod [%s]", pod.Name)
 }
 
-func (e *edged) getSecretsFromMetaManager(pod *v1.Pod) ([]v1.Secret, error) {
+func (e *edged) getImagePullSecretsForPod(pod *v1.Pod) []v1.Secret {
 	var secrets []v1.Secret
 	for _, imagePullSecret := range pod.Spec.ImagePullSecrets {
 		secret, err := e.metaClient.Secrets(pod.Namespace).Get(imagePullSecret.Name)
 		if err != nil {
-			return nil, err
+			klog.Warningf("Unable to retrieve pull secret %s/%s for %s/%s due to %v.  The image pull may not succeed.", pod.Namespace, imagePullSecret.Name, pod.Namespace, pod.Name, err)
+			continue
 		}
 		secrets = append(secrets, *secret)
 	}
 
-	return secrets, nil
+	return secrets
 }
 
 // Get pods which should be resynchronized. Currently, the following pod should be resynchronized:


### PR DESCRIPTION
Cherry pick of #3815 on release-1.9.

#3815: Pods configure imagePullSecret but doesn't exist in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.