### PR TITLE
[bugfix]edgehub process send device twin msg to twingroup directly

### DIFF
--- a/edge/pkg/devicetwin/process.go
+++ b/edge/pkg/devicetwin/process.go
@@ -52,8 +52,10 @@ func (dt *DeviceTwin) distributeMsg(m interface{}) error {
 		klog.Infof("Send msg to the %s module in twin", dtcommon.CommModule)
 		confirmMsg := dttype.DTMessage{Msg: model.NewMessage(message.Msg.GetParentID()), Action: dtcommon.Confirm}
 		if err := dt.DTContexts.CommTo(dtcommon.CommModule, &confirmMsg); err != nil {
+			klog.Errorf("fail to send msg %s to CommModule with err: %+v", confirmMsg.Msg.Header.ID, err)
 			return err
 		}
+		return nil
 	}
 	if !classifyMsg(&message) {
 		return errors.New("not found action")

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -73,6 +73,14 @@ func (*defaultHandler) Process(message *model.Message, clientHub clients.Adapter
 		md = modules.BusGroup
 	}
 
+	// TODO: just for a temporary fix.
+	// The code related to device twin message transmission will be reconstructed
+	//  by using sendSync function instead of send function.
+	if group == messagepkg.TwinGroupName {
+		beehiveContext.SendToGroup(md, *message)
+		return nil
+	}
+
 	isResponse := isSyncResponse(message.GetParentID())
 	if isResponse {
 		beehiveContext.SendResp(*message)


### PR DESCRIPTION
edgehub process send twin msg to twingroup directly to avoid the response of device report be handled by beehiveContext.SendResp()

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Here is the flow chart of the related step of device management. After the `devicetwin` send a message to cloud, the `upstreamController` of `devicecontroller` will handle this message and send a response message back to edge. The response message deliverd to edgehub will be handled by `isSyncResponse()` and will never be sent to `devicetwin` in the current code which will cause that the `dealConfirm()` function will never be triggered and the `ConfirmMap` will never be cleaned correctly. Further more, every 60s after `devicetwin` does not receive any message, the `checkConfirm()` function will range the `ConfirmMap` and send all the history messages to cloud, which will cause many problem.
![设备消息回复流程](https://user-images.githubusercontent.com/100741994/227826981-fab63b4b-338a-4ef4-924e-dd13c8b5197d.png)

In this PR, I intercept the response message of device report at `edgehub` and send it to `devicetwin` directly, which will fix the problem temporarily.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4700 #4437 #4701

**Special notes for your reviewer**:
This bug is related to the reliability transmission mechanism of device messages which could cause many related problems of device. In this patch version, we will use a temporay fix to solve this problem. The code related to device message transmission will be reconstructed in the next offical version, which will completely fix this problem.
