### PR TITLE
fix delete statefulset pod error

### DIFF
--- a/edge/mocks/beego/fake_sqlresult.go
+++ b/edge/mocks/beego/fake_sqlresult.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Source: database/sql/sql.go (interfaces: Result)
+
+Package beego is a generated GoMock package.
+*/
+
+package beego
+
+import (
+	"reflect"
+
+	"github.com/golang/mock/gomock"
+)
+
+// MockSQLResult is a mock of SQL Result
+type MockSQLResult struct {
+	ctrl     *gomock.Controller
+	recorder *MockSQLResultMockRecorder
+}
+
+// MockSQLResultMockRecorder is the mock recorder for MockSQLResult
+type MockSQLResultMockRecorder struct {
+	mock *MockSQLResult
+}
+
+// NewMockDriverRes creates a new mock instance
+func NewMockDriverRes(ctrl *gomock.Controller) *MockSQLResult {
+	mock := &MockSQLResult{ctrl: ctrl}
+	mock.recorder = &MockSQLResultMockRecorder{mock: mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockSQLResult) EXPECT() *MockSQLResultMockRecorder {
+	return m.recorder
+}
+
+// RowsAffected indicates an expected call of RowsAffected
+func (mr *MockSQLResultMockRecorder) RowsAffected() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RowsAffected", reflect.TypeOf((*MockSQLResult)(nil).RowsAffected))
+}
+
+// LastInsertId mocks base LastInsertId method
+func (m *MockSQLResult) LastInsertId() (int64, error) {
+	return 1, nil
+}
+
+// RowsAffected mocks base RowsAffected method
+func (m *MockSQLResult) RowsAffected() (int64, error) {
+	ret := m.ctrl.Call(m, "RowsAffected")
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}

--- a/edge/pkg/metamanager/dao/meta.go
+++ b/edge/pkg/metamanager/dao/meta.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -45,6 +46,17 @@ func DeleteMetaByKey(key string) error {
 	num, err := dbm.DBAccess.QueryTable(MetaTableName).Filter("key", key).Delete()
 	klog.V(4).Infof("Delete affected Num: %d, %v", num, err)
 	return err
+}
+
+// DeleteMetaByKeyAndPodUID delete meta by key and podUID
+func DeleteMetaByKeyAndPodUID(key, podUID string) (int64, error) {
+	sqlStr := fmt.Sprintf("DELETE FROM meta WHERE key = '%s' and value LIKE '%%%s%%'", key, podUID)
+	res, err := dbm.DBAccess.Raw(sqlStr).Exec()
+	if err != nil {
+		klog.Errorf("delete pod by key %s and podUID %s failed, err: %v", key, podUID, err)
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 // UpdateMeta update meta


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

When delete sts pod, the sequence of the downstream `delete` and `insert` messages cannot be guaranteed, and the pod names are the same, so we need to check if podUID equals when we delete the podDB. There are two mistakes here:
- we use `insert` instead of `insert of replace` when we process insert msg, cause `insert` fails when old pod db is not deleted.
- we use query first and then delete, it may cause the new DB be deleted.  So we place the judgment and deletion statement in one stomic sql operation statement in this pr. 
