### PR TITLE
bugfix device status updated when timestamp exists in twin

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -464,7 +464,23 @@ func isProtocolConfigUpdated(oldTwin *v1alpha2.ProtocolConfig, newTwin *v1alpha2
 
 // isDeviceStatusUpdated checks if DeviceStatus is updated
 func isDeviceStatusUpdated(oldTwin *v1alpha2.DeviceStatus, newTwin *v1alpha2.DeviceStatus) bool {
-	return !reflect.DeepEqual(oldTwin, newTwin)
+	oldLen := len(oldTwin.Twins)
+	oldTwins := make(map[string]string)
+	for _, ot := range oldTwin.Twins {
+		oldTwins[ot.PropertyName] = ot.Desired.Value
+	}
+	for _, nt := range newTwin.Twins {
+		ot, exist := oldTwins[nt.PropertyName]
+		if exist {
+			oldLen--
+			if ot != nt.Desired.Value {
+				return true
+			}
+		} else {
+			return true
+		}
+	}
+	return oldLen != 0
 }
 
 // isDeviceDataUpdated checks if DeviceData is updated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
The device status will update too frequently when timestamp exists in the `Metadata` of device twin properties. We only need to check whether the Desired Value for the device twin property is updated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
