### PR TITLE
fix the bug of report illegal devicetwin value for the first time

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -494,16 +494,18 @@ func isTwinValueDiff(twin *dttype.MsgTwin, msgTwin *dttype.MsgTwin, dealType int
 	twinValue := twin.Expected
 	msgTwinValue := msgTwin.Expected
 
+	if twinValue != nil {
+		hasTwin = true
+	}
 	if dealType == DealActual {
 		twinValue = twin.Actual
 		msgTwinValue = msgTwin.Actual
-	}
-	if twinValue != nil {
 		hasTwin = true
 	}
 	if msgTwinValue != nil {
 		hasMsgTwin = true
 	}
+
 	valueType := stringType
 	if strings.Compare(twin.Metadata.Type, dtcommon.TypeDeleted) == 0 {
 		if msgTwin.Metadata != nil {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
update isTwinValueDiff to fix the bug of report illegal devicetwin value for the first time.  fix this bug and enhance the security of KubeEdge Device Management.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubeedge/kubeedge/issues/4684

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

NONE

