### PR TITLE
fix build_with_container.sh

### DIFF
--- a/hack/make-rules/build_with_container.sh
+++ b/hack/make-rules/build_with_container.sh
@@ -23,11 +23,12 @@ set -o pipefail
 KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 MOUNTPATH="${MOUNTPATH:-/kubeedge}"
 KUBEEDGE_BUILD_IMAGE=${KUBEEDGE_BUILD_IMAGE:-"kubeedge/build-tools"}
-DOCKER_GID="${DOCKER_GID:-$(grep '^docker:' /etc/group | cut -f3 -d:)}"
+UID_GID="$UID"
+DOCKER_GID="${DOCKER_GID:-$(grep '^docker:' /etc/group | cut -f3 -d:)}" && UID_GID="${UID}:${DOCKER_GID}"
 CONTAINER_RUN_OPTIONS="${CONTAINER_RUN_OPTIONS:--it}"
 
 echo "start building inside container"
-docker run --rm ${CONTAINER_RUN_OPTIONS} -u "${UID}:${DOCKER_GID}" \
+docker run --rm ${CONTAINER_RUN_OPTIONS} -u "${UID_GID}" \
     --init \
     --sig-proxy=true \
     -e XDG_CACHE_HOME=/tmp/.cache \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I can't run `make` with the current build script on mac as `docker` doesn't exist in `/etc/group`. So I tweak the `build_with_container.sh` script to make it compatible with mac.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

n/a

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
