### PR TITLE
simplify unnecessary groupMap

### DIFF
--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -17,11 +17,10 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 )
 
-var groupMap = map[string]string{
-	"resource": modules.MetaGroup,
-	"twin":     modules.TwinGroup,
-	"func":     modules.MetaGroup,
-	"user":     modules.BusGroup,
+var groupList = []string{
+	modules.MetaGroup,
+	modules.TwinGroup,
+	modules.BusGroup,
 }
 
 var (
@@ -196,7 +195,7 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 		content = connect.CloudDisconnected
 	}
 
-	for _, group := range groupMap {
+	for _, group := range groupList {
 		message := model.NewMessage("").BuildRouter(messagepkg.SourceNodeConnection, group,
 			messagepkg.ResourceTypeNodeConnection, messagepkg.OperationNodeConnection).FillBody(content)
 		beehiveContext.SendToGroup(group, *message)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

No code will use the key of groupMap now, we can simplify it to groupList. Additionally, we can avoid to pubConnectInfo twice to metaGroup when detecting the re-connection between cloud and edge.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
