### PR TITLE
Automated cherry pick of #3943: add release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: build release, release image to DockerHub
+on:
+  release:
+    types:
+      - published
+env:
+  CONTAINER_RUN_OPTIONS: " "
+
+jobs:
+  release-assests:
+    name: release kubeedge components
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        target:
+          - kubeedge
+          - edgesite
+          - keadm
+        os:
+          - linux
+        arch:
+          - amd64
+          - arm64
+          - arm
+        ARM_VERSION:
+          - GOARM7
+          - GOARM8
+          - ""
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+        with:
+          # fetch-depth:
+          # 0 indicates all history for all branches and tags.
+          # for `git describe --tags` in Makefile.
+          fetch-depth: 0
+      - name: Making and packaging
+        run: |
+          docker pull kubeedge/build-tools
+          make release ARM_VERSION=${{ matrix.ARM_VERSION }}
+      - name: Uploading assets...
+        if: ${{ !env.ACT }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            _output/release/${{ github.ref_name }}/${{ matrix.target }}-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
+            _output/release/${{ github.ref_name }}/checksum_${{ matrix.target }}-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz.txt
+
+  publish-image-to-dockerhub:
+    name: publish to DockerHub
+    strategy:
+      matrix:
+        target:
+          - cloudcore
+          - admission
+          - edgesite-agent
+          - edgesite-server
+          - csidriver
+          - iptablesmanager
+          - edgemark
+          - installation-package
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+        with:
+          # fetch-depth:
+          # 0 indicates all history for all branches and tags.
+          # for `git describe --tags` in Makefile.
+          fetch-depth: 0
+      - name: install QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: install Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: build and publish images
+        env:
+          IMAGE_REPO_NAME: kubeedge
+        run: make crossbuildimage WHAT=${{ matrix.target }}

--- a/hack/make-rules/crossbuildimage.sh
+++ b/hack/make-rules/crossbuildimage.sh
@@ -23,7 +23,7 @@ set -o pipefail
 KUBEEDGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 IMAGE_TAG=$(git describe --tags)
 GO_LDFLAGS="$(${KUBEEDGE_ROOT}/hack/make-rules/version.sh)"
-IMAGE_REPO_NAME="kubeedge"
+IMAGE_REPO_NAME="${IMAGE_REPO_NAME:-kubeedge}"
 
 ALL_IMAGES_AND_TARGETS=(
   #{target}:{IMAGE_NAME}:{DOCKERFILE_PATH}
@@ -35,6 +35,7 @@ ALL_IMAGES_AND_TARGETS=(
   csidriver:csidriver:build/csidriver/Dockerfile
   iptablesmanager:iptables-manager:build/iptablesmanager/Dockerfile
   edgemark:edgemark:build/edgemark/Dockerfile
+  installation-package:installation-package:build/docker/installation-package/installation-package.dockerfile
 )
 
 function get_imagename_by_target() {


### PR DESCRIPTION
Cherry pick of #3943 on release-1.10.

#3943: add release ci

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.