### PR TITLE
use nodeIP initialization in Kubelet 

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -3,7 +3,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 
 	"github.com/mitchellh/go-ps"
@@ -125,21 +124,6 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 				}
 				config.Modules.Edged.NodeIP = ip.String()
 				klog.Infof("Get IP address by custom interface successfully, %s: %s", config.Modules.Edged.CustomInterfaceName, config.Modules.Edged.NodeIP)
-			} else {
-				if net.ParseIP(config.Modules.Edged.NodeIP) != nil {
-					klog.Infof("Use node IP address from config: %s", config.Modules.Edged.NodeIP)
-				} else if config.Modules.Edged.NodeIP != "" {
-					klog.Errorf("invalid node IP address specified: %s", config.Modules.Edged.NodeIP)
-					os.Exit(1)
-				} else {
-					nodeIP, err := util.GetLocalIP(util.GetHostname())
-					if err != nil {
-						klog.Errorf("Failed to get Local IP address: %v", err)
-						os.Exit(1)
-					}
-					config.Modules.Edged.NodeIP = nodeIP
-					klog.Infof("Get node local IP address successfully: %s", nodeIP)
-				}
 			}
 
 			registerModules(config)

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -54,7 +54,6 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				TailoredKubeletConfig: &defaultTailedKubeletConfig,
 				TailoredKubeletFlag: TailoredKubeletFlag{
 					HostnameOverride: hostnameOverride,
-					NodeIP:           localIP,
 					ContainerRuntimeOptions: ContainerRuntimeOptions{
 						ContainerRuntime:          constants.DefaultRuntimeType,
 						PodSandboxImage:           constants.DefaultPodSandboxImage,
@@ -190,7 +189,6 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 				TailoredKubeletConfig: &defaultTailedKubeletConfig,
 				TailoredKubeletFlag: TailoredKubeletFlag{
 					HostnameOverride: hostnameOverride,
-					NodeIP:           localIP,
 					ContainerRuntimeOptions: ContainerRuntimeOptions{
 						ContainerRuntime:          constants.DefaultRuntimeType,
 						PodSandboxImage:           constants.DefaultPodSandboxImage,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

drop nodeIP initialization in edged.  NodeIP initialization can be completed in `nodestatus/setters` in Kubelet.

Also Kubelet can get nodeIP periodically and report it to cloud when nodeIP is not setted in `edgecore.yaml`. 

**Which issue(s) this PR fixes**:

Fixes #4638 

