### PR TITLE
migrate kubelet configuration to edged kubelet configuration

### DIFF
--- a/edge/pkg/edged/config/config.go
+++ b/edge/pkg/edged/config/config.go
@@ -2,10 +2,16 @@ package config
 
 import (
 	"sync"
+	"unsafe"
 
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/featuregate"
 	kubeletoptions "k8s.io/kubernetes/cmd/kubelet/app/options"
 	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
 )
@@ -25,6 +31,144 @@ func InitConfigure(e *v1alpha2.Edged) {
 			Edged: *e,
 		}
 	})
+}
+
+func ConvertEdgedKubeletConfigurationToConfigKubeletConfiguration(in *v1alpha2.TailoredKubeletConfiguration, out *kubeletconfig.KubeletConfiguration, s conversion.Scope) error {
+	out.SyncFrequency = in.SyncFrequency
+	out.Address = in.Address
+	out.ReadOnlyPort = in.ReadOnlyPort
+	if err := v1.Convert_Pointer_int32_To_int32(&in.RegistryPullQPS, &out.RegistryPullQPS, s); err != nil {
+		return err
+	}
+	out.RegistryBurst = in.RegistryBurst
+	if err := v1.Convert_Pointer_int32_To_int32(&in.EventRecordQPS, &out.EventRecordQPS, s); err != nil {
+		return err
+	}
+	out.EventBurst = in.EventBurst
+	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableDebuggingHandlers, &out.EnableDebuggingHandlers, s); err != nil {
+		return err
+	}
+	out.EnableContentionProfiling = in.EnableContentionProfiling
+	if err := v1.Convert_Pointer_int32_To_int32(&in.OOMScoreAdj, &out.OOMScoreAdj, s); err != nil {
+		return err
+	}
+	out.ClusterDomain = in.ClusterDomain
+	out.ClusterDNS = *(*[]string)(unsafe.Pointer(&in.ClusterDNS))
+	out.StreamingConnectionIdleTimeout = in.StreamingConnectionIdleTimeout
+	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
+	out.NodeStatusReportFrequency = in.NodeStatusReportFrequency
+	out.NodeLeaseDurationSeconds = in.NodeLeaseDurationSeconds
+	out.ImageMinimumGCAge = in.ImageMinimumGCAge
+	if err := v1.Convert_Pointer_int32_To_int32(&in.ImageGCHighThresholdPercent, &out.ImageGCHighThresholdPercent, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int32_To_int32(&in.ImageGCLowThresholdPercent, &out.ImageGCLowThresholdPercent, s); err != nil {
+		return err
+	}
+	out.VolumeStatsAggPeriod = in.VolumeStatsAggPeriod
+	out.KubeletCgroups = in.KubeletCgroups
+	out.SystemCgroups = in.SystemCgroups
+	out.CgroupRoot = in.CgroupRoot
+	if err := v1.Convert_Pointer_bool_To_bool(&in.CgroupsPerQOS, &out.CgroupsPerQOS, s); err != nil {
+		return err
+	}
+	out.CgroupDriver = in.CgroupDriver
+	out.CPUManagerPolicy = in.CPUManagerPolicy
+	out.CPUManagerPolicyOptions = *(*map[string]string)(unsafe.Pointer(&in.CPUManagerPolicyOptions))
+	out.CPUManagerReconcilePeriod = in.CPUManagerReconcilePeriod
+	out.MemoryManagerPolicy = in.MemoryManagerPolicy
+	out.TopologyManagerPolicy = in.TopologyManagerPolicy
+	out.TopologyManagerScope = in.TopologyManagerScope
+	out.QOSReserved = *(*map[string]string)(unsafe.Pointer(&in.QOSReserved))
+	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
+	out.HairpinMode = in.HairpinMode
+	out.MaxPods = in.MaxPods
+	out.PodCIDR = in.PodCIDR
+	if err := v1.Convert_Pointer_int64_To_int64(&in.PodPidsLimit, &out.PodPidsLimit, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_string_To_string(&in.ResolverConfig, &out.ResolverConfig, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.CPUCFSQuota, &out.CPUCFSQuota, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_v1_Duration_To_v1_Duration(&in.CPUCFSQuotaPeriod, &out.CPUCFSQuotaPeriod, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int32_To_int32(&in.NodeStatusMaxImages, &out.NodeStatusMaxImages, s); err != nil {
+		return err
+	}
+	out.MaxOpenFiles = in.MaxOpenFiles
+	out.ContentType = in.ContentType
+	if err := v1.Convert_Pointer_bool_To_bool(&in.SerializeImagePulls, &out.SerializeImagePulls, s); err != nil {
+		return err
+	}
+	out.EvictionHard = *(*map[string]string)(unsafe.Pointer(&in.EvictionHard))
+	out.EvictionSoft = *(*map[string]string)(unsafe.Pointer(&in.EvictionSoft))
+	out.EvictionSoftGracePeriod = *(*map[string]string)(unsafe.Pointer(&in.EvictionSoftGracePeriod))
+	out.EvictionPressureTransitionPeriod = in.EvictionPressureTransitionPeriod
+	out.EvictionMaxPodGracePeriod = in.EvictionMaxPodGracePeriod
+	out.EvictionMinimumReclaim = *(*map[string]string)(unsafe.Pointer(&in.EvictionMinimumReclaim))
+	out.PodsPerCore = in.PodsPerCore
+	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableControllerAttachDetach, &out.EnableControllerAttachDetach, s); err != nil {
+		return err
+	}
+	out.ProtectKernelDefaults = in.ProtectKernelDefaults
+	if err := v1.Convert_Pointer_bool_To_bool(&in.MakeIPTablesUtilChains, &out.MakeIPTablesUtilChains, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int32_To_int32(&in.IPTablesMasqueradeBit, &out.IPTablesMasqueradeBit, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_int32_To_int32(&in.IPTablesDropBit, &out.IPTablesDropBit, s); err != nil {
+		return err
+	}
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	if err := v1.Convert_Pointer_bool_To_bool(&in.FailSwapOn, &out.FailSwapOn, s); err != nil {
+		return err
+	}
+	out.MemorySwap.SwapBehavior = in.MemorySwap.SwapBehavior
+	out.ContainerLogMaxSize = in.ContainerLogMaxSize
+	if err := v1.Convert_Pointer_int32_To_int32(&in.ContainerLogMaxFiles, &out.ContainerLogMaxFiles, s); err != nil {
+		return err
+	}
+	out.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfig.ResourceChangeDetectionStrategy(in.ConfigMapAndSecretChangeDetectionStrategy)
+	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
+	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
+	out.ReservedSystemCPUs = in.ReservedSystemCPUs
+	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
+	out.SystemReservedCgroup = in.SystemReservedCgroup
+	out.KubeReservedCgroup = in.KubeReservedCgroup
+	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
+	out.AllowedUnsafeSysctls = *(*[]string)(unsafe.Pointer(&in.AllowedUnsafeSysctls))
+	out.VolumePluginDir = in.VolumePluginDir
+	out.KernelMemcgNotification = in.KernelMemcgNotification
+	if err := v1alpha1.Convert_v1alpha1_LoggingConfiguration_To_config_LoggingConfiguration(&in.Logging, &out.Logging, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableSystemLogHandler, &out.EnableSystemLogHandler, s); err != nil {
+		return err
+	}
+	out.ShutdownGracePeriod = in.ShutdownGracePeriod
+	out.ShutdownGracePeriodCriticalPods = in.ShutdownGracePeriodCriticalPods
+	out.ShutdownGracePeriodByPodPriority = *(*[]kubeletconfig.ShutdownGracePeriodByPodPriority)(unsafe.Pointer(&in.ShutdownGracePeriodByPodPriority))
+	out.ReservedMemory = *(*[]kubeletconfig.MemoryReservation)(unsafe.Pointer(&in.ReservedMemory))
+	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableProfilingHandler, &out.EnableProfilingHandler, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableDebugFlagsHandler, &out.EnableDebugFlagsHandler, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_Pointer_bool_To_bool(&in.SeccompDefault, &out.SeccompDefault, s); err != nil {
+		return err
+	}
+	out.MemoryThrottlingFactor = (*float64)(unsafe.Pointer(in.MemoryThrottlingFactor))
+	out.RegisterWithTaints = *(*[]corev1.Taint)(unsafe.Pointer(&in.RegisterWithTaints))
+	if err := v1.Convert_Pointer_bool_To_bool(&in.RegisterNode, &out.RegisterNode, s); err != nil {
+		return err
+	}
+	return nil
 }
 
 func ConvertConfigEdgedFlagToConfigKubeletFlag(in *v1alpha2.TailoredKubeletFlag, out *kubeletoptions.KubeletFlags) {

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -41,7 +41,6 @@ import (
 	kubeletoptions "k8s.io/kubernetes/cmd/kubelet/app/options"
 	"k8s.io/kubernetes/pkg/kubelet"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
-	kubeletconfigv1beta1 "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -143,10 +142,10 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 
 	var kubeletConfig kubeletconfig.KubeletConfiguration
 	var kubeletFlags kubeletoptions.KubeletFlags
-	err = kubeletconfigv1beta1.Convert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(edgedconfig.Config.TailoredKubeletConfig, &kubeletConfig, nil)
+	err = edgedconfig.ConvertEdgedKubeletConfigurationToConfigKubeletConfiguration(edgedconfig.Config.TailoredKubeletConfig, &kubeletConfig, nil)
 	if err != nil {
 		klog.ErrorS(err, "Failed to convert kubelet config")
-		return nil, fmt.Errorf("failed to construct kubelet dependencies")
+		return nil, fmt.Errorf("failed to construct kubelet configuration")
 	}
 	edgedconfig.ConvertConfigEdgedFlagToConfigKubeletFlag(&edgedconfig.Config.TailoredKubeletFlag, &kubeletFlags)
 	// Set Kubelet RegisterNode Parameter in KubeletConfiguration.

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubeedge/kubeedge/common/constants"
 	metaconfig "github.com/kubeedge/kubeedge/pkg/apis/componentconfig/meta/v1alpha1"
 	"github.com/kubeedge/kubeedge/pkg/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewDefaultEdgeCoreConfig returns a full EdgeCoreConfig object
@@ -35,7 +36,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 	localIP, _ := util.GetLocalIP(hostnameOverride)
 
 	defaultTailedKubeletConfig := TailoredKubeletConfiguration{}
-	SetDefaults_KubeletConfiguration(&defaultTailedKubeletConfig)
+	SetDefaultsKubeletConfiguration(&defaultTailedKubeletConfig)
 
 	return &EdgeCoreConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -174,7 +175,7 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 	localIP, _ := util.GetLocalIP(hostnameOverride)
 
 	defaultTailedKubeletConfig := TailoredKubeletConfiguration{}
-	SetDefaults_KubeletConfiguration(&defaultTailedKubeletConfig)
+	SetDefaultsKubeletConfiguration(&defaultTailedKubeletConfig)
 
 	return &EdgeCoreConfig{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -23,14 +23,10 @@ import (
 	"path/filepath"
 	"strconv"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
-	configv1beta1 "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1"
-	utilpointer "k8s.io/utils/pointer"
-
 	"github.com/kubeedge/kubeedge/common/constants"
 	metaconfig "github.com/kubeedge/kubeedge/pkg/apis/componentconfig/meta/v1alpha1"
 	"github.com/kubeedge/kubeedge/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewDefaultEdgeCoreConfig returns a full EdgeCoreConfig object
@@ -38,18 +34,8 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 	hostnameOverride := util.GetHostname()
 	localIP, _ := util.GetLocalIP(hostnameOverride)
 
-	in := kubeletconfigv1beta1.KubeletConfiguration{}
-	in.ContentType = "application/json"
-	in.ImageGCLowThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCLowThreshold)
-	in.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCHighThreshold)
-	in.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy
-	in.FailSwapOn = utilpointer.BoolPtr(false)
-	in.EnableServer = utilpointer.BoolPtr(false)
-	in.Address = constants.ServerAddress
-	in.ReadOnlyPort = constants.ServerPort
-	in.ClusterDomain = constants.DefaultClusterDomain
-	in.NodeStatusMaxImages = utilpointer.Int32Ptr(0)
-	configv1beta1.SetDefaults_KubeletConfiguration(&in)
+	defaultTailedKubeletConfig := TailoredKubeletConfiguration{}
+	SetDefaults_KubeletConfiguration(&defaultTailedKubeletConfig)
 
 	return &EdgeCoreConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -64,7 +50,7 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 		Modules: &Modules{
 			Edged: &Edged{
 				Enable:                true,
-				TailoredKubeletConfig: &in,
+				TailoredKubeletConfig: &defaultTailedKubeletConfig,
 				TailoredKubeletFlag: TailoredKubeletFlag{
 					KubeConfig:       constants.DefaultKubeletConfig,
 					HostnameOverride: hostnameOverride,
@@ -187,18 +173,8 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 	hostnameOverride := util.GetHostname()
 	localIP, _ := util.GetLocalIP(hostnameOverride)
 
-	in := kubeletconfigv1beta1.KubeletConfiguration{}
-	in.ContentType = "application/json"
-	in.ImageGCLowThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCLowThreshold)
-	in.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCHighThreshold)
-	in.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy
-	in.FailSwapOn = utilpointer.BoolPtr(false)
-	in.EnableServer = utilpointer.BoolPtr(false)
-	in.Address = constants.ServerAddress
-	in.ReadOnlyPort = constants.ServerPort
-	in.ClusterDomain = constants.DefaultClusterDomain
-	in.NodeStatusMaxImages = utilpointer.Int32Ptr(0)
-	configv1beta1.SetDefaults_KubeletConfiguration(&in)
+	defaultTailedKubeletConfig := TailoredKubeletConfiguration{}
+	SetDefaults_KubeletConfiguration(&defaultTailedKubeletConfig)
 
 	return &EdgeCoreConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -211,7 +187,7 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 		Modules: &Modules{
 			Edged: &Edged{
 				Enable:                true,
-				TailoredKubeletConfig: &in,
+				TailoredKubeletConfig: &defaultTailedKubeletConfig,
 				TailoredKubeletFlag: TailoredKubeletFlag{
 					KubeConfig:       constants.DefaultKubeletConfig,
 					HostnameOverride: hostnameOverride,

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
@@ -1,24 +1,40 @@
+/*
+Copyright 2022 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+@CHANGELOG
+KubeEdge Authors: To set default tailored kubelet configuration,
+This file is derived from K8S Kubelet apis code with reduced set of methods
+Changes done are
+1. Package edged got some functions from "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1"
+and made some variant
+*/
+
 package v1alpha2
 
 import (
-	"github.com/kubeedge/kubeedge/common/constants"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	configv1beta1 "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	utilpointer "k8s.io/utils/pointer"
-	"time"
-)
 
-const (
-	// TODO: Move these constants to k8s.io/kubelet/config/v1beta1 instead?
-	DefaultIPTablesMasqueradeBit = 14
-	DefaultIPTablesDropBit       = 15
-	DefaultVolumePluginDir       = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
-
-	// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2570-memory-qos
-	DefaultMemoryThrottlingFactor = 0.8
+	"github.com/kubeedge/kubeedge/common/constants"
 )
 
 var (
@@ -28,15 +44,8 @@ var (
 	DefaultNodeAllocatableEnforcement = []string{"pods"}
 )
 
-// DefaultEvictionHard includes default options for hard eviction.
-var DefaultEvictionHard = map[string]string{
-	"memory.available":  "100Mi",
-	"nodefs.available":  "10%",
-	"nodefs.inodesFree": "5%",
-	"imagefs.available": "15%",
-}
-
-func SetDefaults_KubeletConfiguration(obj *TailoredKubeletConfiguration) {
+// SetDefaultsKubeletConfiguration sets defaults for tailored kubelet configuration
+func SetDefaultsKubeletConfiguration(obj *TailoredKubeletConfiguration) {
 	obj.SyncFrequency = metav1.Duration{Duration: 1 * time.Minute}
 	obj.Address = constants.ServerAddress
 	obj.ReadOnlyPort = constants.ServerPort
@@ -66,32 +75,32 @@ func SetDefaults_KubeletConfiguration(obj *TailoredKubeletConfiguration) {
 	obj.HairpinMode = kubeletconfigv1beta1.PromiscuousBridge
 	obj.MaxPods = 110
 	// default nil or negative value to -1 (implies node allocatable pid limit)
-	temp := int64(-1)
-	obj.PodPidsLimit = &temp
-	obj.ResolverConfig = kubetypes.ResolvConfDefault
+	obj.PodPidsLimit = utilpointer.Int64(-1)
+	obj.ResolverConfig = utilpointer.String(kubetypes.ResolvConfDefault)
 	obj.CPUCFSQuota = utilpointer.BoolPtr(true)
 	obj.CPUCFSQuotaPeriod = &metav1.Duration{Duration: 100 * time.Millisecond}
 	obj.NodeStatusMaxImages = utilpointer.Int32Ptr(50)
 	obj.MaxOpenFiles = 1000000
 	obj.ContentType = "application/json"
 	obj.SerializeImagePulls = utilpointer.BoolPtr(true)
-	obj.EvictionHard = DefaultEvictionHard
+	obj.EvictionHard = configv1beta1.DefaultEvictionHard
 	obj.EvictionPressureTransitionPeriod = metav1.Duration{Duration: 5 * time.Minute}
 	obj.EnableControllerAttachDetach = utilpointer.BoolPtr(true)
 	obj.MakeIPTablesUtilChains = utilpointer.BoolPtr(true)
-	obj.IPTablesMasqueradeBit = utilpointer.Int32Ptr(DefaultIPTablesMasqueradeBit)
-	obj.IPTablesDropBit = utilpointer.Int32Ptr(DefaultIPTablesDropBit)
+	obj.IPTablesMasqueradeBit = utilpointer.Int32Ptr(configv1beta1.DefaultIPTablesMasqueradeBit)
+	obj.IPTablesDropBit = utilpointer.Int32Ptr(configv1beta1.DefaultIPTablesDropBit)
 	obj.FailSwapOn = utilpointer.BoolPtr(false)
 	obj.ContainerLogMaxSize = "10Mi"
 	obj.ContainerLogMaxFiles = utilpointer.Int32Ptr(5)
 	obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy
 	obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement
-	obj.VolumePluginDir = DefaultVolumePluginDir
+	obj.VolumePluginDir = configv1beta1.DefaultVolumePluginDir
 	// Use the Default LoggingConfiguration option
 	componentbaseconfigv1alpha1.RecommendedLoggingConfiguration(&obj.Logging)
 	obj.EnableSystemLogHandler = utilpointer.BoolPtr(true)
 	obj.EnableProfilingHandler = utilpointer.BoolPtr(true)
 	obj.EnableDebugFlagsHandler = utilpointer.BoolPtr(true)
 	obj.SeccompDefault = utilpointer.BoolPtr(false)
-	obj.MemoryThrottlingFactor = utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor)
+	obj.MemoryThrottlingFactor = utilpointer.Float64Ptr(configv1beta1.DefaultMemoryThrottlingFactor)
+	obj.RegisterNode = utilpointer.BoolPtr(true)
 }

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
@@ -1,0 +1,97 @@
+package v1alpha2
+
+import (
+	"github.com/kubeedge/kubeedge/common/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/kubernetes/pkg/kubelet/qos"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	utilpointer "k8s.io/utils/pointer"
+	"time"
+)
+
+const (
+	// TODO: Move these constants to k8s.io/kubelet/config/v1beta1 instead?
+	DefaultIPTablesMasqueradeBit = 14
+	DefaultIPTablesDropBit       = 15
+	DefaultVolumePluginDir       = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+
+	// See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2570-memory-qos
+	DefaultMemoryThrottlingFactor = 0.8
+)
+
+var (
+	zeroDuration = metav1.Duration{}
+	// TODO: Move these constants to k8s.io/kubelet/config/v1beta1 instead?
+	// Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node/node-allocatable.md) doc for more information.
+	DefaultNodeAllocatableEnforcement = []string{"pods"}
+)
+
+// DefaultEvictionHard includes default options for hard eviction.
+var DefaultEvictionHard = map[string]string{
+	"memory.available":  "100Mi",
+	"nodefs.available":  "10%",
+	"nodefs.inodesFree": "5%",
+	"imagefs.available": "15%",
+}
+
+func SetDefaults_KubeletConfiguration(obj *TailoredKubeletConfiguration) {
+	obj.SyncFrequency = metav1.Duration{Duration: 1 * time.Minute}
+	obj.Address = constants.ServerAddress
+	obj.ReadOnlyPort = constants.ServerPort
+	obj.ClusterDomain = constants.DefaultClusterDomain
+	obj.RegistryPullQPS = utilpointer.Int32Ptr(5)
+	obj.RegistryBurst = 10
+	obj.EnableDebuggingHandlers = utilpointer.BoolPtr(true)
+	obj.OOMScoreAdj = utilpointer.Int32Ptr(int32(qos.KubeletOOMScoreAdj))
+	obj.StreamingConnectionIdleTimeout = metav1.Duration{Duration: 4 * time.Hour}
+	obj.NodeStatusReportFrequency = metav1.Duration{Duration: 5 * time.Minute}
+	obj.NodeStatusUpdateFrequency = metav1.Duration{Duration: 10 * time.Second}
+	obj.NodeLeaseDurationSeconds = 40
+	obj.ImageMinimumGCAge = metav1.Duration{Duration: 2 * time.Minute}
+	// default is below docker's default dm.min_free_space of 90%
+	obj.ImageGCHighThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCHighThreshold)
+	obj.ImageGCLowThresholdPercent = utilpointer.Int32Ptr(constants.DefaultImageGCLowThreshold)
+	obj.VolumeStatsAggPeriod = metav1.Duration{Duration: time.Minute}
+	obj.CgroupsPerQOS = utilpointer.BoolPtr(true)
+	obj.CgroupDriver = "cgroupfs"
+	obj.CPUManagerPolicy = "none"
+	// Keep the same as default NodeStatusUpdateFrequency
+	obj.CPUManagerReconcilePeriod = metav1.Duration{Duration: 10 * time.Second}
+	obj.MemoryManagerPolicy = kubeletconfigv1beta1.NoneMemoryManagerPolicy
+	obj.TopologyManagerPolicy = kubeletconfigv1beta1.NoneTopologyManagerPolicy
+	obj.TopologyManagerScope = kubeletconfigv1beta1.ContainerTopologyManagerScope
+	obj.RuntimeRequestTimeout = metav1.Duration{Duration: 2 * time.Minute}
+	obj.HairpinMode = kubeletconfigv1beta1.PromiscuousBridge
+	obj.MaxPods = 110
+	// default nil or negative value to -1 (implies node allocatable pid limit)
+	temp := int64(-1)
+	obj.PodPidsLimit = &temp
+	obj.ResolverConfig = kubetypes.ResolvConfDefault
+	obj.CPUCFSQuota = utilpointer.BoolPtr(true)
+	obj.CPUCFSQuotaPeriod = &metav1.Duration{Duration: 100 * time.Millisecond}
+	obj.NodeStatusMaxImages = utilpointer.Int32Ptr(50)
+	obj.MaxOpenFiles = 1000000
+	obj.ContentType = "application/json"
+	obj.SerializeImagePulls = utilpointer.BoolPtr(true)
+	obj.EvictionHard = DefaultEvictionHard
+	obj.EvictionPressureTransitionPeriod = metav1.Duration{Duration: 5 * time.Minute}
+	obj.EnableControllerAttachDetach = utilpointer.BoolPtr(true)
+	obj.MakeIPTablesUtilChains = utilpointer.BoolPtr(true)
+	obj.IPTablesMasqueradeBit = utilpointer.Int32Ptr(DefaultIPTablesMasqueradeBit)
+	obj.IPTablesDropBit = utilpointer.Int32Ptr(DefaultIPTablesDropBit)
+	obj.FailSwapOn = utilpointer.BoolPtr(false)
+	obj.ContainerLogMaxSize = "10Mi"
+	obj.ContainerLogMaxFiles = utilpointer.Int32Ptr(5)
+	obj.ConfigMapAndSecretChangeDetectionStrategy = kubeletconfigv1beta1.GetChangeDetectionStrategy
+	obj.EnforceNodeAllocatable = DefaultNodeAllocatableEnforcement
+	obj.VolumePluginDir = DefaultVolumePluginDir
+	// Use the Default LoggingConfiguration option
+	componentbaseconfigv1alpha1.RecommendedLoggingConfiguration(&obj.Logging)
+	obj.EnableSystemLogHandler = utilpointer.BoolPtr(true)
+	obj.EnableProfilingHandler = utilpointer.BoolPtr(true)
+	obj.EnableDebugFlagsHandler = utilpointer.BoolPtr(true)
+	obj.SeccompDefault = utilpointer.BoolPtr(false)
+	obj.MemoryThrottlingFactor = utilpointer.Float64Ptr(DefaultMemoryThrottlingFactor)
+}

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/validation/validation_test.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/validation/validation_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
 )
@@ -92,7 +91,7 @@ func TestValidateModuleEdged(t *testing.T) {
 				TailoredKubeletFlag: v1alpha2.TailoredKubeletFlag{
 					HostnameOverride: "example.com",
 				},
-				TailoredKubeletConfig: &kubeletconfigv1beta1.KubeletConfiguration{
+				TailoredKubeletConfig: &v1alpha2.TailoredKubeletConfiguration{
 					CgroupDriver: "fake",
 				},
 			},
@@ -106,7 +105,7 @@ func TestValidateModuleEdged(t *testing.T) {
 				TailoredKubeletFlag: v1alpha2.TailoredKubeletFlag{
 					HostnameOverride: "Example%$#com",
 				},
-				TailoredKubeletConfig: &kubeletconfigv1beta1.KubeletConfiguration{
+				TailoredKubeletConfig: &v1alpha2.TailoredKubeletConfiguration{
 					CgroupDriver: v1alpha2.CGroupDriverCGroupFS,
 				},
 			},
@@ -119,7 +118,7 @@ func TestValidateModuleEdged(t *testing.T) {
 				TailoredKubeletFlag: v1alpha2.TailoredKubeletFlag{
 					HostnameOverride: "example.com",
 				},
-				TailoredKubeletConfig: &kubeletconfigv1beta1.KubeletConfiguration{
+				TailoredKubeletConfig: &v1alpha2.TailoredKubeletConfiguration{
 					CgroupDriver: v1alpha2.CGroupDriverCGroupFS,
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind api-change



**What this PR does / why we need it**:

In new feature  edged #4157 of v1.12 version, we import kubelet configuration directly. It is not convenient for us  to managing edged parameters, including tailoring, modification and defining. 

In next version, we will define a set of parameters `TailoredKubeletConfiguration` which KubeEdge need, this parameters are obtained by tailoring the Kubelet configuration and modified properly.


