### PR TITLE
start http server when featuregates requireAuthorization is false

### DIFF
--- a/edge/test/integration/metaserver/metaserver_test.go
+++ b/edge/test/integration/metaserver/metaserver_test.go
@@ -1,7 +1,6 @@
 package metaserver
 
 import (
-	"crypto/tls"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,17 +42,11 @@ var _ = Describe("Test MetaServer", func() {
 				//"Watch with bad method":                         {"POST", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/namespaces/ns/simples/", http.StatusMethodNotAllowed},
 				//"Watch param with bad method": {"POST", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/ns-foo/simples?watch=true", http.StatusMethodNotAllowed},
 			}
-			client := http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true},
-				},
-			}
-			url := "https://127.0.0.1:10550"
+			client := http.Client{}
+			url := "http://127.0.0.1:10550"
 			for _, v := range cases {
 				request, err := http.NewRequest(v.Method, url+v.Path, nil)
 				Expect(err).Should(BeNil())
-				request.Header.Set("Authorization", "xxxxx")
 				response, err := client.Do(request)
 				Expect(err).Should(BeNil())
 				isEqual := v.Status == response.StatusCode


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Start HTTP server when feature gates `requireAuthorization` is false other than HTTPS in MetaServer.
Whereas, when feature gates `requireAuthorization` is true, then the HTTPS server will be started in MetaServer.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
