### PR TITLE
k8s: Add node-role.kubernetes.io/control-plane taint

### DIFF
--- a/build/controllermanager/controllermanager-deploy.yaml
+++ b/build/controllermanager/controllermanager-deploy.yaml
@@ -34,3 +34,6 @@ spec:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"
           effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"

--- a/build/iptablesmanager/iptablesmanager-ds.yaml
+++ b/build/iptablesmanager/iptablesmanager-ds.yaml
@@ -24,6 +24,8 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/master
                 operator: Exists
+              - key: node-role.kubernetes.io/control-plane
+                effect: Exists
       restartPolicy: Always
       containers:
         - name: iptables-manager

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -122,6 +122,9 @@ controllerManager:
     - key: "node-role.kubernetes.io/master"
       operator: "Exists"
       effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
   nodeSelector: {}
   resources:
     limits:

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -117,6 +117,9 @@ controllerManager:
     - key: "node-role.kubernetes.io/master"
       operator: "Exists"
       effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
   nodeSelector: {}
   resources:
     limits:


### PR DESCRIPTION
`node-role.kubernetes.io/master` has been deprecated from 1.20, and replaced by `node-role.kubernetes.io/control-plane.`

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/76980726/210052466-e27e0dd4-67f2-4d64-9ac4-4add402062b9.png">
