### PR TITLE
use module group name instead of src name as argument when `SendToGroup`

### DIFF
--- a/cloud/pkg/cloudhub/channelq/channelq.go
+++ b/cloud/pkg/cloudhub/channelq/channelq.go
@@ -316,9 +316,9 @@ func (q *ChannelMessageQueue) Publish(msg *beehiveModel.Message) error {
 	case application.MetaServerSource:
 		beehiveContext.Send(modules.DynamicControllerModuleName, *msg)
 	case model.ResTwin:
-		beehiveContext.SendToGroup(model.SrcDeviceController, *msg)
+		beehiveContext.SendToGroup(modules.DeviceControllerModuleGroup, *msg)
 	default:
-		beehiveContext.SendToGroup(model.SrcEdgeController, *msg)
+		beehiveContext.SendToGroup(modules.EdgeControllerGroupName, *msg)
 	}
 	return nil
 }

--- a/cloud/pkg/cloudhub/common/model/types.go
+++ b/cloud/pkg/cloudhub/common/model/types.go
@@ -44,10 +44,8 @@ const (
 
 // constants for message source
 const (
-	SrcCloudHub         = "cloudhub"
-	SrcEdgeController   = "edgecontroller"
-	SrcDeviceController = "devicecontroller"
-	SrcManager          = "edgemgr"
+	SrcCloudHub = "cloudhub"
+	SrcManager  = "edgemgr"
 )
 
 // constants for identifier information for edge hub


### PR DESCRIPTION
Signed-off-by: Congrool <chpzhangyifei@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

For `beehiveContext.SendToGroup`, we'd better use common module group name. If using `model.SrcEdgeController` which indicates the `source` name, it's not easy to read.

Additionally, `model.SrcEdgeController` and `model.SrcDeviceController` seem nowhere to be used as `source` of message. So we can remove these redundant constants.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
