### PR TITLE
use command flag for e2e config

### DIFF
--- a/tests/e2e/deployment/e2e_test.go
+++ b/tests/e2e/deployment/e2e_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package deployment
 
 import (
+	"flag"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 
 	"github.com/kubeedge/kubeedge/tests/e2e/utils"
 )
@@ -28,16 +31,23 @@ import (
 var (
 	nodeName     string
 	nodeSelector string
-	//context to load config and access across the package
+	// context to load config and access across the package
 	ctx *utils.TestContext
 )
 
-//Function to run the Ginkgo Test
-func TestEdgecoreAppDeployment(t *testing.T) {
+func TestMain(m *testing.M) {
+	utils.CopyFlags(utils.Flags, flag.CommandLine)
+	utils.RegisterFlags(flag.CommandLine)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	os.Exit(m.Run())
+}
+
+// Function to run the Ginkgo Test
+func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	var _ = BeforeSuite(func() {
 		utils.Infof("Before Suite Execution")
-		//cfg = utils.LoadConfig()
 		ctx = utils.NewTestContext(utils.LoadConfig())
 		nodeName = "edge-node"
 		nodeSelector = "test"

--- a/tests/e2e/keadm/keadm_suite_test.go
+++ b/tests/e2e/keadm/keadm_suite_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package keadm
 
 import (
+	"flag"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 
 	"github.com/kubeedge/kubeedge/tests/e2e/utils"
 )
@@ -32,7 +35,15 @@ var (
 	ctx *utils.TestContext
 )
 
-//Function to run the Ginkgo Test
+func TestMain(m *testing.M) {
+	utils.CopyFlags(utils.Flags, flag.CommandLine)
+	utils.RegisterFlags(flag.CommandLine)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	os.Exit(m.Run())
+}
+
+// Function to run the Ginkgo Test
 func TestKeadmAppDeployment(t *testing.T) {
 	RegisterFailHandler(Fail)
 	var _ = BeforeSuite(func() {

--- a/tests/e2e/scripts/fast_test.sh
+++ b/tests/e2e/scripts/fast_test.sh
@@ -19,31 +19,31 @@ workdir=`pwd`
 cd $workdir
 
 compilemodule=$1
-runtest=$2
-debugflag="-test.v -ginkgo.v"
 
 #setup env
 cd ../
 
 export MASTER_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' test-control-plane`
 export KUBECONFIG=$HOME/.kube/config
-
 export CHECK_EDGECORE_ENVIRONMENT="false"
-
-#Pre-configurations required for running the suite.
-#Any new config addition required corresponding code changes.
-cat >config.json<<END
-{
-        "image_url": ["nginx", "nginx"],
-        "k8smasterforkubeedge":"https://$MASTER_IP:6443",
-        "kubeconfigpath":"$KUBECONFIG"
-}
-END
+export ACK_GINKGO_RC=true
 
 if [ $# -eq 0 ]
 then
     #run testcase
-    ./deployment/deployment.test $debugflag 2>&1 | tee -a /tmp/testcase.log
+    ginkgo -v ./deployment/deployment.test -- \
+    --image-url=nginx \
+    --image-url=nginx \
+    --kube-master="https://$MASTER_IP:6443" \
+    --kubeconfig=$KUBECONFIG \
+    --test.v \
+    2>&1 | tee -a /tmp/testcase.log
 else
-    ./$compilemodule/$compilemodule.test  $debugflag  $runtest 2>&1 | tee -a  /tmp/testcase.log
+   ginkgo -v ./$compilemodule/$compilemodule.test -- \
+    --image-url=nginx \
+    --image-url=nginx \
+    --kube-master="https://$MASTER_IP:6443" \
+    --kubeconfig=$KUBECONFIG \
+    --test.v \
+   2>&1 | tee -a  /tmp/testcase.log
 fi

--- a/tests/e2e/scripts/keadm_e2e.sh
+++ b/tests/e2e/scripts/keadm_e2e.sh
@@ -20,8 +20,6 @@ E2E_DIR=$(realpath $(dirname $0)/..)
 IMAGE_TAG=$(git describe --tags)
 KUBEEDGE_VERSION=$IMAGE_TAG
 
-debugflag="-test.v -ginkgo.v"
-
 function cleanup() {
   sudo pkill edgecore || true
   helm uninstall cloudcore -n kubeedge && kubectl delete ns kubeedge  || true
@@ -74,16 +72,6 @@ function start_kubeedge() {
   sudo systemctl set-environment CHECK_EDGECORE_ENVIRONMENT="false"
   sudo -E CHECK_EDGECORE_ENVIRONMENT="false" /usr/local/bin/keadm join --token=$TOKEN --cloudcore-ipport=$MASTER_IP:10000 --edgenode-name=edge-node --kubeedge-version=$KUBEEDGE_VERSION
 
-  #Pre-configurations required for running the suite.
-  #Any new config addition required corresponding code changes.
-  cat > $E2E_DIR/config.json <<END
-{
-        "image_url": ["nginx", "nginx"],
-        "k8smasterforkubeedge":"https://$MASTER_IP:6443",
-        "kubeconfigpath":"$KUBECONFIG"
-}
-END
-
   # ensure edgenode is ready
   while true; do
       sleep 3
@@ -94,7 +82,16 @@ END
 function run_test() {
   :> /tmp/testcase.log
   cd $E2E_DIR
-  ./keadm/keadm.test $debugflag 2>&1 | tee -a /tmp/testcase.log
+
+  export ACK_GINKGO_RC=true
+
+  ginkgo -v ./keadm/keadm.test -- \
+  --image-url=nginx \
+  --image-url=nginx \
+  --kube-master="https://$MASTER_IP:6443" \
+  --kubeconfig=$KUBECONFIG \
+  --test.v \
+  2>&1 | tee -a /tmp/testcase.log
 
   #stop the edgecore after the test completion
   grep  -e "Running Suite" -e "SUCCESS\!" -e "FAIL\!" /tmp/testcase.log | sed -r 's/\x1B\[([0-9];)?([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g' | sed -r 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind cleanup



**What this PR does / why we need it**:

use non-version config file is not user friendly and user need to look the source code to  understand what they can config, so switch to comman line and we also use ginkgo to run the e2e test and user can config ginkgo to run their wanted test.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
