### PR TITLE
fix HostAliases not working if pod network is set to hostNetwork

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -1083,6 +1083,16 @@ func (e *edged) consumePodAddition(namespacedName *types.NamespacedName) error {
 	if err != nil {
 		return fmt.Errorf("pod %s cache newer failed: %v", podName, err)
 	}
+
+	if pod.Spec.HostNetwork {
+		hostIP, err := e.getNodeIP(e.nodeName, e.customInterfaceName)
+		if err != nil {
+			klog.Errorf("Failed to get host IP: %v", err)
+		} else {
+			curPodStatus.IPs = []string{hostIP}
+		}
+	}
+
 	result := e.containerRuntime.SyncPod(pod, curPodStatus, secrets, e.podAdditionBackoff)
 	e.podLastSyncTime.Store(podUID, time.Now())
 	if err := result.Error(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubeedge/kubeedge/issues/3812

```
apiVersion: v1
kind: Pod
metadata:
  name: hostaliases-pod
spec:
  hostNetwork: true
  restartPolicy: Never
  hostAliases:
  - ip: "127.0.0.1"
    hostnames:
    - "foo.local"
    - "bar.local"
  - ip: "10.1.2.3"
    hostnames:
    - "foo.remote"
    - "bar.remote"
  containers:
  - name: cat-hosts
    image: busybox:1.28
    command:
    - sleep
    args:
    - "99999999"

```

![image](https://user-images.githubusercontent.com/30396467/167415626-3de418b5-d67a-4395-9000-e8aa13a0d966.png)


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
