### PR TITLE
keadm: support --namespace flag to install kubeedge in other namespace

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -101,6 +101,9 @@ func addInitOtherFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 	cmd.Flags().StringVarP(&initOpts.Manifests, types.Files, "f", initOpts.Manifests,
 		"Allow appending file directories of k8s resources to keadm, separated by commas")
 
+	cmd.Flags().StringVarP(&initOpts.Namespace, types.Namespace, "n", constants.SystemNamespace,
+		"Use this key to set the namespace")
+
 	cmd.Flags().BoolVarP(&initOpts.DryRun, types.DryRun, "d", initOpts.DryRun,
 		"Print the generated k8s resources on the stdout, not actual excute. Always use in debug mode")
 
@@ -148,7 +151,7 @@ func AddInit2ToolsList(toolList map[string]types.ToolsInstaller, initOpts *types
 		AdvertiseAddress: initOpts.AdvertiseAddress,
 		KubeEdgeVersion:  initOpts.KubeEdgeVersion,
 		Manifests:        initOpts.Manifests,
-		Namespace:        constants.SystemNamespace,
+		Namespace:        initOpts.Namespace,
 		DryRun:           initOpts.DryRun,
 		Sets:             initOpts.Sets,
 		Profile:          initOpts.Profile,

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -90,6 +90,9 @@ const (
 	// Allow appending manifests paths of manifests to keadm, separated by commas, another supported flag
 	Files = "files"
 
+	// Namespace sets the namespace of kubeedge will be installed
+	Namespace = "namespace"
+
 	// Dry-run flag
 	DryRun = "dry-run"
 


### PR DESCRIPTION
Signed-off-by: xin.li <xin.li@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

keadm: support --namespace flag to install kubeedge in other namespace

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
keadm: support --namespace flag to install kubeedge in other namespace
```
