### PR TITLE
Automated cherry pick of #4430: stream server painc if close channel wrongly

### DIFF
--- a/cloud/pkg/cloudstream/apiserverconnection.go
+++ b/cloud/pkg/cloudstream/apiserverconnection.go
@@ -31,5 +31,5 @@ type APIServerConnection interface {
 	// SetEdgePeerDone indicates send specifical message to let edge peer exist
 	SetEdgePeerDone()
 	// EdgePeerDone indicates whether edge peer ends
-	EdgePeerDone() <-chan struct{}
+	EdgePeerDone() chan struct{}
 }

--- a/cloud/pkg/cloudstream/session.go
+++ b/cloud/pkg/cloudstream/session.go
@@ -95,6 +95,7 @@ func (s *Session) ProxyTunnelMessageToApiserver(message *stream.Message) error {
 	}
 	switch message.MessageType {
 	case stream.MessageTypeRemoveConnect:
+		klog.V(6).Infof("delete connection %v from %v", message.ConnectID, s.String())
 		kubeCon.SetEdgePeerDone()
 	case stream.MessageTypeData:
 		for i := 0; i < len(message.Data); {
@@ -115,8 +116,10 @@ func (s *Session) String() string {
 
 func (s *Session) AddAPIServerConnection(ss *StreamServer, connection APIServerConnection) (APIServerConnection, error) {
 	id := atomic.AddUint64(&(ss.nextMessageID), 1)
+
 	s.apiConnlock.Lock()
 	defer s.apiConnlock.Unlock()
+
 	if s.tunnelClosed {
 		return nil, fmt.Errorf("the tunnel connection of %v has closed", s.String())
 	}

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -136,6 +136,7 @@ func (s *StreamServer) getContainerLogs(r *restful.Request, w *restful.Response)
 		session:      session,
 		ctx:          r.Request.Context(),
 		edgePeerStop: make(chan struct{}),
+		closeChan:    make(chan bool),
 	})
 	if err != nil {
 		err = fmt.Errorf("add apiServer connection into %s error %v", session.String(), err)
@@ -188,6 +189,7 @@ func (s *StreamServer) getMetrics(r *restful.Request, w *restful.Response) {
 		session:      session,
 		ctx:          r.Request.Context(),
 		edgePeerStop: make(chan struct{}),
+		closeChan:    make(chan bool),
 	})
 	if err != nil {
 		err = fmt.Errorf("add apiServer connection into %s error %v", session.String(), err)
@@ -241,6 +243,7 @@ func (s *StreamServer) getExec(request *restful.Request, response *restful.Respo
 		err = fmt.Errorf("request connection cannot be hijacked: %T", response.ResponseWriter)
 		return
 	}
+
 	requestHijackedConn, _, err := requestHijacker.Hijack()
 	if err != nil {
 		klog.V(6).Infof("Unable to hijack response: %v", err)
@@ -254,8 +257,10 @@ func (s *StreamServer) getExec(request *restful.Request, response *restful.Respo
 		Conn:         requestHijackedConn,
 		session:      session,
 		ctx:          request.Request.Context(),
-		edgePeerStop: make(chan struct{}),
+		edgePeerStop: make(chan struct{}, 2),
+		closeChan:    make(chan bool),
 	})
+
 	if err != nil {
 		err = fmt.Errorf("add apiServer exec connection into %s error %v", session.String(), err)
 		return

--- a/pkg/stream/edgedconnection.go
+++ b/pkg/stream/edgedconnection.go
@@ -8,5 +8,7 @@ type EdgedConnection interface {
 	Serve(tunnel SafeWriteTunneler) error
 	CacheTunnelMessage(msg *Message)
 	GetMessageID() uint64
+	CloseReadChannel()
+	CleanChannel()
 	fmt.Stringer
 }

--- a/pkg/stream/edgedexecconnection.go
+++ b/pkg/stream/edgedexecconnection.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -13,11 +14,12 @@ import (
 )
 
 type EdgedExecConnection struct {
-	MessID   uint64
-	URL      url.URL       `json:"url"`
-	Header   http.Header   `json:"header"`
-	Method   string        `json:"method"`
 	ReadChan chan *Message `json:"-"`
+	Stop     chan struct{} `json:"-"`
+	MessID   uint64
+	URL      url.URL     `json:"url"`
+	Header   http.Header `json:"header"`
+	Method   string      `json:"method"`
 }
 
 func (e *EdgedExecConnection) CreateConnectMessage() (*Message, error) {
@@ -40,11 +42,65 @@ func (e *EdgedExecConnection) CacheTunnelMessage(msg *Message) {
 	e.ReadChan <- msg
 }
 
+func (e *EdgedExecConnection) CloseReadChannel() {
+	close(e.ReadChan)
+}
+
+func (e *EdgedExecConnection) CleanChannel() {
+	for {
+		select {
+		case <-e.Stop:
+		default:
+			return
+		}
+	}
+}
+
 type responder struct{}
 
 func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {
 	klog.Errorf("failed to proxy request: %v", err)
 	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+func (e *EdgedExecConnection) receiveFromCloudStream(con net.Conn, stop chan struct{}) {
+	for message := range e.ReadChan {
+		switch message.MessageType {
+		case MessageTypeRemoveConnect:
+			klog.V(6).Infof("%s receive remove client id %v", e.String(), message.ConnectID)
+			stop <- struct{}{}
+		case MessageTypeData:
+			_, err := con.Write(message.Data)
+			klog.V(6).Infof("%s receive exec %v data ", e.String(), message.Data)
+			if err != nil {
+				klog.Errorf("failed to write, err: %v", err)
+			}
+		}
+	}
+	klog.V(6).Infof("%s read channel closed", e.String())
+}
+
+func (e *EdgedExecConnection) write2CloudStream(tunnel SafeWriteTunneler, con net.Conn, stop chan struct{}) {
+	defer func() {
+		stop <- struct{}{}
+	}()
+
+	var data [256]byte
+	for {
+		n, err := con.Read(data[:])
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				klog.Errorf("%v failed to read exec data, err:%v", e.String(), err)
+			}
+			return
+		}
+		msg := NewMessage(e.MessID, MessageTypeData, data[:n])
+		if err := tunnel.WriteMessage(msg); err != nil {
+			klog.Errorf("%v failed to write to tunnel, msg: %+v, err: %v", e.String(), msg, err)
+			return
+		}
+		klog.V(6).Infof("%v write exec data %v", e.String(), data[:n])
+	}
 }
 
 func (e *EdgedExecConnection) Serve(tunnel SafeWriteTunneler) error {
@@ -54,9 +110,6 @@ func (e *EdgedExecConnection) Serve(tunnel SafeWriteTunneler) error {
 		return fmt.Errorf("failed to create exec request, err: %v", err)
 	}
 	req.Header = e.Header
-
-	//handler := proxy.NewUpgradeAwareHandler(&e.URL, nil, false, true, &responder{})
-
 	con, err := tripper.Dial(req)
 	if err != nil {
 		klog.Errorf("failed to dial, err: %v", err)
@@ -64,25 +117,7 @@ func (e *EdgedExecConnection) Serve(tunnel SafeWriteTunneler) error {
 	}
 	defer con.Close()
 
-	stop := make(chan struct{})
-
-	go func() {
-		defer close(stop)
-
-		for message := range e.ReadChan {
-			switch message.MessageType {
-			case MessageTypeRemoveConnect:
-				klog.V(6).Infof("%s receive remove client id %v", e.String(), message.ConnectID)
-				return
-			case MessageTypeData:
-				_, err := con.Write(message.Data)
-				klog.V(6).Infof("%s receive exec %v data ", e.String(), message.Data)
-				if err != nil {
-					klog.Errorf("failed to write, err: %v", err)
-				}
-			}
-		}
-	}()
+	go e.receiveFromCloudStream(con, e.Stop)
 
 	defer func() {
 		for retry := 0; retry < 3; retry++ {
@@ -95,28 +130,9 @@ func (e *EdgedExecConnection) Serve(tunnel SafeWriteTunneler) error {
 		}
 	}()
 
-	go func() {
-		defer close(e.ReadChan)
+	go e.write2CloudStream(tunnel, con, e.Stop)
 
-		var data [256]byte
-		for {
-			n, err := con.Read(data[:])
-			if err != nil {
-				if !errors.Is(err, io.EOF) {
-					klog.Errorf("%v failed to write exec data, err:%v", e.String(), err)
-				}
-				return
-			}
-			msg := NewMessage(e.MessID, MessageTypeData, data[:n])
-			if err := tunnel.WriteMessage(msg); err != nil {
-				klog.Errorf("%v failed to write to tunnel, msg: %+v, err: %v", e.String(), msg, err)
-				return
-			}
-			klog.V(6).Infof("%v write exec data %v", e.String(), data[:n])
-		}
-	}()
-
-	<-stop
+	<-e.Stop
 	klog.V(6).Infof("receive stop signal, so stop exec scan ...")
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #4430 on release-1.13.

#4430: stream server painc if close channel wrongly

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.