### PR TITLE
bugfix get msg content in QUIC protocal

### DIFF
--- a/edge/pkg/metamanager/client/node.go
+++ b/edge/pkg/metamanager/client/node.go
@@ -73,7 +73,7 @@ func (c *nodes) Update(cm *api.Node) error {
 
 func (c *nodes) Patch(name string, data []byte) (*api.Node, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeNodePatch, name)
-	nodeMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.PatchOperation, data)
+	nodeMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.PatchOperation, string(data))
 	resp, err := c.send.SendSync(nodeMsg)
 	if err != nil {
 		return nil, fmt.Errorf("update node failed, err: %v", err)

--- a/edge/pkg/metamanager/client/pod.go
+++ b/edge/pkg/metamanager/client/pod.go
@@ -58,8 +58,7 @@ func (c *pods) Update(cm *corev1.Pod) error {
 
 func (c *pods) Delete(name string, options metav1.DeleteOptions) error {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypePod, name)
-	podOpt, _ := json.Marshal(options)
-	podDeleteMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.DeleteOperation, podOpt)
+	podDeleteMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.DeleteOperation, options)
 	msg, err := c.send.SendSync(podDeleteMsg)
 	if err != nil {
 		return err
@@ -91,7 +90,7 @@ func (c *pods) Get(name string) (*corev1.Pod, error) {
 
 func (c *pods) Patch(name string, patchBytes []byte) (*corev1.Pod, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypePodPatch, name)
-	podMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.PatchOperation, patchBytes)
+	podMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.PatchOperation, string(patchBytes))
 	resp, err := c.send.SendSync(podMsg)
 	if err != nil {
 		return nil, fmt.Errorf("update pod failed, err: %v", err)

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
@@ -179,6 +179,10 @@ func (msg *Message) GetContentData() ([]byte, error) {
 		return data, nil
 	}
 
+	if data, ok := msg.Content.(string); ok {
+		return []byte(data), nil
+	}
+
 	data, err := json.Marshal(msg.Content)
 	if err != nil {
 		return nil, fmt.Errorf("marshal message content failed: %s", err)


### PR DESCRIPTION
**What type of PR is this?**

Add one of the following kinds:
/kind bug

**What this PR does / why we need it**:

- bugfix get msg content in QUIC protocal. When content type is string, the msg content received through QUIC is `byte` type, while it's `string` type in websocket propocal.  
- bugfix `lock` operation in QUIC protocal. We should set lock before `GetStream`, otherwise messges will use same stream, result in message lost.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
