### PR TITLE
Fix wrong default version for edge

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -54,7 +54,7 @@ const (
 	RuntimeType = "runtimetype"
 
 	// DefaultKubeEdgeVersion is the default KubeEdge version
-	DefaultKubeEdgeVersion = "1.12.0"
+	DefaultKubeEdgeVersion = "1.13.0"
 
 	// Token sets the token used when edge applying for the certificate
 	Token = "token"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
The latest release is already 1.13.0, but the default edge revision is 1.12.0,  mybe we should modify it and cherry pick it to release-1.12

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
