### PR TITLE
Fixed the cloudcore panic caused by the ClusterObjectSyncList item error

### DIFF
--- a/pkg/apis/reliablesyncs/v1alpha1/type.go
+++ b/pkg/apis/reliablesyncs/v1alpha1/type.go
@@ -48,7 +48,7 @@ type ClusterObjectSyncList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// List of ClusterObjectSync.
-	Items []ObjectSync `json:"items"`
+	Items []ClusterObjectSync `json:"items"`
 }
 
 // +genclient

--- a/pkg/apis/reliablesyncs/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/reliablesyncs/v1alpha1/zz_generated.deepcopy.go
@@ -60,7 +60,7 @@ func (in *ClusterObjectSyncList) DeepCopyInto(out *ClusterObjectSyncList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]ObjectSync, len(*in))
+		*out = make([]ClusterObjectSync, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

The items in the ClusterObjectSyncList are ObjectSync lists, causing panic to occur when cloudcore format assertions

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4912

**Special notes for your reviewer**:

/cc @fisherxu @AXHMFHNP

**Does this PR introduce a user-facing change?**: no
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```
[root@master1 ~]# kubectl apply -f objectsyncs.yaml
objectsync.reliablesyncs.kubeedge.io/cloudcore-objectsync unchanged
clusterobjectsync.reliablesyncs.kubeedge.io/cloudcore-clusterobjectsync created
[root@master1 ~]# kubectl get pods -nkubeedge
NAME                        READY   STATUS    RESTARTS   AGE
cloudcore-cd58b85fb-kzdgm   1/1     Running   0          21m
[root@master1 ~]# kubectl scale deploy/cloudcore -nkubeedge --replicas=0
deployment.apps/cloudcore scaled
[root@master1 ~]# kubectl scale deploy/cloudcore -nkubeedge --replicas=1
deployment.apps/cloudcore scaled
[root@master1 ~]# kubectl get pods -nkubeedge
NAME                        READY   STATUS    RESTARTS   AGE
cloudcore-cd58b85fb-sfm7v   1/1     Running   0          2s
```
