### PR TITLE
updated github actions timeouts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -131,7 +131,7 @@ jobs:
 
   e2e_test:
     runs-on: ubuntu-18.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: E2e test
     needs: image-prepare
     env:
@@ -180,7 +180,7 @@ jobs:
 
   keadm_deprecated_e2e_test:
     runs-on: ubuntu-18.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: Keadm deprecated e2e test
     needs: image-prepare
     env:
@@ -221,7 +221,7 @@ jobs:
 
   keadm_e2e_test:
     runs-on: ubuntu-18.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: Keadm e2e test
     env:
       GO111MODULE: on
@@ -246,7 +246,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      
+
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
@@ -256,7 +256,7 @@ jobs:
 
   docker_build:
     runs-on: ubuntu-18.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     name: Multiple docker image build
     steps:
       - uses: actions/cache@v2


### PR DESCRIPTION
Signed-off-by: Armin Schlegel <armin.schlegel@gmx.de>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
PR #2604 introduced timeouts for all github actions. However, the timeouts are too short for some runs. 
Looking at the long running actions this PR increases the timeouts

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
