### PR TITLE
Change edge join to use systemd in pure go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/containerd/containerd v1.5.13 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/docker v20.10.2+incompatible

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -107,7 +107,6 @@ const (
 	HelmManifestAction = "manifest"
 
 	CmdGetDNSIP         = "cat /etc/resolv.conf | grep nameserver | grep -v -E ':|#' | awk '{print $2}' | head -n1"
-	CmdGetStatusDocker  = "systemctl status docker |grep Active | awk '{print $2}'"
 	CmdPing             = "ping %s -w %d |grep 'packets transmitted' |awk '{print $6}'"
 	CmdGetMaxProcessNum = "sysctl kernel.pid_max|awk '{print $3}'"
 	CmdGetProcessNum    = "ps -A|wc -l"

--- a/keadm/cmd/keadm/app/cmd/debug/check.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check.go
@@ -347,27 +347,7 @@ func CheckHTTP(url string) error {
 
 func CheckRuntime(runtime string) error {
 	if runtime == common.DefaultRuntime {
-		ctx, cancel := context.WithTimeout(context.Background(), util.SystemdServiceTimeout)
-		defer cancel()
-
-		d, err := util.NewSystemdDbus(ctx)
-		if err != nil {
-			return err
-		}
-
-		results, err := d.ListUnitsByPatternsContext(ctx, []string{"Active"}, []string{"docker"})
-		if err != nil {
-			return err
-		}
-
-		for result := range results {
-			if results[result].ActiveState == "Active" && results[result].Name == "docker" {
-				fmt.Printf("docker is running\n")
-				return nil
-			} else if results[result].ActiveState != "Active" && results[result].Name == "docker" {
-				return fmt.Errorf("docker is not running: %s", results[result].LoadState)
-			}
-		}
+		return util.CheckServiceSystemd(runtime)
 	}
 	return fmt.Errorf("now only support docker: %s", runtime)
 	// TODO

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -38,10 +37,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2/validation"
 	pkgutil "github.com/kubeedge/kubeedge/pkg/util"
-)
-
-const (
-	systemdServiceTimeout = time.Minute * 5
 )
 
 var (
@@ -304,7 +299,7 @@ func runEdgeCore() error {
 	if systemdExist {
 		tip = fmt.Sprintf("KubeEdge edgecore is running, For logs visit: journalctl -u %s.service -xe", common.EdgeCore)
 
-		ctx, cancel := context.WithTimeout(context.Background(), systemdServiceTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), util.SystemdServiceTimeout)
 		defer cancel()
 
 		unitName := fmt.Sprintf("%s.service", common.EdgeCore)

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -507,10 +507,10 @@ func KillKubeEdgeBinary(proc string) error {
 		systemdExist := HasSystemd()
 
 		var serviceName string
-		if running, err := isEdgeCoreServiceRunning("edge"); err == nil && running {
+		if running, err := isServiceRunning("edge"); err == nil && running {
 			serviceName = "edge"
 		}
-		if running, err := isEdgeCoreServiceRunning("edgecore"); err == nil && running {
+		if running, err := isServiceRunning("edgecore"); err == nil && running {
 			serviceName = "edgecore"
 		}
 
@@ -558,7 +558,7 @@ func IsKubeEdgeProcessRunning(proc string) (bool, error) {
 	return false, err
 }
 
-func isEdgeCoreServiceEnabled(serviceName string) (bool, error) {
+func isServiceEnabled(serviceName string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), SystemdServiceTimeout)
 	defer cancel()
 
@@ -582,7 +582,7 @@ func isEdgeCoreServiceEnabled(serviceName string) (bool, error) {
 	return false, err
 }
 
-func isEdgeCoreServiceRunning(serviceName string) (bool, error) {
+func isServiceRunning(serviceName string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), SystemdServiceTimeout)
 	defer cancel()
 
@@ -1038,7 +1038,7 @@ func StopSystemdUnit(ctx context.Context, d *dbus.Conn, unit string) error {
 }
 
 func CheckServiceSystemd(serviceName string) error {
-	status, err := isEdgeCoreServiceRunning(serviceName)
+	status, err := isServiceEnabled(serviceName)
 	if err != nil {
 		return err
 	}

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -1019,7 +1019,7 @@ func StopSystemdUnit(ctx context.Context, d *dbus.Conn, unit string) error {
 }
 
 func CheckServiceSystemd(serviceName string) error {
-	status, err := checkServiceStatus("enabled", serviceName)
+	status, err := checkServiceStatus("Active", serviceName)
 	if err != nil {
 		return err
 	}

--- a/keadm/cmd/keadm/app/cmd/util/rpminstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/rpminstaller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -59,8 +60,6 @@ func (r *RpmOS) InstallMQTT() error {
 	commands := []string{
 		"yum -y install epel-release",
 		"yum -y install mosquitto",
-		"systemctl start mosquitto",
-		"systemctl enable mosquitto",
 	}
 
 	vendorName, err := getOSVendorName()
@@ -79,6 +78,15 @@ func (r *RpmOS) InstallMQTT() error {
 			return err
 		}
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), SystemdServiceTimeout)
+	defer cancel()
+
+	err = EnableAndRunSystemdUnit(ctx, "mosquitto", false)
+	if err != nil {
+		return err
+	}
+
 	fmt.Println("install MQTT service successfully.")
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,6 +200,7 @@ github.com/containernetworking/cni/pkg/version
 # github.com/coreos/go-semver v0.3.0
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd/v22 v22.3.2
+## explicit
 github.com/coreos/go-systemd/v22/daemon
 github.com/coreos/go-systemd/v22/dbus
 github.com/coreos/go-systemd/v22/journal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**: 
This implements the join command using pure go instead of commands. It also adds a 5 minute timeout for starting the service. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3860  

**Special notes for your reviewer**:
The 5 minute timeout is up for debate here on the length of the duration. I feel that it is necessary but that to could be up for debate as there was not one previously. 

`make test`
```
go detail version: go version go1.18.5 linux/amd64
go version: 1.18.5
hack/make-rules/test.sh
running tests cases
ok      github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/model    0.018s
ok      github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/dispatcher      0.012s
ok      github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/session 30.068s
ok      github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer      0.033s
ok      github.com/kubeedge/kubeedge/cloud/pkg/controllermanager/nodegroup      0.072s
ok      github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller/application    0.011s
ok      github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/manager   0.063s
ok      github.com/kubeedge/kubeedge/cloud/pkg/nodeupgradejobcontroller/controller      0.112s
ok      github.com/kubeedge/kubeedge/cloud/pkg/router/messagelayer      0.067s
ok      github.com/kubeedge/kubeedge/cloud/pkg/router/provider/eventbus 0.056s
ok      github.com/kubeedge/kubeedge/cloud/pkg/router/utils     0.023s
ok      github.com/kubeedge/kubeedge/edge/pkg/eventbus/common/util      0.055s
ok      github.com/kubeedge/kubeedge/edge/pkg/eventbus/mqtt     0.034s
ok      github.com/kubeedge/kubeedge/edge/pkg/eventbus/dao      0.063s
ok      github.com/kubeedge/kubeedge/edge/pkg/servicebus/util   0.086s
ok      github.com/kubeedge/kubeedge/edge/pkg/servicebus/dao    0.039s
ok      github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtclient       0.023s
ok      github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dttype 0.058s
ok      github.com/kubeedge/kubeedge/edge/pkg/devicetwin        0.018s
ok      github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtcontext      0.007s
ok      github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtmanager      6.040s
ok      github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtcommon       0.048s
ok      github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtmodule       0.005s
ok      github.com/kubeedge/kubeedge/edge/pkg/edgehub/common/http       0.296s
ok      github.com/kubeedge/kubeedge/edge/pkg/edgehub/common/certutil   0.093s
ok      github.com/kubeedge/kubeedge/edge/pkg/edgehub/clients/wsclient  5.211s
ok      github.com/kubeedge/kubeedge/edge/pkg/edgehub   5.047s
ok      github.com/kubeedge/kubeedge/edge/pkg/metamanager       3.021s
ok      github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao   0.020s
ok      github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util       6.368s
ok      github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/debug      0.011s
ok      github.com/kubeedge/kubeedge/pkg/metaserver/util        0.005s
ok      github.com/kubeedge/kubeedge/pkg/metaserver     0.053s
ok      github.com/kubeedge/kubeedge/pkg/image  0.026s
ok      github.com/kubeedge/kubeedge/pkg/util/validation        0.042s
ok      github.com/kubeedge/kubeedge/pkg/util   0.016s
ok      github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha1/validation      0.006s
ok      github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2/validation      0.008s
ok      github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1/validation     0.004s
```
`make integrationtest`
```
...
Ran 14 of 14 Specs in 27.067 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestEdgecoreEventBus (27.07s)
PASS
+ [[ 0 != 0 ]]
+ ./metaserver/metaserver.test -test.v -ginkgo.v
...
Ran 1 of 1 Specs in 5.039 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestEdgecoreMetaServer (5.04s)
PASS
+ [[ 0 != 0 ]]
+ [[ 0 != 0 ]]
+ echo 'Integration suite successfully passed all the tests !!'
Integration suite successfully passed all the tests !!
+ exit 0
...
