### PR TITLE
[Feature-New-Edged]add serviceaccount|secret client bridge

### DIFF
--- a/edge/pkg/edged/kubeclientbridge/typed/core/v1/core_client_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/core/v1/core_client_bridge.go
@@ -51,3 +51,11 @@ func (c *CoreV1Bridge) PersistentVolumeClaims(namespace string) corev1.Persisten
 func (c *CoreV1Bridge) ConfigMaps(namespace string) corev1.ConfigMapInterface {
 	return &ConfigMapBridge{fakecorev1.FakeConfigMaps{Fake: &c.FakeCoreV1}, namespace, c.MetaClient}
 }
+
+func (c *CoreV1Bridge) Secrets(namespace string) corev1.SecretInterface {
+	return &SecretBridge{fakecorev1.FakeSecrets{Fake: &c.FakeCoreV1}, namespace, c.MetaClient}
+}
+
+func (c *CoreV1Bridge) ServiceAccounts(namespace string) corev1.ServiceAccountInterface {
+	return &ServiceAccountsBridge{fakecorev1.FakeServiceAccounts{Fake: &c.FakeCoreV1}, namespace, c.MetaClient}
+}

--- a/edge/pkg/edged/kubeclientbridge/typed/core/v1/secret_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/core/v1/secret_bridge.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+@CHANGELOG
+KubeEdge Authors: To make a bridge between kubeclient and metaclient,
+This file is derived from K8S client-go code with reduced set of methods
+Changes done are
+1. Package v1 got some functions from "k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go"
+and made some variant
+*/
+
+package v1
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+)
+
+// SecretBridge implements SecretInterface
+type SecretBridge struct {
+	fakecorev1.FakeSecrets
+	ns         string
+	MetaClient client.CoreInterface
+}
+
+// Get takes name of the secret, and returns the corresponding secret object
+func (c *SecretBridge) Get(ctx context.Context, name string, options metav1.GetOptions) (result *corev1.Secret, err error) {
+	return c.MetaClient.Secrets(c.ns).Get(name)
+}

--- a/edge/pkg/edged/kubeclientbridge/typed/core/v1/serviceaccount_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/core/v1/serviceaccount_bridge.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+@CHANGELOG
+KubeEdge Authors: To make a bridge between kubeclient and metaclient,
+This file is derived from K8S client-go code with reduced set of methods
+Changes done are
+1. Package v1 got some functions from "k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go"
+and made some variant
+*/
+
+package v1
+
+import (
+	"context"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+)
+
+// ServiceAccountsBridge implements ServiceAccountInterface
+type ServiceAccountsBridge struct {
+	fakecorev1.FakeServiceAccounts
+	ns         string
+	MetaClient client.CoreInterface
+}
+
+// CreateToken takes the representation of a tokenRequest and creates it.  Returns the server's representation of the tokenRequest, and an error, if there is any.
+func (c *ServiceAccountsBridge) CreateToken(ctx context.Context, serviceAccountName string, tokenRequest *authenticationv1.TokenRequest, opts metav1.CreateOptions) (result *authenticationv1.TokenRequest, err error) {
+	return c.MetaClient.ServiceAccountToken().GetServiceAccountToken(c.ns, serviceAccountName, tokenRequest)
+}


### PR DESCRIPTION
Signed-off-by: Shelley-BaoYue <baoyue2@huawei.com>

**What type of PR is this?**

/kind feature

#4157 

**What this PR does / why we need it**:

add serviceaccount && secret client bridge. New edged use `GetChangeDetectionStrategy` to get serviceaccount/secret/configmap resource. 
