### PR TITLE
bugfix delete statefulset pod 

### DIFF
--- a/edge/pkg/metamanager/process_test.go
+++ b/edge/pkg/metamanager/process_test.go
@@ -432,9 +432,6 @@ func TestProcessDelete(t *testing.T) {
 	})
 
 	// Success Case
-	querySetterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySetterMock).Times(3)
-	querySetterMock.EXPECT().Delete().Return(int64(1), nil).Times(3)
-	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySetterMock).Times(3)
 	resource := fmt.Sprintf("test/%s/nginx", model.ResourceTypePod)
 	msg = model.NewMessage("").BuildRouter(ModuleNameEdged, modules.MetaGroup, resource, model.DeleteOperation)
 	meta.processDelete(*msg)

--- a/tests/e2e/deployment/deployment_test.go
+++ b/tests/e2e/deployment/deployment_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deployment
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -27,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/kubeedge/kubeedge/tests/e2e/constants"
@@ -261,48 +263,46 @@ var _ = Describe("Application deployment test in E2E scenario", func() {
 			By(fmt.Sprintf("wait for pod of StatefulSet %s running", UID))
 			utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, *podList, 240*time.Second)
 		})
+		It("Delete statefulSet pod multi times", func() {
+			replica := int32(2)
+			// Generate the random string and assign as a UID
+			UID = "edge-statefulset-" + utils.GetRandomString(5)
 
-		/*
-			It("Delete statefulSet pod multi times", func() {
-				replica := int32(2)
-				// Generate the random string and assign as a UID
-				UID = "edge-statefulset-" + utils.GetRandomString(5)
+			By(fmt.Sprintf("create StatefulSet %s", UID))
+			d := utils.NewTestStatefulSet(UID, ctx.Cfg.AppImageURL[1], replica)
+			ss, err := utils.CreateStatefulSet(clientSet, d)
+			Expect(err).To(BeNil())
 
-				By(fmt.Sprintf("create StatefulSet %s", UID))
-				d := utils.NewTestStatefulSet(UID, ctx.Cfg.AppImageURL[1], replica)
-				ss, err := utils.CreateStatefulSet(clientSet, d)
+			utils.WaitForStatusReplicas(clientSet, ss, replica)
+
+			By(fmt.Sprintf("get pod for StatefulSet %s", UID))
+			labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
+			podList, err := utils.ListPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
+			Expect(err).To(BeNil())
+			Expect(len(podList.Items)).ShouldNot(Equal(0))
+
+			By(fmt.Sprintf("wait for pod of StatefulSet %s running", UID))
+			utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, *podList, 240*time.Second)
+
+			deletePodName := fmt.Sprintf("%s-1", UID)
+			for i := 0; i < 5; i++ {
+				By(fmt.Sprintf("delete pod %s", deletePodName))
+				err = utils.DeletePod(clientSet, deletePodName, "default")
 				Expect(err).To(BeNil())
 
-				utils.WaitForStatusReplicas(clientSet, ss, replica)
-
-				By(fmt.Sprintf("get pod for StatefulSet %s", UID))
-				labelSelector := labels.SelectorFromSet(map[string]string{"app": UID})
-				podList, err := utils.ListPods(clientSet, corev1.NamespaceDefault, labelSelector, nil)
+				By(fmt.Sprintf("wait for pod %s running again", fmt.Sprintf("%s-1", UID)))
+				err = wait.Poll(5*time.Second, 120*time.Second, func() (bool, error) {
+					pod, err := clientSet.CoreV1().Pods("default").Get(context.TODO(), deletePodName, metav1.GetOptions{})
+					if err != nil {
+						return false, err
+					}
+					if pod.Status.Phase == corev1.PodRunning {
+						return true, nil
+					}
+					return false, nil
+				})
 				Expect(err).To(BeNil())
-				Expect(len(podList.Items)).ShouldNot(Equal(0))
-
-				By(fmt.Sprintf("wait for pod of StatefulSet %s running", UID))
-				utils.WaitforPodsRunning(ctx.Cfg.KubeConfigPath, *podList, 240*time.Second)
-
-				deletePodName := fmt.Sprintf("%s-1", UID)
-				for i := 0; i < 5; i++ {
-					By(fmt.Sprintf("delete pod %s", deletePodName))
-					err = utils.DeletePod(clientSet, deletePodName, "default")
-					Expect(err).To(BeNil())
-
-					By(fmt.Sprintf("wait for pod %s running again", fmt.Sprintf("%s-1", UID)))
-					err = wait.Poll(5*time.Second, 120*time.Second, func() (bool, error) {
-						pod, err := clientSet.CoreV1().Pods("default").Get(context.TODO(), deletePodName, metav1.GetOptions{})
-						if err != nil {
-							return false, err
-						}
-						if pod.Status.Phase == corev1.PodRunning {
-							return true, nil
-						}
-						return false, nil
-					})
-					Expect(err).To(BeNil())
-				}
-			}*/
+			}
+		})
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

When delete statefulset pod, cloud will send create new pod and delete old pod request to edge, which these two request have same resource. Because the processing order on edge is not fully guaranteed, a situation may arise: the pod record that create new pod request insert in DB may be deleted by delete old pod request. So when we delete statefulset, new pod can not running. 

In this PR, when we delete pod recored in DB, we will compare the pod UID. If not equal, don't allow to delete this record.