### PR TITLE
fix comfigmap/secret optional error

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -375,6 +375,11 @@ func noAckRequired(msg *beehivemodel.Message) bool {
 		if ok && content == commonconst.MessageSuccessfulContent {
 			return true
 		}
+		// `error message` is not required to ack
+		_, ok = msg.Content.(error)
+		if ok {
+			return true
+		}
 		fallthrough
 	default:
 		if msg.GetSource() == modules.EdgeControllerModuleName {

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dispatcher
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -72,11 +73,6 @@ func TestNoAckRequired(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "applicationResponse message",
-			message: beehivemodel.NewMessage("").SetResourceOperation("/node/edge-test/ignore/Application/ignore", "applicationResponse"),
-			want:    true,
-		},
-		{
 			name:    "user data message",
 			message: beehivemodel.NewMessage("router").SetRoute("", "user"),
 			want:    true,
@@ -87,13 +83,13 @@ func TestNoAckRequired(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "response ok message",
-			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/node/edge-node", "response").FillBody("OK"),
+			name:    "node message",
+			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/node/edge-node", "response").SetRoute("edgecontroller", "resource"),
 			want:    true,
 		},
 		{
-			name:    "node message",
-			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/node/edge-node", "response").SetRoute("edgecontroller", "resource"),
+			name:    "response error message",
+			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/node/edge-node", "response").FillBody(fmt.Errorf("error")),
 			want:    true,
 		},
 		{

--- a/edge/pkg/metamanager/client/configmap.go
+++ b/edge/pkg/metamanager/client/configmap.go
@@ -56,7 +56,10 @@ func (c *configMaps) Get(name string) (*api.ConfigMap, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get configmap from metaManager failed, err: %v", err)
 	}
-
+	errContent, ok := msg.GetContent().(error)
+	if ok {
+		return nil, errContent
+	}
 	content, err := msg.GetContentData()
 	if err != nil {
 		return nil, fmt.Errorf("parse message to configmap failed, err: %v", err)

--- a/edge/pkg/metamanager/client/secret.go
+++ b/edge/pkg/metamanager/client/secret.go
@@ -55,7 +55,10 @@ func (c *secrets) Get(name string) (*api.Secret, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get secret from metaManager failed, err: %v", err)
 	}
-
+	errContent, ok := msg.GetContent().(error)
+	if ok {
+		return nil, errContent
+	}
 	content, err := msg.GetContentData()
 	if err != nil {
 		return nil, fmt.Errorf("parse message to secret failed, err: %v", err)

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -44,6 +44,13 @@ func feedbackError(err error, info string, request model.Message) {
 	}
 }
 
+func feedbackResponse(message *model.Message, parentID string, resp *model.Message) {
+	resp.BuildHeader(resp.GetID(), parentID, resp.GetTimestamp())
+	sendToEdged(resp, message.IsSync())
+	respToCloud := message.NewRespByMessage(resp, OK)
+	sendToCloud(respToCloud)
+}
+
 func sendToEdged(message *model.Message, sync bool) {
 	if sync {
 		beehiveContext.SendResp(*message)
@@ -413,7 +420,12 @@ func (m *metaManager) processRemoteQuery(message model.Message) {
 			feedbackError(err, "Error to query meta in DB", message)
 			return
 		}
-
+		errContent, ok := resp.GetContent().(error)
+		if ok {
+			klog.V(4).Infof("process remote query err: %v", errContent)
+			feedbackResponse(&message, originalID, &resp)
+			return
+		}
 		klog.V(4).Infof("process remote query: req[%s], resp[%s]", msgDebugInfo(&message), msgDebugInfo(&resp))
 		content, err := resp.GetContentData()
 		if err != nil {
@@ -437,12 +449,7 @@ func (m *metaManager) processRemoteQuery(message model.Message) {
 		if err != nil {
 			klog.Errorf("update meta failed, %s", msgDebugInfo(&resp))
 		}
-		resp.BuildHeader(resp.GetID(), originalID, resp.GetTimestamp())
-
-		sendToEdged(&resp, message.IsSync())
-
-		respToCloud := message.NewRespByMessage(&resp, OK)
-		sendToCloud(respToCloud)
+		feedbackResponse(&message, originalID, &resp)
 	}()
 }
 

--- a/edge/pkg/metamanager/process_test.go
+++ b/edge/pkg/metamanager/process_test.go
@@ -464,6 +464,28 @@ func TestProcessQuery(t *testing.T) {
 		}
 	})
 
+	//process remote query response error content
+	querySetterMock.EXPECT().All(gomock.Any()).Return(int64(1), errFailedDBOperation).Times(1)
+	querySetterMock.EXPECT().Filter(gomock.Any(), gomock.Any()).Return(querySetterMock).Times(1)
+	ormerMock.EXPECT().QueryTable(gomock.Any()).Return(querySetterMock).Times(1)
+	msg = model.NewMessage("").BuildRouter(ModuleNameEdgeHub, GroupResource, "test/"+model.ResourceTypeConfigmap, model.QueryOperation)
+	meta.processQuery(*msg)
+	message, _ = beehiveContext.Receive(ModuleNameEdgeHub)
+	msg = model.NewMessage(message.GetID()).BuildRouter(ModuleNameEdgeHub, GroupResource, "test/"+model.ResourceTypeConfigmap, model.QueryOperation).FillBody(fmt.Errorf("test"))
+	beehiveContext.SendResp(*msg)
+	message, _ = beehiveContext.Receive(ModuleNameEdgeHub)
+	msgEdged, _ := beehiveContext.Receive(ModuleNameEdged)
+	t.Run("ProcessRemoteQueryResponseErrorContent", func(t *testing.T) {
+		want := OK
+		if message.GetContent().(string) != want {
+			t.Errorf("Wrong Error message received : Wanted %v and Got %v", want, message.GetContent())
+		}
+		wantEdged := fmt.Errorf("test").Error()
+		if msgEdged.GetContent().(error).Error() != wantEdged {
+			t.Errorf("Wrong Error message received : Wanted %v and Got %v", wantEdged, msgEdged.GetContent().(error).Error())
+		}
+	})
+
 	//process remote query db fail
 	rawSetterMock.EXPECT().Exec().Return(nil, errFailedDBOperation).Times(1)
 	ormerMock.EXPECT().Raw(gomock.Any(), gomock.Any()).Return(rawSetterMock).Times(1)


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Optional configmap/secret in a pod is allowed. It won't matter if the optional configmap/secret is not found when a pod is launched.
```
  volumes:
  - name: cm-volume
    projected:
      defaultMode: 420
      sources:
      - configMap:
          name: cm-test-opt
          optional: true
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
