### PR TITLE
Fix the issues mentioned in bug #4388

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -121,22 +121,24 @@ func addForceOptionsFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 //AddInit2ToolsList reads the flagData (containing val and default val) and join options to fill the list of tools.
 func AddInit2ToolsList(toolList map[string]types.ToolsInstaller, initOpts *types.InitOptions) error {
 	var latestVersion string
-	var kubeedgeVersion string
-	for i := 0; i < util.RetryTimes; i++ {
-		version, err := util.GetLatestVersion()
-		if err != nil {
-			fmt.Println("Failed to get the latest KubeEdge release version, error: ", err)
-			continue
+	kubeedgeVersion := initOpts.KubeEdgeVersion
+	if kubeedgeVersion == "" {
+		for i := 0; i < util.RetryTimes; i++ {
+			version, err := util.GetLatestVersion()
+			if err != nil {
+				fmt.Println("Failed to get the latest KubeEdge release version, error: ", err)
+				continue
+			}
+			if len(version) > 0 {
+				kubeedgeVersion = strings.TrimPrefix(version, "v")
+				latestVersion = version
+				break
+			}
 		}
-		if len(version) > 0 {
-			kubeedgeVersion = strings.TrimPrefix(version, "v")
-			latestVersion = version
-			break
+		if len(latestVersion) == 0 {
+			kubeedgeVersion = types.DefaultKubeEdgeVersion
+			fmt.Println("Failed to get the latest KubeEdge release version, will use default version: ", kubeedgeVersion)
 		}
-	}
-	if len(latestVersion) == 0 {
-		kubeedgeVersion = types.DefaultKubeEdgeVersion
-		fmt.Println("Failed to get the latest KubeEdge release version, will use default version: ", kubeedgeVersion)
 	}
 
 	common := util.Common{

--- a/keadm/cmd/keadm/app/cmd/helm/installer.go
+++ b/keadm/cmd/keadm/app/cmd/helm/installer.go
@@ -365,6 +365,9 @@ func (cu *KubeCloudHelmInstTool) checkProfile(baseHelmRoot string) error {
 func (cu *KubeCloudHelmInstTool) handleProfile(profileValue string) error {
 	// the current version
 	currentVersion := cu.ToolVersion.String()
+	if !strings.HasPrefix(currentVersion, "v") {
+		currentVersion = "v" + currentVersion
+	}
 	switch cu.ProfileKey {
 	case VersionProfileKey:
 		if profileValue == "" {


### PR DESCRIPTION
Right now keadm try to get the latest version of cloudcore using url `https://kubeedge.io/latestversion` no matter which version is specified with `--kubeedge-version` flag. And I don't think --profile version=1.12.1 is the right way to install the version of cloudcore .

And when --profile iptablesmgr=external is set, keadm sets the wrong version of cloudcore to 1.12.0 instead of v1.12.0.

This PR is to fix #4388 