### PR TITLE
fix the definition of tolerations in helm values.yaml

### DIFF
--- a/docs/proposals/refactor-keadm-on-the-cloud.md
+++ b/docs/proposals/refactor-keadm-on-the-cloud.md
@@ -49,7 +49,7 @@ spec:
           - matchExpressions:
           - key: node-role.kubernetes.io/edge
               operator: DoesNotExist
-    tolerations: {}
+    tolerations: []
     nodeSelector: {}
     resources:
       limits:
@@ -110,7 +110,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/edge
                   operator: DoesNotExist
-    tolerations: {}
+    tolerations: []
     nodeSelector: {}
     resources:
       limits:

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -24,7 +24,7 @@ cloudCore:
         - matchExpressions:
           - key: node-role.kubernetes.io/edge
             operator: DoesNotExist
-  tolerations: {}
+  tolerations: []
   nodeSelector: {}
   resources:
     limits:
@@ -90,7 +90,7 @@ iptablesManager:
         - matchExpressions:
           - key: node-role.kubernetes.io/edge
             operator: DoesNotExist
-  tolerations: {}
+  tolerations: []
   nodeSelector: {}
   resources:
     limits:

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -24,7 +24,7 @@ cloudCore:
         - matchExpressions:
           - key: node-role.kubernetes.io/edge
             operator: DoesNotExist
-  tolerations: {}
+  tolerations: []
   nodeSelector: {}
   resources:
     limits:
@@ -85,7 +85,7 @@ iptablesManager:
         - matchExpressions:
           - key: node-role.kubernetes.io/edge
             operator: DoesNotExist
-  tolerations: {}
+  tolerations: []
   nodeSelector: {}
   resources:
     limits:


### PR DESCRIPTION
Signed-off-by: WillardHu <wei.hu@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
io.k8s.api.core.v1.PodSpec.tolerations is an array type, use '--set cloudCore.tolerations[0].xxx' to set values, cause 'init' command to return an error message: "execute keadm command failed:  cannot build renderer: failed parsing --set data:unable to parse key: interface conversion: interface {} is map[string]interface {}, not []interface {}"

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
