### PR TITLE
add  UT for cloud/pkg/devicecontroller and add package of testtools for kubeclient which the others might use it for UT. 

### DIFF
--- a/cloud/pkg/devicecontroller/config/config_test.go
+++ b/cloud/pkg/devicecontroller/config/config_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+// TestInitConfigure() tests configuration initialized only once
+func TestInitConfigure(t *testing.T) {
+	tests := []struct {
+		name       string
+		controller *v1alpha1.DeviceController
+		want       *v1alpha1.DeviceController
+	}{
+		{
+			name: "Device controller",
+			controller: &v1alpha1.DeviceController{
+				Enable: false,
+			},
+			want: &v1alpha1.DeviceController{
+				Enable: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var testController = &v1alpha1.DeviceController{
+				Enable: true,
+			}
+			InitConfigure(tt.controller)
+			InitConfigure(testController)
+			if !reflect.DeepEqual(*tt.want, Config.DeviceController) {
+				t.Errorf("TestInitConfigure() = %v, want %v", Config.DeviceController, *tt.want)
+			}
+		})
+	}
+}

--- a/cloud/pkg/devicecontroller/devicecontroller_test.go
+++ b/cloud/pkg/devicecontroller/devicecontroller_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2023 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devicecontroller
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/config"
+	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
+	"github.com/kubeedge/kubeedge/pkg/testtools"
+)
+
+func init() {
+	err := testtools.InitKubeClient()
+	if err != nil {
+		klog.Errorf("fail to init kubeclient with err: %+v", err)
+	}
+
+	dc := &v1alpha1.DeviceController{
+		Enable: false,
+		Buffer: &v1alpha1.DeviceControllerBuffer{
+			UpdateDeviceStatus: constants.DefaultUpdateDeviceStatusBuffer,
+			DeviceEvent:        constants.DefaultDeviceEventBuffer,
+			DeviceModelEvent:   constants.DefaultDeviceModelEventBuffer,
+		},
+		Load: &v1alpha1.DeviceControllerLoad{
+			UpdateDeviceStatusWorkers: constants.DefaultUpdateDeviceStatusWorkers,
+		},
+	}
+
+	config.InitConfigure(dc)
+}
+
+func TestNewDeviceControllerAndStartIt(t *testing.T) {
+	tests := []struct {
+		name       string
+		controller *DeviceController
+		want       *DeviceController
+	}{
+		{
+			name: "New Device controller",
+			controller: &DeviceController{
+				enable: true,
+			},
+			want: &DeviceController{
+				enable: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testController := newDeviceController(tt.controller.enable)
+			if !reflect.DeepEqual(tt.want.enable, testController.Enable()) {
+				t.Errorf("TestNewDeviceController() = %v, want %v", (*testController).Enable(), *tt.want)
+			}
+			testController.Start()
+			time.Sleep(2 * time.Second)
+			beehiveContext.Cancel()
+		})
+	}
+}
+
+func TestRegister(t *testing.T) {
+	tests := []struct {
+		name       string
+		controller *v1alpha1.DeviceController
+		want       *v1alpha1.DeviceController
+	}{
+		{
+			name: "Register Device controller",
+			controller: &v1alpha1.DeviceController{
+				Enable: false,
+			},
+			want: &v1alpha1.DeviceController{
+				Enable: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Register(tt.controller)
+			if !reflect.DeepEqual(tt.want.Enable, config.Config.DeviceController.Enable) {
+				t.Errorf("TestRegister() = %v, want %v", config.Config.DeviceController, *tt.want)
+			}
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	t.Run("DeviceController.Name()", func(t *testing.T) {
+		if got := (&DeviceController{}).Name(); got != modules.DeviceControllerModuleName {
+			t.Errorf("DeviceController.Name() returned unexpected result. got = %s, want = DeviceController", got)
+		}
+	})
+}
+
+func TestGroup(t *testing.T) {
+	t.Run("DeviceController.Group()", func(t *testing.T) {
+		if got := (&DeviceController{}).Group(); got != modules.DeviceControllerModuleGroup {
+			t.Errorf("DeviceController.Group() returned unexpected result. got = %s, want = DeviceController", got)
+		}
+	})
+}

--- a/pkg/testtools/const.go
+++ b/pkg/testtools/const.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testtools
+
+const mockKubeConfigContent = `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:8080
+  name: foo-cluster
+contexts:
+- context:
+    cluster: foo-cluster
+    user: foo-user
+    namespace: bar
+  name: foo-context
+current-context: foo-context
+kind: Config
+users:
+- name: foo-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      args:
+      - arg-1
+      - arg-2
+      command: foo-command
+`

--- a/pkg/testtools/testtools.go
+++ b/pkg/testtools/testtools.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package testtools
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
+	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+func InitKubeClient() error {
+	tmpfile, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpfile.Name())
+	if err := os.WriteFile(tmpfile.Name(), []byte(mockKubeConfigContent), 0666); err != nil {
+		return err
+	}
+	client.InitKubeEdgeClient(&v1alpha1.KubeAPIConfig{
+		KubeConfig:  tmpfile.Name(),
+		QPS:         100,
+		Burst:       200,
+		ContentType: "application/vnd.kubernetes.protobuf",
+	})
+
+	client.DefaultGetRestMapper = func() (mapper meta.RESTMapper, err error) { return nil, nil }
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind test

**What this PR does / why we need it**:
add  UT for cloud/pkg/devicecontroller

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/4327

**Special notes for your reviewer**:
i will propose more UT for cloud/pkg/devicecontroller/controller later

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
no
```release-note
add  UT for cloud/pkg/devicecontroller and add package of testtools for kubeclient which the others might use it for UT. 
```
