### PR TITLE
Automated cherry pick of #4641: replace nodeIP initialization in edged

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -3,7 +3,6 @@ package app
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 
 	"github.com/mitchellh/go-ps"
@@ -96,21 +95,6 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 				}
 				config.Modules.Edged.NodeIP = ip.String()
 				klog.Infof("Get IP address by custom interface successfully, %s: %s", config.Modules.Edged.CustomInterfaceName, config.Modules.Edged.NodeIP)
-			} else {
-				if net.ParseIP(config.Modules.Edged.NodeIP) != nil {
-					klog.Infof("Use node IP address from config: %s", config.Modules.Edged.NodeIP)
-				} else if config.Modules.Edged.NodeIP != "" {
-					klog.Errorf("invalid node IP address specified: %s", config.Modules.Edged.NodeIP)
-					os.Exit(1)
-				} else {
-					nodeIP, err := util.GetLocalIP(util.GetHostname())
-					if err != nil {
-						klog.Errorf("Failed to get Local IP address: %v", err)
-						os.Exit(1)
-					}
-					config.Modules.Edged.NodeIP = nodeIP
-					klog.Infof("Get node local IP address successfully: %s", nodeIP)
-				}
 			}
 
 			registerModules(config)

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -66,7 +66,6 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				TailoredKubeletFlag: TailoredKubeletFlag{
 					KubeConfig:       constants.DefaultKubeletConfig,
 					HostnameOverride: hostnameOverride,
-					NodeIP:           localIP,
 					ContainerRuntimeOptions: ContainerRuntimeOptions{
 						ContainerRuntime:          constants.DefaultRuntimeType,
 						DockershimRootDirectory:   constants.DefaultDockershimRootDir,
@@ -213,7 +212,6 @@ func NewMinEdgeCoreConfig() *EdgeCoreConfig {
 				TailoredKubeletFlag: TailoredKubeletFlag{
 					KubeConfig:       constants.DefaultKubeletConfig,
 					HostnameOverride: hostnameOverride,
-					NodeIP:           localIP,
 					ContainerRuntimeOptions: ContainerRuntimeOptions{
 						ContainerRuntime:          constants.DefaultRuntimeType,
 						DockershimRootDirectory:   constants.DefaultDockershimRootDir,


### PR DESCRIPTION
Cherry pick of #4641 on release-1.12.

#4641: replace nodeIP initialization in edged

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.