### PR TITLE
update golang version 1.19.12 for build tool

### DIFF
--- a/build/docker/build-tools/build-tools.dockerfile
+++ b/build/docker/build-tools/build-tools.dockerfile
@@ -1,5 +1,5 @@
 # As a basic image for building various components of KubeEdge
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 ARG ARCH=amd64
 RUN apt-get update && apt-get install -y wget \
     vim git make gcc upx-ucl 
@@ -10,9 +10,9 @@ RUN apt-get autoremove -y &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
 
-RUN if [ "${ARCH}" = "amd64" ]; then wget -c https://dl.google.com/go/go1.17.13.linux-amd64.tar.gz -O - | tar -xz -C /usr/local; \
-    elif [ "${ARCH}" = "arm64" ]; then wget -c https://dl.google.com/go/go1.17.13.linux-arm64.tar.gz -O - | tar -xz -C /usr/local; \
-    elif [ "${ARCH}" = "arm" ]; then wget -c https://dl.google.com/go/go1.17.13.linux-armv6l.tar.gz -O - | tar -xz -C /usr/local; \
+RUN if [ "${ARCH}" = "amd64" ]; then wget -c https://dl.google.com/go/go1.19.12.linux-amd64.tar.gz -O - | tar -xz -C /usr/local; \
+    elif [ "${ARCH}" = "arm64" ]; then wget -c https://dl.google.com/go/go1.19.12.linux-arm64.tar.gz -O - | tar -xz -C /usr/local; \
+    elif [ "${ARCH}" = "arm" ]; then wget -c https://dl.google.com/go/go1.19.12.linux-armv6l.tar.gz -O - | tar -xz -C /usr/local; \
     fi
 
 ENV GO111MODULE=on

--- a/build/docker/build-tools/make-build-tools.sh
+++ b/build/docker/build-tools/make-build-tools.sh
@@ -6,7 +6,7 @@ REPOSITORY=${REPOSITORY:-"kubeedge/build-tools"}
 # image tag for build-tools image, including golang version and build-tools version
 # If there's some modifications for build-tools.dockerfile other than golang version, the build-tools version should be updated e.g. ke1, ke2.
 # If the golang version is updated in build-tools.dockerfile, the build-tools version should be started from ke1.
-IMAGE_TAG=${IMAGE_TAG:-"1.17.13-ke1"}
+IMAGE_TAG=${IMAGE_TAG:-"1.19.12-ke1"}
 WORK_DIR=$(cd "$(dirname "$0")";pwd)
 PUSH_TAG=${1}
 ARCHS=(amd64 arm64 arm)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature



**What this PR does / why we need it**:

The first step for update golang version.  Update the golang version 1.19.12 for build tool and push a kubeedge basic image to image repository. 

**Which issue(s) this PR fixes**:

Fixes #4930 


