### PR TITLE
fix make lint error: GOPATH: unbound variable

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -49,6 +49,7 @@ function check_kind {
 
 # check if golangci-lint installed
 function check_golangci-lint {
+  GOPATH="${GOPATH:-$(go env GOPATH)}"
   echo "checking golangci-lint"
   export PATH=$PATH:$GOPATH/bin
   expectedVersion="1.42.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
when run `make lint`, error is below
```
# make lint
hack/make-rules/lint.sh
checking golangci-lint
/root/go/src/github.com/kubeedge/kubeedge/hack/lib/install.sh: line 53: GOPATH: unbound variable
Makefile:135: recipe for target 'lint' failed
make: *** [lint] Error 1
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
