### PR TITLE
Automated cherry pick of #4234: add nodeupgradejob related rbac to cloudcore deployment

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -36,3 +36,6 @@ rules:
 - apiGroups: ["networking.istio.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["operations.kubeedge.io"]
+  resources: ["nodeupgradejobs", "nodeupgradejobs/status"]
+  verbs: ["get", "list", "watch", "update", "patch"]

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
@@ -37,6 +37,9 @@ rules:
 - apiGroups: ["networking.istio.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["operations.kubeedge.io"]
+  resources: ["nodeupgradejobs", "nodeupgradejobs/status"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Cherry pick of #4234 on release-1.12.

#4234: add nodeupgradejob related rbac to cloudcore deployment

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.