### PR TITLE
deal with error in delete pod upstream msg

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -1090,15 +1090,19 @@ func (uc *UpstreamController) deletePod() {
 				}
 			}
 
+			var resMsg *model.Message
 			err = uc.kubeClient.CoreV1().Pods(namespace).Delete(context.Background(), name, deleteOptions)
 			if err != nil && !errors.IsNotFound(err) && !strings.Contains(err.Error(), "The object might have been deleted and then recreated") {
 				klog.Warningf("Failed to delete pod, namespace: %s, name: %s, err: %v", namespace, name, err)
-				continue
+				resMsg = model.NewMessage(msg.GetID()).
+					FillBody(err).
+					BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, msg.GetResource(), model.ResponseOperation)
+			} else {
+				resMsg = model.NewMessage(msg.GetID()).
+					FillBody(common.MessageSuccessfulContent).
+					BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, msg.GetResource(), model.ResponseOperation)
 			}
 
-			resMsg := model.NewMessage(msg.GetID()).
-				FillBody(common.MessageSuccessfulContent).
-				BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, msg.GetResource(), model.ResponseOperation)
 			if err = uc.messageLayer.Response(*resMsg); err != nil {
 				klog.Errorf("Message: %s process failure, response failed with error: %v", msg.GetID(), err)
 				continue

--- a/edge/pkg/metamanager/client/pod.go
+++ b/edge/pkg/metamanager/client/pod.go
@@ -69,7 +69,12 @@ func (c *pods) Delete(name string, options metav1.DeleteOptions) error {
 		return nil
 	}
 
-	return err
+	err, ok = msg.Content.(error)
+	if ok {
+		return err
+	}
+
+	return fmt.Errorf("delete pod failed, response content type unsupported")
 }
 
 func (c *pods) Get(name string) (*corev1.Pod, error) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The response error when delete pod failed wasn't dealt with. In older version, err in  `edge/pkg/metamanager/client/pod.go` actually is nil. So in this pr, we set err in msg content and parse it at edge.

