### PR TITLE
Automated cherry pick of #4834: Fixed the kubeedge-version flag does not take effect in the

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -17,9 +17,6 @@ limitations under the License.
 package cloud
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -77,7 +74,7 @@ func NewCloudInit() *cobra.Command {
 	return cmd
 }
 
-//newInitOptions will initialise new instance of options everytime
+// newInitOptions will initialise new instance of options everytime
 func newInitOptions() *types.InitOptions {
 	opts := &types.InitOptions{}
 	opts.KubeConfig = types.DefaultKubeConfig
@@ -118,35 +115,15 @@ func addForceOptionsFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 		"Forced installing the cloud components without waiting.")
 }
 
-//AddInit2ToolsList reads the flagData (containing val and default val) and join options to fill the list of tools.
+// AddInit2ToolsList reads the flagData (containing val and default val) and join options to fill the list of tools.
 func AddInit2ToolsList(toolList map[string]types.ToolsInstaller, initOpts *types.InitOptions) error {
-	var latestVersion string
-	var kubeedgeVersion string
-	for i := 0; i < util.RetryTimes; i++ {
-		version, err := util.GetLatestVersion()
-		if err != nil {
-			fmt.Println("Failed to get the latest KubeEdge release version, error: ", err)
-			continue
-		}
-		if len(version) > 0 {
-			kubeedgeVersion = strings.TrimPrefix(version, "v")
-			latestVersion = version
-			break
-		}
-	}
-	if len(latestVersion) == 0 {
-		kubeedgeVersion = types.DefaultKubeEdgeVersion
-		fmt.Println("Failed to get the latest KubeEdge release version, will use default version: ", kubeedgeVersion)
-	}
-
 	common := util.Common{
-		ToolVersion: semver.MustParse(kubeedgeVersion),
+		ToolVersion: semver.MustParse(util.GetHelmVersion(initOpts.KubeEdgeVersion, util.RetryTimes)),
 		KubeConfig:  initOpts.KubeConfig,
 	}
 	toolList["helm"] = &helm.KubeCloudHelmInstTool{
 		Common:           common,
 		AdvertiseAddress: initOpts.AdvertiseAddress,
-		KubeEdgeVersion:  initOpts.KubeEdgeVersion,
 		Manifests:        initOpts.Manifests,
 		Namespace:        constants.SystemNamespace,
 		DryRun:           initOpts.DryRun,
@@ -159,7 +136,7 @@ func AddInit2ToolsList(toolList map[string]types.ToolsInstaller, initOpts *types
 	return nil
 }
 
-//ExecuteInit the installation for each tool and start cloudcore
+// ExecuteInit the installation for each tool and start cloudcore
 func ExecuteInit(toolList map[string]types.ToolsInstaller) error {
 	return toolList["helm"].InstallTools()
 }

--- a/keadm/cmd/keadm/app/cmd/cloud/manifest.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/manifest.go
@@ -17,9 +17,6 @@ limitations under the License.
 package cloud
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -101,35 +98,15 @@ func addManifestsGenerateJoinOtherFlags(cmd *cobra.Command, initOpts *types.Init
 		"Skip printing the contents of CRDs to stdout")
 }
 
-//AddManifestsGenerate2ToolsList Reads the flagData (containing val and default val) and join options to fill the list of tools.
+// AddManifestsGenerate2ToolsList Reads the flagData (containing val and default val) and join options to fill the list of tools.
 func AddManifestsGenerate2ToolsList(toolList map[string]types.ToolsInstaller, flagData map[string]types.FlagData, initOpts *types.InitOptions) error {
-	var latestVersion string
-	var kubeedgeVersion string
-	for i := 0; i < util.RetryTimes; i++ {
-		version, err := util.GetLatestVersion()
-		if err != nil {
-			fmt.Println("Failed to get the latest KubeEdge release version, error: ", err)
-			continue
-		}
-		if len(version) > 0 {
-			kubeedgeVersion = strings.TrimPrefix(version, "v")
-			latestVersion = version
-			break
-		}
-	}
-	if len(latestVersion) == 0 {
-		kubeedgeVersion = types.DefaultKubeEdgeVersion
-		fmt.Println("Failed to get the latest KubeEdge release version, will use default version: ", kubeedgeVersion)
-	}
-
 	common := util.Common{
-		ToolVersion: semver.MustParse(kubeedgeVersion),
+		ToolVersion: semver.MustParse(util.GetHelmVersion(initOpts.KubeEdgeVersion, util.RetryTimes)),
 		KubeConfig:  initOpts.KubeConfig,
 	}
 	toolList["helm"] = &helm.KubeCloudHelmInstTool{
 		Common:           common,
 		AdvertiseAddress: initOpts.AdvertiseAddress,
-		KubeEdgeVersion:  initOpts.KubeEdgeVersion,
 		Manifests:        initOpts.Manifests,
 		Namespace:        constants.SystemNamespace,
 		DryRun:           initOpts.DryRun,
@@ -141,7 +118,7 @@ func AddManifestsGenerate2ToolsList(toolList map[string]types.ToolsInstaller, fl
 	return nil
 }
 
-//ExecuteManifestsGenerate executes the installation for helm
+// ExecuteManifestsGenerate executes the installation for helm
 func ExecuteManifestsGenerate(toolList map[string]types.ToolsInstaller) error {
 	return toolList["helm"].InstallTools()
 }

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -54,7 +54,7 @@ const (
 	RuntimeType = "runtimetype"
 
 	// DefaultKubeEdgeVersion is the default KubeEdge version
-	DefaultKubeEdgeVersion = "1.11.0"
+	DefaultKubeEdgeVersion = "1.12.3"
 
 	// Token sets the token used when edge applying for the certificate
 	Token = "token"

--- a/keadm/cmd/keadm/app/cmd/helm/installer.go
+++ b/keadm/cmd/keadm/app/cmd/helm/installer.go
@@ -59,7 +59,6 @@ var (
 type KubeCloudHelmInstTool struct {
 	util.Common
 	AdvertiseAddress string
-	KubeEdgeVersion  string
 	Manifests        string
 	Namespace        string
 	Sets             []string

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -375,3 +375,38 @@ func TestValidateStableVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestGetHelmVersion(t *testing.T) {
+	cases := []struct {
+		name       string
+		version    string
+		retryTimes int    // if zero, means don't obtant remote version
+		want       string // if want is empty, means not check result
+	}{
+		{
+			name:    "get input version",
+			version: "v1.14.0",
+			want:    "1.14.0",
+		},
+		{
+			name:       "get default version",
+			version:    "1-14-0",
+			retryTimes: 0,
+			want:       types.DefaultKubeEdgeVersion,
+		},
+		{
+			name:       "get remote version",
+			version:    "1-14-0",
+			retryTimes: 1,
+			want:       "", // obtain the remote version is not controllable
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := GetHelmVersion(c.version, c.retryTimes)
+			if c.want != "" && c.want != res {
+				t.Fatalf("expected output: %s, got: %s", c.want, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #4834 on release-1.12.

#4834: Fixed the kubeedge-version flag does not take effect in the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.