### PR TITLE
drop useless parameters in kubelet flags

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -47,6 +47,7 @@ const (
 	BootstrapFile = "/etc/kubeedge/bootstrap-edgecore.conf"
 
 	// Edged
+	DefaultRootDir               = "/var/lib/edged"
 	DefaultDockerAddress         = "unix:///var/run/docker.sock"
 	DefaultRuntimeType           = "remote"
 	DefaultDockershimRootDir     = "/var/lib/dockershim"

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -47,8 +47,6 @@ const (
 	BootstrapFile = "/etc/kubeedge/bootstrap-edgecore.conf"
 
 	// Edged
-	DefaultKubeletConfig         = "/etc/kubeedge/config/kubeconfig"
-	DefaultRootDir               = "/var/lib/edged"
 	DefaultDockerAddress         = "unix:///var/run/docker.sock"
 	DefaultRuntimeType           = "remote"
 	DefaultDockershimRootDir     = "/var/lib/dockershim"

--- a/edge/pkg/edged/config/config.go
+++ b/edge/pkg/edged/config/config.go
@@ -28,7 +28,6 @@ func InitConfigure(e *v1alpha2.Edged) {
 }
 
 func ConvertConfigEdgedFlagToConfigKubeletFlag(in *v1alpha2.TailoredKubeletFlag, out *kubeletoptions.KubeletFlags) {
-	out.KubeConfig = in.KubeConfig
 	out.HostnameOverride = in.HostnameOverride
 	out.NodeIP = in.NodeIP
 	out.RootDirectory = in.RootDirectory

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -66,7 +66,6 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				Enable:                true,
 				TailoredKubeletConfig: &in,
 				TailoredKubeletFlag: TailoredKubeletFlag{
-					KubeConfig:       constants.DefaultKubeletConfig,
 					HostnameOverride: hostnameOverride,
 					NodeIP:           localIP,
 					ContainerRuntimeOptions: ContainerRuntimeOptions{
@@ -213,7 +212,6 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 				Enable:                true,
 				TailoredKubeletConfig: &in,
 				TailoredKubeletFlag: TailoredKubeletFlag{
-					KubeConfig:       constants.DefaultKubeletConfig,
 					HostnameOverride: hostnameOverride,
 					NodeIP:           localIP,
 					ContainerRuntimeOptions: ContainerRuntimeOptions{

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -170,15 +170,6 @@ type TailoredKubeletFlag struct {
 	ExperimentalNodeAllocatableIgnoreEvictionThreshold bool `json:"experimentalNodeAllocatableIgnoreEvictionThreshold,omitempty"`
 	// Node Labels are the node labels to add when registering the node in the cluster
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
-	// lockFilePath is the path that kubelet will use to as a lock file.
-	// It uses this file as a lock to synchronize with other kubelet processes
-	// that may be running.
-	LockFilePath string `json:"lockFilePath,omitempty"`
-	// ExitOnLockContention is a flag that signifies to the kubelet that it is running
-	// in "bootstrap" mode. This requires that 'LockFilePath' has been set.
-	// This will cause the kubelet to listen to inotify events on the lock file,
-	// releasing it and exiting when another process tries to open that file.
-	ExitOnLockContention bool `json:"exitOnLockContention,omitempty"`
 	// seccompProfileRoot is the directory path for seccomp profiles.
 	SeccompProfileRoot string `json:"seccompProfileRoot,omitempty"`
 	// DEPRECATED FLAGS

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -120,7 +120,6 @@ type Edged struct {
 }
 
 type TailoredKubeletFlag struct {
-	KubeConfig string `json:"kubeConfig,omitempty"`
 	// HostnameOverride is the hostname used to identify the kubelet instead
 	// of the actual hostname.
 	// default os.Hostname()

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -247,20 +247,6 @@ type ContainerRuntimeOptions struct {
 	// cache files
 	// default "/var/lib/cni/cache"
 	CNICacheDir string `json:"cniCacheDir,omitempty"`
-
-	// Image credential provider plugin options
-
-	// ImageCredentialProviderConfigFile is the path to the credential provider plugin config file.
-	// This config file is a specification for what credential providers are enabled and invokved
-	// by the kubelet. The plugin config should contain information about what plugin binary
-	// to execute and what container images the plugin should be called for.
-	// +optional
-	ImageCredentialProviderConfigFile string `json:"imageCredentialProviderConfigFile,omitempty"`
-	// ImageCredentialProviderBinDir is the path to the directory where credential provider plugin
-	// binaries exist. The name of each plugin binary is expected to match the name of the plugin
-	// specified in imageCredentialProviderConfigFile.
-	// +optional
-	ImageCredentialProviderBinDir string `json:"imageCredentialProviderBinDir,omitempty"`
 }
 
 // EdgeHub indicates the EdgeHub module config

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -136,10 +136,6 @@ type TailoredKubeletFlag struct {
 	// mounts,etc).
 	// default "/var/lib/edged"
 	RootDirectory string `json:"rootDirectory,omitempty"`
-	// The Kubelet will load its initial configuration from this file.
-	// The path may be absolute or relative; relative paths are under the Kubelet's current working directory.
-	// Omit this flag to use the combination of built-in default configuration values and flags.
-	KubeletConfigFile string `json:"kubeletConfigFile,omitempty"`
 	// registerNode enables automatic registration with the apiserver.
 	// default true
 	// DEPRECATED: This parameter should be set via the TailoredKubeletConfig


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

drop useless parameters in kubelet flags:
- kubeConfig.  For we use metaclient to replace kubeclient, no need to use kubeConfig to new kubeclient.
- kubeConfigFile. We don't need this way of loading parameters in KubeEdge.
- LockFilePath. No need to consider the scenario that multiple edgecore may run on same node.
- ImageCredentialProvider. Image Credential Provider plugin is not supported in KubeEdge currently.

**Special notes for your reviewer**:

This pr involves the API changes, need to be merged in next release version and wait for updating the kubernetes version.
