### PR TITLE
[Course Task] ut-nodestatus

### DIFF
--- a/edge/pkg/metamanager/client/nodestatus_test.go
+++ b/edge/pkg/metamanager/client/nodestatus_test.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	edgeapi "github.com/kubeedge/kubeedge/common/types"
+)
+
+type mockSender struct {
+	SendInterface
+}
+
+func (s *mockSender) SendSync(message *model.Message) (*model.Message, error) {
+	return &model.Message{}, nil
+}
+
+type mockErrorSender struct {
+	SendInterface
+}
+
+func (s *mockErrorSender) SendSync(message *model.Message) (*model.Message, error) {
+	return nil, errors.New("raise error")
+}
+
+func Test_nodeStatus_Update(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		send      SendInterface
+		rsName    string
+		ns        edgeapi.NodeStatusRequest
+		wantErr   bool
+	}{
+		{
+			name:      "base",
+			namespace: "default",
+			send:      &mockSender{},
+		},
+		{
+			name:      "send with error",
+			namespace: "default",
+			send:      &mockErrorSender{},
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &nodeStatus{
+				namespace: tt.namespace,
+				send:      tt.send,
+			}
+			if err := c.Update(tt.rsName, tt.ns); (err != nil) != tt.wantErr {
+				t.Errorf("nodeStatus.Update() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: xian-jie.shen <327411586@qq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind test
-->


**What this PR does / why we need it**:
ut

**Which issue(s) this PR fixes**:
[124](https://github.com/kubeedge/community/issues/124)

**Special notes for your reviewer**:
```sh
go test lease.go volumeattachment.go persistentvolumeclaim.go persistentvolume.go serviceaccount.go secret.go node.go configmap.go pod.go podstatus.go nodestatus.go nodestatus_test.go metaclient.go -v -cover -coverprofile=cover.out && go tool cover -func=cover.out && go tool cover -html=cover.out -o coverage.html
=== RUN   Test_nodeStatus_Update
=== RUN   Test_nodeStatus_Update/base
=== RUN   Test_nodeStatus_Update/send_with_error
--- PASS: Test_nodeStatus_Update (0.00s)
    --- PASS: Test_nodeStatus_Update/base (0.00s)
    --- PASS: Test_nodeStatus_Update/send_with_error (0.00s)
PASS
home/going/workspace/kubeedge/edge/pkg/metamanager/client/nodestatus.go:30:            newNodeStatus                                   0.0%
/home/going/workspace/kubeedge/edge/pkg/metamanager/client/nodestatus.go:37:            Create                                          0.0%
/home/going/workspace/kubeedge/edge/pkg/metamanager/client/nodestatus.go:41:            Update                                          100.0%
/home/going/workspace/kubeedge/edge/pkg/metamanager/client/nodestatus.go:52:            Delete                                          0.0%
/home/going/workspace/kubeedge/edge/pkg/metamanager/client/nodestatus.go:56:            Get                                             0.0%
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
