### PR TITLE
Automated cherry pick of #4299: keadm reset supports remote runtime remove mqtt container

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -87,8 +87,10 @@ type CollectOptions struct {
 }
 
 type ResetOptions struct {
-	Kubeconfig string
-	Force      bool
+	Kubeconfig  string
+	Force       bool
+	RuntimeType string
+	Endpoint    string
 }
 
 type GettokenOptions struct {


### PR DESCRIPTION
Cherry pick of #4299 on release-1.12.

#4299: keadm reset supports remote runtime remove mqtt container

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.