### PR TITLE
Extended EdgeApplication to select NodeGroups by label

### DIFF
--- a/build/crds/apps/apps_v1alpha1_edgeapplication.yaml
+++ b/build/crds/apps/apps_v1alpha1_edgeapplication.yaml
@@ -42,6 +42,94 @@ spec:
                 description: WorkloadScope represents which node groups the workload
                   will be deployed in.
                 properties:
+                  targetNodeGroupSelectors:
+                    description: TargetNodeGroupSelectors are used to select target
+                      node groups that have these labels.
+                    items:
+                      description: TargetNodeGroupSelector are used to select target
+                        node groups of workload to be deployed, including override
+                        rules to apply for this node groups.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels are used to select target node
+                            groups that have these labels.
+                          type: object
+                        overriders:
+                          description: Overriders represents the override rules that
+                            would apply on workload.
+                          properties:
+                            imageOverriders:
+                              description: ImageOverriders represents the rules dedicated
+                                to handling image overrides.
+                              items:
+                                description: ImageOverrider represents the rules dedicated
+                                  to handling image overrides.
+                                properties:
+                                  component:
+                                    description: 'Component is part of image name.
+                                      Basically we presume an image can be made of
+                                      ''[registry/]repository[:tag]''. The registry
+                                      could be: - k8s.gcr.io - fictional.registry.example:10443
+                                      The repository could be: - kube-apiserver -
+                                      fictional/nginx The tag cloud be: - latest -
+                                      v1.19.1 - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c'
+                                    enum:
+                                    - Registry
+                                    - Repository
+                                    - Tag
+                                    type: string
+                                  operator:
+                                    description: Operator represents the operator
+                                      which will apply on the image.
+                                    enum:
+                                    - add
+                                    - remove
+                                    - replace
+                                    type: string
+                                  predicate:
+                                    description: "Predicate filters images before
+                                      applying the rule. \n Defaults to nil, in that
+                                      case, the system will automatically detect image
+                                      fields if the resource type is Pod, ReplicaSet,
+                                      Deployment or StatefulSet by following rule:
+                                      \  - Pod: spec/containers/<N>/image   - ReplicaSet:
+                                      spec/template/spec/containers/<N>/image   -
+                                      Deployment: spec/template/spec/containers/<N>/image
+                                      \  - StatefulSet: spec/template/spec/containers/<N>/image
+                                      In addition, all images will be processed if
+                                      the resource object has more than one containers.
+                                      \n If not nil, only images matches the filters
+                                      will be processed."
+                                    properties:
+                                      path:
+                                        description: Path indicates the path of target
+                                          field
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  value:
+                                    description: Value to be applied to image. Must
+                                      not be empty when operator is 'add' or 'replace'.
+                                      Defaults to empty and ignored when operator
+                                      is 'remove'.
+                                    type: string
+                                required:
+                                - component
+                                - operator
+                                type: object
+                              type: array
+                            replicas:
+                              description: Replicas will override the replicas field
+                                of deployment
+                              type: integer
+                          type: object
+                      required:
+                      - matchLabels
+                      type: object
+                    type: array
                   targetNodeGroups:
                     description: TargetNodeGroups represents the target node groups
                       of workload to be deployed.

--- a/cloud/pkg/controllermanager/controllermanager.go
+++ b/cloud/pkg/controllermanager/controllermanager.go
@@ -59,7 +59,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager) error {
 		Client: cli,
 	}
 
