### PR TITLE
Automated cherry pick of #3972: update deprecate dependency

### DIFF
--- a/edge/test/cloudhub/stub.go
+++ b/edge/test/cloudhub/stub.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -113,13 +112,12 @@ func (tm *stubCloudHub) podHandler(w http.ResponseWriter, req *http.Request) {
 func (tm *stubCloudHub) Start() {
 	defer tm.Cleanup()
 
-	router := mux.NewRouter()
-	router.HandleFunc("/{group_id}/events", tm.serveEvent) // for edge-hub
-	router.HandleFunc("/pod", tm.podHandler)               // for pod test
-
+	mux := http.NewServeMux()
+	mux.HandleFunc("/{group_id}/events", tm.serveEvent) // for edge-hub
+	mux.HandleFunc("/pod", tm.podHandler)               // for pod test
 	s := http.Server{
 		Addr:    "127.0.0.1:20000",
-		Handler: router,
+		Handler: mux,
 	}
 	klog.Info("Start cloud hub service")
 	err := s.ListenAndServe()

--- a/external-dependency.md
+++ b/external-dependency.md
@@ -49,7 +49,6 @@
 |gofuzz |Apache License 2.0 | https://github.com/google/gofuzz
 |uuid |Apache License 2.0 | https://github.com/google/uuid
 |gnostic |Apache License 2.0 | https://github.com/googleapis/gnostic
-|mux |BSD-3-Clause | https://github.com/gorilla/mux
 |websocket |BSD-3-Clause | https://github.com/gorilla/websocket
 |golang-lru |MLP-2.0 | https://github.com/hashicorp/golang-lru
 |gopass |ISC | https://github.com/howeyc/gopass
@@ -110,7 +109,6 @@
 |k8s.io/kube-openapi | Apache License 2.0  |https://github.com/kubernetes/kube-openapi
 |k8s.io/kubernetes | Apache License 2.0  |https://github.com/kubernetes/kubernetes
 |k8s.io/utils | Apache License 2.0  |https://github.com/kubernetes/utils
-|paypal/gatt |BSD-3-Clause |https://github.com/paypal/gatt
 |go-ansiterm |MIT |https://github.com/Azure/go-ansiterm
 |win_pdh | |github.com/JeffAshton/win_pdh
 |go-winio |MIT |github.com/Microsoft/go-winio

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/cadvisor v0.39.3
 	github.com/google/uuid v1.2.0
-	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/kubeedge/beehive v0.0.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -380,7 +380,6 @@ github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/jsonschema
 github.com/googleapis/gnostic/openapiv2
 # github.com/gorilla/mux v1.8.0
-## explicit
 github.com/gorilla/mux
 # github.com/gorilla/websocket v1.4.2
 ## explicit


### PR DESCRIPTION
Cherry pick of #3972 on release-1.10.

#3972: update deprecate dependency

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.