### PR TITLE
fix keadm_deprecated_e2e error

### DIFF
--- a/tests/e2e/scripts/keadm_deprecated_e2e.sh
+++ b/tests/e2e/scripts/keadm_deprecated_e2e.sh
@@ -24,6 +24,8 @@ VERSION=${GIT_VERSION}
 
 function cleanup() {
   sudo pkill edgecore || true
+  sudo systemctl stop edgecore.service && systemctl disable edgecore.service && rm /etc/systemd/system/edgecore.service || true
+  sudo rm -rf /var/lib/kubeedge || true
   sudo pkill cloudcore || true
   kind delete cluster --name test
   sudo rm -rf /var/log/kubeedge /etc/kubeedge /etc/systemd/system/edgecore.service $E2E_DIR/keadm/keadm.test $E2E_DIR/config.json
@@ -88,13 +90,28 @@ function run_test() {
   --kube-master="https://$MASTER_IP:6443" \
   --kubeconfig=$KUBECONFIG \
   --test.v
-  if [[ $? != 0 ]]; then
+  GINKGO_TESTING_RESULT=$?
+
+  if [[ $GINKGO_TESTING_RESULT != 0 ]]; then
     echo "Integration suite has failures, Please check !!"
+    echo "edgecore logs are as below"
+    journalctl -u edgecore.service -xe > /var/log/kubeedge/edgecore.log
+    set -x
+    cat /var/log/kubeedge/edgecore.log
+    set +x
+    echo "================================================="
+    echo "================================================="
+    echo "cloudcore logs are as below"
+    set -x
+    cat /var/log/kubeedge/cloudcore.log
+    set +x
     exit 1
+  else
+    echo "Integration suite successfully passed all the tests !!"
+    exit 0
   fi
 }
 
-set -Ee
 trap cleanup EXIT
 trap cleanup ERR
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
In `keadm deprecated e2e`, we will run 2 versions test: one is based on the latest source codes, the other is based on the latest official release. So we must cleanup all related things of the first e2e test before we run the second e2e test. And in `keadm deprecated e2e`, we'll use systemd to start edgecore, so we must cleanup edgecore.service also
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
