### PR TITLE
support kubectl attach in KubeEdge 

### DIFF
--- a/cloud/pkg/cloudstream/containerattach_connection.go
+++ b/cloud/pkg/cloudstream/containerattach_connection.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2023 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudstream
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/emicklei/go-restful"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+// ContainerAttachConnection indicates the container attach request initiated by kube-apiserver
+type ContainerAttachConnection struct {
+	MessageID    uint64
+	ctx          context.Context
+	r            *restful.Request
+	Conn         net.Conn
+	session      *Session
+	edgePeerStop chan struct{}
+	closeChan    chan bool
+}
+
+func (ah *ContainerAttachConnection) String() string {
+	return fmt.Sprintf("APIServer_AttachConnection MessageID %v", ah.MessageID)
+}
+
+func (ah *ContainerAttachConnection) WriteToAPIServer(p []byte) (n int, err error) {
+	return ah.Conn.Write(p)
+}
+
+func (ah *ContainerAttachConnection) SetMessageID(id uint64) {
+	ah.MessageID = id
+}
+
+func (ah *ContainerAttachConnection) GetMessageID() uint64 {
+	return ah.MessageID
+}
+
+func (ah *ContainerAttachConnection) SetEdgePeerDone() {
+	select {
+	case <-ah.closeChan:
+		return
+	case ah.EdgePeerDone() <- struct{}{}:
+		klog.V(6).Infof("success send channel deleting connection with messageID %v", ah.MessageID)
+	}
+}
+
+func (ah *ContainerAttachConnection) EdgePeerDone() chan struct{} {
+	return ah.edgePeerStop
+}
+
+func (ah *ContainerAttachConnection) WriteToTunnel(m *stream.Message) error {
+	return ah.session.WriteMessageToTunnel(m)
+}
+
+func (ah *ContainerAttachConnection) SendConnection() (stream.EdgedConnection, error) {
+	// todo: new edged connection and create connect message
+	return nil, nil
+}
+
+func (ah *ContainerAttachConnection) Serve() error {
+	// todo: send to connection, read response date and write to tunnel
+	return nil
+}
+
+var _ APIServerConnection = &ContainerAttachConnection{}

--- a/edge/pkg/edgestream/tunnel.go
+++ b/edge/pkg/edgestream/tunnel.go
@@ -121,7 +121,7 @@ func (s *TunnelSession) ServeConnection(m *stream.Message) {
 		}
 	case stream.MessageTypeAttachConnect:
 		if err := s.serveContainerAttachConnection(m); err != nil {
-			klog.Errorf("Serve Metrics connection error %s", m.String())
+			klog.Errorf("Serve Attach connection error %s", m.String())
 		}
 	default:
 		panic(fmt.Sprintf("Wrong message type %v", m.MessageType))
@@ -191,7 +191,7 @@ func (s *TunnelSession) Serve() error {
 			return fmt.Errorf("close tunnel stream connection, error:%s", string(mess.Data))
 		}
 
-		if mess.MessageType < stream.MessageTypeData {
+		if (mess.MessageType < stream.MessageTypeData) || (mess.MessageType >= stream.MessageTypeAttachConnect) {
 			go s.ServeConnection(mess)
 		}
 		s.WriteToLocalConnection(mess)

--- a/pkg/stream/constants.go
+++ b/pkg/stream/constants.go
@@ -8,6 +8,7 @@ const (
 const (
 	MessageTypeLogsConnect MessageType = iota
 	MessageTypeExecConnect
+	MessageTypeAttachConnect
 	MessageTypeMetricConnect
 	MessageTypeData
 	MessageTypeRemoveConnect

--- a/pkg/stream/constants.go
+++ b/pkg/stream/constants.go
@@ -8,9 +8,9 @@ const (
 const (
 	MessageTypeLogsConnect MessageType = iota
 	MessageTypeExecConnect
-	MessageTypeAttachConnect
 	MessageTypeMetricConnect
 	MessageTypeData
 	MessageTypeRemoveConnect
 	MessageTypeCloseConnect
+	MessageTypeAttachConnect
 )

--- a/pkg/stream/edgedattachconnection.go
+++ b/pkg/stream/edgedattachconnection.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+)
+
+type EdgedAttachConnection struct {
+	ReadChan chan *Message `json:"-"`
+	Stop     chan struct{} `json:"-"`
+	MessID   uint64
+	URL      url.URL     `json:"url"`
+	Header   http.Header `json:"header"`
+	Method   string      `json:"method"`
+}
+
+func (ah *EdgedAttachConnection) CreateConnectMessage() (*Message, error) {
+	data, err := json.Marshal(ah)
+	if err != nil {
+		return nil, err
+	}
+	return NewMessage(ah.MessID, MessageTypeExecConnect, data), nil
+}
+
+func (ah *EdgedAttachConnection) GetMessageID() uint64 {
+	return ah.MessID
+}
+
+func (ah *EdgedAttachConnection) String() string {
+	return fmt.Sprintf("EDGE_ATTACH_CONNECTOR Message MessageID %v", ah.MessID)
+}
+
+func (ah *EdgedAttachConnection) CacheTunnelMessage(msg *Message) {
+	ah.ReadChan <- msg
+}
+
+func (ah *EdgedAttachConnection) CloseReadChannel() {
+	close(ah.ReadChan)
+}
+
+func (ah *EdgedAttachConnection) CleanChannel() {
+	for {
+		select {
+		case <-ah.Stop:
+		default:
+			return
+		}
+	}
+}
+
+func (ah *EdgedAttachConnection) receiveFromCloudStream(con net.Conn, stop chan struct{}) {
+	// todo: read msg from cloudstream
+}
+
+func (ah *EdgedAttachConnection) write2CloudStream(tunnel SafeWriteTunneler, con net.Conn, stop chan struct{}) {
+	// todo: write response to tunnel
+}
+
+func (ah *EdgedAttachConnection) Serve(tunnel SafeWriteTunneler) error {
+	// todo: serve msg from clousstream, send req to edged and write response to tunnel
+	return nil
+}
+
+var _ EdgedConnection = &EdgedAttachConnection{}

--- a/pkg/stream/message.go
+++ b/pkg/stream/message.go
@@ -35,6 +35,8 @@ func (m MessageType) String() string {
 		return "LOGS_CONNECT"
 	case MessageTypeExecConnect:
 		return "EXEC_CONNECT"
+	case MessageTypeAttachConnect:
+		return "ATTACH_CONNECT"
 	case MessageTypeMetricConnect:
 		return "METRIC_CONNECT"
 	case MessageTypeData:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind feature

**What this PR does / why we need it**:

Currently, in a native kubernetes cluster, `kubectl exec` command can execute a command in a container. `kubectl logs` command can print the logs for a container in a pod. `kubectl attach` command can attach to a running container.
Users can execute these commands in the cloud and do not need to operate on the nodes.
we plan to implement `kubectl exec`, `kubectl logs` and `kubectl attach` feature based on edge computing scenarios.
These two commands(`kubectl exec`, `kubectl logs`) are currently integrated, and this PR is to integrate the `kubectl attach` command.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/4424

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The user can use the `kubectl attach` command to access the pod of the edge node.
```
