### PR TITLE
[cloudHub] move some helper function to package common

### DIFF
--- a/cloud/pkg/cloudhub/common/helper.go
+++ b/cloud/pkg/cloudhub/common/helper.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	hubmodel "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/model"
+	"github.com/kubeedge/kubeedge/common/constants"
+)
+
+// VolumePattern constants for error message
+const (
+	VolumePattern = `^\w[-\w.+]*/` + constants.CSIResourceTypeVolume + `/\w[-\w.+]*`
+)
+
+// VolumeRegExp is used to validate the volume resource
+var VolumeRegExp = regexp.MustCompile(VolumePattern)
+
+func IsVolumeResource(resource string) bool {
+	return VolumeRegExp.MatchString(resource)
+}
+
+// GetMessageUID returns the UID of the object in message
+func GetMessageUID(msg model.Message) (string, error) {
+	accessor, err := meta.Accessor(msg.Content)
+	if err != nil {
+		return "", err
+	}
+
+	return string(accessor.GetUID()), nil
+}
+
+// GetMessageDeletionTimestamp returns the deletionTimestamp of the object in message
+func GetMessageDeletionTimestamp(msg *model.Message) (*v1.Time, error) {
+	accessor, err := meta.Accessor(msg.Content)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessor.GetDeletionTimestamp(), nil
+}
+
+func TrimMessage(msg *model.Message) {
+	resource := msg.GetResource()
+	if strings.HasPrefix(resource, hubmodel.ResNode) {
+		tokens := strings.Split(resource, "/")
+		if len(tokens) < 3 {
+			klog.Warningf("event resource %s starts with node but length less than 3", resource)
+		} else {
+			msg.SetResourceOperation(strings.Join(tokens[2:], "/"), msg.GetOperation())
+		}
+	}
+}
+
+func ConstructConnectMessage(info *hubmodel.HubInfo, isConnected bool) *model.Message {
+	connected := hubmodel.OpConnect
+	if !isConnected {
+		connected = hubmodel.OpDisConnect
+	}
+	body := map[string]interface{}{
+		"event_type": connected,
+		"timestamp":  time.Now().Unix(),
+		"client_id":  info.NodeID}
+	content, _ := json.Marshal(body)
+
+	msg := model.NewMessage("")
+	msg.BuildRouter(hubmodel.SrcCloudHub, hubmodel.GpResource, hubmodel.NewResource(hubmodel.ResNode, info.NodeID, nil), connected)
+	msg.FillBody(content)
+	return msg
+}


### PR DESCRIPTION
Signed-off-by: wackxu <xushiwei5@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #


split https://github.com/kubeedge/kubeedge/pull/4105 into serveral small pr

in https://github.com/kubeedge/kubeedge/pull/4105 Cloudhub refactor implementation, we do some refactor to make the cloudhub layering clearer and more robust. In that PR, we move serveral helper function to the common package,  but it will make the CIFUZZ unhappy, because the CIFUZZ will run the fuzz that according to the code package, such as fuzz_volume_regexp， in https://github.com/cncf/cncf-fuzzing/blob/main/projects/kubeedge/build.sh

```
cp $SRC/cncf-fuzzing/projects/kubeedge/cloudhub_messagehandler_fuzzer.go $SRC/kubeedge/cloud/pkg/cloudhub/handler/
compile_go_fuzzer github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/handler FuzzVolumeRegExp fuzz_volume_regexp
```

we move the VolumeRegExp to the common package so the CIFUZZ will failed. 

So we extract this pr and modify the fuzz check rules in https://github.com/cncf/cncf-fuzzing/blob/main/projects/kubeedge/ to make fuzz happy 



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
