### PR TITLE
fix bug: use of closed network connection

### DIFF
--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -485,8 +486,11 @@ func (mh *MessageHandle) MessageWriteLoop(info *model.HubInfo, stopServe chan Ex
 				info.NodeID, dumpMessageMetadata(copyMsg), err.Error())
 			nodeQueue.Add(key.(string))
 			if strings.Contains(err.Error(), "use of closed network connection") {
-				mh.nodeConns.Delete(info.NodeID)
-				continue
+				if newConn, ok := mh.nodeConns.Load(info.NodeID); ok {
+					if reflect.DeepEqual(conn, newConn) {
+						mh.nodeConns.Delete(info.NodeID)
+					}
+				}
 			}
 			time.Sleep(time.Second * 2)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
边缘edgecore重连的时候，cloudcore会丢失新的连接，无法与edgecore交互和下发消息。报错use of close network connection
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
此pr解决了两个问题
1.边缘edgecore重连的时候，cloudcore会删除新的连接，在nodeConns.Delete的之前，没有判断是否是新的连接，导致
将新的连接误删
2.直接continue导致当前消息没有执行queue.Done,消息没有加入到队尾，造成消息泄漏


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4070

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
