### PR TITLE
wait for cache sync

### DIFF
--- a/cloud/pkg/common/informers/informer_manager.go
+++ b/cloud/pkg/common/informers/informer_manager.go
@@ -240,7 +240,8 @@ func (ifs *informers) addInformerPair(gvr schema.GroupVersionResource) (*Informe
 
 	ifs.informersByGVR[gvr] = informerPair
 
-	if informerPair.Informer.HasSynced() {
+	if !informerPair.Informer.HasSynced() {
+		klog.V(4).Infof("waiting for %s Informer to sync", gvr.String())
 		// Wait for it to sync before returning the Informer so that folks don't read from a stale cache.
 		if !cache.WaitForCacheSync(ifs.stopCh, informerPair.Informer.HasSynced) {
 			return nil, fmt.Errorf("failed waiting for %s Informer to sync", gvr.String())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
informerPair.Informer.HasSynced() is false in the cloudcore rebooting stage, the object (especially crd) not found error will occur, and then the function `manageObject` in the syncController will delete the edge object incorrectly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
