### PR TITLE
remove default KubeConfig for cloudcore

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -73,7 +73,6 @@ const (
 
 	// Config
 	DefaultKubeContentType         = "application/vnd.kubernetes.protobuf"
-	DefaultKubeConfig              = "/root/.kube/config"
 	DefaultKubeNamespace           = v1.NamespaceAll
 	DefaultKubeQPS                 = 100.0
 	DefaultKubeBurst               = 200

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -38,11 +38,9 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 			TunnelPort: constants.ServerPort,
 		},
 		KubeAPIConfig: &KubeAPIConfig{
-			Master:      "",
 			ContentType: constants.DefaultKubeContentType,
 			QPS:         constants.DefaultKubeQPS,
 			Burst:       constants.DefaultKubeBurst,
-			KubeConfig:  constants.DefaultKubeConfig,
 		},
 		Modules: &Modules{
 			CloudHub: &CloudHub{
@@ -172,10 +170,6 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 		TypeMeta: metav1.TypeMeta{
 			Kind:       Kind,
 			APIVersion: path.Join(GroupName, APIVersion),
-		},
-		KubeAPIConfig: &KubeAPIConfig{
-			Master:     "",
-			KubeConfig: constants.DefaultKubeConfig,
 		},
 		Modules: &Modules{
 			CloudHub: &CloudHub{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


Cloudcore uses containerized deployment for now and use the in cluster kubeconfig in pod that was generated by serviceaccount token by default, so we  do not need set default value for the kubeconfig. otherwise  we need set empty value explicitly for the kubeconfig when we uses containerized deployment


![image](https://user-images.githubusercontent.com/30396467/167433423-9575c480-8c02-4b62-a780-c328d9475527.png)



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
