### PR TITLE
replace default runtime docker with containerd

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -193,8 +193,16 @@ jobs:
         run: |
           docker load < /home/runner/build-tools/build-tools.tar
 
+      # for QUIC protocol, we will use docker as edgecore container runtime
+      # for WebSocket protocol, we will use containerd as edgecore container runtime
+      # just for covering both docker and CRI runtime e2e cases
       - run: |
           export PROTOCOL=${{ matrix.PROTOCOL }}
+          if [[ ${{ matrix.PROTOCOL }} == "QUIC" ]]; then
+            export CONTAINER_RUNTIME="docker"
+          elif [[ ${{ matrix.PROTOCOL }} == "WebSocket" ]]; then
+            export CONTAINER_RUNTIME="remote"
+          fi
           make e2e
 
       - uses: actions/upload-artifact@v3

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -44,10 +44,10 @@ const (
 	// Edged
 	DefaultKubeletConfig         = "/etc/kubeedge/config/kubeconfig"
 	DefaultDockerAddress         = "unix:///var/run/docker.sock"
-	DefaultRuntimeType           = "docker"
+	DefaultRuntimeType           = "remote"
 	DefaultEdgedMemoryCapacity   = 7852396000
-	DefaultRemoteRuntimeEndpoint = "unix:///var/run/dockershim.sock"
-	DefaultRemoteImageEndpoint   = "unix:///var/run/dockershim.sock"
+	DefaultRemoteRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
+	DefaultRemoteImageEndpoint   = "unix:///run/containerd/containerd.sock"
 	DefaultMosquittoImage        = "eclipse-mosquitto:1.6.15"
 	// update PodSandboxImage version when bumping k8s vendor version, consistent with vendor/k8s.io/kubernetes/cmd/kubelet/app/options/container_runtime.go defaultPodSandboxImageVersion
 	// When this value are updated, also update comments in pkg/apis/componentconfig/edgecore/v1alpha1/types.go

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -78,6 +78,14 @@ function install_golangci-lint {
     export PATH=$PATH:$GOPATH/bin
 }
 
+verify_containerd_installed(){
+  # verify the containerd installed
+  command -v containerd >/dev/null || {
+    echo "must install the containerd first"
+    exit 1
+  }
+}
+
 verify_docker_installed(){
   # verify the docker installed
   command -v docker >/dev/null || {
@@ -86,3 +94,15 @@ verify_docker_installed(){
   }
 }
 
+# install CNI plugins
+function install_cni_plugins() {
+  # install CNI plugins if not exist
+  if [ ! -f "/opt/cni/bin/loopback" ]; then
+    echo -e "install CNI plugins..."
+    mkdir -p /opt/cni/bin
+    wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
+    tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
+  else
+    echo "CNI plugins already installed and no need to install"
+  fi
+}

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -20,6 +20,7 @@ LOG_DIR=${LOG_DIR:-"/tmp"}
 LOG_LEVEL=${LOG_LEVEL:-2}
 TIMEOUT=${TIMEOUT:-60}s
 PROTOCOL=${PROTOCOL:-"WebSocket"}
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"remote"}
 
 if [[ "${CLUSTER_NAME}x" == "x" ]];then
     CLUSTER_NAME="test"
@@ -31,7 +32,16 @@ function check_prerequisites {
   kubeedge::golang::verify_golang_version
   check_kubectl
   check_kind
-  verify_docker_installed
+  if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
+    # if we will use docker as edgecore container runtime, we need to verify whether docker already installed
+    verify_docker_installed
+  elif [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
+    # we will use containerd as cri runtime, so need to verify whether containerd already installed
+    verify_containerd_installed
+  else
+    echo "not supported container runtime ${CONTAINER_RUNTIME}"
+    exit 1
+  fi
 }
 
 # spin up cluster with kind command
@@ -141,6 +151,14 @@ function start_edgecore {
     sed -i '/websocket:/{n;s/true/false/;}' ${EDGE_CONFIGFILE}
   fi
 
+  # if we will use docker as edgecore container runtime
+  # we need to change edgecore container runtime from default containerd to docker
+  if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
+    sed -i 's|containerRuntime: .*|containerRuntime: docker|' ${EDGE_CONFIGFILE}
+    sed -i 's|remoteImageEndpoint: .*|remoteImageEndpoint: unix:///var/run/dockershim.sock|' ${EDGE_CONFIGFILE}
+    sed -i 's|remoteRuntimeEndpoint: .*|remoteRuntimeEndpoint: unix:///var/run/dockershim.sock|' ${EDGE_CONFIGFILE}
+  fi
+
   token=`kubectl get secret -nkubeedge tokensecret -o=jsonpath='{.data.tokendata}' | base64 -d`
 
   sed -i -e "s|token: .*|token: ${token}|g" \
@@ -226,6 +244,12 @@ build_cloudcore
 build_edgecore
 
 kind_up_cluster
+
+# install CNI plugins
+if [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
+  # we need to install CNI plugins only when we use remote(containerd) as edgecore container runtime
+  install_cni_plugins
+fi
 
 export KUBECONFIG=$HOME/.kube/config
 

--- a/keadm/cmd/keadm/app/cmd/config.go
+++ b/keadm/cmd/keadm/app/cmd/config.go
@@ -45,7 +45,7 @@ func newDefaultConfiguration() *Configuration {
 	return &Configuration{
 		ImageRepository: "kubeedge",
 		Part:            "",
-		RuntimeType:     kubetypes.DockerContainerRuntime,
+		RuntimeType:     kubetypes.RemoteContainerRuntime,
 	}
 }
 
@@ -150,7 +150,7 @@ func AddImagesCommonConfigFlags(cmd *cobra.Command, cfg *Configuration) {
 		"Use this key to set which part keadm will install: cloud part or edge part. If not set, keadm will list/pull all images used by both cloud part and edge part.")
 
 	cmd.Flags().StringVar(&cfg.RuntimeType, cmdcommon.RuntimeType, cfg.RuntimeType,
-		"Container runtime type, default is docker")
+		"Container runtime type, default is remote")
 
 	cmd.Flags().StringVar(&cfg.RemoteRuntimeEndpoint, cmdcommon.RemoteRuntimeEndpoint, cfg.RemoteRuntimeEndpoint,
 		"The endpoint of remote runtime service in edge node")

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -134,7 +134,7 @@ func AddJoinOtherFlags(cmd *cobra.Command, joinOptions *common.JoinOptions) {
 		"KubeEdge Node unique identification string, If flag not used then the command will generate a unique id on its own")
 
 	cmd.Flags().StringVarP(&joinOptions.RemoteRuntimeEndpoint, common.RemoteRuntimeEndpoint, "p", joinOptions.RemoteRuntimeEndpoint,
-		"KubeEdge Edge Node RemoteRuntimeEndpoint string, If flag not set, it will use unix:///var/run/dockershim.sock")
+		"KubeEdge Edge Node RemoteRuntimeEndpoint string, If flag not set, it will use unix:///run/containerd/containerd.sock")
 
 	cmd.Flags().StringVarP(&joinOptions.Token, common.Token, "t", joinOptions.Token,
 		"Used for edge to apply for the certificate")
@@ -161,7 +161,8 @@ func newOption() *common.JoinOptions {
 	joinOptions.WithMQTT = true
 	joinOptions.CGroupDriver = v1alpha2.CGroupDriverCGroupFS
 	joinOptions.CertPath = common.DefaultCertPath
-	joinOptions.RuntimeType = kubetypes.DockerContainerRuntime
+	joinOptions.RuntimeType = kubetypes.RemoteContainerRuntime
+	joinOptions.RemoteRuntimeEndpoint = constants.DefaultRemoteRuntimeEndpoint
 	return joinOptions
 }
 

--- a/keadm/cmd/keadm/app/cmd/reset.go
+++ b/keadm/cmd/keadm/app/cmd/reset.go
@@ -51,7 +51,7 @@ keadm reset
 func newResetOptions() *common.ResetOptions {
 	opts := &common.ResetOptions{}
 	opts.Kubeconfig = common.DefaultKubeConfig
-	opts.RuntimeType = kubetypes.DockerContainerRuntime
+	opts.RuntimeType = kubetypes.RemoteContainerRuntime
 	return opts
 }
 

--- a/tests/e2e/scripts/keadm_deprecated_e2e.sh
+++ b/tests/e2e/scripts/keadm_deprecated_e2e.sh
@@ -19,6 +19,7 @@ WORKDIR=$(dirname $0)
 E2E_DIR=$(realpath $(dirname $0)/..)
 
 source "${KUBEEDGE_ROOT}/hack/lib/golang.sh"
+source "${KUBEEDGE_ROOT}/hack/lib/install.sh"
 kubeedge::version::get_version_info
 VERSION=${GIT_VERSION}
 
@@ -95,9 +96,8 @@ function run_test() {
   if [[ $GINKGO_TESTING_RESULT != 0 ]]; then
     echo "Integration suite has failures, Please check !!"
     echo "edgecore logs are as below"
-    journalctl -u edgecore.service -xe > /var/log/kubeedge/edgecore.log
     set -x
-    cat /var/log/kubeedge/edgecore.log
+    journalctl -u edgecore.service --no-pager
     set +x
     echo "================================================="
     echo "================================================="
@@ -124,6 +124,8 @@ export KUBECONFIG=$HOME/.kube/config
 
 echo -e "\nPreparing cluster..."
 prepare_cluster
+
+install_cni_plugins
 
 kubeedge_version=${VERSION: 1}
 #if we use the local release version compiled with the latest codes, we need to copy release file and checksum file.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
now we use docker as edgecore default container runtime type, this patch change it to containerd.
this patch is a prerequisite of https://github.com/kubeedge/kubeedge/pull/4509 , so https://github.com/kubeedge/kubeedge/pull/4509 can focus on bumping k8s vendor, but not contain changes about container runtime
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
replace default runtime docker with containerd
```
