### PR TITLE
add support for cluster scope resource reliable delivery

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/cloud/pkg/synccontroller"
 	commonconst "github.com/kubeedge/kubeedge/common/constants"
+	v2 "github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/v2"
 	"github.com/kubeedge/kubeedge/pkg/apis/reliablesyncs/v1alpha1"
 	reliableclient "github.com/kubeedge/kubeedge/pkg/client/clientset/versioned"
 	synclisters "github.com/kubeedge/kubeedge/pkg/client/listers/reliablesyncs/v1alpha1"
@@ -245,7 +246,6 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 	item, exist, _ := nodeStore.GetByKey(messageKey)
 	if exist {
 		msgInStore := item.(*beehivemodel.Message)
-
 		if isDeleteMessage(msgInStore) ||
 			synccontroller.CompareResourceVersion(msg.GetResourceVersion(), msgInStore.GetResourceVersion()) <= 0 {
 			// If the message resource version is older than the message in store or the operation
@@ -256,13 +256,87 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 		return
 	}
 
-	// If the message doesn't exist in the store, then compare it with the version stored in the objectSync.
+	// If the message doesn't exist in the store, then compare it with
+	// the version stored in the objectSync or clusterObjectSync.
+	resourceNamespace, _ := messagelayer.GetNamespace(*msg)
+	if resourceNamespace == v2.NullNamespace {
+		shouldEnqueue = md.enqueueNonNamespacedResource(nodeID, msg)
+	} else {
+		shouldEnqueue = md.enqueueNamespacedResource(nodeID, msg)
+	}
+}
+
+func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *beehivemodel.Message) bool {
+	resourceName, _ := messagelayer.GetResourceName(*msg)
+	resourceUID, err := common.GetMessageUID(*msg)
+	if err != nil {
+		klog.Errorf("fail to get message UID for message: %s", msg.Header.ID)
+		return false
+	}
+
+	clusterObjectSyncName := synccontroller.BuildObjectSyncName(nodeID, resourceUID)
+	clusterObjectSync, err := md.clusterObjectSyncLister.Get(clusterObjectSyncName)
+
+	switch {
+	case err == nil && clusterObjectSync.Status.ObjectResourceVersion != "":
+		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0 {
+			return true
+		}
+
+	case err != nil && apierrors.IsNotFound(err):
+		// If clusterObjectSync is not exist, this indicates that the message is coming
+		// for the first time, We create clusterObjectSync for the resource directly.
+
+		clusterObjectSync := &v1alpha1.ClusterObjectSync{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterObjectSyncName,
+			},
+			Spec: v1alpha1.ObjectSyncSpec{
+				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
+				ObjectKind:       util.GetMessageResourceType(msg),
+				ObjectName:       resourceName,
+			},
+		}
+
+		clusterObjectSync, err := md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			Create(context.Background(), clusterObjectSync, metav1.CreateOptions{})
+		if err != nil {
+			klog.ErrorS(err, "Failed to create clusterObjectSync",
+				"clusterObjectSyncName", clusterObjectSyncName,
+				"resourceName", resourceName)
+			return false
+		}
+
+		clusterObjectSync.Status.ObjectResourceVersion = "0"
+		_, err = md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			UpdateStatus(context.Background(), clusterObjectSync, metav1.UpdateOptions{})
+		if err != nil {
+			klog.ErrorS(err, "Failed to update clusterObjectSync",
+				"clusterObjectSyncName", clusterObjectSyncName,
+				"resourceName", resourceName)
+			return false
+		}
+
+		return true
+
+	case err != nil:
+		klog.Errorf("failed to get clusterObjectSync %s: %v", clusterObjectSyncName, err)
+	}
+
+	return false
+}
+
+func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehivemodel.Message) bool {
 	resourceNamespace, _ := messagelayer.GetNamespace(*msg)
 	resourceName, _ := messagelayer.GetResourceName(*msg)
 	resourceUID, err := common.GetMessageUID(*msg)
 	if err != nil {
 		klog.Errorf("fail to get message UID for message: %s", msg.Header.ID)
-		return
+		return false
 	}
 
 	objectSyncName := synccontroller.BuildObjectSyncName(nodeID, resourceUID)
@@ -271,13 +345,13 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 	switch {
 	case err == nil && objectSync.Status.ObjectResourceVersion != "":
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0 {
-			shouldEnqueue = true
-			return
+			return true
 		}
 
 	case err != nil && apierrors.IsNotFound(err):
 		// If objectSync is not exist, this indicates that the message is coming
 		// for the first time, We create objectSync for the resource directly.
+
 		objectSync := &v1alpha1.ObjectSync{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      objectSyncName,
@@ -299,7 +373,7 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 				"objectSyncName", objectSyncName,
 				"resourceNamespace", resourceNamespace,
 				"resourceName", resourceName)
-			return
+			return false
 		}
 
 		objectSyncStatus.Status.ObjectResourceVersion = "0"
@@ -312,14 +386,16 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 				"objectSyncName", objectSyncName,
 				"resourceNamespace", resourceNamespace,
 				"resourceName", resourceName)
