### PR TITLE
fix e2e use fixed edge node for test and cleanup

### DIFF
--- a/tests/e2e/constants/constants.go
+++ b/tests/e2e/constants/constants.go
@@ -3,9 +3,16 @@ package constants
 import "time"
 
 const (
-	AppHandler        = "/api/v1/namespaces/default/pods"
-	DeploymentHandler = "/apis/apps/v1/namespaces/default/deployments"
-
 	Interval = 5 * time.Second
 	Timeout  = 10 * time.Minute
+
+	E2ELabelKey   = "kubeedge"
+	E2ELabelValue = "e2e-test"
+)
+
+var (
+	// KubeEdgeE2ELabel labels resources created during e2e testing
+	KubeEdgeE2ELabel = map[string]string{
+		E2ELabelKey: E2ELabelValue,
+	}
 )

--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -19,13 +19,12 @@ package deployment
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -38,7 +37,7 @@ import (
 
 var DeploymentTestTimerGroup = utils.NewTestTimerGroup()
 
-//Run Test cases
+// Run Test cases
 var _ = Describe("Application deployment test in E2E scenario", func() {
 	var UID string
 	var testTimer *utils.TestTimer
@@ -57,59 +56,68 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			// Start test timer
 			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
+
 		AfterEach(func() {
 			// End test timer
 			testTimer.End()
 			// Print result
 			testTimer.PrintResult()
-			var podlist corev1.PodList
-			var deploymentList appsv1.DeploymentList
-			err := utils.GetDeployments(&deploymentList, ctx.Cfg.K8SMasterForKubeEdge+constants.DeploymentHandler)
+
+			By(fmt.Sprintf("get deployment %s", UID))
+			deployment, err := utils.GetDeployment(clientSet, metav1.NamespaceDefault, UID)
 			Expect(err).To(BeNil())
-			for _, deployment := range deploymentList.Items {
-				if deployment.Name == UID {
-					label := nodeName
-					podlist, err = utils.GetPods(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, label)
-					Expect(err).To(BeNil())
-					StatusCode := utils.DeleteDeployment(ctx.Cfg.K8SMasterForKubeEdge+constants.DeploymentHandler, deployment.Name)
-					Expect(StatusCode).Should(Equal(http.StatusOK))
-				}
-			}
-			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
+
+			By(fmt.Sprintf("list pod for deploy %s", UID))
+			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
+			_, err = utils.GetPods(clientSet, metav1.NamespaceDefault, labelSelector, nil)
+			Expect(err).To(BeNil())
+
+			By(fmt.Sprintf("delete deploy %s", UID))
+			err = utils.DeleteDeployment(clientSet, deployment.Namespace, deployment.Name)
+			Expect(err).To(BeNil())
+
+			By(fmt.Sprintf("wait for pod of deploy %s to disappear", UID))
+			err = utils.WaitForPodsToDisappear(clientSet, metav1.NamespaceDefault, labelSelector, constants.Interval, constants.Timeout)
+			Expect(err).To(BeNil())
+
 			utils.PrintTestcaseNameandStatus()
 		})
 
 		It("E2E_APP_DEPLOYMENT_1: Create deployment and check the pods are coming up correctly", func() {
-			replica := 1
+			replica := int32(1)
 			//Generate the random string and assign as a UID
 			UID = "edgecore-depl-app-" + utils.GetRandomString(5)
-			CreateDeploymentTest(replica, UID, nodeName, nodeSelector, ctx)
+			CreateDeploymentTest(clientSet, replica, UID, ctx)
 		})
+
 		It("E2E_APP_DEPLOYMENT_2: Create deployment with replicas and check the pods are coming up correctly", func() {
-			replica := 3
+			replica := int32(3)
 			//Generate the random string and assign as a UID
 			UID = "edgecore-depl-app-" + utils.GetRandomString(5)
-			CreateDeploymentTest(replica, UID, nodeName, nodeSelector, ctx)
+			CreateDeploymentTest(clientSet, replica, UID, ctx)
 		})
 
 		It("E2E_APP_DEPLOYMENT_3: Create deployment and check deployment ctrler re-creating pods when user deletes the pods manually", func() {
-			replica := 3
+			replica := int32(3)
 			//Generate the random string and assign as a UID
 			UID = "edgecore-depl-app-" + utils.GetRandomString(5)
-			podlist := CreateDeploymentTest(replica, UID, nodeName, nodeSelector, ctx)
-			for _, pod := range podlist.Items {
-				_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + pod.Name)
-				Expect(StatusCode).Should(Equal(http.StatusOK))
+			podList := CreateDeploymentTest(clientSet, replica, UID, ctx)
+			for _, pod := range podList.Items {
+				err := utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+				Expect(err).To(BeNil())
 			}
-			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
-			label := nodeName
-			podlist, err := utils.GetPods(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, label)
+			utils.CheckPodDeleteState(clientSet, podList)
+
+			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
+			podList, err := utils.GetPods(clientSet, metav1.NamespaceDefault, labelSelector, nil)
 			Expect(err).To(BeNil())
-			Expect(len(podlist.Items)).Should(Equal(replica))
-			utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, podlist, 240*time.Second)
+			Expect(len(podList.Items)).Should(Equal(int(replica)))
+
+			utils.WaitForPodsRunning(clientSet, podList, 240*time.Second)
 		})
 
 	})
