### PR TITLE
fix panic when edgehub retry connect to cloudhub

### DIFF
--- a/edge/pkg/edgehub/clients/quicclient/quicclient.go
+++ b/edge/pkg/edgehub/clients/quicclient/quicclient.go
@@ -83,24 +83,27 @@ func (qcc *QuicClient) Init() error {
 	return nil
 }
 
-//UnInit closes the quic connection
+// UnInit closes the quic connection
 func (qcc *QuicClient) UnInit() {
 	qcc.client.Close()
 }
 
-//Send sends the message as JSON object through the connection
+// Send sends the message as JSON object through the connection
 func (qcc *QuicClient) Send(message model.Message) error {
+	if qcc.client == nil {
+		return fmt.Errorf("quic connection is closed and message %v will not be sent", message.GetID())
+	}
 	return qcc.client.WriteMessageAsync(&message)
 }
 
-//Receive reads the binary message through the connection
+// Receive reads the binary message through the connection
 func (qcc *QuicClient) Receive() (model.Message, error) {
 	message := model.Message{}
 	err := qcc.client.ReadMessage(&message)
 	return message, err
 }
 
-//Notify logs info
+// Notify logs info
 func (qcc *QuicClient) Notify(authInfo map[string]string) {
 	klog.Infof("Don not care")
 }

--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -98,13 +98,16 @@ func (wsc *WebSocketClient) Init() error {
 	return errors.New("max retry count reached when connecting to cloud")
 }
 
-//UnInit closes the websocket connection
+// UnInit closes the websocket connection
 func (wsc *WebSocketClient) UnInit() {
 	wsc.connection.Close()
 }
 
-//Send sends the message as JSON object through the connection
+// Send sends the message as JSON object through the connection
 func (wsc *WebSocketClient) Send(message model.Message) error {
+	if wsc.connection == nil {
+		return fmt.Errorf("web socket connection is closed and message %v will not be sent", message.GetID())
+	}
 	err := wsc.connection.SetWriteDeadline(time.Now().Add(wsc.config.WriteDeadline))
 	if err != nil {
 		return err
@@ -112,14 +115,14 @@ func (wsc *WebSocketClient) Send(message model.Message) error {
 	return wsc.connection.WriteMessageAsync(&message)
 }
 
-//Receive reads the binary message through the connection
+// Receive reads the binary message through the connection
 func (wsc *WebSocketClient) Receive() (model.Message, error) {
 	message := model.Message{}
 	err := wsc.connection.ReadMessage(&message)
 	return message, err
 }
 
-//Notify logs info
+// Notify logs info
 func (wsc *WebSocketClient) Notify(authInfo map[string]string) {
 	klog.Infof("no op")
 }


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Edgecore will panic when retry connects to cloudhub. When the connection was interrupted, edgehub client will be re-init and reconnect to cloudhub, the `client.connection` is still nil if reconnect failed and it SHOULD NOT send a message meantime.

Panic is listed as follows.
![image](https://user-images.githubusercontent.com/49225405/194698760-ea2871f1-b793-405a-acde-9fbf21999a65.png)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
