### PR TITLE
Automated cherry pick of #4245: use kubelet default NodeStatusUpdateFrequency and

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -49,7 +49,6 @@ const (
 	DefaultRemoteRuntimeEndpoint       = "unix:///var/run/dockershim.sock"
 	DefaultRemoteImageEndpoint         = "unix:///var/run/dockershim.sock"
 	DefaultPodSandboxImage             = "kubeedge/pause:3.1"
-	DefaultNodeStatusUpdateFrequency   = 10 * time.Second
 	DefaultImagePullProgressDeadline   = time.Minute
 	DefaultImageGCHighThreshold        = 80
 	DefaultImageGCLowThreshold         = 40

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -40,7 +40,6 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 
 	in := kubeletconfigv1beta1.KubeletConfiguration{}
 	in.ContentType = "application/json"
-	in.NodeStatusUpdateFrequency = metav1.Duration{Duration: constants.DefaultNodeStatusUpdateFrequency}
 	in.ImageGCLowThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCLowThreshold)
 	in.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCHighThreshold)
 	in.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy
@@ -188,7 +187,6 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 
 	in := kubeletconfigv1beta1.KubeletConfiguration{}
 	in.ContentType = "application/json"
-	in.NodeStatusUpdateFrequency = metav1.Duration{Duration: constants.DefaultNodeStatusUpdateFrequency}
 	in.ImageGCLowThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCLowThreshold)
 	in.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCHighThreshold)
 	in.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy


### PR DESCRIPTION
Cherry pick of #4245 on release-1.12.

#4245: use kubelet default NodeStatusUpdateFrequency and

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.