### PR TITLE
remove not used kubeedge-version flag in keadm init command

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -86,9 +86,6 @@ func newInitOptions() *types.InitOptions {
 }
 
 func addInitOtherFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
-	cmd.Flags().StringVar(&initOpts.KubeEdgeVersion, types.KubeEdgeVersion, initOpts.KubeEdgeVersion,
-		"Use this key to set the default image tag")
-
 	cmd.Flags().StringVar(&initOpts.AdvertiseAddress, types.AdvertiseAddress, initOpts.AdvertiseAddress,
 		"Use this key to set IPs in cloudcore's certificate SubAltNames field. eg: 10.10.102.78,10.10.102.79")
 
@@ -146,7 +143,6 @@ func AddInit2ToolsList(toolList map[string]types.ToolsInstaller, initOpts *types
 	toolList["helm"] = &helm.KubeCloudHelmInstTool{
 		Common:           common,
 		AdvertiseAddress: initOpts.AdvertiseAddress,
-		KubeEdgeVersion:  initOpts.KubeEdgeVersion,
 		Manifests:        initOpts.Manifests,
 		Namespace:        constants.SystemNamespace,
 		DryRun:           initOpts.DryRun,

--- a/keadm/cmd/keadm/app/cmd/cloud/manifest.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/manifest.go
@@ -129,7 +129,6 @@ func AddManifestsGenerate2ToolsList(toolList map[string]types.ToolsInstaller, fl
 	toolList["helm"] = &helm.KubeCloudHelmInstTool{
 		Common:           common,
 		AdvertiseAddress: initOpts.AdvertiseAddress,
-		KubeEdgeVersion:  initOpts.KubeEdgeVersion,
 		Manifests:        initOpts.Manifests,
 		Namespace:        constants.SystemNamespace,
 		DryRun:           initOpts.DryRun,

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -33,7 +33,6 @@ type InitBaseOptions struct {
 //InitOptions has the kubeedge cloud init information filled by CLI
 type InitOptions struct {
 	KubeConfig       string
-	KubeEdgeVersion  string
 	AdvertiseAddress string
 	Manifests        string
 	Namespace        string

--- a/keadm/cmd/keadm/app/cmd/helm/installer.go
+++ b/keadm/cmd/keadm/app/cmd/helm/installer.go
@@ -59,7 +59,6 @@ var (
 type KubeCloudHelmInstTool struct {
 	util.Common
 	AdvertiseAddress string
-	KubeEdgeVersion  string
 	Manifests        string
 	Namespace        string
 	Sets             []string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
remove not used kubeedge-version flag in keadm init command
this flag is never used, we can remove it(now we use --profile version=v1.10.1 to set image version)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
