### PR TITLE
fix helm default values

### DIFF
--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -1,14 +1,14 @@
 # Default values for kubeedge.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-appVersion: "1.12.0"
+appVersion: "1.13.0"
 
 cloudCore:
   replicaCount: 1
-  hostNetWork: "true"
+  hostNetWork: true
   image:
     repository: "kubeedge/cloudcore"
-    tag: "v1.12.0"
+    tag: "v1.13.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -43,20 +43,20 @@ cloudCore:
         - ""
       nodeLimit: "1000"
       websocket:
-        enable: "true"
+        enable: true
       quic:
-        enable: "false"
+        enable: false
         maxIncomingStreams: "10000"
       https:
-        enable: "true"
+        enable: true
     cloudStream:
-      enable: "true"
+      enable: true
     dynamicController:
-      enable: "false"
+      enable: false
     router:
-      enable: "false"
+      enable: false
   service:
-    enable: "true"
+    enable: true
     type: "NodePort"
     cloudhubNodePort: "30000"
     cloudhubQuicNodePort: "30001"
@@ -66,7 +66,7 @@ cloudCore:
     annotations: {}
 
 iptablesManager:
-  enable: "true"
+  enable: true
   mode: "internal"
   hostNetWork: true
   image:

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -1,14 +1,14 @@
 # Default values for kubeedge.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-appVersion: "1.12.0"
+appVersion: "1.13.0"
 
 cloudCore:
   replicaCount: 1
-  hostNetWork: "true"
+  hostNetWork: true
   image:
     repository: "kubeedge/cloudcore"
-    tag: "v1.12.0"
+    tag: "v1.13.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext: 
@@ -39,20 +39,20 @@ cloudCore:
         - ""              # At least a public IP Address or an IP which can be accessed by edge nodes must be provided!           
       nodeLimit: "1000"
       websocket:
-        enable: "true"
+        enable: true
       quic:
-        enable: "false"
+        enable: false
         maxIncomingStreams: "10000"
       https:
-        enable: "true"
+        enable: true
     cloudStream:
-      enable: "true"
+      enable: true
     dynamicController:
-      enable: "false"
+      enable: false
     router:
-      enable: "false"
+      enable: false
   service:
-    enable: "false"
+    enable: false
     type: "NodePort"
     cloudhubNodePort: "30000"
     cloudhubQuicNodePort: "30001"
@@ -61,7 +61,7 @@ cloudCore:
     tunnelNodePort: "30004"
 
 iptablesManager:
-  enable: "true"
+  enable: true
   mode: "internal"
   hostNetWork: true
   image:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

1. Upgrade cloudcore default image tag to "v1.13.0" (controllermanager and iptables-manager no "v1.13.0" tag in dockerhub).
2. If the property `cloudCore.hostNetWork` is a string value,  The expression `{{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}` is always `false` in service_cloudcore.yaml, this means service will not be a NodePort type.
3. Set all enable fields to bool type.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