-	edgeApplicationControllere := &edgeapplication.Controller{
+	edgeApplicationController := &edgeapplication.Controller{
 		Client:        cli,
 		Serializer:    Serializer,
 		StatusManager: statusmanager.NewStatusManager(ctx, mgr, cli, Serializer),
@@ -77,7 +77,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager) error {
 	if err := nodeGroupController.SetupWithManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to setup nodegroup controller, %v", err)
 	}
-	if err := edgeApplicationControllere.SetupWithManager(mgr); err != nil {
+	if err := edgeApplicationController.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("failed to setup edgeapplication controller, %v", err)
 	}
 	return nil

--- a/cloud/pkg/controllermanager/edgeapplication/statusmanager/reconciler.go
+++ b/cloud/pkg/controllermanager/edgeapplication/statusmanager/reconciler.go
@@ -68,7 +68,11 @@ func (r *statusReconciler) sync(ctx context.Context, edgeApp *appsv1alpha1.EdgeA
 		} else {
 			// Apply overriders to get the actual template that applied to
 			// each nodegroup. Currently, only NameOverrider is applied.
-			overrideInfos := utils.GetAllOverriders(edgeApp)
+			overrideInfos, err := utils.GetAllOverriders(ctx, edgeApp, r.Client)
+			if err != nil {
+				klog.Errorf("failed to get overriders for edgeApp %s/%s, %v", edgeApp.Namespace, edgeApp.Name, err)
+			}
+
 			for _, overrideInfo := range overrideInfos {
 				copy := tmpl.DeepCopy()
 				if err := r.Overrider.ApplyOverrides(copy, overrideInfo); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/imdario/mergo v0.3.12
 	github.com/kubeedge/beehive v0.0.0
 	github.com/kubeedge/viaduct v0.0.0
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1

--- a/manifests/charts/cloudcore/crds/apps_v1alpha1_edgeapplication.yaml
+++ b/manifests/charts/cloudcore/crds/apps_v1alpha1_edgeapplication.yaml
@@ -42,6 +42,94 @@ spec:
                 description: WorkloadScope represents which node groups the workload
                   will be deployed in.
                 properties:
+                  targetNodeGroupSelectors:
+                    description: TargetNodeGroupSelectors are used to select target
+                      node groups that have these labels.
+                    items:
+                      description: TargetNodeGroupSelector are used to select target
+                        node groups of workload to be deployed, including override
+                        rules to apply for this node groups.
+                      properties:
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: MatchLabels are used to select target node
+                            groups that have these labels.
+                          type: object
+                        overriders:
+                          description: Overriders represents the override rules that
+                            would apply on workload.
+                          properties:
+                            imageOverriders:
+                              description: ImageOverriders represents the rules dedicated
+                                to handling image overrides.
+                              items:
+                                description: ImageOverrider represents the rules dedicated
+                                  to handling image overrides.
+                                properties:
+                                  component:
+                                    description: 'Component is part of image name.
+                                      Basically we presume an image can be made of
+                                      ''[registry/]repository[:tag]''. The registry
+                                      could be: - k8s.gcr.io - fictional.registry.example:10443
+                                      The repository could be: - kube-apiserver -
+                                      fictional/nginx The tag cloud be: - latest -
+                                      v1.19.1 - @sha256:dbcc1c35ac38df41fd2f5e4130b32ffdb93ebae8b3dbe638c23575912276fc9c'
+                                    enum:
+                                    - Registry
+                                    - Repository
+                                    - Tag
+                                    type: string
+                                  operator:
+                                    description: Operator represents the operator
+                                      which will apply on the image.
+                                    enum:
+                                    - add
+                                    - remove
+                                    - replace
+                                    type: string
+                                  predicate:
+                                    description: "Predicate filters images before
+                                      applying the rule. \n Defaults to nil, in that
+                                      case, the system will automatically detect image
+                                      fields if the resource type is Pod, ReplicaSet,
+                                      Deployment or StatefulSet by following rule:
+                                      \  - Pod: spec/containers/<N>/image   - ReplicaSet:
+                                      spec/template/spec/containers/<N>/image   -
+                                      Deployment: spec/template/spec/containers/<N>/image
+                                      \  - StatefulSet: spec/template/spec/containers/<N>/image
+                                      In addition, all images will be processed if
+                                      the resource object has more than one containers.
+                                      \n If not nil, only images matches the filters
+                                      will be processed."
+                                    properties:
+                                      path:
+                                        description: Path indicates the path of target
+                                          field
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  value:
+                                    description: Value to be applied to image. Must
+                                      not be empty when operator is 'add' or 'replace'.
+                                      Defaults to empty and ignored when operator
+                                      is 'remove'.
+                                    type: string
+                                required:
+                                - component
+                                - operator
+                                type: object
+                              type: array
+                            replicas:
+                              description: Replicas will override the replicas field
+                                of deployment
+                              type: integer
+                          type: object
+                      required:
+                      - matchLabels
+                      type: object
+                    type: array
                   targetNodeGroups:
                     description: TargetNodeGroups represents the target node groups
                       of workload to be deployed.

--- a/pkg/apis/apps/v1alpha1/edgeapplication_types.go
+++ b/pkg/apis/apps/v1alpha1/edgeapplication_types.go
@@ -35,6 +35,21 @@ type WorkloadScope struct {
 	// TargetNodeGroups represents the target node groups of workload to be deployed.
 	// +optional
 	TargetNodeGroups []TargetNodeGroup `json:"targetNodeGroups,omitempty"`
+
+	// TargetNodeGroupSelectors are used to select target node groups that have these labels.
+	// +optional
+	TargetNodeGroupSelectors []TargetNodeGroupSelector `json:"targetNodeGroupSelectors,omitempty"`
+}
+
+// TargetNodeGroupSelector are used to select target node groups of workload to be deployed, including
+// override rules to apply for this node groups.
+type TargetNodeGroupSelector struct {
+
+	// MatchLabels are used to select target node groups that have these labels.
+	MatchLabels map[string]string `json:"matchLabels"`
+
+	// Overriders represents the override rules that would apply on workload.
+	Overriders Overriders `json:"overriders,omitempty"`
 }
 
 // TargetNodeGroup represents the target node group of workload to be deployed, including


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change

**What this PR does / why we need it**:

Motivation:

We have many independently operated nodes on which the same software stack, which consists of deployments and services, is to be rolled out. It is important that the corresponding services are only accessible locally on the devices.

This is currently realized by giving each individual node its own nodegroup and manually entering all nodegroups in the edge application. Accordingly, we always have a manual step as soon as a new nodegroup is added.

Using a label selector, we can label the new nodegroup and automatically receive the software stack without manual entry into the edgeapplication.

**Which issue(s) this PR fixes**:

Fixes #3959

**Does this PR introduce a user-facing change?**:

```release-note
Extended EdgeApplication to be able to select NodeGroups by label
```
