### PR TITLE
Automated cherry pick of #3885: fix failed to rotate log for container for docker runtime

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -79,6 +79,7 @@ import (
 	serverstats "k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/kubelet/stats"
 	kubestatus "k8s.io/kubernetes/pkg/kubelet/status"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/kubelet/util/queue"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
@@ -554,13 +555,16 @@ func newEdged(enable bool) (*edged, error) {
 	//      which may cause issues like 'out of order sample' when sending these metrics to prometheus.
 	ed.machineInfo.Timestamp = time.Time{}
 
-	// create a log manager
-	logManager, err := logs.NewContainerLogManager(runtimeService, ed.os, "10Mi", 5)
-	if err != nil {
-		return nil, fmt.Errorf("new container log manager failed, err: %s", err.Error())
+	if ed.containerRuntimeName == kubetypes.RemoteContainerRuntime {
+		// create a log manager
+		logManager, err := logs.NewContainerLogManager(runtimeService, ed.os, "10Mi", 5)
+		if err != nil {
+			return nil, fmt.Errorf("new container log manager failed, err: %s", err.Error())
+		}
+		ed.logManager = logManager
+	} else {
+		ed.logManager = logs.NewStubContainerLogManager()
 	}
-
-	ed.logManager = logManager
 
 	containerRuntime, err := kuberuntime.NewKubeGenericRuntimeManager(
 		recorder,


### PR DESCRIPTION
Cherry pick of #3885 on release-1.11.

#3885: fix failed to rotate log for container for docker runtime

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.