### PR TITLE
Automated cherry pick of #4578: bugfix container terminated when edgecore restart

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -300,8 +300,6 @@ func (e *edged) handlePodListFromMetaManager(content []byte, updatesChan chan<- 
 	}
 
 	var pods []*v1.Pod
-	var podsUpdate []*v1.Pod
-
 	for _, list := range lists {
 		var pod v1.Pod
 		err = json.Unmarshal([]byte(list), &pod)
@@ -309,17 +307,12 @@ func (e *edged) handlePodListFromMetaManager(content []byte, updatesChan chan<- 
 			return err
 		}
 
-		// if edge-core stop or panic when pod is deleting, pod need add into podDeletionQueue after edge-core restart.
 		if filterPodByNodeName(&pod, e.nodeName) {
-			if pod.DeletionTimestamp == nil {
-				pods = append(pods, &pod)
-			} else {
-				podsUpdate = append(podsUpdate, &pod)
-			}
+			pods = append(pods, &pod)
 		}
 	}
 
-	updates := &kubelettypes.PodUpdate{Op: kubelettypes.SET, Pods: podsUpdate, Source: kubelettypes.ApiserverSource}
+	updates := &kubelettypes.PodUpdate{Op: kubelettypes.SET, Pods: pods, Source: kubelettypes.ApiserverSource}
 	updatesChan <- *updates
 
 	return nil


### PR DESCRIPTION
Cherry pick of #4578 on release-1.13.

#4578: bugfix container terminated when edgecore restart

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.