### PR TITLE
set NodeStatusImage not to be reported

### DIFF
--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -48,6 +48,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 	in.Address = constants.ServerAddress
 	in.ReadOnlyPort = constants.ServerPort
 	in.ClusterDomain = constants.DefaultClusterDomain
+	in.NodeStatusMaxImages = utilpointer.Int32Ptr(0)
 	configv1beta1.SetDefaults_KubeletConfiguration(&in)
 
 	return &EdgeCoreConfig{
@@ -196,6 +197,7 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 	in.Address = constants.ServerAddress
 	in.ReadOnlyPort = constants.ServerPort
 	in.ClusterDomain = constants.DefaultClusterDomain
+	in.NodeStatusMaxImages = utilpointer.Int32Ptr(0)
 	configv1beta1.SetDefaults_KubeletConfiguration(&in)
 
 	return &EdgeCoreConfig{


### PR DESCRIPTION
**What type of PR is this?**

/kind feature



**What this PR does / why we need it**:

Set the default value of NodeStatusMaxImage zero, for we don't need to report node image info, which may affect message transmission performance. 

If you need to report this info, you can set the value of NodeStatusMaxImage in edgecore.yaml. 
