### PR TITLE
Fix e2e variable GOPATH not set

### DIFF
--- a/tests/e2e/scripts/execute.sh
+++ b/tests/e2e/scripts/execute.sh
@@ -22,6 +22,8 @@ cd $workdir
 curpath=$PWD
 echo $PWD
 
+GOPATH=${GOPATH:-$(go env GOPATH)}
+
 check_ginkgo_v2() {
     # check if ginkgo is installed
     which ginkgo &> /dev/null || (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
I try to run `make e2e` on my physical machine, but it reports an error like below.
```
# make e2e
tests/e2e/scripts/execute.sh
/root/go/src/github.com/kubeedge/kubeedge
ginkgo is not found, install first
cp: cannot stat '/bin/ginkgo': No such file or directory
Makefile:293: recipe for target 'e2e' failed
make: *** [e2e] Error 1
```
For go, GOPATH is not set as an environment variable, so it's better to get it using `go env GOPATH`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