+
 	Context("Test application deployment using Pod spec", func() {
 		BeforeEach(func() {
 			// Get current test SpecReport
@@ -122,71 +130,80 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			testTimer.End()
 			// Print result
 			testTimer.PrintResult()
-			var podlist corev1.PodList
-			label := nodeName
-			podlist, err := utils.GetPods(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, label)
+
+			labelSelector := labels.SelectorFromSet(constants.KubeEdgeE2ELabel)
+			podList, err := utils.GetPods(clientSet, metav1.NamespaceDefault, labelSelector, nil)
 			Expect(err).To(BeNil())
-			for _, pod := range podlist.Items {
-				_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + pod.Name)
-				Expect(StatusCode).Should(Equal(http.StatusOK))
+
+			for _, pod := range podList.Items {
+				err = utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+				Expect(err).To(BeNil())
 			}
-			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
+
+			utils.CheckPodDeleteState(clientSet, podList)
+
 			utils.PrintTestcaseNameandStatus()
 		})
 
 		It("E2E_POD_DEPLOYMENT_1: Create a pod and check the pod is coming up correctly", func() {
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
-			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
+			pod := utils.NewPod(podName, ctx.Cfg.AppImageURL[0])
 
-			CreatePodTest(nodeName, podName, ctx, pod)
+			CreatePodTest(clientSet, pod)
 		})
 
 		It("E2E_POD_DEPLOYMENT_2: Create the pod and delete pod happening successfully", func() {
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
-			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
+			pod := utils.NewPod(podName, ctx.Cfg.AppImageURL[0])
 
-			podlist := CreatePodTest(nodeName, podName, ctx, pod)
-			for _, pod := range podlist.Items {
-				_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + pod.Name)
-				Expect(StatusCode).Should(Equal(http.StatusOK))
+			podList := CreatePodTest(clientSet, pod)
+			for _, pod := range podList.Items {
+				err := utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+				Expect(err).To(BeNil())
 			}
-			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
+
+			utils.CheckPodDeleteState(clientSet, podList)
 		})
+
 		It("E2E_POD_DEPLOYMENT_3: Create pod and delete the pod successfully, and delete already deleted pod and check the behaviour", func() {
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
-			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
+			pod := utils.NewPod(podName, ctx.Cfg.AppImageURL[0])
 
-			podlist := CreatePodTest(nodeName, podName, ctx, pod)
-			for _, pod := range podlist.Items {
-				_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + pod.Name)
-				Expect(StatusCode).Should(Equal(http.StatusOK))
+			podList := CreatePodTest(clientSet, pod)
+			for _, pod := range podList.Items {
+				err := utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+				Expect(err).To(BeNil())
 			}
-			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
-			_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + UID)
-			Expect(StatusCode).Should(Equal(http.StatusNotFound))
+
+			utils.CheckPodDeleteState(clientSet, podList)
+
+			err := utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
+
 		It("E2E_POD_DEPLOYMENT_4: Create and delete pod multiple times and check all the Pod created and deleted successfully", func() {
 			//Generate the random string and assign as a UID
 			for i := 0; i < 10; i++ {
 				//Generate the random string and assign as podName
 				podName := "pod-app-" + utils.GetRandomString(5)
-				pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
+				pod := utils.NewPod(podName, ctx.Cfg.AppImageURL[0])
 
-				podlist := CreatePodTest(nodeName, podName, ctx, pod)
-				for _, pod := range podlist.Items {
-					_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + pod.Name)
-					Expect(StatusCode).Should(Equal(http.StatusOK))
+				podList := CreatePodTest(clientSet, pod)
+				for _, pod := range podList.Items {
+					err := utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+					Expect(err).To(BeNil())
 				}
-				utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
+				utils.CheckPodDeleteState(clientSet, podList)
 			}
 		})
+
 		It("E2E_POD_DEPLOYMENT_5: Create pod with hostpath volume successfully", func() {
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
-			pod := utils.NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeSelector)
+			pod := utils.NewPod(podName, ctx.Cfg.AppImageURL[0])
 
 			pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
 				Name:      "hp",
@@ -199,12 +216,12 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 				},
 			}}
 
-			podlist := CreatePodTest(nodeName, podName, ctx, pod)
-			for _, pod := range podlist.Items {
-				_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + pod.Name)
-				Expect(StatusCode).Should(Equal(http.StatusOK))
+			podList := CreatePodTest(clientSet, pod)
+			for _, pod := range podList.Items {
+				err := utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+				Expect(err).To(BeNil())
 			}
-			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
+			utils.CheckPodDeleteState(clientSet, podList)
 		})
 	})
 
