### PR TITLE
remove GetMirrorPodByPod function

### DIFF
--- a/edge/pkg/edged/edged_pods.go
+++ b/edge/pkg/edged/edged_pods.go
@@ -1334,9 +1334,7 @@ func (e *edged) GetKubeletContainerLogs(ctx context.Context, podFullName, contai
 	}
 
 	podUID := pod.UID
-	if mirrorPod, ok := e.podManager.GetMirrorPodByPod(pod); ok {
-		podUID = mirrorPod.UID
-	}
+
 	podStatus, found := e.statusManager.GetPodStatus(podUID)
 	if !found {
 		// If there is no cached status, use the status from the

--- a/edge/pkg/edged/podmanager/pod_manager.go
+++ b/edge/pkg/edged/podmanager/pod_manager.go
@@ -122,7 +122,3 @@ func (pm *podManager) GetUIDTranslations() (podToMirror map[kubetypes.ResolvedPo
 func (pm *podManager) TranslatePodUID(uid types.UID) kubetypes.ResolvedPodUID {
 	return kubetypes.ResolvedPodUID(uid)
 }
-
-func (pm *podManager) GetMirrorPodByPod(*v1.Pod) (*v1.Pod, bool) {
-	return nil, false
-}

--- a/edge/pkg/edged/status/status_manager.go
+++ b/edge/pkg/edged/status/status_manager.go
@@ -396,8 +396,6 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	cachedStatus, isCached := m.podStatuses[pod.UID]
 	if isCached {
 		oldStatus = cachedStatus.status
-	} else if mirrorPod, ok := m.podManager.GetMirrorPodByPod(pod); ok {
-		oldStatus = mirrorPod.Status
 	} else {
 		oldStatus = pod.Status
 	}


### PR DESCRIPTION
Signed-off-by: crui <crui@relaper.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
We don't have static pod(in kubeedge), so we don't need GetMirrorPodByPod.
If we call  GetMirrorPodByPod, only false&nil will be returned. this is a meaningless judgment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
