### PR TITLE
Automated cherry pick of #4784: update the timeout to 40 mins for docker image ci test

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -298,7 +298,7 @@ jobs:
 
   docker_build:
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     name: Multiple docker image build
     steps:
       - uses: actions/cache@v3


### PR DESCRIPTION
Cherry pick of #4784 on release-1.13.

#4784: update the timeout to 40 mins for docker image ci test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.