@@ -228,7 +245,7 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 
 			By(fmt.Sprintf("list pod for StatefulSet %s", UID))
 			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
-			_, err = utils.ListPods(clientSet, metav1.NamespaceDefault, labelSelector, nil)
+			_, err = utils.GetPods(clientSet, metav1.NamespaceDefault, labelSelector, nil)
 			Expect(err).To(BeNil())
 
 			By(fmt.Sprintf("delete StatefulSet %s", UID))
@@ -256,12 +273,12 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 
 			By(fmt.Sprintf("get pod for StatefulSet %s", UID))
 			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
-			podList, err := utils.ListPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
+			podList, err := utils.GetPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
 			Expect(err).To(BeNil())
 			Expect(len(podList.Items)).ShouldNot(Equal(0))
 
 			By(fmt.Sprintf("wait for pod of StatefulSet %s running", UID))
-			utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, *podList, 240*time.Second)
+			utils.WaitForPodsRunning(clientSet, podList, 240*time.Second)
 		})
 
 		It("Delete statefulSet pod multi times", func() {
@@ -278,17 +295,17 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 
 			By(fmt.Sprintf("get pod for StatefulSet %s", UID))
 			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
-			podList, err := utils.ListPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
+			podList, err := utils.GetPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
 			Expect(err).To(BeNil())
 			Expect(len(podList.Items)).ShouldNot(Equal(0))
 
 			By(fmt.Sprintf("wait for pod of StatefulSet %s running", UID))
-			utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, *podList, 240*time.Second)
+			utils.WaitForPodsRunning(clientSet, podList, 240*time.Second)
 
 			deletePodName := fmt.Sprintf("%s-1", UID)
 			for i := 0; i < 5; i++ {
 				By(fmt.Sprintf("delete pod %s", deletePodName))
-				err = utils.DeletePod(clientSet, deletePodName, "default")
+				err = utils.DeletePod(clientSet, "default", deletePodName)
 				Expect(err).To(BeNil())
 
 				By(fmt.Sprintf("wait for pod %s running again", fmt.Sprintf("%s-1", UID)))

--- a/tests/e2e/deployment/device_crd_test.go
+++ b/tests/e2e/deployment/device_crd_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/kubeedge/kubeedge/pkg/apis/devices/v1alpha2"
 	"github.com/kubeedge/kubeedge/tests/e2e/utils"
@@ -43,6 +45,12 @@ var CRDTestTimerGroup = utils.NewTestTimerGroup()
 var _ = Describe("Device Management test in E2E scenario", func() {
 	var testTimer *utils.TestTimer
 	var testSpecReport SpecReport
+	var clientSet clientset.Interface
+
+	BeforeEach(func() {
+		clientSet = utils.NewKubeClient(ctx.Cfg.KubeConfigPath)
+	})
+
 	Context("Test Device Model Creation, Updation and deletion", func() {
 		BeforeEach(func() {
 			// Delete any pre-existing device models
@@ -319,8 +327,8 @@ var _ = Describe("Device Management test in E2E scenario", func() {
 			Expect(isEqual).Should(Equal(true))
 		})
 		It("E2E_CREATE_DEVICE_4: Create device instance for incorrect device instance", func() {
-			statusCode := utils.DeleteConfigmap(ctx.Cfg.K8SMasterForKubeEdge + ConfigmapHandler + "/" + "device-profile-config-" + nodeName)
-			Expect(statusCode == http.StatusOK || statusCode == http.StatusNotFound).Should(Equal(true))
+			err := utils.DeleteConfigMap(clientSet, metav1.NamespaceDefault, "device-profile-config-"+nodeName)
+			Expect(err).To(BeNil())
 			IsDeviceModelCreated, statusCode := utils.HandleDeviceModel(http.MethodPost, ctx.Cfg.K8SMasterForKubeEdge+DeviceModelHandler, "", "led")
 			Expect(IsDeviceModelCreated).Should(BeTrue())
 			Expect(statusCode).Should(Equal(http.StatusCreated))

--- a/tests/e2e/deployment/e2e_test.go
+++ b/tests/e2e/deployment/e2e_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 var (
-	nodeName     string
-	nodeSelector string
+	nodeName string
 	// context to load config and access across the package
 	ctx *utils.TestContext
 )
@@ -50,7 +49,6 @@ func TestE2E(t *testing.T) {
 		utils.Infof("Before Suite Execution")
 		ctx = utils.NewTestContext(utils.LoadConfig())
 		nodeName = "edge-node"
-		nodeSelector = "test"
 
 		err := utils.MqttConnect()
 		Expect(err).To(BeNil())

--- a/tests/e2e/edgesite/edgesite_suite_test.go
+++ b/tests/e2e/edgesite/edgesite_suite_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 var (
-	nodeName     string
-	nodeSelector string
 	//context to load config and access across the package
 	ctx *utils.TestContext
 )

--- a/tests/e2e/keadm/keadm_suite_test.go
+++ b/tests/e2e/keadm/keadm_suite_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 var (
-	nodeName string
-
 	//context to load config and access across the package
 	ctx *utils.TestContext
 )
@@ -49,7 +47,6 @@ func TestKeadmAppDeployment(t *testing.T) {
 	var _ = BeforeSuite(func() {
 		utils.Infof("Before Suite Execution")
 		ctx = utils.NewTestContext(utils.LoadConfig())
-		nodeName = "edge-node"
 	})
 	AfterSuite(func() {
 		By("After Suite Execution....!")

--- a/tests/e2e/keadm/keadm_test.go
+++ b/tests/e2e/keadm/keadm_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package keadm
 
 import (
-	"net/http"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/kubeedge/kubeedge/tests/e2e/constants"
 	. "github.com/kubeedge/kubeedge/tests/e2e/testsuite"
@@ -35,6 +34,13 @@ var DeploymentTestTimerGroup = utils.NewTestTimerGroup()
 var _ = Describe("Application deployment test in keadm E2E scenario", func() {
 	var testTimer *utils.TestTimer
 	var testSpecReport SpecReport
+
+	var clientSet clientset.Interface
+
+	BeforeEach(func() {
+		clientSet = utils.NewKubeClient(ctx.Cfg.KubeConfigPath)
+	})
+
 	Context("Test application deployment using Pod spec", func() {
 		BeforeEach(func() {
 			// Get current test SpecReport
@@ -47,44 +53,27 @@ var _ = Describe("Application deployment test in keadm E2E scenario", func() {
 			testTimer.End()
 			// Print result
 			testTimer.PrintResult()
-			var podlist corev1.PodList
-			label := nodeName
-			podlist, err := utils.GetPods(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, label)
+
+			labelSelector := labels.SelectorFromSet(constants.KubeEdgeE2ELabel)
+			podList, err := utils.GetPods(clientSet, metav1.NamespaceDefault, labelSelector, nil)
 			Expect(err).To(BeNil())
-			for _, pod := range podlist.Items {
-				_, StatusCode := utils.DeletePods(ctx.Cfg.K8SMasterForKubeEdge + constants.AppHandler + "/" + pod.Name)
-				Expect(StatusCode).Should(Equal(http.StatusOK))
+
+			for _, pod := range podList.Items {
+				err = utils.DeletePod(clientSet, pod.Namespace, pod.Name)
+				Expect(err).To(BeNil())
 			}
-			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
+
+			utils.CheckPodDeleteState(clientSet, podList)
+
 			utils.PrintTestcaseNameandStatus()
 		})
 
 		It("E2E_POD_DEPLOYMENT: Create a pod and check the pod is coming up correctly", func() {
 			//Generate the random string and assign as podName
 			podName := "pod-app-" + utils.GetRandomString(5)
-			pod := NewPodObj(podName, ctx.Cfg.AppImageURL[0], nodeName)
+			pod := utils.NewPod(podName, ctx.Cfg.AppImageURL[0])
 
-			CreatePodTest(nodeName, podName, ctx, pod)
+			CreatePodTest(clientSet, pod)
 		})
 	})
 })
-
-func NewPodObj(podName, imgURL, nodeName string) *corev1.Pod {
-	pod := corev1.Pod{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   podName,
-			Labels: map[string]string{"app": "nginx"},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "nginx",
-					Image: imgURL,
-				},
-			},
-			NodeName: nodeName,
-		},
-	}
-	return &pod
-}

--- a/tests/e2e/utils/common.go
+++ b/tests/e2e/utils/common.go
@@ -24,27 +24,21 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os/exec"
 	"reflect"
 	"strings"
 	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/apis/devices/v1alpha2"
-	"github.com/kubeedge/viaduct/pkg/api"
+	"github.com/kubeedge/kubeedge/tests/e2e/constants"
 )
 
 const (
@@ -134,424 +128,86 @@ type ServicebusResponse struct {
 	Body string `json:"body"`
 }
 
-// Function to get nginx deployment spec
-func nginxDeploymentSpec(imgURL, selector string, replicas int) *apps.DeploymentSpec {
-	var nodeselector map[string]string
-	if selector == "" {
-		nodeselector = map[string]string{}
-	} else {
-		nodeselector = map[string]string{"disktype": selector}
-	}
-	deplObj := apps.DeploymentSpec{
-		Replicas: func() *int32 { i := int32(replicas); return &i }(),
-		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "nginx"}},
-		Template: v1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"app": "nginx"},
-			},
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{
-					{
-						Name:  "nginx",
-						Image: imgURL,
-					},
-				},
-				NodeSelector: nodeselector,
-			},
-		},
-	}
-
-	return &deplObj
-}
-
-// Function to get edgecore deploymentspec object
-func edgecoreDeploymentSpec(imgURL, configmap string, replicas int) *apps.DeploymentSpec {
-	IsSecureCtx := true
-	deplObj := apps.DeploymentSpec{
-		Replicas: func() *int32 { i := int32(replicas); return &i }(),
-		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "edgecore"}},
-		Template: v1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"app": "edgecore"},
-			},
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{
-					{
-						Name:            "edgecore",
-						Image:           imgURL,
-						SecurityContext: &v1.SecurityContext{Privileged: &IsSecureCtx},
-						ImagePullPolicy: v1.PullPolicy("IfNotPresent"),
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("200m"),
-								v1.ResourceMemory: resource.MustParse("100Mi"),
-							},
-							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("200m"),
-								v1.ResourceMemory: resource.MustParse("100Mi"),
-							},
-						},
-						Env:          []v1.EnvVar{{Name: "DOCKER_HOST", Value: "tcp://localhost:2375"}},
-						VolumeMounts: []v1.VolumeMount{{Name: "cert", MountPath: "/etc/kubeedge/certs"}, {Name: "conf", MountPath: "/etc/kubeedge/edge/conf"}},
-					}, {
-						Name:            "dind-daemon",
-						SecurityContext: &v1.SecurityContext{Privileged: &IsSecureCtx},
-						Image:           "docker:dind",
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("20m"),
-								v1.ResourceMemory: resource.MustParse("256Mi"),
-							},
-						},
-						VolumeMounts: []v1.VolumeMount{{Name: "docker-graph-storage", MountPath: "/var/lib/docker"}},
-					},
-				},
-				NodeSelector: map[string]string{"k8snode": "kb-perf-node"},
-				Volumes: []v1.Volume{
-					{Name: "cert", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubeedge/certs"}}},
-					{Name: "conf", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: configmap}}}},
-					{Name: "docker-graph-storage", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
-				},
-			},
-		},
-	}
-	return &deplObj
-}
-
-// Function to create cloudcore deploymentspec object
-func cloudcoreDeploymentSpec(imgURL, configmap string, replicas int) *apps.DeploymentSpec {
-	portInfo := []v1.ContainerPort{{ContainerPort: 10000, Protocol: "TCP", Name: "websocket"}, {ContainerPort: 10001, Protocol: "UDP", Name: "quic"}}
-
-	deplObj := apps.DeploymentSpec{
-		Replicas: func() *int32 { i := int32(replicas); return &i }(),
-		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "cloudcore"}},
-		Template: v1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"app": "cloudcore"},
-			},
-			Spec: v1.PodSpec{
-				HostNetwork:   true,
-				RestartPolicy: "Always",
-				Containers: []v1.Container{
-					{
-						Name:            "cloudcore",
-						Image:           imgURL,
-						ImagePullPolicy: v1.PullPolicy("IfNotPresent"),
-						Resources: v1.ResourceRequirements{
-							Requests: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("100m"),
-								v1.ResourceMemory: resource.MustParse("512Mi"),
-							},
-						},
-						Ports:        portInfo,
-						VolumeMounts: []v1.VolumeMount{{Name: "cert", MountPath: "/etc/kubeedge/certs"}, {Name: "conf", MountPath: "/etc/kubeedge/cloud/conf"}},
-					},
-				},
-				Volumes: []v1.Volume{
-					{Name: "cert", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubeedge/certs"}}},
-					{Name: "conf", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: configmap}}}},
-				},
-			},
-		},
-	}
-	return &deplObj
-}
-
-func newDeployment(cloudcore, edgecore bool, name, imgURL, nodeselector, configmap string, replicas int) *apps.Deployment {
-	var depObj *apps.DeploymentSpec
-	var namespace string
-
-	if edgecore {
-		depObj = edgecoreDeploymentSpec(imgURL, configmap, replicas)
-		namespace = Namespace
-	} else if cloudcore {
-		depObj = cloudcoreDeploymentSpec(imgURL, configmap, replicas)
-		namespace = Namespace
-	} else {
-		depObj = nginxDeploymentSpec(imgURL, nodeselector, replicas)
-		namespace = Namespace
-	}
-
+func NewDeployment(name, imgURL string, replicas int32) *apps.Deployment {
 	deployment := apps.Deployment{
-		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Labels:    map[string]string{"app": constants.SystemName},
-			Namespace: namespace,
+			Labels:    map[string]string{"app": name},
+			Namespace: Namespace,
 		},
-		Spec: *depObj,
+		Spec: apps.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":                 name,
+					constants.E2ELabelKey: constants.E2ELabelValue,
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":                 name,
+						constants.E2ELabelKey: constants.E2ELabelValue,
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  name,
+							Image: imgURL,
+						},
+					},
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io/edge": "",
+					},
+				},
+			},
+		},
 	}
 	return &deployment
 }
 
