### PR TITLE
support http proxy for websocket client

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -78,6 +78,7 @@ func (wsc *WebSocketClient) Init() error {
 		Addr:             wsc.config.URL,
 		AutoRoute:        false,
 		ConnUse:          api.UseTypeMessage,
+		Proxy:            http.ProxyFromEnvironment,
 	}
 	exOpts := api.WSClientOption{Header: make(http.Header)}
 	exOpts.Header.Set("node_id", wsc.config.NodeID)

--- a/staging/src/github.com/kubeedge/viaduct/pkg/client/client.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/client/client.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -38,6 +40,8 @@ type Options struct {
 	HandshakeTimeout time.Duration
 	// consumer for raw data
 	Consumer io.Writer
+	// Proxy specifies a function to return a proxy for a given request
+	Proxy func(*http.Request) (*url.URL, error)
 }
 
 // client including common options and extend options

--- a/staging/src/github.com/kubeedge/viaduct/pkg/client/ws.go
+++ b/staging/src/github.com/kubeedge/viaduct/pkg/client/ws.go
@@ -33,6 +33,7 @@ func NewWSClient(options Options, exOpts interface{}) *WSClient {
 		dialer: &websocket.Dialer{
 			TLSClientConfig:  options.TLSConfig,
 			HandshakeTimeout: options.HandshakeTimeout,
+			Proxy:            options.Proxy,
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Read the proxy from the environment value of the edge node and connect the websocket server of cloudhub through such proxy.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
