### PR TITLE
fix panic when listing error

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go
@@ -150,8 +150,9 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 		}
 		klog.Infof("[metaserver/reststorage] successfully process list req (%v) at local", info.Path)
 	}
-
-	decorateList(ctx, list)
+	if err == nil {
+		decorateList(ctx, list)
+	}
 	return list, err
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
fix panic when listing error
```
E0527 17:40:58.591975 2427600 storage.go:131] [metaserver/reststorage] failed to list obj from cloud:
E0527 17:40:58.592080 2427600 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1236 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x27f3080, 0x4a845c0})
        /home/src/kubeedge/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x7d
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0xc000b234c0, 0x1, 0x1892106})
        /home/src/kubeedge/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x27f3080, 0x4a845c0})
        /root/.gvm/gos/go1.17.13/src/runtime/panic.go:1038 +0x215
github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage.decorateList({0x30fe3f8, 0xc001245a40}, {0x0, 0x0})
        /home/src/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go:71 +0x81
github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage.(*REST).List(0xc0006c6fa0, {0x30fe3f8, 0xc001245a40}, 0x0)
        /home/src/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go:154 +0x225
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
