### PR TITLE
remove invalid url

### DIFF
--- a/docs/proposals/cri.md
+++ b/docs/proposals/cri.md
@@ -65,7 +65,6 @@ for docker runtime using dockershim is not considered in edged
 ## High Level Design
 
 ### Edged with CRI support
-<img src="../images/edged/docker-cri.png">
 
 ## Low Level Design
 


### PR DESCRIPTION
/kind cleanup

The image seems removed in commit: https://github.com/kubeedge/kubeedge/commit/f3678bc02426ab38d724a864f9bd8ece1b046a79

Maybe we should remove the corresponding reference or restore the previous image.