### PR TITLE
restore device integration test

### DIFF
--- a/edge/test/integration/device/device_suite_test.go
+++ b/edge/test/integration/device/device_suite_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtcommon"
+	"github.com/kubeedge/kubeedge/edge/test/integration/utils"
 	"github.com/kubeedge/kubeedge/edge/test/integration/utils/common"
 	"github.com/kubeedge/kubeedge/edge/test/integration/utils/edge"
 	"github.com/kubeedge/kubeedge/edge/test/integration/utils/helpers"
@@ -71,8 +72,8 @@ func TestEdgecoreEventBus(t *testing.T) {
 
 		cfg = edge.LoadConfig()
 		ctx = edge.NewTestContext(cfg)
-		//Expect(utils.CreateEdgeCoreConfigFile()).Should(BeNil())
-		//Expect(utils.StartEdgeCore()).Should(BeNil())
+		Expect(utils.CreateEdgeCoreConfigFile(cfg.NodeID)).Should(BeNil())
+		Expect(utils.StartEdgeCore()).Should(BeNil())
 	})
 	AfterSuite(func() {
 		By("After Suite Executing....!")

--- a/edge/test/integration/scripts/fast_test.sh
+++ b/edge/test/integration/scripts/fast_test.sh
@@ -42,10 +42,10 @@ if [[ $# -eq 0 ]]; then
     #if [[ $? != 0 ]]; then
     #  GINKGO_EXIT_CODE=1
     #fi
-    #./device/device.test  $debugflag
-    #if [[ $? != 0 ]]; then
-    #  GINKGO_EXIT_CODE=1
-    #fi
+    ./device/device.test  $debugflag
+    if [[ $? != 0 ]]; then
+      GINKGO_EXIT_CODE=1
+    fi
     ./metaserver/metaserver.test $debugflag
     if [[ $? != 0 ]]; then
       GINKGO_EXIT_CODE=1


### PR DESCRIPTION
**What type of PR is this?**

/kind test


**What this PR does / why we need it**:

deployment integration test is not suitable in new edged which Kubelet integrated, so comment out deployment test temporarily here. And device integration test need start edgecore by itself. 

