### PR TITLE
fix possible nil pointer of message

### DIFF
--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -116,7 +116,10 @@ func (mh *MessageHandle) HandleServer(container *mux.MessageContainer, writer mu
 		klog.Errorf("Fail to serve node %s, reach node limit", nodeID)
 		return
 	}
-
+	if container.Message == nil {
+		klog.Errorf("Handle a nil message error, node : %s", nodeID)
+		return
+	}
 	klog.V(4).Infof("[cloudhub/HandlerServer] get msg from edge(%v): %+v", nodeID, container.Message)
 	if container.Message.GetOperation() == model.OpKeepalive {
 		klog.V(4).Infof("Keepalive message received from node: %s", nodeID)
@@ -388,8 +391,15 @@ func (mh *MessageHandle) ListMessageWriteLoop(info *model.HubInfo, stopServe cha
 			klog.Errorf("nodeListStore for node %s doesn't exist", info.NodeID)
 			continue
 		}
-		msg := obj.(*beehiveModel.Message)
-
+		msg, ok := obj.(*beehiveModel.Message)
+		if !ok {
+			klog.Errorf("list message type %T is invalid for node: %s", obj, info.NodeID)
+			continue
+		}
+		if msg == nil {
+			klog.Errorf("list message is nil for node: %s", info.NodeID)
+			continue
+		}
 		if model.IsNodeStopped(msg) {
 			klog.Warningf("node %s is deleted, data for node will be cleaned up", info.NodeID)
 			nodeQueue.ShutDown()

--- a/cloud/pkg/router/listener/message.go
+++ b/cloud/pkg/router/listener/message.go
@@ -74,6 +74,9 @@ func Process(module string) {
 }
 
 func (mh *MessageHandler) HandleMessage(message *model.Message) error {
+	if message == nil {
+		return fmt.Errorf("nil message error")
+	}
 	if message.GetParentID() != "" {
 		mh.callback(message)
 		return nil

--- a/staging/src/github.com/kubeedge/viaduct/pkg/conn/quic.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/conn/quic.go
@@ -61,6 +61,10 @@ func NewQuicConn(options *ConnectionOptions) *QuicConnection {
 
 // process header message
 func (conn *QuicConnection) headerMessage(msg *model.Message) error {
+	if msg == nil {
+		klog.Errorf("nil message error")
+		return fmt.Errorf("nil message error")
+	}
 	headers := make(http.Header)
 	err := json.Unmarshal(msg.GetContent().([]byte), &headers)
 	if err != nil {

--- a/staging/src/github.com/kubeedge/viaduct/pkg/mux/pattern.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/mux/pattern.go
@@ -39,10 +39,18 @@ func (pattern *MessagePattern) Op(operation string) *MessagePattern {
 }
 
 func (pattern *MessagePattern) matchOp(message *model.Message) bool {
+	if message == nil {
+		klog.Errorf("nil message can't be matched, operation: %s", pattern.operation)
+		return false
+	}
 	return strings.Compare(pattern.operation, message.GetOperation()) == 0 ||
 		strings.Compare(pattern.operation, "*") == 0
 }
 
 func (pattern *MessagePattern) Match(message *model.Message) bool {
+	if message == nil {
+		klog.Errorf("nil message can't be matched, resource: %s", pattern.resource)
+		return false
+	}
 	return pattern.resExpr.Matcher.Match([]byte(message.GetResource())) && pattern.matchOp(message)
 }


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
a nil value could be passed which could trigger a nil-pointer dereference panic. These do not necessarily impose a risk in terms of security. Even if these do not have security implications now, this might change every time changes are made to the KubeEdge source tree.
Nil-pointers can be exploitable by an attacker if triggerable by an attacker under the right conditions. Naturally, whether a possible nil-pointer dereference is triggerable by an attacker depends largely on how the function is used. In many cases it is never possible to pass nil. As a rule of thumb, we recommend checking pointers for nil at the beginning of the function body. In our analysis of pointer-handling in KubeEdge, we used the Message type as an example to demonstrate an area for improvement.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
