### PR TITLE
[bugfix] add the right to deleting configmaps in rbac of cloudcore to support device-profile

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
   resources: ["nodes", "nodes/status", "pods/status"]
   verbs: ["patch"]
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "configmaps"]
   verbs: ["delete"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
@@ -17,7 +17,7 @@ rules:
   resources: ["nodes", "nodes/status", "pods/status"]
   verbs: ["patch"]
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "configmaps"]
   verbs: ["delete"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]


### PR DESCRIPTION
 add the right to deleting configmaps in rbac of cloudcore to support devicecontroller to delete configmaps of device-profile

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4812 

