### PR TITLE
fix: Ignore the cache timestamp of the MachineInfo Metrics

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -542,6 +542,17 @@ func newEdged(enable bool) (*edged, error) {
 	if ed.machineInfo, err = ed.newMachineInfo(); err != nil {
 		return nil, err
 	}
+	// Avoid adding timestamp to machine metrics when they're cached
+	// Please refer to the following K8s PRs for more details:
+	//    link: https://github.com/kubernetes/kubernetes/pull/95210#issuecomment-726143798
+	//    link: https://github.com/kubernetes/kubernetes/pull/97006
+	// Analysis of causes :
+	//   1. The cadvisor collects machine metrics when it launches and then caches them for later scrape.
+	//      It is assumed that as long as the machine is not restarted, the hardware will not change and so do the machine metrics.
+	//   2. This timestamp of the machine metrics should be set when they're scraped, not when they're cached.
+	//   3. If using the timestamp when the machine metrics are cached, the timestamp when these metrics are scraped will be outdated
+	//      which may cause issues like 'out of order sample' when sending these metrics to prometheus.
+	ed.machineInfo.Timestamp = time.Time{}
 
 	// create a log manager
 	logManager, err := logs.NewContainerLogManager(runtimeService, ed.os, "10Mi", 5)


### PR DESCRIPTION
Signed-off-by: tl <tonyzaizai@kubesphere.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->/kind bug


**What this PR does / why we need it**:

Avoid adding timestamp to machine metrics when they're cached.
Please refer to the following K8s PRs for more details:
link: https://github.com/kubernetes/kubernetes/pull/95210#issuecomment-726143798
link: https://github.com/kubernetes/kubernetes/pull/97006
Analysis of causes :
1. The cadvisor collects machine metrics when it launches and then caches them for later scrape.
It is assumed that as long as the machine is not restarted, the hardware will not change and so do the machine metrics.
2. This timestamp of the machine metrics should be set when they're scraped, not when they're cached.
3. If using the timestamp when the machine metrics are cached, the timestamp when these metrics are scraped will be outdated
which may cause issues like 'out of order sample' when sending these metrics to prometheus.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
