### PR TITLE
add 'kind' to syncObject to edge

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -44,6 +44,7 @@ func (sctl *SyncController) manageObject(sync *v1alpha1.ObjectSync) {
 		newObject.SetNamespace(sync.Namespace)
 		newObject.SetName(sync.Spec.ObjectName)
 		newObject.SetUID(types.UID(getObjectUID(sync.Name)))
+		newObject.SetKind(resourceType)
 		if msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.DeleteOperation, newObject); msg != nil {
 			beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
 		} else {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
At edge nodes, errors often occur：

imitator.go:227] failed to unmarshal message content to unstructured obj: Object 'Kind' is missing in ''

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
