### PR TITLE
fix ‘keadm join --certPath not work’

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -42,7 +42,7 @@ const (
 	CertPath = "certPath"
 
 	// DefaultCertPath is the default certificate path in edge node
-	DefaultCertPath = "/etc/kubeedge/certs"
+	DefaultCertPath = "/etc/kubeedge/"
 
 	// DefaultK8SMinimumVersion is the minimum version of K8S
 	DefaultK8SMinimumVersion = 11

--- a/keadm/cmd/keadm/app/cmd/debug/collect.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect.go
@@ -259,7 +259,7 @@ func collectEdgecoreData(tmpPath string, config *v1alpha2.EdgeCoreConfig, ops *c
 		}
 	} else {
 		printDetail(fmt.Sprintf("not found cert config, use default path: %s", tmpPath))
-		if err = CopyFile(common.DefaultCertPath+"/", tmpPath); err != nil {
+		if err = CopyFile(common.DefaultCertPath+"certs/", tmpPath); err != nil {
 			return err
 		}
 	}

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -212,9 +213,9 @@ func join(opt *common.JoinOptions, step *common.Step) error {
 	// if edgecore start, it will get ca/certs from cloud
 	// if ca/certs generated, we can remove bootstrap file
 	err = wait.Poll(10*time.Second, 300*time.Second, func() (bool, error) {
-		if util.FileExists(edgeCoreConfig.Modules.EdgeHub.TLSCAFile) &&
-			util.FileExists(edgeCoreConfig.Modules.EdgeHub.TLSCertFile) &&
-			util.FileExists(edgeCoreConfig.Modules.EdgeHub.TLSPrivateKeyFile) {
+		if util.FileExists(path.Join(opt.CertPath, "ca/rootCA.crt")) &&
+			util.FileExists(path.Join(opt.CertPath, "certs/server.crt")) &&
+			util.FileExists(path.Join(opt.CertPath, "certs/server.key")) {
 			return true, nil
 		}
 		return false, nil
@@ -313,6 +314,11 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 		edgeCoreConfig.Modules.EdgeHub.HTTPServer = "https://" + net.JoinHostPort(host, "10002")
 	}
 	edgeCoreConfig.Modules.EdgeStream.TunnelServer = net.JoinHostPort(host, strconv.Itoa(constants.DefaultTunnelPort))
+	if opt.CertPath != "" {
+		edgeCoreConfig.Modules.EdgeHub.TLSCAFile = path.Join(opt.CertPath, "ca/rootCA.crt")
+		edgeCoreConfig.Modules.EdgeHub.TLSCertFile = path.Join(opt.CertPath, "certs/server.crt")
+		edgeCoreConfig.Modules.EdgeHub.TLSPrivateKeyFile = path.Join(opt.CertPath, "certs/server.key")
+	}
 
 	if len(opt.Labels) > 0 {
 		edgeCoreConfig.Modules.Edged.NodeLabels = setEdgedNodeLabels(opt)
@@ -380,6 +386,11 @@ func createV1alpha1EdgeConfigFiles(opt *common.JoinOptions) error {
 		edgeCoreConfig.Modules.EdgeHub.HTTPServer = "https://" + net.JoinHostPort(host, "10002")
 	}
 	edgeCoreConfig.Modules.EdgeStream.TunnelServer = net.JoinHostPort(host, strconv.Itoa(constants.DefaultTunnelPort))
+	if opt.CertPath != "" {
+		edgeCoreConfig.Modules.EdgeHub.TLSCAFile = path.Join(opt.CertPath, "ca/rootCA.crt")
+		edgeCoreConfig.Modules.EdgeHub.TLSCertFile = path.Join(opt.CertPath, "certs/server.crt")
+		edgeCoreConfig.Modules.EdgeHub.TLSPrivateKeyFile = path.Join(opt.CertPath, "certs/server.key")
+	}
 
 	if len(opt.Labels) > 0 {
 		edgeCoreConfig.Modules.Edged.Labels = setEdgedNodeLabels(opt)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**: 

- fix ‘keadm join param certPath does not work’
- keadm(version > 1.13) joins edgecore(<1.12）will cause panic，for it still uses v1alpha2 edgecore config as below. 

![image](https://github.com/kubeedge/kubeedge/assets/48788150/ad6f1ce4-0d29-4f98-9e27-240410b00670)


**Which issue(s) this PR fixes**:

Fixes #2974 


