### PR TITLE
fix delete and the recreate statefulset pod is not running bug

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -167,10 +167,7 @@ func getMsgKey(obj interface{}) (string, error) {
 	msg := obj.(*beehiveModel.Message)
 
 	if msg.GetGroup() == edgeconst.GroupResource {
-		resourceType, _ := messagelayer.GetResourceType(*msg)
-		resourceNamespace, _ := messagelayer.GetNamespace(*msg)
-		resourceName, _ := messagelayer.GetResourceName(*msg)
-		return strings.Join([]string{resourceType, resourceNamespace, resourceName}, "/"), nil
+		return GetMessageUID(*msg)
 	}
 
 	return "", fmt.Errorf("failed to get message key")

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -1313,7 +1313,7 @@ func (e *edged) handlePod(op string, content []byte) (err error) {
 		case model.UpdateOperation:
 			e.updatePod(&pod)
 		case model.DeleteOperation:
-			if delPod, ok := e.podManager.GetPodByName(pod.Namespace, pod.Name); ok {
+			if delPod, ok := e.podManager.GetPodByUID(pod.UID); ok {
 				e.deletePod(delPod)
 			}
 		}

--- a/tests/e2e/constants/constants.go
+++ b/tests/e2e/constants/constants.go
@@ -1,6 +1,11 @@
 package constants
 
+import "time"
+
 const (
 	AppHandler        = "/api/v1/namespaces/default/pods"
 	DeploymentHandler = "/apis/apps/v1/namespaces/default/deployments"
+
+	Interval = 5 * time.Second
+	Timeout  = 10 * time.Minute
 )

--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package deployment
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -24,6 +26,10 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/kubeedge/kubeedge/tests/e2e/constants"
 	. "github.com/kubeedge/kubeedge/tests/e2e/testsuite"
@@ -37,6 +43,13 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 	var UID string
 	var testTimer *utils.TestTimer
 	var testSpecReport SpecReport
+
+	var clientSet clientset.Interface
+
+	BeforeEach(func() {
+		clientSet = utils.NewKubeClient(ctx.Cfg.KubeConfigPath)
+	})
+
 	Context("Test application deployment and delete deployment using deployment spec", func() {
 		BeforeEach(func() {
 			// Get current test SpecReport
@@ -192,6 +205,105 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 				Expect(StatusCode).Should(Equal(http.StatusOK))
 			}
 			utils.CheckPodDeleteState(ctx.Cfg.K8SMasterForKubeEdge+constants.AppHandler, podlist)
+		})
+	})
+
+	Context("StatefulSet lifecycle test in edge node", func() {
+		BeforeEach(func() {
+			// Get current test SpecReport
+			testSpecReport = CurrentSpecReport()
+			// Start test timer
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
+		})
+
+		AfterEach(func() {
+			// End test timer
+			testTimer.End()
+			// Print result
+			testTimer.PrintResult()
+
+			By(fmt.Sprintf("get StatefulSet %s", UID))
+			statefulSet, err := utils.GetStatefulSet(clientSet, metav1.NamespaceDefault, UID)
+			Expect(err).To(BeNil())
+
+			By(fmt.Sprintf("list pod for StatefulSet %s", UID))
+			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
+			_, err = utils.ListPods(clientSet, metav1.NamespaceDefault, labelSelector, nil)
+			Expect(err).To(BeNil())
+
+			By(fmt.Sprintf("delete StatefulSet %s", UID))
+			err = utils.DeleteStatefulSet(clientSet, statefulSet.Namespace, statefulSet.Name)
+			Expect(err).To(BeNil())
+
+			By(fmt.Sprintf("wait for pod of StatefulSet %s disappear", UID))
+			err = utils.WaitForPodsToDisappear(clientSet, metav1.NamespaceDefault, labelSelector, constants.Interval, constants.Timeout)
+			Expect(err).To(BeNil())
+
+			utils.PrintTestcaseNameandStatus()
+		})
+
+		It("Basic StatefulSet test", func() {
+			replica := int32(2)
+			// Generate the random string and assign as a UID
+			UID = "edge-statefulset-" + utils.GetRandomString(5)
+
+			By(fmt.Sprintf("create StatefulSet %s", UID))
+			d := utils.NewTestStatefulSet(UID, ctx.Cfg.AppImageURL[1], replica)
+			ss, err := utils.CreateStatefulSet(clientSet, d)
+			Expect(err).To(BeNil())
+
+			utils.WaitForStatusReplicas(clientSet, ss, replica)
+
+			By(fmt.Sprintf("get pod for StatefulSet %s", UID))
+			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
+			podList, err := utils.ListPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
+			Expect(err).To(BeNil())
+			Expect(len(podList.Items)).ShouldNot(Equal(0))
+
+			By(fmt.Sprintf("wait for pod of StatefulSet %s running", UID))
+			utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, *podList, 240*time.Second)
+		})
+
+		It("Delete statefulSet pod multi times", func() {
+			replica := int32(2)
+			// Generate the random string and assign as a UID
+			UID = "edge-statefulset-" + utils.GetRandomString(5)
+
+			By(fmt.Sprintf("create StatefulSet %s", UID))
+			d := utils.NewTestStatefulSet(UID, ctx.Cfg.AppImageURL[1], replica)
+			ss, err := utils.CreateStatefulSet(clientSet, d)
+			Expect(err).To(BeNil())
+
+			utils.WaitForStatusReplicas(clientSet, ss, replica)
+
+			By(fmt.Sprintf("get pod for StatefulSet %s", UID))
+			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
+			podList, err := utils.ListPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
+			Expect(err).To(BeNil())
+			Expect(len(podList.Items)).ShouldNot(Equal(0))
+
+			By(fmt.Sprintf("wait for pod of StatefulSet %s running", UID))
+			utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, *podList, 240*time.Second)
+
+			deletePodName := fmt.Sprintf("%s-1", UID)
+			for i := 0; i < 5; i++ {
+				By(fmt.Sprintf("delete pod %s", deletePodName))
+				err = utils.DeletePod(clientSet, deletePodName, "default")
+				Expect(err).To(BeNil())
+
+				By(fmt.Sprintf("wait for pod %s running again", fmt.Sprintf("%s-1", UID)))
+				err = wait.Poll(5*time.Second, 120*time.Second, func() (bool, error) {
+					pod, err := clientSet.CoreV1().Pods("default").Get(context.TODO(), deletePodName, metav1.GetOptions{})
+					if err != nil {
+						return false, err
+					}
+					if pod.Status.Phase == corev1.PodRunning {
+						return true, nil
+					}
+					return false, nil
+				})
+				Expect(err).To(BeNil())
+			}
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: wackxu <xushiwei5@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 
https://github.com/kubeedge/kubeedge/issues/4090
https://github.com/kubeedge/kubeedge/issues/4055

Now, In the message key func, that resources with the same name in the same namespace have the same key. When a pod with the same name is deleted and then quickly created, The deletion event of the old pod will arrive first, and it will be stored in the message queue and store. Then the new pod creation event will arrive, because the message is sent asynchronously, So there is a possibility that the deletion event of the old pod is still in the store, but the creation event of the new pod has arrived.  For now we do not compare the resource UID when compare with the message in the store, and the store message is a delete message so the new resouce message can not add to the queue and lead to the resource can not send to the edge node. This usually happens when a statefulSet deletes a pod and new pod are quickly created.

In this PR, we changed the message key func to use the resouce UID, In the kubernetes the UID is globally unique，So We can avoid the problem of quickly deleting and recreate pods with the same name.



I also add e2e for the statefulset lifecycle in the edge node


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
