### PR TITLE
fix bug when list-watch namespace resource

### DIFF
--- a/pkg/metaserver/key.go
+++ b/pkg/metaserver/key.go
@@ -76,6 +76,11 @@ func KeyFuncReq(ctx context.Context, _ string) (string, error) {
 	resource := info.Resource
 	namespace := info.Namespace
 	name := info.Name
+
+	// if the request resource is namespaces, set the ns to null in the key
+	if resource == "namespaces" {
+		namespace = v2.NullNamespace
+	}
 	if namespace == "" {
 		namespace = v2.NullNamespace
 	}

--- a/pkg/metaserver/key_test.go
+++ b/pkg/metaserver/key_test.go
@@ -118,7 +118,7 @@ func TestKeyFuncReq(t *testing.T) {
 	}
 	stdResult := []string{
 		"/core/v1/namespaces/null/null",
-		"/core/v1/namespaces/other/other", //a namespace called other
+		"/core/v1/namespaces/null/other", //a namespace called other
 
 		"/core/v1/pods/other/null",
 		"/core/v1/pods/other/foo",

--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -49,6 +49,7 @@ func UnsafeResourceToKind(r string) string {
 		"endpoints":                    "Endpoints",
 		"endpointslices":               "EndpointSlice",
 		"nodes":                        "Node",
+		"namespaces":                   "Namespace",
 		"services":                     "Service",
 		"podstatus":                    "PodStatus",
 		"nodestatus":                   "NodeStatus",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind bug
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # part of https://github.com/kubeedge/kubeedge/issues/4582 
fix https://github.com/kubeedge/kubeedge/issues/4819

before this fix, when get an exist namespace,
```
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "namespaces \"ppp\" not found",
  "reason": "NotFound",
  "details": {
    "name": "ppp",
    "kind": "namespaces"
  },
  "code": 404
}
```

after

```
{
  "apiVersion": "v1",
  "kind": "Namespace",
  "metadata": {
    "creationTimestamp": "2023-04-26T07:21:13Z",
    "labels": {
      "kubernetes.io/metadata.name": "ppp"
    },
    "managedFields": [
      {
        "apiVersion": "v1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:metadata": {
            "f:labels": {
              ".": {},
              "f:kubernetes.io/metadata.name": {}
            }
          }
        },
        "manager": "kubectl-create",
        "operation": "Update",
        "time": "2023-04-26T07:21:13Z"
      }
    ],
    "name": "ppp",
    "resourceVersion": "741",
    "uid": "a493ad82-aa21-4a2e-8810-2e04f2d132f4"
  },
  "spec": {
    "finalizers": [
      "kubernetes"
    ]
  },
  "status": {
    "phase": "Active"
  }
}
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
