### PR TITLE
Automated cherry pick of #4231: bugfix grep nodeReady in local-up shell

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -255,7 +255,7 @@ if [[ "${ENABLE_DAEMON}" = false ]]; then
 else
     while true; do
         sleep 3
-        kubectl get nodes | grep edge-node | grep -q Ready && break
+        kubectl get nodes | grep edge-node | grep -q -w Ready && break
     done
     kubectl label node edge-node disktype=test
 fi


### PR DESCRIPTION
Cherry pick of #4231 on release-1.12.

#4231: bugfix grep nodeReady in local-up shell

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.