### PR TITLE
Don't run docker prune in local-up cluster

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -70,8 +70,6 @@ function cleanup {
 
   echo "Running kind: [kind delete cluster ${CLUSTER_CONTEXT}]"
   kind delete cluster ${CLUSTER_CONTEXT}
-
-  docker system prune -f
 }
 
 if [[ "${ENABLE_DAEMON}" = false ]]; then
@@ -189,8 +187,6 @@ function start_edgecore {
   export CHECK_EDGECORE_ENVIRONMENT="false"
   nohup sudo -E ${EDGE_BIN} --config=${EDGE_CONFIGFILE} --v=${LOG_LEVEL} > "${EDGECORE_LOG}" 2>&1 &
   EDGECORE_PID=$!
-  docker system prune -f
-
 }
 
 function check_control_plane_ready {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When I run `local-up` in my local host, the `docker system prune -f` in cleanup will always remove the kind images because it has no tag, not friendly to developers.

![image](https://github.com/kubeedge/kubeedge/assets/28776356/9b02cd39-693c-45c5-9117-036b2fd6ab93)


And `docker system prune -f` is mainly used for `keadm test`, `docker system prune -f` in local-up script will not affect `keadm test`


**Which issue(s) this PR fixes*, *:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

cc @WillardHu @wlq1212 @Shelley-BaoYue 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
