### PR TITLE
Fix admission not work: bump admissionregistration.k8s.io/v1beta1 to admissionregistration.k8s.io/v1

### DIFF
--- a/cloud/pkg/admissioncontroller/admit_devicemodel.go
+++ b/cloud/pkg/admissioncontroller/admit_devicemodel.go
@@ -4,20 +4,20 @@ import (
 	"net/http"
 	"strings"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	devicesv1alpha2 "github.com/kubeedge/kubeedge/pkg/apis/devices/v1alpha2"
 )
 
-func admitDeviceModel(review admissionv1beta1.AdmissionReview) *admissionv1beta1.AdmissionResponse {
-	reviewResponse := admissionv1beta1.AdmissionResponse{}
+func admitDeviceModel(review admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	reviewResponse := admissionv1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 	var msg string
 
 	switch review.Request.Operation {
-	case admissionv1beta1.Create, admissionv1beta1.Update:
+	case admissionv1.Create, admissionv1.Update:
 		raw := review.Request.Object.Raw
 		devicemodel := devicesv1alpha2.DeviceModel{}
 		deserializer := codecs.UniversalDeserializer()
@@ -26,7 +26,7 @@ func admitDeviceModel(review admissionv1beta1.AdmissionReview) *admissionv1beta1
 			return toAdmissionResponse(err)
 		}
 		msg = validateDeviceModel(&devicemodel, &reviewResponse)
-	case admissionv1beta1.Delete, admissionv1beta1.Connect:
+	case admissionv1.Delete, admissionv1.Connect:
 		//no rule defined for above operations, greenlight for all of above.
 		reviewResponse.Allowed = true
 	default:
@@ -40,7 +40,7 @@ func admitDeviceModel(review admissionv1beta1.AdmissionReview) *admissionv1beta1
 	return &reviewResponse
 }
 
-func validateDeviceModel(devicemodel *devicesv1alpha2.DeviceModel, response *admissionv1beta1.AdmissionResponse) string {
+func validateDeviceModel(devicemodel *devicesv1alpha2.DeviceModel, response *admissionv1.AdmissionResponse) string {
 	//device properties must be either Int or String while additional properties is not banned.
 	var msg string
 	for _, property := range devicemodel.Spec.Properties {

--- a/cloud/pkg/admissioncontroller/admit_rule.go
+++ b/cloud/pkg/admissioncontroller/admit_rule.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/klog/v2"
 
 	rulesv1 "github.com/kubeedge/kubeedge/pkg/apis/rules/v1"
@@ -18,11 +18,11 @@ var (
 	}
 )
 
-func admitRule(review admissionv1beta1.AdmissionReview) *admissionv1beta1.AdmissionResponse {
-	reviewResponse := admissionv1beta1.AdmissionResponse{}
+func admitRule(review admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	reviewResponse := admissionv1.AdmissionResponse{}
 
 	switch review.Request.Operation {
-	case admissionv1beta1.Create:
+	case admissionv1.Create:
 		raw := review.Request.Object.Raw
 		rule := rulesv1.Rule{}
 		deserializer := codecs.UniversalDeserializer()
@@ -36,7 +36,7 @@ func admitRule(review admissionv1beta1.AdmissionReview) *admissionv1beta1.Admiss
 		}
 		reviewResponse.Allowed = true
 		return &reviewResponse
-	case admissionv1beta1.Delete, admissionv1beta1.Connect:
+	case admissionv1.Delete, admissionv1.Connect:
 		//no rule defined for above operations, greenlight for all of above.
 		reviewResponse.Allowed = true
 		return &reviewResponse

--- a/cloud/pkg/admissioncontroller/admit_ruleendpoint.go
+++ b/cloud/pkg/admissioncontroller/admit_ruleendpoint.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"net/http"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/klog/v2"
 
 	rulesv1 "github.com/kubeedge/kubeedge/pkg/apis/rules/v1"
 )
 
-func admitRuleEndpoint(review admissionv1beta1.AdmissionReview) *admissionv1beta1.AdmissionResponse {
-	reviewResponse := admissionv1beta1.AdmissionResponse{}
+func admitRuleEndpoint(review admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	reviewResponse := admissionv1.AdmissionResponse{}
 	switch review.Request.Operation {
-	case admissionv1beta1.Create:
+	case admissionv1.Create:
 		raw := review.Request.Object.Raw
 		ruleEndpoint := rulesv1.RuleEndpoint{}
 		deserializer := codecs.UniversalDeserializer()
@@ -27,7 +27,7 @@ func admitRuleEndpoint(review admissionv1beta1.AdmissionReview) *admissionv1beta
 		}
 		reviewResponse.Allowed = true
 		return &reviewResponse
-	case admissionv1beta1.Delete, admissionv1beta1.Connect:
+	case admissionv1.Delete, admissionv1.Connect:
 		//no rule defined for above operations, greenlight for all of above.
 		reviewResponse.Allowed = true
 		return &reviewResponse

--- a/cloud/pkg/admissioncontroller/common.go
+++ b/cloud/pkg/admissioncontroller/common.go
@@ -6,16 +6,16 @@ import (
 	"io"
 	"net/http"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	admissionregistrationv1beta1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
+	admissionregistrationv1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	"k8s.io/klog/v2"
 )
 
-func registerValidateWebhook(client admissionregistrationv1beta1client.ValidatingWebhookConfigurationInterface,
-	webhooks []admissionregistrationv1beta1.ValidatingWebhookConfiguration) error {
+func registerValidateWebhook(client admissionregistrationv1client.ValidatingWebhookConfigurationInterface,
+	webhooks []admissionregistrationv1.ValidatingWebhookConfiguration) error {
 	for _, hook := range webhooks {
 		existing, err := client.Get(context.Background(), hook.Name, metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
@@ -37,8 +37,8 @@ func registerValidateWebhook(client admissionregistrationv1beta1client.Validatin
 	return nil
 }
 
-func registerMutatingWebhook(client admissionregistrationv1beta1client.MutatingWebhookConfigurationInterface,
-	webhooks []admissionregistrationv1beta1.MutatingWebhookConfiguration) error {
+func registerMutatingWebhook(client admissionregistrationv1client.MutatingWebhookConfigurationInterface,
+	webhooks []admissionregistrationv1.MutatingWebhookConfiguration) error {
 	for _, hook := range webhooks {
 		existing, err := client.Get(context.Background(), hook.Name, metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
@@ -61,7 +61,7 @@ func registerMutatingWebhook(client admissionregistrationv1beta1client.MutatingW
 }
 
 // hookFunc is the type we use for all of our validators and mutators
-type hookFunc func(admissionv1beta1.AdmissionReview) *admissionv1beta1.AdmissionResponse
+type hookFunc func(admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 
 func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 	var body []byte
@@ -74,19 +74,20 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 	// verify the content type is accurate
 	contentType := r.Header.Get("Content-Type")
 	if contentType != "application/json" {
-		klog.Exitf("contentType=%s, expect application/json", contentType)
+		klog.Errorf("contentType=%s, expect application/json", contentType)
 		return
 	}
 
 	// The AdmissionReview that was sent to the webhook
-	requestedAdmissionReview := admissionv1beta1.AdmissionReview{}
+	requestedAdmissionReview := admissionv1.AdmissionReview{}
 
 	// The AdmissionReview that will be returned
-	responseAdmissionReview := admissionv1beta1.AdmissionReview{}
+	responseAdmissionReview := admissionv1.AdmissionReview{}
+	responseAdmissionReview.SetGroupVersionKind(admissionv1.SchemeGroupVersion.WithKind("AdmissionReview"))
 
 	deserializer := codecs.UniversalDeserializer()
 	if _, _, err := deserializer.Decode(body, nil, &requestedAdmissionReview); err != nil {
-		klog.Exitf("decode failed with error: %v", err)
+		klog.Errorf("decode failed with error: %v", err)
 		responseAdmissionReview.Response = toAdmissionResponse(err)
 	} else {
 		responseAdmissionReview.Response = hook(requestedAdmissionReview)
@@ -98,16 +99,18 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 
 	respBytes, err := json.Marshal(responseAdmissionReview)
 	if err != nil {
-		klog.Exitf("cannot marshal to a valid response %v", err)
+		klog.Errorf("cannot marshal to a valid response %v", err)
+		return
 	}
 	if _, err := w.Write(respBytes); err != nil {
-		klog.Exitf("cannot write response %v", err)
+		klog.Errorf("cannot write response %v", err)
+		return
 	}
 }
 
 // toAdmissionResponse is a helper function to create an AdmissionResponse
-func toAdmissionResponse(err error) *admissionv1beta1.AdmissionResponse {
-	return &admissionv1beta1.AdmissionResponse{
+func toAdmissionResponse(err error) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
 		Result: &metav1.Status{
 			Message: err.Error(),
 		},

--- a/cloud/pkg/admissioncontroller/mutate_offlinemigration.go
+++ b/cloud/pkg/admissioncontroller/mutate_offlinemigration.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -15,8 +15,8 @@ type patchMapValue struct {
 	Value []interface{} `json:"value,omitempty"`
 }
 
-func mutateOfflineMigration(review admissionv1beta1.AdmissionReview) *admissionv1beta1.AdmissionResponse {
-	reviewResponse := admissionv1beta1.AdmissionResponse{
+func mutateOfflineMigration(review admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+	reviewResponse := admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 
@@ -37,7 +37,7 @@ func mutateOfflineMigration(review admissionv1beta1.AdmissionReview) *admissionv
 	}
 
 	reviewResponse.Patch = patch
-	pt := admissionv1beta1.PatchTypeJSONPatch
+	pt := admissionv1.PatchTypeJSONPatch
 	reviewResponse.PatchType = &pt
 	return &reviewResponse
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
by k8s official docs, 
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122
```
The admissionregistration.k8s.io/v1beta1 API version of MutatingWebhookConfiguration and ValidatingWebhookConfiguration is no longer served as of v1.22.
```
And now kubeedge depends on k8s v1.22.6(https://github.com/kubeedge/kubeedge/pull/3624), so we should upgrade admissionregistration.k8s.io/v1beta1 to admissionregistration.k8s.io/v1


when i use admission to register webhook for CRDs, there're some errors:
`failed to register the webhook with error: the server could not find the requested resource`: So I replace v1beta1 admission with v1 admission.

And for webhook, we must set both `SideEffects` and `AdmissionReviewVersions` fields, or it will report errors.

And we must use `responseAdmissionReview.SetGroupVersionKind(admissionv1.SchemeGroupVersion.WithKind("AdmissionReview"))` to set AdmissionReview GVK, or it will also report error 
```
Failed calling webhook, failing open validateupgrade.kubeedge.io: failed calling webhook "validateupgrade.kubeedge.io": received invalid webhook response: expected webhook response of admission.k8s.io/v1, Kind=AdmissionReview, got /, Kind=
```

And do some clean up work

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
