### PR TITLE
Automated cherry pick of #4882: fix parsing response message err in metamanager

### DIFF
--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -352,6 +352,7 @@ func (m *metaManager) processRemote(message model.Message) {
 			return
 		}
 		mapContent, ok := resp.GetContent().(map[string]interface{})
+		respDB := resp
 		if ok && isObjectResp(mapContent) {
 			if mapContent["Err"] != nil {
 				klog.V(4).Infof("process remote objResp err: %v", mapContent["Err"])
@@ -359,9 +360,9 @@ func (m *metaManager) processRemote(message model.Message) {
 				return
 			}
 			klog.V(4).Infof("process remote objResp: %+v", mapContent["Object"])
-			resp.Content = mapContent["Object"]
+			respDB.Content = mapContent["Object"]
 		}
-		if err := m.handleMessage(&resp); err != nil {
+		if err := m.handleMessage(&respDB); err != nil {
 			feedbackError(err, message)
 			return
 		}


### PR DESCRIPTION
Cherry pick of #4882 on release-1.14.

#4882: fix parsing resp err

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.