### PR TITLE
fix update-vendor-Licenses script

### DIFF
--- a/LICENSES/vendor/github.com/coreos/go-systemd/LICENSE
+++ b/LICENSES/vendor/github.com/coreos/go-systemd/LICENSE
@@ -1,9 +1,0 @@
-= vendor/github.com/coreos/go-systemd licensed under: =
-
-CoreOS Project
-Copyright 2018 CoreOS, Inc
-
-This product includes software developed at CoreOS, Inc.
-(http://www.coreos.com/).
-
-= vendor/github.com/coreos/go-systemd/v22/NOTICE 71fd50a7bd34670ef7cd3a7740046f77

--- a/hack/update-vendor-licenses.sh
+++ b/hack/update-vendor-licenses.sh
@@ -192,8 +192,10 @@ if [ -f "${LICENSE_ROOT}/LICENSE" ]; then
   mv "${TMP_LICENSE_FILE}" "${TMP_LICENSES_DIR}/LICENSE"
 fi
 
+# Capture all module dependencies
+modules=$(go list -m -json all | jq -r .Path | sort -f)
 # Loop through every vendored package
-for PACKAGE in $(go list -m -json all | jq -r .Path | sort -f); do
+for PACKAGE in ${modules}; do
   if [[ -e "staging/src/${PACKAGE}" ]]; then
     echo "${PACKAGE} is a staging package, skipping" >&2
     continue
@@ -202,31 +204,15 @@ for PACKAGE in $(go list -m -json all | jq -r .Path | sort -f); do
     echo "${PACKAGE} doesn't exist in ${DEPS_DIR}, skipping" >&2
     continue
   fi
-  # Skip a directory if 1) it has no files and 2) all the subdirectories contain a go.mod file.
-  misses_go_mod=false
-  DEPS_SUBDIR="${DEPS_DIR}/${PACKAGE}"
-  search_for_mods () {
-    if [[ -z "$(find "${DEPS_SUBDIR}/" -mindepth 1 -maxdepth 1 -type f)" ]]; then
-      while read -d "" -r SUBDIR; do
-          if [[ ! -e "${SUBDIR}/go.mod" ]]; then
-              DEPS_SUBDIR=${SUBDIR}
-              search_for_mods
-          fi
-      done < <(find "${DEPS_SUBDIR}/" -mindepth 1 -maxdepth 1 -type d -print0)
-    else
-      misses_go_mod=true
-    fi
-  }
-  search_for_mods
-  if [[ $misses_go_mod = false ]]; then
-      echo "${PACKAGE} has no files, skipping" >&2
+  # if there are no files vendored under this package...
+  if [[ -z "$(find "${DEPS_DIR}/${PACKAGE}" -mindepth 1 -maxdepth 1 -type f)" ]]; then
+    # and we have the same number of submodules as subdirectories...
+    if [[ "$(find "${DEPS_DIR}/${PACKAGE}/" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq "$(echo "${modules}" | grep -cE "^${PACKAGE}/")" ]]; then
+      echo "Only submodules of ${PACKAGE} are vendored, skipping" >&2
       continue
+    fi
   fi
-  if [[ "${PACKAGE}" = "go.etcd.io/etcd" ]]; then
-    # temporarily treat this way until find out a better rule
-    echo "${PACKAGE}, temporarily skipping" >&2
-    continue
-  fi
+  
   echo "${PACKAGE}"
 
   process_content "${PACKAGE}" LICENSE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When i try to update golang to 1.17 in #4427 , i found licence check cannot be passed.
it always report error `No license could be found for github.com/godbus/dbus - aborting.`

I found that we don't use `github.com/godbus/dbus`, but we use `github.com/godbus/dbus/v5`, so `vendor/github.com/godbus/dbus` directory only contains a `v5` subdirectory, we don't need to check package `github.com/godbus/dbus` licenses, we only need to check  `github.com/godbus/dbus/v5` licenses

So update update-vendor-licenses script, ref: https://github.com/kubernetes/kubernetes/blob/master/hack/update-vendor-licenses.sh
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
