### PR TITLE
fix the bug  in local-up mode that causes cni to not launch

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -96,12 +96,74 @@ verify_docker_installed(){
 
 # install CNI plugins
 function install_cni_plugins() {
+  CNI_DOWNLOAD_ADDR=${CNI_DOWNLOAD_ADDR:-"https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz"}
+  CNI_PKG=${CNI_DOWNLOAD_ADDR##*/}
+  CNI_CONF_OVERWRITE=${CNI_CONF_OVERWRITE:-"true"}
+  echo -e "The installation of the cni plugin will overwrite the cni config file. Use export CNI_CONFIG_FILE=false to disable it."
+
   # install CNI plugins if not exist
   if [ ! -f "/opt/cni/bin/loopback" ]; then
-    echo -e "install CNI plugins..."
-    mkdir -p /opt/cni/bin
-    wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
-    tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
+    echo -e "start installing CNI plugins..."
+    sudo mkdir -p /opt/cni/bin
+    wget ${CNI_DOWNLOAD_ADDR}
+    if [ ! -f ${CNI_PKG} ]; then
+      echo -e "cni plugins package does not exits"
+      exit 1
+    fi
+    sudo tar Cxzvf /opt/cni/bin ${CNI_PKG}
+    rm -rf ${CNI_PKG}
+    if [ ! -f "/opt/cni/bin/loopback" ]; then
+      echo -e "the ${CNI_PKG} package does not contain a loopback file."
+      exit 1
+    fi
+
+    # create CNI netconf file
+    CNI_CONFIG_FILE="/etc/cni/net.d/10-containerd-net.conflist"
+    if [ -f ${CNI_CONFIG_FILE} ]; then
+      if [ ${CNI_CONF_OVERWRITE} == "false" ]; then
+        echo -e "CNI netconf file already exist and will no overwrite"
+        return
+      fi
+      echo -e "Configuring cni, ${CNI_CONFIG_FILE} already exists, will be backup as ${CNI_CONFIG_FILE}-bak ..."
+      sudo mv ${CNI_CONFIG_FILE} ${CNI_CONFIG_FILE}-bak
+    fi
+    sudo mkdir -p "/etc/cni/net.d/"
+    sudo sh -c 'cat > '${CNI_CONFIG_FILE}' <<EOF
+{
+  "cniVersion": "1.0.0",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{
+            "subnet": "10.88.0.0/16"
+          }],
+          [{
+            "subnet": "2001:db8:4860::/64"
+          }]
+        ],
+        "routes": [
+          { "dst": "0.0.0.0/0" },
+          { "dst": "::/0" }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF'
+    sudo systemctl restart containerd
+    sleep 2
   else
     echo "CNI plugins already installed and no need to install"
   fi

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -21,6 +21,7 @@ LOG_LEVEL=${LOG_LEVEL:-2}
 TIMEOUT=${TIMEOUT:-60}s
 PROTOCOL=${PROTOCOL:-"WebSocket"}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"remote"}
+echo -e "The installation of the cni plugin will overwrite the cni config file. Use export CNI_CONFIG_FILE=false to disable it."
 
 if [[ "${CLUSTER_NAME}x" == "x" ]];then
     CLUSTER_NAME="test"
@@ -254,12 +255,6 @@ build_edgecore
 
 kind_up_cluster
 
-# install CNI plugins
-if [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
-  # we need to install CNI plugins only when we use remote(containerd) as edgecore container runtime
-  install_cni_plugins
-fi
-
 export KUBECONFIG=$HOME/.kube/config
 
 check_control_plane_ready
@@ -277,6 +272,12 @@ create_serviceaccountaccess_crd
 generate_streamserver_cert
 
 start_cloudcore
+
+# install CNI plugins
+if [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
+# we need to install CNI plugins only when we use remote(containerd) as edgecore container runtime
+install_cni_plugins
+fi
 
 sleep 2
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The local-up script does not produce cni netconf when I use it to install the cluster on a clean node. Edgenode will become notReady as a result.
If the netconf file doesn't already exist, one must be created.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

cc @fisherxu 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
none
```


Core process：
```
**Saving to: ‘cni-plugins-linux-amd64-v1.1.1.tgz’**
100%

2023-07-25 17:32:44 (1.46 GB/s) - ‘cni-plugins-linux-amd64-v1.1.1.tgz’ saved [36336160/36336160]

./
./macvlan
./static
./vlan
./portmap
./host-local
./vrf
./bridge
./tuning
./firewall
./host-device
./sbr
./loopback
./dhcp
./ptp
./ipvlan
./bandwidth
**creating CNI netconf file...**
daemonset.apps "kindnet" deleted
namespace/kubeedge created
creating the device crd...
customresourcedefinition.apiextensions.k8s.io/devices.devices.kubeedge.io created
customresourcedefinition.apiextensions.k8s.io/devicemodels.devices.kubeedge.io created
creating the objectsync crd...
customresourcedefinition.apiextensions.k8s.io/clusterobjectsyncs.reliablesyncs.kubeedge.io created
customresourcedefinition.apiextensions.k8s.io/objectsyncs.reliablesyncs.kubeedge.io created
creating the rule crd...
customresourcedefinition.apiextensions.k8s.io/rules.rules.kubeedge.io created
customresourcedefinition.apiextensions.k8s.io/ruleendpoints.rules.kubeedge.io created
creating the operation crd...
customresourcedefinition.apiextensions.k8s.io/nodeupgradejobs.operations.kubeedge.io created
creating the saaccess crd...
customresourcedefinition.apiextensions.k8s.io/serviceaccountaccesses.policy.kubeedge.io created
Generating RSA private key, 2048 bit long modulus
........+++
............................................+++
e is 65537 (0x10001)
Signature ok
subject=/C=CN/ST=Zhejiang/L=Hangzhou/O=KubeEdge
Getting CA Private Key
start cloudcore...
start edgecore...
Local KubeEdge cluster is running. Press Ctrl-C to shut it down.
Logs:
  /tmp/cloudcore.log
  /tmp/edgecore.log

To start using your kubeedge, you can run:

  export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/bin
  export KUBECONFIG=/root/.kube/config
  kubectl get nodes

**kubectl get node
NAME                 STATUS   ROLES        AGE    VERSION
edge-node            Ready    agent,edge   113m   v1.24.14-kubeedge-v1.14.0-39+3649891e032e28-dirty
test-control-plane   Ready    master       114m   v1.19.1**

```
