### PR TITLE
Update timeout to 30min and kind vesion to 0.17 for e2e ci

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -195,7 +195,7 @@ jobs:
       - name: Install dependences
         run: |
           command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@${{ env.GINKGO_VERSION }}
-          go install sigs.k8s.io/kind@v0.14.0
+          go install sigs.k8s.io/kind@v0.17.0
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.24.14/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
       - name: Checkout code
@@ -255,7 +255,7 @@ jobs:
       - name: Install dependences
         run: |
           command -v ginkgo || go install github.com/onsi/ginkgo/ginkgo@${{ env.GINKGO_VERSION }}
-          go install sigs.k8s.io/kind@v0.14.0
+          go install sigs.k8s.io/kind@v0.17.0
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.24.14/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
       - name: Checkout code

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -176,7 +176,7 @@ jobs:
             version: v1.23.0
           - protocol: QUIC
             version: v1.22.0
-    timeout-minutes: 60
+    timeout-minutes: 30
     name: E2e test
     needs: image-prepare
     env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Now the timeout is `60min`,  and the ci test can complete within 20mins, so update it to 30min to avoid taking up too much time if there's bugs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
