### PR TITLE
use kubelet default NodeStatusUpdateFrequency and NodeStatusReportFre…

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -49,7 +49,6 @@ const (
 	DefaultRemoteRuntimeEndpoint       = "unix:///var/run/dockershim.sock"
 	DefaultRemoteImageEndpoint         = "unix:///var/run/dockershim.sock"
 	DefaultPodSandboxImage             = "kubeedge/pause:3.1"
-	DefaultNodeStatusUpdateFrequency   = 10 * time.Second
 	DefaultImagePullProgressDeadline   = time.Minute
 	DefaultImageGCHighThreshold        = 80
 	DefaultImageGCLowThreshold         = 40

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -40,7 +40,6 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 
 	in := kubeletconfigv1beta1.KubeletConfiguration{}
 	in.ContentType = "application/json"
-	in.NodeStatusUpdateFrequency = metav1.Duration{Duration: constants.DefaultNodeStatusUpdateFrequency}
 	in.ImageGCLowThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCLowThreshold)
 	in.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCHighThreshold)
 	in.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy
@@ -189,7 +188,6 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 
 	in := kubeletconfigv1beta1.KubeletConfiguration{}
 	in.ContentType = "application/json"
-	in.NodeStatusUpdateFrequency = metav1.Duration{Duration: constants.DefaultNodeStatusUpdateFrequency}
 	in.ImageGCLowThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCLowThreshold)
 	in.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCHighThreshold)
 	in.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy


### PR DESCRIPTION
…quency

Signed-off-by: wackxu <xushiwei5@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

If we set NodeStatusUpdateFrequency default to 10s, the NodeStatusReportFrequency will also be the same with the NodeStatusUpdateFrequency,  In big scale, this may cause the api server pressure, so we can keep the default with kubelet

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
