### PR TITLE
fix 10s delay for edge request when the node is offline

### DIFF
--- a/edge/pkg/common/cloudconnection/cloud_connection.go
+++ b/edge/pkg/common/cloudconnection/cloud_connection.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudconnection
+
+import "sync"
+
+// constants for cloud connection
+const (
+	CloudConnected    = "cloud_connected"
+	CloudDisconnected = "cloud_disconnected"
+)
+
+var (
+	// isCloudConnected indicate Whether the connection was
+	// successfully established between edge and cloud
+	isCloudConnected = false
+
+	lock sync.RWMutex
+)
+
+// SetConnected set isCloudConnected value
+// true indicates edge and cloud establish connection successfully
+// false indicates edge and cloud connection interrupted.
+func SetConnected(isConnected bool) {
+	lock.Lock()
+	defer lock.Unlock()
+	isCloudConnected = isConnected
+}
+
+// IsConnected return isCloudConnected
+func IsConnected() bool {
+	lock.RLock()
+	defer lock.RUnlock()
+	return isCloudConnected
+}

--- a/edge/pkg/common/cloudconnection/cloud_connection.go
+++ b/edge/pkg/common/cloudconnection/cloud_connection.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package cloudconnection
 
-import "sync"
+import (
+	"errors"
+	"sync"
+)
 
 // constants for cloud connection
 const (
@@ -30,6 +33,9 @@ var (
 	isCloudConnected = false
 
 	lock sync.RWMutex
+
+	// ErrConnectionLost is sentinel err to indicates connection is lost between EdgeCore and CloudCore
+	ErrConnectionLost = errors.New("connection lost between EdgeCore and CloudCore")
 )
 
 // SetConnected set isCloudConnected value

--- a/edge/pkg/common/cloudconnection/cloudconstants.go
+++ b/edge/pkg/common/cloudconnection/cloudconstants.go
@@ -1,7 +1,0 @@
-package cloudconnection
-
-//constants for cloud connection
-const (
-	CloudConnected    = "cloud_connected"
-	CloudDisconnected = "cloud_disconnected"
-)

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -190,6 +190,9 @@ func (eh *EdgeHub) keepalive() {
 }
 
 func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
+	// update connected info
+	connect.SetConnected(isConnected)
+
 	// var info model.Message
 	content := connect.CloudConnected
 	if !isConnected {

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -18,10 +18,9 @@ import (
 )
 
 var groupMap = map[string]string{
-	"resource": modules.MetaGroup,
-	"twin":     modules.TwinGroup,
-	"func":     modules.MetaGroup,
-	"user":     modules.BusGroup,
+	"twin": modules.TwinGroup,
+	"func": modules.MetaGroup,
+	"user": modules.BusGroup,
 }
 
 var (

--- a/edge/pkg/metamanager/config/config.go
+++ b/edge/pkg/metamanager/config/config.go
@@ -10,10 +10,6 @@ import (
 var Config Configure
 var once sync.Once
 
-// Connected stands for whether it is connected
-// TODO need consider to add lock @kadisi
-var Connected = false
-
 type Configure struct {
 	v1alpha2.MetaManager
 }

--- a/edge/pkg/metamanager/metaserver/agent/agent_test.go
+++ b/edge/pkg/metamanager/metaserver/agent/agent_test.go
@@ -25,6 +25,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	commontypes "github.com/kubeedge/kubeedge/common/types"
+	connect "github.com/kubeedge/kubeedge/edge/pkg/common/cloudconnection"
 )
 
 func TestApplicationGC(t *testing.T) {
@@ -49,6 +50,8 @@ func TestApplicationGC(t *testing.T) {
 			}
 			ctx := apirequest.WithRequestInfo(context.Background(), requestInfo)
 			ctx = context.WithValue(ctx, commontypes.AuthorizationKey, "Bearer xxxx")
+
+			connect.SetConnected(true)
 
 			app, _ := a.Generate(ctx, "get", metav1.GetOptions{}, nil)
 			app.Close()

--- a/edge/pkg/metamanager/process_test.go
+++ b/edge/pkg/metamanager/process_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 
@@ -436,22 +435,13 @@ func TestProcessQuery(t *testing.T) {
 	}
 	beehiveContext.AddModule(edged)
 
-	//process remote query sync error case
-	msg := model.NewMessage("").BuildRouter(ModuleNameEdged, GroupResource, model.ResourceTypePodStatus, OperationNodeConnection).FillBody(connect.CloudConnected)
-	meta.processNodeConnection(*msg)
-	//wait for message to be received by metaManager and get processed
-	time.Sleep(1 * time.Second)
-	t.Run("ConnectedTrue", func(t *testing.T) {
-		if !metaManagerConfig.Connected {
-			t.Errorf("Connected was not set to true")
-		}
-	})
+	connect.SetConnected(true)
 
 	//process remote query jsonMarshall error
 	querySetterMock.EXPECT().All(gomock.Any()).Return(int64(1), errFailedDBOperation).Times(1)
 	querySetterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySetterMock).Times(1)
 	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySetterMock).Times(1)
-	msg = model.NewMessage("").BuildRouter(ModuleNameEdgeHub, GroupResource, "test/"+model.ResourceTypeConfigmap, model.QueryOperation)
+	msg := model.NewMessage("").BuildRouter(ModuleNameEdgeHub, GroupResource, "test/"+model.ResourceTypeConfigmap, model.QueryOperation)
 	meta.processQuery(*msg)
 	message, _ := beehiveContext.Receive(ModuleNameEdgeHub)
 	msg = model.NewMessage(message.GetID()).BuildRouter(ModuleNameEdgeHub, GroupResource, "test/"+model.ResourceTypeConfigmap, model.QueryOperation).FillBody(make(chan int))
@@ -551,50 +541,6 @@ func TestProcessQuery(t *testing.T) {
 		bytesGot, _ := json.Marshal(message.GetContent())
 		if string(bytesGot) != string(bytesWant) {
 			t.Errorf("Wrong message receive : Wanted %v and Got %v", want, message.GetContent())
-		}
-	})
-}
-
-// TestProcessNodeConnection is function to test processNodeConnection
-func TestProcessNodeConnection(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	ormerMock := beego.NewMockOrmer(mockCtrl)
-	dbm.DBAccess = ormerMock
-	meta := newMetaManager(true)
-	core.Register(meta)
-
-	add := &common.ModuleInfo{
-		ModuleName: meta.Name(),
-		ModuleType: common.MsgCtxTypeChannel,
-	}
-	beehiveContext.AddModule(add)
-	beehiveContext.AddModuleGroup(meta.Name(), meta.Group())
-	edgeHub := &common.ModuleInfo{
-		ModuleName: ModuleNameEdgeHub,
-		ModuleType: common.MsgCtxTypeChannel,
-	}
-	beehiveContext.AddModule(edgeHub)
-
-	//connected true
-	msg := model.NewMessage("").BuildRouter(ModuleNameEdgeHub, GroupResource, model.ResourceTypePodStatus, OperationNodeConnection).FillBody(connect.CloudConnected)
-	meta.processNodeConnection(*msg)
-	//wait for message to be received by metaManager and get processed
-	time.Sleep(1 * time.Second)
-	t.Run("ConnectedTrue", func(t *testing.T) {
-		if !metaManagerConfig.Connected {
-			t.Errorf("Connected was not set to true")
-		}
-	})
-
-	//connected false
-	msg = model.NewMessage("").BuildRouter(ModuleNameEdgeHub, GroupResource, model.ResourceTypePodStatus, OperationNodeConnection).FillBody(connect.CloudDisconnected)
-	meta.processNodeConnection(*msg)
-	//wait for message to be received by metaManager and get processed
-	time.Sleep(1 * time.Second)
-	t.Run("ConnectedFalse", func(t *testing.T) {
-		if metaManagerConfig.Connected {
-			t.Errorf("Connected was not set to false")
 		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
Add one of the following kinds:
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # part of #4423 

fix 10s delay for edge request when the node is offline

when the node if offline, the request for metaserver will generate the application and apply the application to the cloudcore, 
in the apply func, we use the sendSync function and will wait max time 10s to get the result

```
resp, err := beehiveContext.SendSync(edgemodule.EdgeHubModuleName, *msg, 10*time.Second)
```
but due to the network is lost between edgecore and cloudcore and the apply will spend 10s every time when process the request and this will affect code processing, such as edgemesh, will have a 10s deplay for get and list request when the node is offline. So if the node is offline, we do not generate the application since it is useless

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