+			return false
 		}
 
-		// enqueue message that comes for the first time
-		shouldEnqueue = true
+		return true
 
 	case err != nil:
 		klog.Errorf("failed to get ObjectSync %s/%s: %v", resourceNamespace, objectSyncName, err)
 	}
+
+	return false
 }
 
 func isDeleteMessage(msg *beehivemodel.Message) bool {

--- a/cloud/pkg/synccontroller/clusterobjectsync.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync.go
@@ -1,3 +1,107 @@
 package synccontroller
 
-// TODO: sync for cluster level objects
+import (
+	"context"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	commonconst "github.com/kubeedge/kubeedge/common/constants"
+	v2 "github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/v2"
+	"github.com/kubeedge/kubeedge/pkg/apis/reliablesyncs/v1alpha1"
+	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
+)
+
+func (sctl *SyncController) reconcileClusterObjectSync(sync *v1alpha1.ClusterObjectSync) {
+	var object metav1.Object
+
+	gv, err := schema.ParseGroupVersion(sync.Spec.ObjectAPIVersion)
+	if err != nil {
+		return
+	}
+	resource := util.UnsafeKindToResource(sync.Spec.ObjectKind)
+	gvr := gv.WithResource(resource)
+	nodeName := getNodeName(sync.Name)
+	resourceType := strings.ToLower(sync.Spec.ObjectKind)
+
+	lister, err := sctl.informerManager.GetLister(gvr)
+	if err != nil {
+		return
+	}
+
+	ret, err := lister.Get(sync.Spec.ObjectName)
+	if apierrors.IsNotFound(err) {
+		sctl.gcOrphanedClusterObjectSync(sync)
+		return
+	}
+
+	if err != nil || ret == nil {
+		klog.Errorf("failed to get obj(gvr:%v, name:%v): %v", gvr, sync.Spec.ObjectName, err)
+		return
+	}
+
+	object, err = meta.Accessor(ret)
+	if err != nil {
+		klog.Errorf("failed to Accessor obj(gvr:%v, name:%v): %v", gvr, sync.Spec.ObjectName, err)
+		return
+	}
+
+	syncObjUID := getObjectUID(sync.Name)
+	if syncObjUID != string(object.GetUID()) {
+		sctl.gcOrphanedClusterObjectSync(sync)
+		return
+	}
+
+	sendClusterObjectSyncEvent(nodeName, sync, resourceType, object.GetResourceVersion(), object)
+}
+
+// gcOrphanedClusterObjectSync try to send delete message to the edge node
+// to make sure that the resource is deleted in the edge node. After the
+// message ACK is received by `cloudHub`, the objectSync will be deleted
+// directly in the `cloudHub`. But if message build failed, the ClusterObjectSync
+// will be deleted directly in the `syncController`.
+func (sctl *SyncController) gcOrphanedClusterObjectSync(sync *v1alpha1.ClusterObjectSync) {
+	resourceType := strings.ToLower(sync.Spec.ObjectKind)
+	nodeName := getNodeName(sync.Name)
+	klog.V(4).Infof("%s: %s has been deleted in K8s, send the delete event to edge in sync loop", resourceType, sync.Spec.ObjectName)
+
+	object := &unstructured.Unstructured{}
+	object.SetName(sync.Spec.ObjectName)
+	object.SetUID(types.UID(getObjectUID(sync.Name)))
+	if msg := buildEdgeControllerMessage(nodeName, v2.NullNamespace, resourceType, sync.Spec.ObjectName, model.DeleteOperation, object); msg != nil {
+		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
+	} else {
+		if err := sctl.crdclient.ReliablesyncsV1alpha1().ClusterObjectSyncs().Delete(context.Background(), sync.Name, *metav1.NewDeleteOptions(0)); err != nil {
+			klog.Errorf("Failed to delete clusterObjectSync %s: %v", sync.Name, err)
+		}
+	}
+}
+
+func sendClusterObjectSyncEvent(nodeName string, sync *v1alpha1.ClusterObjectSync, resourceType string,
+	objectResourceVersion string, obj interface{}) {
+	runtimeObj := obj.(runtime.Object)
+	if err := util.SetMetaType(runtimeObj); err != nil {
+		klog.Warningf("failed to set metatype :%v", err)
+	}
+
+	if sync.Status.ObjectResourceVersion == "" {
+		klog.Errorf("The ObjectResourceVersion is empty in status of clusterObjectSync: %s", sync.Name)
+		return
+	}
+
+	if CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
+		// trigger the update event
+		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
+		msg := buildEdgeControllerMessage(nodeName, v2.NullNamespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
+		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
+	}
+}

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
 )
 
