### PR TITLE
ignore kube-proxy environment checking

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -154,7 +154,8 @@ func environmentCheck() error {
 		case "kubelet": // if kubelet is running, return error
 			return errors.New("kubelet should not running on edge node when running edgecore")
 		case "kube-proxy": // if kube-proxy is running, return error
-			return errors.New("kube-proxy should not running on edge node when running edgecore")
+			klog.Warningf("kube-proxy is running on edge node, please make sure the kube-proxy is running in the right mode")
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
If we launch an edge node and then restart it, an error occurs:
```
failed to check the running environment: kube-proxy should not running on edge node when running edgecore
```
because pod `kube-proxy` will be launched on every node if there is a deamonset in the K8s cluster.

So, it would be more kind to log a warning rather than exit the edgecore process.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
