### PR TITLE
[Course Task] ut-edge-config-helper

### DIFF
--- a/pkg/apis/componentconfig/edgecore/v1alpha2/helper_test.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/helper_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEdgeCoreConfig_Parse(t *testing.T) {
+	// unmarshal
+	f, _ := os.CreateTemp(os.TempDir(), "config.yaml")
+	_, _ = f.WriteString("aaa")
+	// marshal
+	conf := EdgeCoreConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "test",
+		},
+	}
+	out, _ := yaml.Marshal(conf)
+	f2, _ := os.CreateTemp(os.TempDir(), "config2.yaml")
+	_, _ = f2.WriteString(string(out))
+	defer func() {
+		f.Close()
+		f2.Close()
+		os.Remove(f.Name())
+		os.Remove(f2.Name())
+	}()
+
+	tests := []struct {
+		name         string
+		TypeMeta     metav1.TypeMeta
+		DataBase     *DataBase
+		Modules      *Modules
+		FeatureGates map[string]bool
+		filename     string
+		wantErr      bool
+	}{
+		{
+			name:     "base",
+			filename: "notexist",
+			wantErr:  true,
+		},
+		{
+			name:     "file exist but cannot unmarshal content",
+			filename: f.Name(),
+			wantErr:  true,
+		},
+		{
+			name:     "file exist and can marshal properly",
+			TypeMeta: metav1.TypeMeta{Kind: "test"},
+			filename: f2.Name(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &EdgeCoreConfig{
+				TypeMeta:     tt.TypeMeta,
+				DataBase:     tt.DataBase,
+				Modules:      tt.Modules,
+				FeatureGates: tt.FeatureGates,
+			}
+			if err := c.Parse(tt.filename); (err != nil) != tt.wantErr {
+				t.Errorf("EdgeCoreConfig.Parse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: xian-jie.shen <327411586@qq.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind test
-->


**What this PR does / why we need it**:
ut

**Which issue(s) this PR fixes**:
[126](https://github.com/kubeedge/community/issues/126)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
none

```release-note
go test types.go helper_test.go helper.go -v -cover -coverprofile=cover.out && go tool cover -func=cover.out && go tool cover -html=cover.out -o coverage.html
=== RUN   TestEdgeCoreConfig_Parse
=== RUN   TestEdgeCoreConfig_Parse/base
E1216 21:16:07.576249 2600035 helper.go:29] Failed to read configfile notexist: open notexist: no such file or directory
=== RUN   TestEdgeCoreConfig_Parse/file_exist_but_cannot_unmarshal_content
E1216 21:16:07.602321 2600035 helper.go:34] Failed to unmarshal configfile /tmp/config.yaml1495768119: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1alpha2.EdgeCoreConfig
=== RUN   TestEdgeCoreConfig_Parse/file_exist_and_can_marshal_properly
--- PASS: TestEdgeCoreConfig_Parse (0.03s)
    --- PASS: TestEdgeCoreConfig_Parse/base (0.00s)
    --- PASS: TestEdgeCoreConfig_Parse/file_exist_but_cannot_unmarshal_content (0.01s)
    --- PASS: TestEdgeCoreConfig_Parse/file_exist_and_can_marshal_properly (0.00s)
PASS
coverage: 100.0% of statements
ok      command-line-arguments  0.092s  coverage: 100.0% of statements
/home/going/workspace/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2/helper.go:26: Parse           100.0%
total:                                                                                  (statements)    100.0%
```
