### PR TITLE
Automated cherry pick of #3975: Missing error check for unsafe method

### DIFF
--- a/edge/pkg/common/util/config.go
+++ b/edge/pkg/common/util/config.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
 )
 
 //GenerateTestCertificate generates fake certificates and stores them at the path specified.
@@ -91,7 +92,12 @@ func createPEMfile(path string, pemBlock pem.Block) error {
 		return err
 	}
 
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			klog.Errorf("failed to close file, path: %v, error: %v", path, err)
+		}
+	}()
 	err = pem.Encode(file, &pemBlock)
 	return err
 }

--- a/edge/pkg/edged/volume/csi/csi_util.go
+++ b/edge/pkg/edged/volume/csi/csi_util.go
@@ -60,7 +60,12 @@ func saveVolumeData(dir string, fileName string, data map[string]string) error {
 		klog.Error(log("failed to save volume data file %s: %v", dataFilePath, err))
 		return err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			klog.Errorf("failed to close file, path: %v, error: %v", dataFilePath, err)
+		}
+	}()
 	if err := json.NewEncoder(file).Encode(data); err != nil {
 		klog.Error(log("failed to save volume data file %s: %v", dataFilePath, err))
 		return err
@@ -80,7 +85,12 @@ func loadVolumeData(dir string, fileName string) (map[string]string, error) {
 		klog.Error(log("failed to open volume data file [%s]: %v", dataFileName, err))
 		return nil, err
 	}
-	defer file.Close()
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			klog.Errorf("failed to close file, path: %v, error: %v", dataFileName, err)
+		}
+	}()
 	data := map[string]string{}
 	if err := json.NewDecoder(file).Decode(&data); err != nil {
 		klog.Error(log("failed to parse volume data file [%s]: %v", dataFileName, err))

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -572,7 +572,13 @@ func computeSHA512Checksum(filepath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			fmt.Printf("failed to close file, path: %v, error: %v \n", filepath, err)
+		}
+	}()
 
 	h := sha512.New()
 	if _, err := io.Copy(h, f); err != nil {
@@ -649,13 +655,16 @@ func retryDownload(filename, checksumFilename string, version semver.Version, ta
 }
 
 // Compress compresses folders or files
-func Compress(tarName string, paths []string) (err error) {
+func Compress(tarName string, paths []string) error {
 	tarFile, err := os.Create(tarName)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		err = tarFile.Close()
+		err := tarFile.Close()
+		if err != nil {
+			fmt.Printf("failed to close tar file, path: %v, error: %v \n", tarName, err)
+		}
 	}()
 
 	absTar, err := filepath.Abs(tarName)
@@ -724,7 +733,14 @@ func Compress(tarName string, paths []string) (err error) {
 			if err != nil {
 				return err
 			}
-			defer srcFile.Close()
+
+			defer func() {
+				err := srcFile.Close()
+				if err != nil {
+					fmt.Printf("failed to close file, path: %v, error: %v \n", file, err)
+				}
+			}()
+
 			_, err = io.Copy(tw, srcFile)
 			if err != nil {
 				return err


### PR DESCRIPTION
Cherry pick of #3975 on release-1.11.

#3975: Missing error check for unsafe method

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.