### PR TITLE
Use multiple goroutines to send watch events

### DIFF
--- a/cloud/pkg/common/messagelayer/context.go
+++ b/cloud/pkg/common/messagelayer/context.go
@@ -18,6 +18,7 @@ package messagelayer
 
 import (
 	"strings"
+	"sync"
 
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
@@ -71,35 +72,61 @@ func isRouterMsg(message model.Message) bool {
 	return len(resourceArray) == 2 && (resourceArray[0] == model.ResourceTypeRule || resourceArray[0] == model.ResourceTypeRuleEndpoint)
 }
 
+var (
+	edgeControllerOnce         sync.Once
+	edgeControllerMessageLayer MessageLayer
+
+	deviceControllerOnce         sync.Once
+	deviceControllerMessageLayer MessageLayer
+
+	dynamicControllerOnce         sync.Once
+	dynamicControllerMessageLayer MessageLayer
+
+	nodeUpgradeJobControllerOnce         sync.Once
+	nodeUpgradeJobControllerMessageLayer MessageLayer
+)
+
 func EdgeControllerMessageLayer() MessageLayer {
-	return &ContextMessageLayer{
-		SendModuleName:       modules.CloudHubModuleName,
-		SendRouterModuleName: modules.RouterModuleName,
-		ReceiveModuleName:    modules.EdgeControllerModuleName,
-		ResponseModuleName:   modules.CloudHubModuleName,
-	}
+	edgeControllerOnce.Do(func() {
+		edgeControllerMessageLayer = &ContextMessageLayer{
+			SendModuleName:       modules.CloudHubModuleName,
+			SendRouterModuleName: modules.RouterModuleName,
+			ReceiveModuleName:    modules.EdgeControllerModuleName,
+			ResponseModuleName:   modules.CloudHubModuleName,
+		}
+	})
+	return edgeControllerMessageLayer
 }
 
 func DeviceControllerMessageLayer() MessageLayer {
-	return &ContextMessageLayer{
-		SendModuleName:     modules.CloudHubModuleName,
-		ReceiveModuleName:  modules.DeviceControllerModuleName,
-		ResponseModuleName: modules.CloudHubModuleName,
-	}
+	deviceControllerOnce.Do(func() {
+		deviceControllerMessageLayer = &ContextMessageLayer{
+			SendModuleName:     modules.CloudHubModuleName,
+			ReceiveModuleName:  modules.DeviceControllerModuleName,
+			ResponseModuleName: modules.CloudHubModuleName,
+		}
+	})
+	return deviceControllerMessageLayer
 }
 
 func DynamicControllerMessageLayer() MessageLayer {
-	return &ContextMessageLayer{
-		SendModuleName:     modules.CloudHubModuleName,
-		ReceiveModuleName:  modules.DynamicControllerModuleName,
-		ResponseModuleName: modules.CloudHubModuleName,
-	}
+	dynamicControllerOnce.Do(func() {
+		dynamicControllerMessageLayer = &ContextMessageLayer{
+			SendModuleName:     modules.CloudHubModuleName,
+			ReceiveModuleName:  modules.DynamicControllerModuleName,
+			ResponseModuleName: modules.CloudHubModuleName,
+		}
+	})
+	return dynamicControllerMessageLayer
 }
 
 func NodeUpgradeJobControllerMessageLayer() MessageLayer {
-	return &ContextMessageLayer{
-		SendModuleName:     modules.CloudHubModuleName,
-		ReceiveModuleName:  modules.NodeUpgradeJobControllerModuleName,
-		ResponseModuleName: modules.CloudHubModuleName,
-	}
+	nodeUpgradeJobControllerOnce.Do(func() {
+		nodeUpgradeJobControllerMessageLayer = &ContextMessageLayer{
+			SendModuleName:     modules.CloudHubModuleName,
+			ReceiveModuleName:  modules.NodeUpgradeJobControllerModuleName,
+			ResponseModuleName: modules.CloudHubModuleName,
+		}
+	})
+	return nodeUpgradeJobControllerMessageLayer
 }

--- a/cloud/pkg/dynamiccontroller/application/application.go
+++ b/cloud/pkg/dynamiccontroller/application/application.go
@@ -368,7 +368,7 @@ func (c *Center) getWatchDiff(allWatchAppInEdge map[string]metaserver.Applicatio
 	for ID, listener := range listenerInCloud {
 		if _, exist := allWatchAppInEdge[ID]; !exist {
 			removedListeners = append(removedListeners, listener)
-			klog.Infof("need removed listener %s", listener.id)
+			klog.Infof("need removed listener %s", listener.ID)
 		}
 	}
 

--- a/cloud/pkg/dynamiccontroller/application/listener_manager.go
+++ b/cloud/pkg/dynamiccontroller/application/listener_manager.go
@@ -47,19 +47,19 @@ func (lm *listenerManager) AddListener(listener *SelectorListener) {
 	lm.lock.Lock()
 	defer lm.lock.Unlock()
 
-	klog.Infof("add listener %s node %s", listener.id, listener.nodeName)
+	klog.Infof("add listener %s node %s", listener.ID, listener.nodeName)
 
 	_, exists := lm.listenerByNodeID[listener.nodeName]
 	if !exists {
 		lm.listenerByNodeID[listener.nodeName] = map[string]*SelectorListener{}
 	}
-	lm.listenerByNodeID[listener.nodeName][listener.id] = listener
+	lm.listenerByNodeID[listener.nodeName][listener.ID] = listener
 
 	_, exists = lm.listenerByGVR[listener.gvr]
 	if !exists {
 		lm.listenerByGVR[listener.gvr] = map[string]*SelectorListener{}
 	}
-	lm.listenerByGVR[listener.gvr][listener.id] = listener
+	lm.listenerByGVR[listener.gvr][listener.ID] = listener
 }
 
 func (lm *listenerManager) DeleteListener(listener *SelectorListener) {
@@ -68,7 +68,7 @@ func (lm *listenerManager) DeleteListener(listener *SelectorListener) {
 
 	listeners, exists := lm.listenerByNodeID[listener.nodeName]
 	if exists {
-		delete(listeners, listener.id)
+		delete(listeners, listener.ID)
 		if len(lm.listenerByNodeID[listener.nodeName]) == 0 {
 			delete(lm.listenerByNodeID, listener.nodeName)
 		}
@@ -76,7 +76,7 @@ func (lm *listenerManager) DeleteListener(listener *SelectorListener) {
 
 	listeners, exists = lm.listenerByGVR[listener.gvr]
 	if exists {
-		delete(listeners, listener.id)
+		delete(listeners, listener.ID)
 		if len(lm.listenerByGVR[listener.gvr]) == 0 {
 			delete(lm.listenerByGVR, listener.gvr)
 		}

--- a/cloud/pkg/dynamiccontroller/application/listener_manager_test.go
+++ b/cloud/pkg/dynamiccontroller/application/listener_manager_test.go
@@ -58,8 +58,8 @@ func TestAddGetListener(t *testing.T) {
 	}
 
 	expected := map[string]*SelectorListener{
-		listener1.id: listener1,
-		listener2.id: listener2,
+		listener1.ID: listener1,
+		listener2.ID: listener2,
 	}
 
 	if !reflect.DeepEqual(expected, listenerByGVR) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
In the old code implementation, we use a goroutine to send watch eventsg to each listener, which has low processing efficiency and high latency, and if a listener processes slowly, other listeners will be affected. In the new implementation, Every listener use its input channel and one goroutine to send watch event and it will improve processing efficiency

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # part of #4423

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
