### PR TITLE
revert build tool ubuntu version to 18.04

### DIFF
--- a/build/docker/build-tools/build-tools.dockerfile
+++ b/build/docker/build-tools/build-tools.dockerfile
@@ -1,5 +1,5 @@
 # As a basic image for building various components of KubeEdge
-FROM ubuntu:22.04
+FROM ubuntu:18.04
 ARG ARCH=amd64
 RUN apt-get update && apt-get install -y wget \
     vim git make gcc upx-ucl 

--- a/build/docker/build-tools/make-build-tools.sh
+++ b/build/docker/build-tools/make-build-tools.sh
@@ -6,7 +6,7 @@ REPOSITORY=${REPOSITORY:-"kubeedge/build-tools"}
 # image tag for build-tools image, including golang version and build-tools version
 # If there's some modifications for build-tools.dockerfile other than golang version, the build-tools version should be updated e.g. ke1, ke2.
 # If the golang version is updated in build-tools.dockerfile, the build-tools version should be started from ke1.
-IMAGE_TAG=${IMAGE_TAG:-"1.19.12-ke1"}
+IMAGE_TAG=${IMAGE_TAG:-"1.19.12-ke2"}
 WORK_DIR=$(cd "$(dirname "$0")";pwd)
 PUSH_TAG=${1}
 ARCHS=(amd64 arm64 arm)

--- a/build/docker/installation-package/installation-package.dockerfile
+++ b/build/docker/installation-package/installation-package.dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p bin && \
     make WHAT=edgecore BUILD_WITH_CONTAINER=false && cp _output/local/bin/edgecore bin/edgecore && \
     make WHAT=keadm BUILD_WITH_CONTAINER=false && cp _output/local/bin/keadm bin/keadm
 
-FROM ubuntu:22.04
+FROM ubuntu:18.04
 COPY --from=builder /work/_output/local/bin/edgecore /usr/local/bin/edgecore
 COPY --from=builder /work/_output/local/bin/keadm /usr/local/bin/keadm
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:

revert build tool ubuntu version to 18.04. If using Ubuntu 22.04 to build, we may encounter similar errors below when running on lower versions of Ubuntu machines.

![image](https://github.com/kubeedge/kubeedge/assets/48788150/26f105e2-d332-4dee-96cf-89294a6e1f48)
