### PR TITLE
local up cluster support edge list-watch

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -108,6 +108,10 @@ function start_cloudcore {
   if [[ "${PROTOCOL}" = "QUIC" ]]; then
     sed -i '/quic:/{n;N;s/false/true/;}' ${CLOUD_CONFIGFILE}
   fi
+
+  # enable dynamic controller
+  sed -i '/dynamicController:/{n;s/false/true/;}' ${CLOUD_CONFIGFILE}
+
   sed -i -e "s|kubeConfig: .*|kubeConfig: ${KUBECONFIG}|g" \
     -e "s|/var/lib/kubeedge/|/tmp&|g" \
     -e "s|/etc/|/tmp/etc/|g" \
@@ -130,6 +134,7 @@ function start_edgecore {
   ${EDGE_BIN} --defaultconfig >  ${EDGE_CONFIGFILE}
 
   sed -i '/edgeStream:/{n;s/false/true/;}' ${EDGE_CONFIGFILE}
+  sed -i '/metaServer:/{n;s/false/true/;}' ${EDGE_CONFIGFILE}
 
   if [[ "${PROTOCOL}" = "QUIC" ]]; then
     sed -i '/quic:/{n;s/false/true/;}' ${EDGE_CONFIGFILE}


### PR DESCRIPTION
Signed-off-by: wackxu <xushiwei5@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

local up cluster support for edge list-watch

This will be used for add E2E test for list watch, so add it in the local-up-cluster.sh 




```
root@wackxu-dev:~/gowork/src/github.com/kubeedge/kubeedge# curl -v -XGET  -H "Accept: application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json" -H "User-Agent: kubectl/v1.23.13 (linux/amd64) kubernetes/592eca0" 'http://127.0.0.1:10550/api/v1/configmaps?resourceVersion=740&watch=true'
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 10550 (#0)
> GET /api/v1/configmaps?resourceVersion=740&watch=true HTTP/1.1
> Host: 127.0.0.1:10550
> Accept: application/json;as=Table;v=v1;g=meta.k8s.io,application/json;as=Table;v=v1beta1;g=meta.k8s.io,application/json
> User-Agent: kubectl/v1.23.13 (linux/amd64) kubernetes/592eca0
> 
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Fri, 04 Nov 2022 06:51:34 GMT
< Transfer-Encoding: chunked
< 
{"type":"ADDED","object":{"apiVersion":"v1","data":{"Corefile":".:53 {\n    errors\n    health {\n       lameduck 5s\n    }\n    ready\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n       pods insecure\n       fallthrough in-addr.arpa ip6.arpa\n       ttl 30\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf {\n       max_concurrent 1000\n    }\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n"},"kind":"ConfigMap","metadata":{"creationTimestamp":"2022-11-04T06:33:32Z","managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:data":{".":{},"f:Corefile":{}}},"manager":"kubeadm","operation":"Update","time":"2022-11-04T06:33:32Z"}],"name":"coredns","namespace":"kube-system","resourceVersion":"249","uid":"ada399db-5314-41cf-97ff-17bbe8a1da66"}}}
{"type":"ADDED","object":{"apiVersion":"v1","kind":"ConfigMap","metadata":{"annotations":{"tunnelportrecord.kubeedge.io":"{\"ipTunnelPort\":{\"10.0.0.235\":10351},\"port\":{\"10351\":true}}"},"creationTimestamp":"2022-11-04T06:34:09Z","managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:tunnelportrecord.kubeedge.io":{}}}},"manager":"cloudcore","operation":"Update","time":"2022-11-04T06:34:09Z"}],"name":"tunnelport","namespace":"kubeedge","resourceVersion":"628","uid":"37d0a102-3162-4730-b4db-44144c72c0bb"}}}
{"type":"ADDED","object":{"apiVersion":"v1","data":{"ca.crt":"-----BEGIN CERTIFICATE-----\nMIIC5zCCAc+gAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl\ncm5ldGVzMB4XDTIyMTEwNDA2MzMwOVoXDTMyMTEwMTA2MzMwOVowFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALhJ\n+rUnYsP/HMEDieBNw2ENp7tUwpWXqkt6jO8+4A5p07u/8w4/bO5XUQf2FORizxJT\nDDtDR+hCyxiYrIw9jCjaknWC3rdGP7Rzz42vSJ65LKi2fFcUR6bMc9XcvtWkHGOy\nmCGJkc43XGy5enDN5aISByqg1UZ1QggODzTQu9crCPTVkIO0k2cYDho4569Q3zc1\nX4nWv+rzyg6ltJiRylu8xDls1kIzZ0T+UWEnw+voUncK/h3BpRWEMO4ESBM0/HBs\nwQznjHmK9TRT76YhLi32xOhlHUz5rrjIu2x8/BmUIg+NpSeTohBhbHRTMDbNae5+\nMG73CV6wDqLvFzazftkCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB\n/wQFMAMBAf8wHQYDVR0OBBYEFClaQQ9soFSs7JrAzNyHHbk3pdbRMA0GCSqGSIb3\nDQEBCwUAA4IBAQAPBydfuWp+bVKkINhwsG5V1usdHgF+CkaFje+J9uTwXUSXxM8p\nGPZTsTJVLwVor5xFzp4uTBIQMJWD8g9eSJbT3m4TbS0KQ0eM6+R5kXw9WDq4iI/a\nionFf7YYUmdEyr7rC0JtVE+nKK5+dVqPh0wjE9oZI3sU94FYjCEisBCZNvbZN0ho\nLGnLOQHHMNBax+QkoSI2Jpog1uhgaQGqWNM4TJYfo7XMSlBY01T3QCn2VU8I5P5o\nn6BHXe+diGA4mS/k1xwb+FM9qM+wMCcwWEQx6t6hNAqh2wPbKpWYRN7Jh4y1OBrf\nVGB2Se/9BDZZ1vcFNvOOh49oukbBMXMcg48Z\n-----END CERTIFICATE-----\n"},"kind":"ConfigMap","metadata":{"creationTimestamp":"2022-11-04T06:33:47Z","managedFields":[{"apiVersion":"v1","fieldsType":"FieldsV1","fieldsV1":{"f:data":{".":{},"f:ca.crt":{}}},"manager":"kube-controller-manager","operation":"Update","time":"2022-11-04T06:33:47Z"}],"name":"kube-root-ca.crt","namespace":"local-path-storage","resourceVersion":"420","uid":"3275599c-587e-47cf-8cc5-01872b764864"}}}
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
