### PR TITLE
Automated cherry pick of #3917: fix sendresp stuck occasionally when sendsync receive select

### DIFF
--- a/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
@@ -152,7 +152,12 @@ func (ctx *Context) SendResp(message model.Message) {
 	ctx.anonChsLock.RLock()
 	defer ctx.anonChsLock.RUnlock()
 	if channel, exist := ctx.anonChannels[anonName]; exist {
-		channel <- message
+		select {
+		case channel <- message:
+		default:
+			klog.Warningf("no goroutine is ready for receive the message from "+
+				"unbuffered response channel, discard this resp message for %s", message.GetParentID())
+		}
 		return
 	}
 


### PR DESCRIPTION
Cherry pick of #3917 on release-1.11.

#3917: fix sendresp stuck occasionally when sendsync receive select

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.