### PR TITLE
fix the problem of not being able to create multiple servicebus to rest's rules

### DIFF
--- a/edge/pkg/servicebus/servicebus.go
+++ b/edge/pkg/servicebus/servicebus.go
@@ -124,8 +124,8 @@ func processMessage(msg *beehiveModel.Message) {
 	resource := msg.GetResource()
 	switch msg.GetOperation() {
 	case "start":
+		dao.InsertUrls(resource)
 		if atomic.CompareAndSwapInt32(&inited, 0, 1) {
-			dao.InsertUrls(resource)
 			go server(c)
 		}
 	case "stop":


### PR DESCRIPTION
fix the problem of not being able to create multiple servicebus to rest's rules

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Because servicebus to rest rules are supported from version 1.9 onwards. refer to #3254 #3301 
_A HTTP server is added to ServiceBus, to support custom http request routing from edge to cloud
for applications. This simplifies the rest api access with http server on the cloud while client is in the edge._
But we found that we can only add one rule which source is servicebus and target is rest. The reason is that edgecore process the rule message with below:
```
func processMessage(msg *beehiveModel.Message) {
	source := msg.GetSource()
	if source != sourceType {
		return
	}
	resource := msg.GetResource()
	switch msg.GetOperation() {
	case "start":
		if atomic.CompareAndSwapInt32(&inited, 0, 1) {
		        dao.InsertUrls(resource)
			go server(c)
		}
         ······
}
```
If we have already added rule, the &inited is 1. So, when we add second rule,  atomic.CompareAndSwapInt32(&inited, 0, 1) will return false, it will not execute dao.InsertUrls(resource). So the rule will not be added by edgecore. But the rule has been added by cloudcore. This is not correct. So we need this pr to fix this problem.
