### PR TITLE
Automated cherry pick of #4249: start http server when featuregates requireAuthorization is

### DIFF
--- a/edge/test/integration/metaserver/metaserver_test.go
+++ b/edge/test/integration/metaserver/metaserver_test.go
@@ -1,7 +1,6 @@
 package metaserver
 
 import (
-	"crypto/tls"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,17 +42,11 @@ var _ = Describe("Test MetaServer", func() {
 				//"Watch with bad method":                         {"POST", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/namespaces/ns/simples/", http.StatusMethodNotAllowed},
 				//"Watch param with bad method": {"POST", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/ns-foo/simples?watch=true", http.StatusMethodNotAllowed},
 			}
-			client := http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true},
-				},
-			}
-			url := "https://127.0.0.1:10550"
+			client := http.Client{}
+			url := "http://127.0.0.1:10550"
 			for _, v := range cases {
 				request, err := http.NewRequest(v.Method, url+v.Path, nil)
 				Expect(err).Should(BeNil())
-				request.Header.Set("Authorization", "xxxxx")
 				response, err := client.Do(request)
 				Expect(err).Should(BeNil())
 				isEqual := v.Status == response.StatusCode


### PR DESCRIPTION
Cherry pick of #4249 on release-1.12.

#4249: start http server when featuregates requireAuthorization is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.