### PR TITLE
fix delete and create same name pod failed occasionally

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -356,7 +356,7 @@ func (uc *UpstreamController) updatePodStatus() {
 			case model.UpdateOperation:
 				for _, podStatus := range podStatuses {
 					getPod, err := uc.kubeClient.CoreV1().Pods(namespace).Get(context.Background(), podStatus.Name, metaV1.GetOptions{})
-					if errors.IsNotFound(err) {
+					if (err == nil && getPod.UID != podStatus.UID) || errors.IsNotFound(err) {
 						klog.Warningf("message: %s, pod not found, namespace: %s, name: %s", msg.GetID(), namespace, podStatus.Name)
 
 						// Send request to delete this pod on edge side


### PR DESCRIPTION
Signed-off-by: wackxu <xushiwei5@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

in PR https://github.com/kubeedge/kubeedge/pull/4116, we fixed delete and the recreate statefulset pod is not running bug. But in some extreme case, there is a chance that the new pod info is deleted by the old pod info use the podUID,  if we use  podManager.GetPodByName in the sync for pod, it will be failed

![image](https://user-images.githubusercontent.com/30396467/190978913-7857a553-d7b3-4b72-8492-83d532814b4c.png)


```
E0919 04:19:01.491325   22146 edged.go:1021] worker [2] handle pod addition item [edge-statefulset-rgqyc-1] failed with not found error.
E0919 04:19:01.491335   22146 edged.go:1025] worker [2] handle pod addition item [edge-statefulset-rgqyc-1] failed: sync pod failed: failed to "StartContainer" for "nginx" with CreateContainerConfigError: "cannot find volume \"kube-api-access-8r2rz\" to mount into container \"nginx\"", re-add to queue
I0919 04:19:01.497013   22146 edged.go:957] sync loop ignore event: [ContainerDied], with pod [5f66b9c3-6142-4f16-b52a-3d553c72eb3f] not found
I0919 04:19:01.497036   22146 edged.go:957] sync loop ignore event: [ContainerStarted], with pod [5f66b9c3-6142-4f16-b52a-3d553c72eb3f] not found
I0919 04:19:02.511745   22146 edged.go:957] sync loop ignore event: [ContainerDied], with pod [5f66b9c3-6142-4f16-b52a-3d553c72eb3f] not found
```

we must not use podManager.GetPodByName, in kubernetes GetPodByName is only used for the log/exec API, and in the inner logic of kubelet, the GetPodByUID is used.

in a pod create and delete process, the pod info can be filled again to the podManager if we use GetPodByUID to sync the pod  and the GetPodByName can work for the log/exec. 



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
