### PR TITLE
Automated cherry pick of #4224: update NodeUpgradeJob Image description

### DIFF
--- a/build/crds/operations/operations_v1alpha1_nodeupgradejob.yaml
+++ b/build/crds/operations/operations_v1alpha1_nodeupgradejob.yaml
@@ -40,9 +40,10 @@ spec:
                 description: 'Image specifies a container image name, the image contains:
                   keadm and edgecore. keadm is used as upgradetool, to install the
                   new version of edgecore. The image name consists of registry hostname
-                  and repository name, but cannot includes the tag, Version above
-                  will be used as the tag. If the registry hostname is empty, docker.io
-                  will be used as default. The default image name is: kubeedge/installation-package.'
+                  and repository name, if it includes the tag or digest, the tag or
+                  digest will be overwritten by Version field above. If the registry
+                  hostname is empty, docker.io will be used as default. The default
+                  image name is: kubeedge/installation-package.'
                 type: string
               labelSelector:
                 description: LabelSelector is a filter to select member clusters by

--- a/cloud/pkg/nodeupgradejobcontroller/controller/util.go
+++ b/cloud/pkg/nodeupgradejobcontroller/controller/util.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/distribution/distribution/v3/reference"
 	metav1 "k8s.io/api/core/v1"
 
 	"github.com/kubeedge/kubeedge/common/constants"
@@ -135,4 +136,14 @@ func mergeAnnotationUpgradeHistory(origin, fromVersion, toVersion string) string
 
 	sets = append(sets, newHistory)
 	return strings.Join(sets, ";")
+}
+
+// GetImageRepo gets repo from a container image
+func GetImageRepo(image string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image name: %v", err)
+	}
+
+	return named.Name(), nil
 }

--- a/cloud/pkg/nodeupgradejobcontroller/controller/util_test.go
+++ b/cloud/pkg/nodeupgradejobcontroller/controller/util_test.go
@@ -220,3 +220,35 @@ func TestMergeAnnotationUpgradeHistory(t *testing.T) {
 		})
 	}
 }
+
+func TestGetImageRepo(t *testing.T) {
+	tests := []struct {
+		Image      string
+		ExpectRepo string
+	}{
+		{Image: "name", ExpectRepo: "docker.io/library/name"},
+		{Image: "name:tag", ExpectRepo: "docker.io/library/name"},
+		{Image: "name@sha256:59329e44d499406bd2e620473b0ba0b531abb7e326cef0156f33e5957cdfe259", ExpectRepo: "docker.io/library/name"},
+		{Image: "org/name", ExpectRepo: "docker.io/org/name"},
+		{Image: "org/name:tag", ExpectRepo: "docker.io/org/name"},
+		{Image: "org/name@sha256:59329e44d499406bd2e620473b0ba0b531abb7e326cef0156f33e5957cdfe259", ExpectRepo: "docker.io/org/name"},
+		{Image: "registry:8080/name", ExpectRepo: "registry:8080/name"},
+		{Image: "registry:8080/name:tag", ExpectRepo: "registry:8080/name"},
+		{Image: "registry:8080/name@sha256:59329e44d499406bd2e620473b0ba0b531abb7e326cef0156f33e5957cdfe259", ExpectRepo: "registry:8080/name"},
+		{Image: "registry:8080/org/name", ExpectRepo: "registry:8080/org/name"},
+		{Image: "registry:8080/org/name:tag", ExpectRepo: "registry:8080/org/name"},
+		{Image: "registry:8080/org/name@sha256:59329e44d499406bd2e620473b0ba0b531abb7e326cef0156f33e5957cdfe259", ExpectRepo: "registry:8080/org/name"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Image, func(t *testing.T) {
+			repo, err := GetImageRepo(test.Image)
+			if err != nil {
+				t.Errorf("error: %v", err)
+			}
+			if repo != test.ExpectRepo {
+				t.Errorf("Got = %v, Want = %v", repo, test.ExpectRepo)
+			}
+		})
+	}
+}

--- a/edge/pkg/edgehub/upgrade/upgrade.go
+++ b/edge/pkg/edgehub/upgrade/upgrade.go
@@ -117,15 +117,7 @@ func (*keadmUpgrade) Upgrade(upgradeReq *commontypes.NodeUpgradeJobRequest) erro
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}
 
-	var image string
-	imageTag := upgradeReq.Version
-	// if users specify Image, we'll use upgrade Version as its image tag
-	// if not, we'll use default image: kubeedge/installation-package:${Version}
-	if upgradeReq.Image != "" {
-		image = fmt.Sprintf("%s:%s", upgradeReq.Image, imageTag)
-	} else {
-		image = fmt.Sprintf("%s:%s", "kubeedge/installation-package", imageTag)
-	}
+	image := upgradeReq.Image
 
 	// TODO: do some verification 1.sha256(pass in using CRD) 2.image signature verification
 	// TODO: release verification mechanism

--- a/manifests/charts/cloudcore/crds/operations_v1alpha1_nodeupgradejob.yaml
+++ b/manifests/charts/cloudcore/crds/operations_v1alpha1_nodeupgradejob.yaml
@@ -40,9 +40,10 @@ spec:
                 description: 'Image specifies a container image name, the image contains:
                   keadm and edgecore. keadm is used as upgradetool, to install the
                   new version of edgecore. The image name consists of registry hostname
-                  and repository name, but cannot includes the tag, Version above
-                  will be used as the tag. If the registry hostname is empty, docker.io
-                  will be used as default. The default image name is: kubeedge/installation-package.'
+                  and repository name, if it includes the tag or digest, the tag or
+                  digest will be overwritten by Version field above. If the registry
+                  hostname is empty, docker.io will be used as default. The default
+                  image name is: kubeedge/installation-package.'
                 type: string
               labelSelector:
                 description: LabelSelector is a filter to select member clusters by

--- a/pkg/apis/operations/v1alpha1/type.go
+++ b/pkg/apis/operations/v1alpha1/type.go
@@ -81,8 +81,8 @@ type NodeUpgradeJobSpec struct {
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 	// Image specifies a container image name, the image contains: keadm and edgecore.
 	// keadm is used as upgradetool, to install the new version of edgecore.
-	// The image name consists of registry hostname and repository name, but cannot includes the tag,
-	// Version above will be used as the tag.
+	// The image name consists of registry hostname and repository name,
+	// if it includes the tag or digest, the tag or digest will be overwritten by Version field above.
 	// If the registry hostname is empty, docker.io will be used as default.
 	// The default image name is: kubeedge/installation-package.
 	// +optional


### PR DESCRIPTION
Cherry pick of #4224 on release-1.12.

#4224: update NodeUpgradeJob Image description

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.