### PR TITLE
Automated cherry pick of #4620: fix iptables-manager controller-manager image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,17 +88,17 @@ jobs:
     name: publish to DockerHub
     strategy:
       matrix:
-        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptablesmanager, edgemark, installation-package, controllermanager]
+        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptables-manager, edgemark, installation-package, controller-manager]
     outputs:
       hash-digest-cloudcore: ${{ steps.hash.outputs.hash-digest-cloudcore }}
       hash-digest-admission: ${{ steps.hash.outputs.hash-digest-admission }}
       hash-digest-edgesite-agent: ${{ steps.hash.outputs.hash-digest-edgesite-agent }}
       hash-digest-edgesite-server: ${{ steps.hash.outputs.hash-digest-edgesite-server }}
       hash-digest-csidriver: ${{ steps.hash.outputs.hash-digest-csidriver }}
-      hash-digest-iptablesmanager: ${{ steps.hash.outputs.hash-digest-iptablesmanager }}
+      hash-digest-iptables-manager: ${{ steps.hash.outputs.hash-digest-iptables-manager }}
       hash-digest-edgemark: ${{ steps.hash.outputs.hash-digest-edgemark }}
       hash-digest-installation-package: ${{ steps.hash.outputs.hash-digest-installation-package }}
-      hash-digest-controllermanager: ${{ steps.hash.outputs.hash-digest-controllermanager }}
+      hash-digest-controller-manager: ${{ steps.hash.outputs.hash-digest-controller-manager }}
     runs-on: ubuntu-22.04
     steps:
       - name: checkout code
@@ -141,7 +141,7 @@ jobs:
     needs: [publish-image-to-dockerhub]
     strategy:
       matrix:
-        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptablesmanager, edgemark, installation-package, controllermanager]
+        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptables-manager, edgemark, installation-package, controller-manager]
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.

--- a/hack/make-rules/crossbuildimage.sh
+++ b/hack/make-rules/crossbuildimage.sh
@@ -33,11 +33,11 @@ ALL_IMAGES_AND_TARGETS=(
   edgesite-agent:edgesite-agent:build/edgesite/agent-build.Dockerfile
   edgesite-server:edgesite-server:build/edgesite/server-build.Dockerfile
   csidriver:csidriver:build/csidriver/Dockerfile
-  iptablesmanager:iptables-manager:build/iptablesmanager/Dockerfile
+  iptables-manager:iptables-manager:build/iptablesmanager/Dockerfile
   edgemark:edgemark:build/edgemark/Dockerfile
   conformance:conformance:build/conformance/Dockerfile
   installation-package:installation-package:build/docker/installation-package/installation-package.dockerfile
-  controllermanager:controller-manager:build/controllermanager/Dockerfile
+  controller-manager:controller-manager:build/controllermanager/Dockerfile
 )
 
 function get_imagename_by_target() {

--- a/hack/make-rules/imageprocess.sh
+++ b/hack/make-rules/imageprocess.sh
@@ -31,10 +31,10 @@ ALL_IMAGES_AND_TARGETS=(
   edgesite-agent:edgesite-agent:build/edgesite/agent-build.Dockerfile
   edgesite-server:edgesite-server:build/edgesite/server-build.Dockerfile
   csidriver:csidriver:build/csidriver/Dockerfile
-  iptablesmanager:iptables-manager:build/iptablesmanager/Dockerfile
+  iptables-manager:iptables-manager:build/iptablesmanager/Dockerfile
   edgemark:edgemark:build/edgemark/Dockerfile
   installation-package:installation-package:build/docker/installation-package/installation-package.dockerfile
-  controllermanager:controller-manager:build/controllermanager/Dockerfile
+  controller-manager:controller-manager:build/controllermanager/Dockerfile
 )
 
 function get_imagename_by_target() {


### PR DESCRIPTION
Cherry pick of #4620 on release-1.13.

#4620: fix iptables-manager controller-manager image name

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.