### PR TITLE
replaced io/ioutil with "os / io" package.

### DIFF
--- a/keadm/cmd/keadm/app/cmd/helm/installer.go
+++ b/keadm/cmd/keadm/app/cmd/helm/installer.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -261,7 +260,7 @@ func (cu *KubeCloudHelmInstTool) runHelmManifest(r *Renderer, stdout io.Writer) 
 	var buf bytes.Buffer
 	if cu.Manifests != "" {
 		for _, manifest := range strings.Split(cu.Manifests, ",") {
-			body, err := ioutil.ReadFile(manifest)
+			body, err := os.ReadFile(manifest)
 			if err != nil {
 				return fmt.Errorf("cannot open file %s, error: %s", manifest, err.Error())
 			}


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As of Go >=1.16, this function "ioutil.ReadFile" simply calls os.ReadFile.
We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil

