### PR TITLE
Automated cherry pick of #4192: fix residual terminating pods problem after edge node

### DIFF
--- a/cloud/pkg/cloudhub/handler/messagehandler.go
+++ b/cloud/pkg/cloudhub/handler/messagehandler.go
@@ -480,11 +480,8 @@ func (mh *MessageHandle) MessageWriteLoop(info *model.HubInfo, stopServe chan Ex
 		if err != nil {
 			klog.Errorf("Failed to send event to node: %s, affected event: %s, err: %s",
 				info.NodeID, dumpMessageMetadata(copyMsg), err.Error())
+			nodeQueue.Done(key)
 			nodeQueue.Add(key.(string))
-			if strings.Contains(err.Error(), "use of closed network connection") {
-				mh.nodeConns.Delete(info.NodeID)
-				continue
-			}
 			time.Sleep(time.Second * 2)
 		}
 


### PR DESCRIPTION
Cherry pick of #4192 on release-1.11.

#4192: fix residual terminating pods problem after edge node

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.