-func (sctl *SyncController) manageObject(sync *v1alpha1.ObjectSync) {
+func (sctl *SyncController) reconcileObjectSync(sync *v1alpha1.ObjectSync) {
 	var object metav1.Object
 
 	gv, err := schema.ParseGroupVersion(sync.Spec.ObjectAPIVersion)

--- a/pkg/metaserver/key.go
+++ b/pkg/metaserver/key.go
@@ -76,6 +76,11 @@ func KeyFuncReq(ctx context.Context, _ string) (string, error) {
 	resource := info.Resource
 	namespace := info.Namespace
 	name := info.Name
+
+	// if the request resource is namespaces, set the ns to null in the key
+	if resource == "namespaces" {
+		namespace = v2.NullNamespace
+	}
 	if namespace == "" {
 		namespace = v2.NullNamespace
 	}

--- a/pkg/metaserver/key_test.go
+++ b/pkg/metaserver/key_test.go
@@ -118,7 +118,7 @@ func TestKeyFuncReq(t *testing.T) {
 	}
 	stdResult := []string{
 		"/core/v1/namespaces/null/null",
-		"/core/v1/namespaces/other/other", //a namespace called other
+		"/core/v1/namespaces/null/other", //a namespace called other
 
 		"/core/v1/pods/other/null",
 		"/core/v1/pods/other/foo",

--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -49,6 +49,7 @@ func UnsafeResourceToKind(r string) string {
 		"endpoints":                    "Endpoints",
 		"endpointslices":               "EndpointSlice",
 		"nodes":                        "Node",
+		"namespaces":                   "Namespace",
 		"services":                     "Service",
 		"podstatus":                    "PodStatus",
 		"nodestatus":                   "NodeStatus",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind feature

**What this PR does / why we need it**:

At present, when the global resources are delivered to the edge side, there is no reliability guarantee, especially when using list-watch global resources, the global resources cannot be delivered to the edge side, and the business cannot work normally.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
