### PR TITLE
Automated cherry pick of #3956: add controllermanager release

### DIFF
--- a/hack/make-rules/crossbuildimage.sh
+++ b/hack/make-rules/crossbuildimage.sh
@@ -36,6 +36,7 @@ ALL_IMAGES_AND_TARGETS=(
   iptablesmanager:iptables-manager:build/iptablesmanager/Dockerfile
   edgemark:edgemark:build/edgemark/Dockerfile
   installation-package:installation-package:build/docker/installation-package/installation-package.dockerfile
+  controllermanager:controller-manager:build/controllermanager/Dockerfile
 )
 
 function get_imagename_by_target() {

--- a/hack/make-rules/release.sh
+++ b/hack/make-rules/release.sh
@@ -76,9 +76,9 @@ function release() {
         ;;
       "kubeedge")
         if [ "${ARCH}" == "amd64" ]; then
-          hack/make-rules/build.sh cloudcore admission edgecore csidriver iptablesmanager
+          hack/make-rules/build.sh cloudcore admission edgecore csidriver iptablesmanager controllermanager
         else
-          hack/make-rules/crossbuild.sh cloudcore admission edgecore csidriver iptablesmanager ${arm_version}
+          hack/make-rules/crossbuild.sh cloudcore admission edgecore csidriver iptablesmanager controllermanager ${arm_version}
         fi
 
         build_kubeedge_release $VERSION $ARCH
@@ -109,6 +109,7 @@ function build_kubeedge_release() {
   mkdir -p _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/cloudcore
   mkdir -p _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/csidriver
   mkdir -p _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/iptablesmanager
+  mkdir -p _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/controllermanager
   mkdir -p _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/edge
 
   echo ${VERSION} > _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/version
@@ -116,6 +117,7 @@ function build_kubeedge_release() {
   cp _output/local/bin/cloudcore _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/cloudcore
   cp _output/local/bin/csidriver _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/csidriver
   cp _output/local/bin/iptablesmanager _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/iptablesmanager
+  cp _output/local/bin/controllermanager _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/cloud/controllermanager
 
   cp _output/local/bin/edgecore _output/release/${VERSION}/kubeedge-${VERSION}-linux-${ARCH}/edge
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	CloudAdmission       = "admission"
-	CloudCloudcore       = "cloudcore"
-	CloudIptablesManager = "iptables-manager"
+	CloudAdmission         = "admission"
+	CloudCloudcore         = "cloudcore"
+	CloudIptablesManager   = "iptables-manager"
+	CloudControllerManager = "controller-manager"
 )
 
 const (
@@ -35,9 +36,10 @@ const (
 type Set map[string]string
 
 var cloudComponentSet = Set{
-	CloudAdmission:       "kubeedge/admission",
-	CloudCloudcore:       "kubeedge/cloudcore",
-	CloudIptablesManager: "kubeedge/iptables-manager",
+	CloudAdmission:         "kubeedge/admission",
+	CloudCloudcore:         "kubeedge/cloudcore",
+	CloudIptablesManager:   "kubeedge/iptables-manager",
+	CloudControllerManager: "kubeedge/controller-manager",
 }
 
 var cloudThirdPartySet = Set{}


### PR DESCRIPTION
Cherry pick of #3956 on release-1.11.

#3956: add controllermanager release

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.