### PR TITLE
Automated cherry pick of #4915: Fixed the cloudcore panic caused by the ClusterObjectSyncList

### DIFF
--- a/pkg/apis/reliablesyncs/v1alpha1/type.go
+++ b/pkg/apis/reliablesyncs/v1alpha1/type.go
@@ -48,7 +48,7 @@ type ClusterObjectSyncList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 
 	// List of ClusterObjectSync.
-	Items []ObjectSync `json:"items"`
+	Items []ClusterObjectSync `json:"items"`
 }
 
 // +genclient

--- a/pkg/apis/reliablesyncs/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/reliablesyncs/v1alpha1/zz_generated.deepcopy.go
@@ -60,7 +60,7 @@ func (in *ClusterObjectSyncList) DeepCopyInto(out *ClusterObjectSyncList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]ObjectSync, len(*in))
+		*out = make([]ClusterObjectSync, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
Cherry pick of #4915 on release-1.14.

#4915: Fixed the cloudcore panic caused by the ClusterObjectSyncList

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.