### PR TITLE
use NodePort as default cloudcore service type

### DIFF
--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -5,7 +5,7 @@ appVersion: "1.12.0"
 
 cloudCore:
   replicaCount: 1
-  hostNetWork: "true"
+  hostNetWork: false
   image:
     repository: "kubeedge/cloudcore"
     tag: "v1.12.0"
@@ -56,7 +56,7 @@ cloudCore:
     router:
       enable: "false"
   service:
-    enable: "true"
+    enable: true
     type: "NodePort"
     cloudhubNodePort: "30000"
     cloudhubQuicNodePort: "30001"

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -5,7 +5,7 @@ appVersion: "1.12.0"
 
 cloudCore:
   replicaCount: 1
-  hostNetWork: "true"
+  hostNetWork: false
   image:
     repository: "kubeedge/cloudcore"
     tag: "v1.12.0"
@@ -52,7 +52,7 @@ cloudCore:
     router:
       enable: "false"
   service:
-    enable: "false"
+    enable: true
     type: "NodePort"
     cloudhubNodePort: "30000"
     cloudhubQuicNodePort: "30001"

--- a/tests/e2e/scripts/keadm_e2e.sh
+++ b/tests/e2e/scripts/keadm_e2e.sh
@@ -59,7 +59,7 @@ function start_kubeedge() {
   export KUBECONFIG=$HOME/.kube/config
   docker run --rm kubeedge/installation-package:$IMAGE_TAG cat /usr/local/bin/keadm > /usr/local/bin/keadm && chmod +x /usr/local/bin/keadm
 
-  /usr/local/bin/keadm init --advertise-address=$MASTER_IP --profile version=$KUBEEDGE_VERSION --set cloudCore.service.enable=false --kube-config=$KUBECONFIG --force
+  /usr/local/bin/keadm init --advertise-address=$MASTER_IP --profile version=$KUBEEDGE_VERSION --kube-config=$KUBECONFIG --force
   
   # ensure tokensecret is generated
   while true; do
@@ -70,7 +70,7 @@ function start_kubeedge() {
   cd $KUBEEDGE_ROOT
   export TOKEN=$(sudo /usr/local/bin/keadm gettoken --kube-config=$KUBECONFIG)
   sudo systemctl set-environment CHECK_EDGECORE_ENVIRONMENT="false"
-  sudo -E CHECK_EDGECORE_ENVIRONMENT="false" /usr/local/bin/keadm join --token=$TOKEN --cloudcore-ipport=$MASTER_IP:10000 --edgenode-name=edge-node --kubeedge-version=$KUBEEDGE_VERSION
+  sudo -E CHECK_EDGECORE_ENVIRONMENT="false" /usr/local/bin/keadm join --token=$TOKEN --certport 30002 --cloudcore-ipport=$MASTER_IP:30000 --edgenode-name=edge-node --kubeedge-version=$KUBEEDGE_VERSION
 
   # ensure edgenode is ready
   while true; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
now we use ClusterIP as cloudcore service type, this patch change it to NodePort

service type is defined by .Values.cloudCore.service.type .Values.cloudCore.hostNetWork
https://github.com/kubeedge/kubeedge/blob/2f33fccbb999af56794a08fcd2fea98010ac9975/manifests/charts/cloudcore/templates/service_cloudcore.yaml#L12-L17

the default hostNetwork is set to "true"
https://github.com/kubeedge/kubeedge/blob/2f33fccbb999af56794a08fcd2fea98010ac9975/manifests/charts/cloudcore/values.yaml#L6-L8

the default servicetype is set to NodePort
https://github.com/kubeedge/kubeedge/blob/2f33fccbb999af56794a08fcd2fea98010ac9975/manifests/charts/cloudcore/values.yaml#L58-L60

So we can change .Values.cloudCore.hostNetWork from "true" to false, so that it uses NodePort as cloudcore serviceType
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
