### PR TITLE
Automated cherry pick of #4299: keadm reset supports remote runtime remove mqtt container

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -87,8 +87,10 @@ type CollectOptions struct {
 }
 
 type ResetOptions struct {
-	Kubeconfig string
-	Force      bool
+	Kubeconfig  string
+	Force       bool
+	RuntimeType string
+	Endpoint    string
 }
 
 type GettokenOptions struct {

--- a/keadm/cmd/keadm/app/cmd/reset.go
+++ b/keadm/cmd/keadm/app/cmd/reset.go
@@ -18,17 +18,14 @@ package cmd
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
-	dockertypes "github.com/docker/docker/api/types"
-	dockerfilters "github.com/docker/docker/api/types/filters"
-	dockerclient "github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/reset"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	utilsexec "k8s.io/utils/exec"
 
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
@@ -54,6 +51,7 @@ keadm reset
 func newResetOptions() *common.ResetOptions {
 	opts := &common.ResetOptions{}
 	opts.Kubeconfig = common.DefaultKubeConfig
+	opts.RuntimeType = kubetypes.DockerContainerRuntime
 	return opts
 }
 
@@ -109,7 +107,7 @@ func NewKubeEdgeReset() *cobra.Command {
 			}
 
 			// cleanup mqtt container
-			if err := RemoveMqttContainer(); err != nil {
+			if err := RemoveMqttContainer(reset.RuntimeType, reset.Endpoint); err != nil {
 				fmt.Printf("Failed to remove MQTT container: %v\n", err)
 			}
 			//4. TODO: clean status information
@@ -122,32 +120,13 @@ func NewKubeEdgeReset() *cobra.Command {
 	return cmd
 }
 
-func RemoveMqttContainer() error {
-	ctx := context.Background()
-
-	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv)
+func RemoveMqttContainer(runtimeType string, endpoint string) error {
+	runtime, err := util.NewContainerRuntime(runtimeType, endpoint)
 	if err != nil {
-		return fmt.Errorf("init docker dockerclient failed: %v", err)
+		return fmt.Errorf("failed to new container runtime: %v", err)
 	}
 
-	options := dockertypes.ContainerListOptions{}
-	options.Filters = dockerfilters.NewArgs()
-	options.Filters.Add("ancestor", "eclipse-mosquitto:1.6.15")
-
-	mqttContainers, err := cli.ContainerList(ctx, options)
-	if err != nil {
-		fmt.Printf("List MQTT containers failed: %v\n", err)
-		return err
-	}
-
-	for _, c := range mqttContainers {
-		err = cli.ContainerRemove(ctx, c.ID, dockertypes.ContainerRemoveOptions{RemoveVolumes: true, Force: true})
-		if err != nil {
-			fmt.Printf("failed to remove MQTT container: %v\n", err)
-		}
-	}
-
-	return nil
+	return runtime.RemoveMQTT()
 }
 
 // TearDownKubeEdge will bring down either cloud or edge components,
@@ -220,4 +199,8 @@ func addResetFlags(cmd *cobra.Command, resetOpts *common.ResetOptions) {
 		"Use this key to set kube-config path, eg: $HOME/.kube/config")
 	cmd.Flags().BoolVar(&resetOpts.Force, "force", resetOpts.Force,
 		"Reset the node without prompting for confirmation")
+	cmd.Flags().StringVar(&resetOpts.RuntimeType, common.RuntimeType, resetOpts.RuntimeType,
+		"Use this key to set container runtime")
+	cmd.Flags().StringVar(&resetOpts.Endpoint, common.RemoteRuntimeEndpoint, resetOpts.Endpoint,
+		"Use this key to set container runtime endpoint")
 }

--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -37,10 +37,14 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/image"
 )
 
+// mqttLabel is used to select MQTT containers
+var mqttLabel = map[string]string{"io.kubeedge.edgecore/mqtt": image.EdgeMQTT}
+
 type ContainerRuntime interface {
 	PullImages(images []string) error
 	CopyResources(edgeImage string, dirs map[string]string, files map[string]string) error
 	RunMQTT(mqttImage string) error
+	RemoveMQTT() error
 }
 
 func NewContainerRuntime(runtimeType string, endpoint string) (ContainerRuntime, error) {
@@ -140,6 +144,29 @@ func (runtime *DockerRuntime) RunMQTT(mqttImage string) error {
 		return err
 	}
 	return runtime.Client.ContainerStart(runtime.ctx, container.ID, dockertypes.ContainerStartOptions{})
+}
+
+func (runtime *DockerRuntime) RemoveMQTT() error {
+	options := dockertypes.ContainerListOptions{
+		All: true,
+	}
+	options.Filters = filters.NewArgs()
+	options.Filters.Add("ancestor", "eclipse-mosquitto:1.6.15")
+
+	mqttContainers, err := runtime.Client.ContainerList(runtime.ctx, options)
+	if err != nil {
+		fmt.Printf("List MQTT containers failed: %v\n", err)
+		return err
+	}
+
+	for _, c := range mqttContainers {
+		err = runtime.Client.ContainerRemove(runtime.ctx, c.ID, dockertypes.ContainerRemoveOptions{RemoveVolumes: true, Force: true})
+		if err != nil {
+			fmt.Printf("failed to remove MQTT container: %v\n", err)
+		}
+	}
+
+	return nil
 }
 
 // CopyResources copies binary and configuration file from the image to the host.
@@ -293,6 +320,7 @@ func (runtime *CRIRuntime) RunMQTT(mqttImage string) error {
 				HostPort:      9001,
 			},
 		},
+		Labels: mqttLabel,
 	}
 	sandbox, err := runtime.RuntimeService.RunPodSandbox(psc, "")
 	if err != nil {
@@ -316,6 +344,31 @@ func (runtime *CRIRuntime) RunMQTT(mqttImage string) error {
 		return err
 	}
 	return runtime.RuntimeService.StartContainer(containerID)
+}
+
+func (runtime *CRIRuntime) RemoveMQTT() error {
+	sandboxFilter := &runtimeapi.PodSandboxFilter{
+		LabelSelector: mqttLabel,
+	}
+
+	sandbox, err := runtime.RuntimeService.ListPodSandbox(sandboxFilter)
+	if err != nil {
+		fmt.Printf("List MQTT containers failed: %v\n", err)
+		return err
+	}
+
+	for _, c := range sandbox {
+		// by reference doc
+		// RemovePodSandbox removes the sandbox. If there are running containers in the
+		// sandbox, they should be forcibly removed.
+		// so we can remove mqtt containers totally.
+		err = runtime.RuntimeService.RemovePodSandbox(c.Id)
+		if err != nil {
+			fmt.Printf("failed to remove MQTT container: %v\n", err)
+		}
+	}
+
+	return nil
 }
 
 func copyResourcesCmd(dirs map[string]string, files map[string]string) string {


### PR DESCRIPTION
Cherry pick of #4299 on release-1.11.

#4299: keadm reset supports remote runtime remove mqtt container

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.