### PR TITLE
fix cni issue for containerd/cni in localup

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -21,6 +21,7 @@ LOG_LEVEL=${LOG_LEVEL:-2}
 TIMEOUT=${TIMEOUT:-60}s
 PROTOCOL=${PROTOCOL:-"WebSocket"}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"remote"}
+CNI_DOWNLOAD_ADDR="https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz"
 
 if [[ "${CLUSTER_NAME}x" == "x" ]];then
     CLUSTER_NAME="test"
@@ -249,12 +250,6 @@ build_edgecore
 
 kind_up_cluster
 
-# install CNI plugins
-if [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
-  # we need to install CNI plugins only when we use remote(containerd) as edgecore container runtime
-  install_cni_plugins
-fi
-
 export KUBECONFIG=$HOME/.kube/config
 
 check_control_plane_ready
@@ -262,6 +257,12 @@ check_control_plane_ready
 # edge side don't support kind cni now, delete kind cni plugin for workaround
 kubectl delete daemonset kindnet -nkube-system
 kubectl create ns kubeedge
+
+# install CNI plugins
+if [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
+  # we need to install CNI plugins only when we use remote(containerd) as edgecore container runtime
+  install_cni_plugins
+fi
 
 create_device_crd
 create_objectsync_crd


### PR DESCRIPTION
Signed-off-by: fisherxu <fisherxu1@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When I use localup script to install the cluste, the edgenode will get  notReady, since there's no cni netconf file in node. So it's need to create a netconf file if it doesn't exist.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
cc @gy95 @vincentgoat 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
