### PR TITLE
add rate limiter for edgehub

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -145,4 +145,7 @@ const (
 
 	// MessageSuccessfulContent is the successful content value of Message struct
 	MessageSuccessfulContent string = "OK"
+
+	DefaultQPS   = 30
+	DefaultBurst = 60
 )

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -219,6 +219,8 @@ func TestRouteToCloud(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+	config.Config.MessageQPS = 3
+	config.Config.MessageBurst = 6
 	hub := newEdgeHub(true)
 	hub.chClient = mockAdapter
 

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -87,6 +87,8 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 			EdgeHub: &EdgeHub{
 				Enable:            true,
 				Heartbeat:         15,
+				MessageQPS:        constants.DefaultQPS,
+				MessageBurst:      constants.DefaultBurst,
 				ProjectID:         "e632aba927ea4ac2b575ec1603d56f10",
 				TLSCAFile:         constants.DefaultCAFile,
 				TLSCertFile:       constants.DefaultCertFile,

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -246,6 +246,12 @@ type EdgeHub struct {
 	// Heartbeat indicates heart beat (second)
 	// default 15
 	Heartbeat int32 `json:"heartbeat,omitempty"`
+	// MessageQPS is the QPS to allow while send message to cloudHub.
+	// DefaultQPS: 30
+	MessageQPS int32 `json:"messageQPS,omitempty"`
+	// MessageBurst is the burst to allow while send message to cloudHub.
+	// DefaultBurst: 60
+	MessageBurst int32 `json:"messageBurst,omitempty"`
 	// ProjectID indicates project id
 	// default e632aba927ea4ac2b575ec1603d56f10
 	ProjectID string `json:"projectID,omitempty"`

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation.go
@@ -91,6 +91,16 @@ func ValidateModuleEdgeHub(h v1alpha1.EdgeHub) field.ErrorList {
 			h.Quic.Enable, "websocket.enable and quic.enable cannot be true and false at the same time"))
 	}
 
+	if h.MessageQPS < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("messageQPS"), h.MessageQPS,
+			"MessageQPS must not be a negative number"))
+	}
+
+	if h.MessageBurst < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("messageBurst"), h.MessageBurst,
+			"MessageBurst must not be a negative number"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha1/validation/validation_test.go
@@ -161,6 +161,36 @@ func TestValidateModuleEdgeHub(t *testing.T) {
 			},
 			result: field.ErrorList{},
 		},
+		{
+			name: "case4 MessageQPS must not be a negative number",
+			input: v1alpha1.EdgeHub{
+				Enable: true,
+				WebSocket: &v1alpha1.EdgeHubWebSocket{
+					Enable: true,
+				},
+				Quic: &v1alpha1.EdgeHubQUIC{
+					Enable: false,
+				},
+				MessageQPS: -1,
+			},
+			result: field.ErrorList{field.Invalid(field.NewPath("messageQPS"),
+				int32(-1), "MessageQPS must not be a negative number")},
+		},
+		{
+			name: "case5 MessageBurst must not be a negative number",
+			input: v1alpha1.EdgeHub{
+				Enable: true,
+				WebSocket: &v1alpha1.EdgeHubWebSocket{
+					Enable: true,
+				},
+				Quic: &v1alpha1.EdgeHubQUIC{
+					Enable: false,
+				},
+				MessageBurst: -1,
+			},
+			result: field.ErrorList{field.Invalid(field.NewPath("messageBurst"),
+				int32(-1), "MessageBurst must not be a negative number")},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


add rate limiter for edgehub


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add rate limiter for edgehub to allow uses to set rate when send message to cloudHub. Users could edit the config `MessageQPS` and `MessageBurst` field in `edgeHub` config, the default QPS is 30 and default burst is 60.
```
