### PR TITLE
fix keadm beta reset failed on edge node

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -149,24 +149,27 @@ func GetOSInterface() types.OSTypeInstaller {
 
 // RunningModuleV2 identifies cloudcore/edgecore running or not.
 // only used for cloudcore container install and edgecore binary install
-func RunningModuleV2(opt *types.ResetOptions) (types.ModuleRunning, error) {
+func RunningModuleV2(opt *types.ResetOptions) types.ModuleRunning {
 	osType := GetOSInterface()
 	cloudCoreRunning, err := IsCloudcoreContainerRunning(constants.SystemNamespace, opt.Kubeconfig)
 	if err != nil {
-		return types.NoneRunning, err
+		// just log the error, maybe we do not care
+		klog.Warningf("failed to check cloudcore is running: %v", err)
 	}
 	if cloudCoreRunning {
-		return types.KubeEdgeCloudRunning, nil
+		return types.KubeEdgeCloudRunning
 	}
 
 	edgeCoreRunning, err := osType.IsKubeEdgeProcessRunning(KubeEdgeBinaryName)
+	if err != nil {
+		// just log the error, maybe we do not care
+		klog.Warningf("failed to check edgecore is running: %v", err)
+	}
 	if edgeCoreRunning {
-		return types.KubeEdgeEdgeRunning, nil
-	} else if err != nil {
-		return types.NoneRunning, err
+		return types.KubeEdgeEdgeRunning
 	}
 
-	return types.NoneRunning, nil
+	return types.NoneRunning
 }
 
 // RunningModule identifies cloudcore/edgecore running or not.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
fix keadm beta reset failed on edge node
on edge node, we don't have /root/.kube/config file, so keadm exit. so just ignore the error
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3870 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
