### PR TITLE
drop initial tls options in Kubelet

### DIFF
--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -129,9 +129,6 @@ type TailoredKubeletFlag struct {
 	NodeIP string `json:"nodeIP,omitempty"`
 	// Container-runtime-specific options.
 	ContainerRuntimeOptions
-	// certDirectory is the directory where the TLS certs are located.
-	// If tlsCertFile and tlsPrivateKeyFile are provided, this flag will be ignored.
-	CertDirectory string `json:"certDirectory,omitempty"`
 	// rootDirectory is the directory path to place kubelet files (volume
 	// mounts,etc).
 	RootDirectory string `json:"rootDirectory,omitempty"`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:

Drop initial tls optoins in kubelet, otherwise it will generate useless kubelet.crt and kubelet.key in current direatory.

**Special notes for your reviewer**:

This pr needs to be merged after updating corresponding content in kubeedge/kubernetes.  You can review it first,
