### PR TITLE
Change eventbus to eventBus

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -77,7 +77,7 @@ NA
 
 ### Other Notable Changes
 
-- Eventbus add tls config when connect to mqtt ([#2109](https://github.com/kubeedge/kubeedge/pull/2109), [@lvchenggang](https://github.com/lvchenggang))
+- EventBus add tls config when connect to mqtt ([#2109](https://github.com/kubeedge/kubeedge/pull/2109), [@lvchenggang](https://github.com/lvchenggang))
 - Add zero judgment when pods is obtained from the cache ([#2115](https://github.com/kubeedge/kubeedge/pull/2115), [@XiaoJiangWang](https://github.com/XiaoJiangWang))
 - Add metrics api support in streamserver ([#2125](https://github.com/kubeedge/kubeedge/pull/2125), [@luogangyi](https://github.com/luogangyi))
 - Support config domain URL for cloudcore ([#2126](https://github.com/kubeedge/kubeedge/pull/2126), [@ls889](https://github.com/ls889))

--- a/tests/e2e/utils/rule.go
+++ b/tests/e2e/utils/rule.go
@@ -16,18 +16,18 @@ import (
 func NewRule(sourceType, targetType rulesv1.RuleEndpointTypeDef) *rulesv1.Rule {
 	switch {
 	case sourceType == rulesv1.RuleEndpointTypeRest && targetType == rulesv1.RuleEndpointTypeEventBus:
-		return NewRest2EventbusRule()
+		return NewRest2EventBusRule()
 	case sourceType == rulesv1.RuleEndpointTypeEventBus && targetType == rulesv1.RuleEndpointTypeRest:
-		return NewEventbus2RestRule()
+		return NewEventBus2RestRule()
 	case sourceType == rulesv1.RuleEndpointTypeRest && targetType == rulesv1.RuleEndpointTypeServiceBus:
-		return NewRest2ServicebusRule()
+		return NewRest2ServiceBusRule()
 	case sourceType == rulesv1.RuleEndpointTypeServiceBus && targetType == rulesv1.RuleEndpointTypeRest:
-		return NewServicebus2Rest()
+		return NewServiceBus2Rest()
 	}
 	return nil
 }
 
-func NewEventbus2RestRule() *rulesv1.Rule {
+func NewEventBus2RestRule() *rulesv1.Rule {
 	rule := rulesv1.Rule{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Rule",
@@ -55,7 +55,7 @@ func NewEventbus2RestRule() *rulesv1.Rule {
 	return &rule
 }
 
-func NewRest2EventbusRule() *rulesv1.Rule {
+func NewRest2EventBusRule() *rulesv1.Rule {
 	rule := rulesv1.Rule{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Rule",
@@ -82,7 +82,7 @@ func NewRest2EventbusRule() *rulesv1.Rule {
 	return &rule
 }
 
-func NewRest2ServicebusRule() *rulesv1.Rule {
+func NewRest2ServiceBusRule() *rulesv1.Rule {
 	rule := rulesv1.Rule{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Rule",
@@ -109,7 +109,7 @@ func NewRest2ServicebusRule() *rulesv1.Rule {
 	return &rule
 }
 
-func NewServicebus2Rest() *rulesv1.Rule {
+func NewServiceBus2Rest() *rulesv1.Rule {
 	rule := rulesv1.Rule{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "Rule",
@@ -167,7 +167,7 @@ func newRestRuleEndpoint() *rulesv1.RuleEndpoint {
 }
 
 func newEventBusRuleEndpoint() *rulesv1.RuleEndpoint {
-	eventbusRuleEndpoint := rulesv1.RuleEndpoint{
+	eventBusRuleEndpoint := rulesv1.RuleEndpoint{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "RuleEndpoint",
 			APIVersion: "rules.kubeedge.io/v1",
@@ -180,11 +180,11 @@ func newEventBusRuleEndpoint() *rulesv1.RuleEndpoint {
 			RuleEndpointType: rulesv1.RuleEndpointTypeEventBus,
 		},
 	}
-	return &eventbusRuleEndpoint
+	return &eventBusRuleEndpoint
 }
 
 func newServiceBusRuleEndpoint() *rulesv1.RuleEndpoint {
-	servicebusRuleEndpoint := rulesv1.RuleEndpoint{
+	serviceBusRuleEndpoint := rulesv1.RuleEndpoint{
 		TypeMeta: v1.TypeMeta{
 			Kind:       "RuleEndpoint",
 			APIVersion: "rules.kubeedge.io/v1",
@@ -199,7 +199,7 @@ func newServiceBusRuleEndpoint() *rulesv1.RuleEndpoint {
 				"service_port": "9000"},
 		},
 	}
-	return &servicebusRuleEndpoint
+	return &serviceBusRuleEndpoint
 }
 
 func ListRule(c edgeclientset.Interface, ns string) ([]rulesv1.Rule, error) {


### PR DESCRIPTION
Signed-off-by: zhuzhenghao <zhenghao.zhu@daocloud.io>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The correct camelCase version of "eventbus" would be "eventBus". 

FYI:https://github.com/greenrobot/EventBus/blob/1d995077d0b620a6aae9c60a8b96443113752305/EventBusTestJava/src/main/java/org/greenrobot/eventbus/EventBusStickyEventTest.java#L61

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
