### PR TITLE
Fixed the issue that the Resource field in the message cloudcore sent to edgecore was not the same when the targetUrl started with /

### DIFF
--- a/cloud/pkg/router/provider/servicebus/servicebus.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus.go
@@ -60,9 +60,9 @@ func (sf *servicebusFactory) GetSource(ep *v1.RuleEndpoint, sourceResource map[s
 }
 
 func (sb *ServiceBus) RegisterListener(handle listener.Handle) error {
-	listener.MessageHandlerInstance.AddListener(fmt.Sprintf("servicebus/%v/%v", path.Join("node", sb.nodeName), sb.TargetURL), handle)
+	listener.MessageHandlerInstance.AddListener(path.Join("servicebus/node", sb.nodeName, sb.TargetURL), handle)
 	msg := model.NewMessage("")
-	msg.SetResourceOperation(fmt.Sprintf("%v/%v", path.Join("node", sb.nodeName), sb.TargetURL), "start")
+	msg.SetResourceOperation(path.Join("node", sb.nodeName, sb.TargetURL), "start")
 	msg.SetRoute(modules.RouterSourceServiceBus, modules.UserGroup)
 	beehiveContext.Send(modules.CloudHubModuleName, *msg)
 	return nil


### PR DESCRIPTION
Fixed the issue that the Resource field in the message cloudcore sent to edgecore was not the same when the targetUrl started with /

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In cloudcore, the RegisterListener and UnregisterListener methods of servicebus use different methods for splicing TargetURLs, resulting in inconsistent splicing results when the TargetURL starts with /, and different Resource fields in the final message sent to edgecore.

![fix](https://github.com/kubeedge/kubeedge/assets/102210430/7e4aa95a-e293-46d0-a185-ddeb9da6f8dd)


