### PR TITLE
csi example panic when creating volume

### DIFF
--- a/docs/proposals/csi.md
+++ b/docs/proposals/csi.md
@@ -278,7 +278,7 @@ Here is a `DaemonSet` example for CSI HostPath Driver at edge.
 
 ```yaml
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-hostpath-edge
 spec:


### PR DESCRIPTION
Signed-off-by: vincentgoat <linguohui1@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Solving panic of csidriver when creating/deleting a volume.
```
panic: interface conversion: interface {} is map[string]interface {}, not string

goroutine 65 [running]:
github.com/kubeedge/kubeedge/cloud/pkg/csidriver.(*controllerServer).CreateVolume(0xc0000793c0, 0xeb9c60, 0xc0003c5920, 0xc00047a1c0, 0xc0000793c0, 0x1468509, 0xc000160e70)
	/go/src/github.com/kubeedge/kubeedge/cloud/pkg/csidriver/controllerserver.go:115 +0x107e
github.com/kubeedge/kubeedge/vendor/github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler.func1(0xeb9c60, 0xc0003c5920, 0xd2e4c0, 0xc00047a1c0, 0xc00022d9f0, 0x1, 0x1, 0xc000176380)
	/go/src/github.com/kubeedge/kubeedge/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi.pb.go:5146 +0x86
github.com/kubeedge/kubeedge/cloud/pkg/csidriver.logGRPC(0xeb9c60, 0xc0003c5920, 0xd2e4c0, 0xc00047a1c0, 0xc000436f20, 0xc000436f40, 0xc00009ca80, 0x4f4918, 0xcfe240, 0xc0003c5920)
	/go/src/github.com/kubeedge/kubeedge/cloud/pkg/csidriver/utils.go:132 +0x1b2
github.com/kubeedge/kubeedge/vendor/github.com/container-storage-interface/spec/lib/go/csi._Controller_CreateVolume_Handler(0xd13600, 0xc0000793c0, 0xeb9c60, 0xc0003c5920, 0xc000472540, 0xddede0, 0xeb9c60, 0xc0003c5920, 0xc0003bd3c0, 0x40)
	/go/src/github.com/kubeedge/kubeedge/vendor/github.com/container-storage-interface/spec/lib/go/csi/csi.pb.go:5148 +0x14b
github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000c98c0, 0xec2d20, 0xc000174600, 0xc0000b5000, 0xc00013ced0, 0x14c56c0, 0x0, 0x0, 0x0)
	/go/src/github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc/server.go:995 +0x460
github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc.(*Server).handleStream(0xc0000c98c0, 0xec2d20, 0xc000174600, 0xc0000b5000, 0x0)
	/go/src/github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc/server.go:1275 +0xd97
github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0001e4030, 0xc0000c98c0, 0xec2d20, 0xc000174600, 0xc0000b5000)
	/go/src/github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc/server.go:710 +0xbb
created by github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
	/go/src/github.com/kubeedge/kubeedge/vendor/google.golang.org/grpc/server.go:708 +0xa1
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

If the error:
 `E0131 13:01:34.052669       1 controller.go:1213] provision "default/csi-hostpath-pvc" class "csi-hostpath-sc": unexpected errorgetting claim reference: selfLink was empty, can't make reference
` 
occurred in the container provision, please update kube-apiserver config `--feature-gates=RemoveSelfLink=false` for a workaround as follows.

```
spec:
  containers:
  - command:
    - kube-apiserver
    - --feature-gates=RemoveSelfLink=false
    ...
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
