### PR TITLE
dynamiccontroller: fix selector match return false when selector is e…

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/selector.go
+++ b/cloud/pkg/dynamiccontroller/application/selector.go
@@ -45,7 +45,7 @@ func (lf *LabelFieldSelector) String() string {
 }
 
 func (lf *LabelFieldSelector) Match(set labels.Set, set2 fields.Set) bool {
-	return lf.Labels().Matches(set) && lf.Fields().Matches(set2)
+	return (lf.Labels().Empty() || lf.Labels().Matches(set)) && (lf.Field.Empty() || lf.Fields().Matches(set2))
 }
 
 func (lf *LabelFieldSelector) MatchObj(obj runtime.Object) bool {


### PR DESCRIPTION
…mpty

Signed-off-by: chengengkun <1366542563@qq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:

If we curl http://127.0.0.1:10550/api/v1/namespaces/default/pods?watch=true, we want to watch all pod in default namespace, but no pod was watched. Because dynamiccontroller listener selector's labels is empty, and can not match any pod.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
