### PR TITLE
Pass go env variables in build_with_container.sh

### DIFF
--- a/hack/make-rules/build_with_container.sh
+++ b/hack/make-rules/build_with_container.sh
@@ -31,5 +31,6 @@ docker run --rm ${CONTAINER_RUN_OPTIONS} -u "${UID}:${DOCKER_GID}" \
     --init \
     --sig-proxy=true \
     -e XDG_CACHE_HOME=/tmp/.cache \
+    --env-file <(env | grep -E "^GO*") \
     -v ${KUBEEDGE_ROOT}:${MOUNTPATH} \
     -w ${MOUNTPATH} ${KUBEEDGE_BUILD_IMAGE} "$@"


### PR DESCRIPTION
Signed-off-by: Kaitian Xie <kaitian96@outlook.com>


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

To make sure commands like `make all WHAT=cloudcore GOLDFLAGS="" GOGCFLAGS="-N -l"` could work as expected.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3884

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
