### PR TITLE
fix application wrong cache ID

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application.go
+++ b/cloud/pkg/dynamiccontroller/application/application.go
@@ -2,7 +2,7 @@ package application
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -155,7 +155,9 @@ func (a *Application) Identifier() string {
 	b = append(b, []byte(a.Verb)...)
 	b = append(b, a.Option...)
 	b = append(b, a.ReqBody...)
-	a.ID = fmt.Sprintf("%x", md5.Sum(b))
+	b = append(b, []byte(a.Subresource)...)
+	b = append(b, []byte(a.Token)...)
+	a.ID = fmt.Sprintf("%x", sha256.Sum256(b))
 	return a.ID
 }
 func (a *Application) String() string {

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -148,12 +148,11 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				ContextSendModule:  metaconfig.ModuleNameEdgeHub,
 				RemoteQueryTimeout: constants.DefaultRemoteQueryTimeout,
 				MetaServer: &MetaServer{
-					Enable:                       false,
-					AutonomyWithoutAuthorization: false,
-					Server:                       constants.DefaultMetaServerAddr,
-					TLSCaFile:                    constants.DefaultCAFile,
-					TLSCertFile:                  constants.DefaultCertFile,
-					TLSPrivateKeyFile:            constants.DefaultKeyFile,
+					Enable:            false,
+					Server:            constants.DefaultMetaServerAddr,
+					TLSCaFile:         constants.DefaultCAFile,
+					TLSCertFile:       constants.DefaultCertFile,
+					TLSPrivateKeyFile: constants.DefaultKeyFile,
 				},
 			},
 			ServiceBus: &ServiceBus{

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -425,15 +425,11 @@ type MetaManager struct {
 }
 
 type MetaServer struct {
-	Enable bool `json:"enable"`
-	// AutonomyWithoutAuthorization is a switch to determine whether app can List/Watch
-	// meta data from local host db without authorization when the edge node is off-line.
-	// The default value is false, means won't be allowed.
-	AutonomyWithoutAuthorization bool   `json:"autonomyWithoutAuthorization"`
-	Server                       string `json:"server"`
-	TLSCaFile                    string `json:"tlsCaFile"`
-	TLSCertFile                  string `json:"tlsCertFile"`
-	TLSPrivateKeyFile            string `json:"tlsPrivateKeyFile"`
+	Enable            bool   `json:"enable"`
+	Server            string `json:"server"`
+	TLSCaFile         string `json:"tlsCaFile"`
+	TLSCertFile       string `json:"tlsCertFile"`
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile"`
 }
 
 // ServiceBus indicates the ServiceBus module config


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Application will cache application data but with wrong `key`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
