### PR TITLE
Fixed the kubeedge-version flag does not take effect

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -18,7 +18,6 @@ package cloud
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
@@ -77,7 +76,7 @@ func NewCloudInit() *cobra.Command {
 	return cmd
 }
 
-//newInitOptions will initialise new instance of options everytime
+// newInitOptions will initialise new instance of options everytime
 func newInitOptions() *types.InitOptions {
 	opts := &types.InitOptions{}
 	opts.KubeConfig = types.DefaultKubeConfig
@@ -118,35 +117,15 @@ func addForceOptionsFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 		"Forced installing the cloud components without waiting.")
 }
 
-//AddInit2ToolsList reads the flagData (containing val and default val) and join options to fill the list of tools.
+// AddInit2ToolsList reads the flagData (containing val and default val) and join options to fill the list of tools.
 func AddInit2ToolsList(toolList map[string]types.ToolsInstaller, initOpts *types.InitOptions) error {
-	var latestVersion string
-	var kubeedgeVersion string
-	for i := 0; i < util.RetryTimes; i++ {
-		version, err := util.GetLatestVersion()
-		if err != nil {
-			fmt.Println("Failed to get the latest KubeEdge release version, error: ", err)
-			continue
-		}
-		if len(version) > 0 {
-			kubeedgeVersion = strings.TrimPrefix(version, "v")
-			latestVersion = version
-			break
-		}
-	}
-	if len(latestVersion) == 0 {
-		kubeedgeVersion = types.DefaultKubeEdgeVersion
-		fmt.Println("Failed to get the latest KubeEdge release version, will use default version: ", kubeedgeVersion)
-	}
-
 	common := util.Common{
-		ToolVersion: semver.MustParse(kubeedgeVersion),
+		ToolVersion: semver.MustParse(util.GetHelmVersion(initOpts.KubeEdgeVersion, util.RetryTimes)),
 		KubeConfig:  initOpts.KubeConfig,
 	}
 	toolList["helm"] = &helm.KubeCloudHelmInstTool{
 		Common:           common,
 		AdvertiseAddress: initOpts.AdvertiseAddress,
-		KubeEdgeVersion:  initOpts.KubeEdgeVersion,
 		Manifests:        initOpts.Manifests,
 		Namespace:        constants.SystemNamespace,
 		DryRun:           initOpts.DryRun,
@@ -159,7 +138,7 @@ func AddInit2ToolsList(toolList map[string]types.ToolsInstaller, initOpts *types
 	return nil
 }
 
-//ExecuteInit the installation for each tool and start cloudcore
+// ExecuteInit the installation for each tool and start cloudcore
 func ExecuteInit(toolList map[string]types.ToolsInstaller) error {
 	return toolList["helm"].InstallTools()
 }

--- a/keadm/cmd/keadm/app/cmd/cloud/manifest.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/manifest.go
@@ -18,7 +18,6 @@ package cloud
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
@@ -101,35 +100,15 @@ func addManifestsGenerateJoinOtherFlags(cmd *cobra.Command, initOpts *types.Init
 		"Skip printing the contents of CRDs to stdout")
 }
 
-//AddManifestsGenerate2ToolsList Reads the flagData (containing val and default val) and join options to fill the list of tools.
+// AddManifestsGenerate2ToolsList Reads the flagData (containing val and default val) and join options to fill the list of tools.
 func AddManifestsGenerate2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string]types.FlagData, initOpts *types.InitOptions) error {
-	var latestVersion string
-	var kubeedgeVersion string
-	for i := 0; i < util.RetryTimes; i++ {
-		version, err := util.GetLatestVersion()
-		if err != nil {
-			fmt.Println("Failed to get the latest KubeEdge release version, error: ", err)
-			continue
-		}
-		if len(version) > 0 {
-			kubeedgeVersion = strings.TrimPrefix(version, "v")
-			latestVersion = version
-			break
-		}
-	}
-	if len(latestVersion) == 0 {
-		kubeedgeVersion = types.DefaultKubeEdgeVersion
-		fmt.Println("Failed to get the latest KubeEdge release version, will use default version: ", kubeedgeVersion)
-	}
-
 	common := util.Common{
-		ToolVersion: semver.MustParse(kubeedgeVersion),
+		ToolVersion: semver.MustParse(util.GetHelmVersion(initOpts.KubeEdgeVersion, util.RetryTimes)),
 		KubeConfig:  initOpts.KubeConfig,
 	}
 	toolList["helm"] = &helm.KubeCloudHelmInstTool{
 		Common:           common,
 		AdvertiseAddress: initOpts.AdvertiseAddress,
-		KubeEdgeVersion:  initOpts.KubeEdgeVersion,
 		Manifests:        initOpts.Manifests,
 		Namespace:        constants.SystemNamespace,
 		DryRun:           initOpts.DryRun,
@@ -141,7 +120,7 @@ func AddManifestsGenerate2ToolsList(toolList map[string]types.ToolsInstaller, fl
 	return nil
 }
 
-//ExecuteManifestsGenerate executes the installation for helm
+// ExecuteManifestsGenerate executes the installation for helm
 func ExecuteManifestsGenerate(toolList map[string]types.ToolsInstaller) error {
 	return toolList["helm"].InstallTools()
 }

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -53,8 +53,8 @@ const (
 	// RuntimeType is default runtime type
 	RuntimeType = "runtimetype"
 
-	// DefaultKubeEdgeVersion is the default KubeEdge version
-	DefaultKubeEdgeVersion = "1.13.0"
+	// DefaultKubeEdgeVersion is the default KubeEdge version, it must have no prefix 'v'
+	DefaultKubeEdgeVersion = "1.14.0"
 
 	// Token sets the token used when edge applying for the certificate
 	Token = "token"

--- a/keadm/cmd/keadm/app/cmd/helm/installer.go
+++ b/keadm/cmd/keadm/app/cmd/helm/installer.go
@@ -58,7 +58,6 @@ var (
 type KubeCloudHelmInstTool struct {
 	util.Common
 	AdvertiseAddress string
-	KubeEdgeVersion  string
 	Manifests        string
 	Namespace        string
 	Sets             []string

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -375,3 +375,38 @@ func TestValidateStableVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestGetHelmVersion(t *testing.T) {
+	cases := []struct {
+		name       string
+		version    string
+		retryTimes int    // if zero, means don't obtant remote version
+		want       string // if want is empty, means not check result
+	}{
+		{
+			name:    "get input version",
+			version: "v1.14.0",
+			want:    "1.14.0",
+		},
+		{
+			name:       "get default version",
+			version:    "1-14-0",
+			retryTimes: 0,
+			want:       types.DefaultKubeEdgeVersion,
+		},
+		{
+			name:       "get remote version",
+			version:    "1-14-0",
+			retryTimes: 1,
+			want:       "", // obtain the remote version is not controllable
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := GetHelmVersion(c.version, c.retryTimes)
+			if c.want != "" && c.want != res {
+				t.Fatalf("expected output: %s, got: %s", c.want, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixed the kubeedge-version flag does not take effect in the init & manifest generate command.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Please see the comments with exclamation marks in codes:
```golang
// init.go  #AddInit2ToolsList(..)
var latestVersion string
var kubeedgeVersion string
for i := 0; i < util.RetryTimes; i++ {
    version, err := util.GetLatestVersion()
    if err != nil {
        fmt.Println("Failed to get the latest KubeEdge release version, error: ", err)
        continue
    }
    if len(version) > 0 {
        kubeedgeVersion = strings.TrimPrefix(version, "v")
        latestVersion = version
        break
    }
}
if len(latestVersion) == 0 {
    kubeedgeVersion = types.DefaultKubeEdgeVersion
    fmt.Println("Failed to get the latest KubeEdge release version, will use default version: ", kubeedgeVersion)
}

common := util.Common{
    // !!! ToolVersion is always be set to remote version or default version
    ToolVersion: semver.MustParse(kubeedgeVersion),
    KubeConfig:  initOpts.KubeConfig,
}
toolList["helm"] = &helm.KubeCloudHelmInstTool{
    Common:           common,
    AdvertiseAddress: initOpts.AdvertiseAddress,
    // !!! KubeEdgeVersion has no effect after that
    KubeEdgeVersion:  initOpts.KubeEdgeVersion, 
    Manifests:        initOpts.Manifests,
    Namespace:        constants.SystemNamespace,
    DryRun:           initOpts.DryRun,
    Sets:             initOpts.Sets,
    Profile:          initOpts.Profile,
    ExternalHelmRoot: initOpts.ExternalHelmRoot,
    Force:            initOpts.Force,
    Action:           types.HelmInstallAction,
}

// helm/installer.go  #InstallTools(..)
...
cu.SetKubeEdgeVersion(cu.ToolVersion) 
...
// !!! Later, only use toolversion to indicate the kubeedge version
// !!! E.g.: 
currentVersion := cu.ToolVersion.String()
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
