### PR TITLE
bugfix sqlite 'transaction has already been committed or rolled back' 

### DIFF
--- a/edge/pkg/common/dbm/db.go
+++ b/edge/pkg/common/dbm/db.go
@@ -37,3 +37,19 @@ func InitDBConfig(driverName, dbName, dataSource string) {
 		}
 	})
 }
+
+type newOrmerFunc func() orm.Ormer
+
+var DefaultOrmFunc newOrmerFunc = newOrmer
+
+func newOrmer() orm.Ormer {
+	return orm.NewOrm()
+}
+
+// RollbackTransaction rollback transaction and log err if rollback fail
+func RollbackTransaction(orm orm.Ormer) {
+	err := orm.Rollback()
+	if err != nil {
+		klog.Errorf("failed to rollback transaction, err: %v", err)
+	}
+}

--- a/edge/pkg/devicetwin/dtclient/deviceattr_db_test.go
+++ b/edge/pkg/devicetwin/dtclient/deviceattr_db_test.go
@@ -61,7 +61,7 @@ func TestSaveDeviceAttr(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			ormerMock.EXPECT().Insert(gomock.Any()).Return(test.returnInt, test.returnErr).Times(1)
-			err := SaveDeviceAttr(&DeviceAttr{})
+			err := SaveDeviceAttr(dbm.DBAccess, &DeviceAttr{})
 			if test.returnErr != err {
 				t.Errorf("Save Device Attr Case failed: wanted error %v and got error %v", test.returnErr, err)
 			}
@@ -116,7 +116,7 @@ func TestDeleteDeviceAttrByDeviceID(t *testing.T) {
 			querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(1)
 			querySeterMock.EXPECT().Delete().Return(test.deleteReturnInt, test.deleteReturnErr).Times(1)
 			ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
-			err := DeleteDeviceAttrByDeviceID("test")
+			err := DeleteDeviceAttrByDeviceID(dbm.DBAccess, "test")
 			if test.deleteReturnErr != err {
 				t.Errorf("DeleteDeviceAttrByDeviceID Case failed: wanted error %v and got error %v", test.deleteReturnErr, err)
 			}
@@ -170,7 +170,7 @@ func TestDeleteDeviceAttr(t *testing.T) {
 		querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(2)
 		querySeterMock.EXPECT().Delete().Return(test.deleteReturnInt, test.deleteReturnErr).Times(1)
 		ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
-		err := DeleteDeviceAttr("test", "test")
+		err := DeleteDeviceAttr(dbm.DBAccess, "test", "test")
 		t.Run(test.name, func(t *testing.T) {
 			if test.deleteReturnErr != err {
 				t.Errorf("DeleteDeviceAttr Case failed: wanted error %v and got error %v", test.deleteReturnErr, err)
@@ -281,7 +281,7 @@ func TestUpdateDeviceAttrFields(t *testing.T) {
 			querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(2)
 			querySeterMock.EXPECT().Update(gomock.Any()).Return(test.updateReturnInt, test.updateReturnErr).Times(1)
 			ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
-			err := UpdateDeviceAttrFields("test", "test", make(map[string]interface{}))
+			err := UpdateDeviceAttrFields(dbm.DBAccess, "test", "test", make(map[string]interface{}))
 			if test.updateReturnErr != err {
 				t.Errorf("UpdateDeviceAttrFields Case failed: wanted error %v and got error %v", test.updateReturnErr, err)
 			}
@@ -558,6 +558,9 @@ func TestDeviceAttrTrans(t *testing.T) {
 	deletes = append(deletes, DeviceDelete{DeviceID: "test", Name: "test"})
 	updates = append(updates, DeviceAttrUpdate{DeviceID: "test", Name: "test", Cols: make(map[string]interface{})})
 
+	dbm.DefaultOrmFunc = func() orm.Ormer {
+		return ormerMock
+	}
 	// run the test cases
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {

--- a/edge/pkg/devicetwin/dtclient/devicetwin_db_test.go
+++ b/edge/pkg/devicetwin/dtclient/devicetwin_db_test.go
@@ -60,7 +60,7 @@ func TestSaveDeviceTwin(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			ormerMock.EXPECT().Insert(gomock.Any()).Return(test.returnInt, test.returnErr).Times(1)
-			err := SaveDeviceTwin(&DeviceTwin{})
+			err := SaveDeviceTwin(dbm.DBAccess, &DeviceTwin{})
 			if test.returnErr != err {
 				t.Errorf("Save Device Twin Case failed: wanted error %v and got error %v", test.returnErr, err)
 			}
@@ -115,7 +115,7 @@ func TestDeleteDeviceTwinByDeviceID(t *testing.T) {
 			querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(1)
 			querySeterMock.EXPECT().Delete().Return(test.deleteReturnInt, test.deleteReturnErr).Times(1)
 			ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
-			err := DeleteDeviceTwinByDeviceID("test")
+			err := DeleteDeviceTwinByDeviceID(dbm.DBAccess, "test")
 			if test.deleteReturnErr != err {
 				t.Errorf("DeleteDeviceTwinByDeviceID Case failed: wanted error %v and got error %v", test.deleteReturnErr, err)
 			}
@@ -170,7 +170,7 @@ func TestDeleteDeviceTwin(t *testing.T) {
 			querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(2)
 			querySeterMock.EXPECT().Delete().Return(test.deleteReturnInt, test.deleteReturnErr).Times(1)
 			ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
-			err := DeleteDeviceTwin("test", "test")
+			err := DeleteDeviceTwin(dbm.DBAccess, "test", "test")
 			if test.deleteReturnErr != err {
 				t.Errorf("DeleteDeviceTwin Case failed: wanted error %v and got error %v", test.deleteReturnErr, err)
 			}
@@ -280,7 +280,7 @@ func TestUpdateDeviceTwinFields(t *testing.T) {
 			querySeterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(test.filterReturn).Times(2)
 			querySeterMock.EXPECT().Update(gomock.Any()).Return(test.updateReturnInt, test.updateReturnErr).Times(1)
 			ormerMock.EXPECT().QueryTable(gomock.Any()).Return(test.queryTableReturn).Times(1)
-			err := UpdateDeviceTwinFields("test", "test", make(map[string]interface{}))
+			err := UpdateDeviceTwinFields(dbm.DBAccess, "test", "test", make(map[string]interface{}))
 			if test.updateReturnErr != err {
 				t.Errorf("UpdateDeviceTwinFields Case failed: wanted error %v and got error %v", test.updateReturnErr, err)
 			}
@@ -556,6 +556,10 @@ func TestDeviceTwinTrans(t *testing.T) {
 	adds = append(adds, DeviceTwin{DeviceID: "Test"})
 	deletes = append(deletes, DeviceDelete{DeviceID: "test", Name: "test"})
 	updates = append(updates, DeviceTwinUpdate{DeviceID: "test", Name: "test", Cols: make(map[string]interface{})})
+
+	dbm.DefaultOrmFunc = func() orm.Ormer {
+		return ormerMock
+	}
 
 	// run the test cases
 	for _, test := range cases {

--- a/edge/pkg/devicetwin/dtmanager/device_test.go
+++ b/edge/pkg/devicetwin/dtmanager/device_test.go
@@ -306,6 +306,9 @@ func TestUpdateDeviceAttr(t *testing.T) {
 	ormerMock = beego.NewMockOrmer(mockCtrl)
 	querySeterMock = beego.NewMockQuerySeter(mockCtrl)
 	dbm.DBAccess = ormerMock
+	dbm.DefaultOrmFunc = func() orm.Ormer {
+		return ormerMock
+	}
 
 	dtContexts, _ := dtcontext.InitDTContext()
 	dtContexts.DeviceList.Store("EmptyDevice", "Device")

--- a/edge/pkg/devicetwin/dtmanager/membership.go
+++ b/edge/pkg/devicetwin/dtmanager/membership.go
@@ -261,6 +261,7 @@ func removeDevice(context *dtcontext.DTContext, toRemove []dttype.Device, baseMe
 	if !delta {
 		baseMessage.EventID = ""
 	}
+
 	for _, device := range toRemove {
 		//update sqlite
 		_, deviceExist := context.GetDevice(device.ID)

--- a/edge/pkg/devicetwin/dtmanager/membership_test.go
+++ b/edge/pkg/devicetwin/dtmanager/membership_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/astaxie/beego/orm"
 	"github.com/golang/mock/gomock"
 
 	"github.com/kubeedge/beehive/pkg/core/model"
@@ -185,6 +186,9 @@ func TestDealMembershipUpdateValidAddedDevice(t *testing.T) {
 	defer mockCtrl.Finish()
 	ormerMock = beego.NewMockOrmer(mockCtrl)
 	dbm.DBAccess = ormerMock
+	dbm.DefaultOrmFunc = func() orm.Ormer {
+		return ormerMock
+	}
 
 	ormerMock.EXPECT().Begin().Return(nil)
 	ormerMock.EXPECT().Insert(gomock.Any()).Return(int64(1), nil).Times(1)

--- a/edge/pkg/devicetwin/dtmanager/twin_test.go
+++ b/edge/pkg/devicetwin/dtmanager/twin_test.go
@@ -394,6 +394,9 @@ func TestDealDeviceTwin(t *testing.T) {
 	mockOrmer = beego.NewMockOrmer(mockCtrl)
 	mockQuerySeter = beego.NewMockQuerySeter(mockCtrl)
 	dbm.DBAccess = mockOrmer
+	dbm.DefaultOrmFunc = func() orm.Ormer {
+		return mockOrmer
+	}
 
 	str := typeString
 	optionTrue := true
@@ -520,6 +523,9 @@ func TestDealDeviceTwinResult(t *testing.T) {
 	mockOrmer = beego.NewMockOrmer(mockCtrl)
 	mockQuerySeter = beego.NewMockQuerySeter(mockCtrl)
 	dbm.DBAccess = mockOrmer
+	dbm.DefaultOrmFunc = func() orm.Ormer {
+		return mockOrmer
+	}
 
 	str := typeString
 	optionTrue := true
@@ -609,6 +615,9 @@ func TestDealDeviceTwinTrans(t *testing.T) {
 	mockOrmer = beego.NewMockOrmer(mockCtrl)
 	mockQuerySeter = beego.NewMockQuerySeter(mockCtrl)
 	dbm.DBAccess = mockOrmer
+	dbm.DefaultOrmFunc = func() orm.Ormer {
+		return mockOrmer
+	}
 
 	str := typeString
 	optionTrue := true


### PR DESCRIPTION
Signed-off-by: Shelley-BaoYue <baoyue2@huawei.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
DB operation in edgecore devicetwin  use a global variables `DBAccess orm.Ormer` to begin a transaction. When this transaction commit or rollback in devicetwin operation, other db operation which use the same variables. `orm.Ormer` will fail with the err `transaction has already been committed or rolled back`.  

In this PR, we use a new `Ormer` to begin a transaction in devicetwin, avoid  affecting other db operation.

**Which issue(s) this PR fixes**:

Fixes #3978

