### PR TITLE
modify RetryInterval for db operation of device to avoid occasional failure

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/common.go
+++ b/edge/pkg/devicetwin/dtcommon/common.go
@@ -6,7 +6,7 @@ const (
 	// RetryTimes for retry times
 	RetryTimes = 5
 	// RetryInterval for retry interval
-	RetryInterval = 10 * time.Second
+	RetryInterval = 1 * time.Second
 
 	// LifeCycleConnectETPrefix the topic prefix for connected event
 	LifeCycleConnectETPrefix = "$hw/events/connected/"


### PR DESCRIPTION
modify RetryInterval for db operation of device to avoid occasional failure in e2e

Signed-off-by: RyanZhaoXB <zhaoran11@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
modify RetryInterval for db operation of device to avoid occasional failure in e2e. see https://github.com/kubeedge/kubeedge/issues/4212
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubeedge/kubeedge/issues/4212

**Special notes for your reviewer**:
we can fix this problem temporaily in this pr and optimize the operation of database in https://github.com/kubeedge/kubeedge/issues/4126

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

