### PR TITLE
Make mosquitto image:tag can be easy replaced in future.

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -48,6 +48,7 @@ const (
 	DefaultEdgedMemoryCapacity         = 7852396000
 	DefaultRemoteRuntimeEndpoint       = "unix:///var/run/dockershim.sock"
 	DefaultRemoteImageEndpoint         = "unix:///var/run/dockershim.sock"
+	DefaultMosquittoImage              = "eclipse-mosquitto:1.6.15"
 	DefaultPodSandboxImage             = "kubeedge/pause:3.1"
 	DefaultImagePullProgressDeadline   = time.Minute
 	DefaultImageGCHighThreshold        = 80

--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 
+	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/image"
 )
 
@@ -151,7 +152,7 @@ func (runtime *DockerRuntime) RemoveMQTT() error {
 		All: true,
 	}
 	options.Filters = filters.NewArgs()
-	options.Filters.Add("ancestor", "eclipse-mosquitto:1.6.15")
+	options.Filters.Add("ancestor", constants.DefaultMosquittoImage)
 
 	mqttContainers, err := runtime.Client.ContainerList(runtime.ctx, options)
 	if err != nil {

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -18,6 +18,8 @@ package image
 
 import (
 	"strings"
+
+	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 const (
@@ -49,8 +51,8 @@ var edgeComponentSet = Set{
 }
 
 var edgeThirdPartySet = Set{
-	EdgeMQTT:  "eclipse-mosquitto:1.6.15",
-	EdgePause: "kubeedge/pause:3.1",
+	EdgeMQTT:  constants.DefaultMosquittoImage,
+	EdgePause: constants.DefaultPodSandboxImage,
 }
 
 func EdgeSet(imageRepository, version string) Set {

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -3,6 +3,8 @@ package image
 import (
 	"reflect"
 	"testing"
+
+	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 func TestEdgeSet(t *testing.T) {
@@ -23,8 +25,8 @@ func TestEdgeSet(t *testing.T) {
 			},
 			want: Set{
 				EdgeCore:  "kubeedge/installation-package:v1.9.1",
-				EdgeMQTT:  "eclipse-mosquitto:1.6.15",
-				EdgePause: "kubeedge/pause:3.1",
+				EdgeMQTT:  constants.DefaultMosquittoImage,
+				EdgePause: constants.DefaultPodSandboxImage,
 			},
 		},
 		{
@@ -35,8 +37,8 @@ func TestEdgeSet(t *testing.T) {
 			},
 			want: Set{
 				EdgeCore:  "kubeedge/installation-package",
-				EdgeMQTT:  "eclipse-mosquitto:1.6.15",
-				EdgePause: "kubeedge/pause:3.1",
+				EdgeMQTT:  constants.DefaultMosquittoImage,
+				EdgePause: constants.DefaultPodSandboxImage,
 			},
 		},
 		{
@@ -47,7 +49,7 @@ func TestEdgeSet(t *testing.T) {
 			},
 			want: Set{
 				EdgeCore:  "kubeedge-test/installation-package:v1.9.1",
-				EdgeMQTT:  "kubeedge-test/eclipse-mosquitto:1.6.15",
+				EdgeMQTT:  "kubeedge-test/" + constants.DefaultMosquittoImage,
 				EdgePause: "kubeedge-test/pause:3.1",
 			},
 		},
@@ -59,7 +61,7 @@ func TestEdgeSet(t *testing.T) {
 			},
 			want: Set{
 				EdgeCore:  "kubeedge-test/installation-package",
-				EdgeMQTT:  "kubeedge-test/eclipse-mosquitto:1.6.15",
+				EdgeMQTT:  "kubeedge-test/" + constants.DefaultMosquittoImage,
 				EdgePause: "kubeedge-test/pause:3.1",
 			},
 		},


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I search the [https://hub.docker.com/_/eclipse-mosquitto](https://hub.docker.com/_/eclipse-mosquitto) and [https://github.com/eclipse/mosquitto/tags](https://github.com/eclipse/mosquitto/tags)
now kubeedge adapt to mosquitto v1.6.15 , maybe will change in near future . 
So we should change 
`DefaultMosquittoImage              = "eclipse-mosquitto:1.6.15"`
replaced work will be easy.