### PR TITLE
Automated cherry pick of #4232: fix cloudcore cluster role

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -13,7 +13,7 @@ rules:
   resources: ["namespaces"]
   verbs: ["get", "create", "list", "watch"]
 - apiGroups: [""]
-  resources: ["nodes", "pods/status"]
+  resources: ["nodes", "nodes/status", "pods/status"]
   verbs: ["patch"]
 - apiGroups: [""]
   resources: ["pods"]

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
@@ -14,7 +14,7 @@ rules:
   resources: ["namespaces"]
   verbs: ["get", "create", "list", "watch"]
 - apiGroups: [""]
-  resources: ["nodes", "pods/status"]
+  resources: ["nodes", "nodes/status", "pods/status"]
   verbs: ["patch"]
 - apiGroups: [""]
   resources: ["pods"]


### PR DESCRIPTION
Cherry pick of #4232 on release-1.12.

#4232: fix cloudcore cluster role

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.