-func NewPodObj(podName, imgURL, nodeselector string) *v1.Pod {
+func NewPod(podName, imgURL string) *v1.Pod {
 	pod := v1.Pod{
-		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   podName,
-			Labels: map[string]string{"app": "nginx"},
+			Name:      podName,
+			Namespace: v1.NamespaceDefault,
+			Labels: map[string]string{
+				"app":                 podName,
+				constants.E2ELabelKey: constants.E2ELabelValue,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:  "nginx",
+					Name:  podName,
 					Image: imgURL,
 				},
 			},
-			NodeSelector: map[string]string{"disktype": nodeselector},
+			NodeSelector: map[string]string{
+				"node-role.kubernetes.io/edge": "",
+			},
 		},
 	}
 	return &pod
 }
 
-// GetDeployments to get the deployments list
-func GetDeployments(list *apps.DeploymentList, getDeploymentAPI string) error {
-	resp, err := SendHTTPRequest(http.MethodGet, getDeploymentAPI)
-	if err != nil {
-		Fatalf("HTTP Response reading has failed: %v", err)
-		return err
-	}
-	defer resp.Body.Close()
-	contents, err := io.ReadAll(resp.Body)
-	if err != nil {
-		Fatalf("HTTP Response reading has failed: %v", err)
-		return err
-	}
-	err = json.Unmarshal(contents, &list)
-	if err != nil {
-		Fatalf("Unmarshal HTTP Response has failed: %v", err)
-		return err
-	}
-	return nil
-}
-func VerifyDeleteDeployment(getDeploymentAPI string) int {
-	resp, err := SendHTTPRequest(http.MethodGet, getDeploymentAPI)
-	if err != nil {
-		Fatalf("Send HTTP Request failed: %v", err)
-		return -1
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode
+func GetDeployment(c clientset.Interface, ns, name string) (*apps.Deployment, error) {
+	return c.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-// HandlePod to handle app deployment/delete using pod spec.
-func HandlePod(operation string, apiserver string, UID string, pod *v1.Pod) bool {
-	var req *http.Request
-	var err error
-	var body io.Reader
-
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{
-		Transport: tr,
-	}
-	switch operation {
-	case http.MethodPost:
-		body := pod
-		respBytes, err := json.Marshal(body)
-		if err != nil {
-			Fatalf("Marshalling body failed: %v", err)
-		}
-		req, err = http.NewRequest(http.MethodPost, apiserver, bytes.NewBuffer(respBytes))
-	case http.MethodDelete:
-		req, err = http.NewRequest(http.MethodDelete, apiserver+UID, body)
-	}
-	if err != nil {
-		// handle error
-		Fatalf("Frame HTTP request failed: %v", err)
-		return false
-	}
-	req.Header.Set("Content-Type", "application/json")
-	t := time.Now()
-	resp, err := client.Do(req)
-	if err != nil {
-		// handle error
-		Fatalf("HTTP request is failed :%v", err)
-		return false
-	}
-	defer resp.Body.Close()
-	Infof("%s %s %v in %v", req.Method, req.URL, resp.Status, time.Since(t))
-	return true
-}
-
-// HandleDeployment to handle app deployment/delete deployment.
-func HandleDeployment(IsCloudCore, IsEdgeCore bool, operation, apiserver, UID, ImageURL, nodeselector, configmapname string, replica int) bool {
-	var req *http.Request
-	var err error
-	var body io.Reader
-
-	defer ginkgo.GinkgoRecover()
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	client := &http.Client{
-		Transport: tr,
-	}
-
-	switch operation {
-	case http.MethodPost:
-		depObj := newDeployment(IsCloudCore, IsEdgeCore, UID, ImageURL, nodeselector, configmapname, replica)
-		if err != nil {
-			Fatalf("GenerateDeploymentBody marshalling failed: %v", err)
-		}
-		respBytes, err := json.Marshal(depObj)
-		if err != nil {
-			Fatalf("Marshalling body failed: %v", err)
-		}
-		req, err = http.NewRequest(http.MethodPost, apiserver, bytes.NewBuffer(respBytes))
-	case http.MethodDelete:
-		req, err = http.NewRequest(http.MethodDelete, apiserver+UID, body)
-	}
-	if err != nil {
-		// handle error
-		Fatalf("Frame HTTP request failed: %v", err)
-		return false
-	}
-	req.Header.Set("Content-Type", "application/json")
-	t := time.Now()
-	resp, err := client.Do(req)
-	if err != nil {
-		// handle error
-		Fatalf("HTTP request is failed :%v", err)
-		return false
-	}
-	defer resp.Body.Close()
-	Infof("%s %s %v in %v", req.Method, req.URL, resp.Status, time.Since(t))
-	return true
+func CreateDeployment(c clientset.Interface, deployment *apps.Deployment) (*apps.Deployment, error) {
+	return c.AppsV1().Deployments(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
 }
 
 // DeleteDeployment to delete deployment
-func DeleteDeployment(DeploymentAPI, deploymentname string) int {
-	resp, err := SendHTTPRequest(http.MethodDelete, DeploymentAPI+"/"+deploymentname)
-	if err != nil {
-		// handle error
-		Fatalf("HTTP request is failed :%v", err)
-		return -1
+func DeleteDeployment(c clientset.Interface, ns, name string) error {
+	err := c.AppsV1().Deployments(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil
 	}
 
-	defer resp.Body.Close()
-
-	return resp.StatusCode
-}
-
-// PrintCombinedOutput to show the os command injuction in combined format
-func PrintCombinedOutput(cmd *exec.Cmd) error {
-	Infof("===========> Executing: %s\n", strings.Join(cmd.Args, " "))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		Infof("CombinedOutput failed %v", err)
-		return err
-	}
-	if len(output) > 0 {
-		Infof("=====> Output: %s\n", string(output))
-	}
-	return nil
-}
-
-// ExposeCloudService function to expose the service for cloud deployment
-func ExposeCloudService(name, serviceHandler string) error {
-	ServiceObj := CreateServiceObject(name)
-	respBytes, err := json.Marshal(ServiceObj)
-	if err != nil {
-		Fatalf("Marshalling body failed: %v", err)
-	}
-	req, err := http.NewRequest(http.MethodPost, serviceHandler, bytes.NewBuffer(respBytes))
-	if err != nil {
-		// handle error
-		Fatalf("Frame HTTP request failed: %v", err)
-		return err
-	}
-	client := &http.Client{}
-	req.Header.Set("Content-Type", "application/json")
-	t := time.Now()
-	resp, err := client.Do(req)
-	if err != nil {
-		// handle error
-		Fatalf("HTTP request is failed :%v", err)
-		return err
-	}
-	defer resp.Body.Close()
-	Infof("%s %s %v in %v", req.Method, req.URL, resp.Status, time.Since(t))
-	gomega.Expect(resp.StatusCode).Should(gomega.Equal(http.StatusCreated))
-	return nil
-}
-
-// CreateServiceObject function to create a servcice object
-func CreateServiceObject(name string) *v1.Service {
-	portInfo := []v1.ServicePort{
-		{
-			Name: "websocket", Protocol: "TCP", Port: 10000, TargetPort: intstr.FromInt(10000),
-		}, {
-			Name: "quic", Protocol: "UDP", Port: 10001, TargetPort: intstr.FromInt(10001),
-		},
-	}
-
-	Service := v1.Service{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
-		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"app": constants.SystemName}},
-
-		Spec: v1.ServiceSpec{
-			Ports:    portInfo,
-			Selector: map[string]string{"app": "cloudcore"},
-			Type:     "NodePort",
-		},
-	}
-	return &Service
-}
-
-// GetServicePort function to get the service port created for deployment.
-func GetServicePort(cloudName, serviceHandler string) (int32, int32) {
-	var svc v1.ServiceList
-	var wssport, quicport int32
-	resp, err := SendHTTPRequest(http.MethodGet, serviceHandler)
-	if err != nil {
-		// handle error
-		Fatalf("HTTP request is failed :%v", err)
-		return -1, -1
-	}
-	defer resp.Body.Close()
-
-	contents, err := io.ReadAll(resp.Body)
-	if err != nil {
-		Fatalf("HTTP Response reading has failed: %v", err)
-		return -1, -1
-	}
-
-	err = json.Unmarshal(contents, &svc)
-	if err != nil {
-		Fatalf("Unmarshal HTTP Response has failed: %v", err)
-		return -1, -1
-	}
-
-	for _, svcs := range svc.Items {
-		if svcs.Name == cloudName {
-			for _, nodePort := range svcs.Spec.Ports {
-				if nodePort.Name == api.ProtocolTypeQuic {
-					quicport = nodePort.NodePort
-				}
-				if nodePort.Name == api.ProtocolTypeWS {
-					wssport = nodePort.NodePort
-				}
-			}
-			break
-		}
-	}
-	return wssport, quicport
-}
-
-// DeleteSvc function to delete service
-func DeleteSvc(svcname string) int {
-	resp, err := SendHTTPRequest(http.MethodDelete, svcname)
-	if err != nil {
-		// handle error
-		Fatalf("HTTP request is failed :%v", err)
-		return -1
-	}
-
-	defer resp.Body.Close()
-
-	return resp.StatusCode
+	return err
 }
 
 // HandleDeviceModel to handle app deployment/delete using pod spec.
@@ -1064,13 +720,22 @@ func NewTestStatefulSet(name, imgURL string, replicas int32) *apps.StatefulSet {
 		Spec: apps.StatefulSetSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": name},
+				MatchLabels: map[string]string{
+					"app":                 name,
+					constants.E2ELabelKey: constants.E2ELabelValue,
+				},
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": name},
+					Labels: map[string]string{
+						"app":                 name,
+						constants.E2ELabelKey: constants.E2ELabelValue,
+					},
 				},
 				Spec: v1.PodSpec{
+					NodeSelector: map[string]string{
+						"node-role.kubernetes.io/edge": "",
+					},
 					Containers: []v1.Container{
 						{
 							Name:  "nginx",

--- a/tests/e2e/utils/context.go
+++ b/tests/e2e/utils/context.go
@@ -19,9 +19,6 @@ import (
 	"crypto/tls"
 	"io"
 	"net/http"
-	"net/url"
-	"sort"
-	"strings"
 	"time"
 )
 
@@ -64,14 +61,4 @@ func SendHTTPRequest(method, reqAPI string) (*http.Response, error) {
 	}
 	Infof("%s %s %v in %v", req.Method, req.URL, resp.Status, time.Since(t))
 	return resp, nil
-}
-
-//MapLabels function add label selector
-func MapLabels(ls map[string]string) string {
-	selector := make([]string, 0, len(ls))
-	for key, value := range ls {
-		selector = append(selector, key+"="+value)
-	}
-	sort.StringSlice(selector).Sort()
-	return url.QueryEscape(strings.Join(selector, ","))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

1、for now, e2e test will always use edge-node to test, this is not user friendly if they want to run e2e on their own node but without a edge-node name. so update the test code to let deploy to run on edge node (with label `"node-role.kubernetes.io/edge": ""`) when run e2e test 

2、 cleanup the code, use kubernetes client-go rather than use self-encapsulated http request

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
