### PR TITLE
Update hollow_edge_node_template.yaml

### DIFF
--- a/build/edgemark/hollow_edge_node_template.yaml
+++ b/build/edgemark/hollow_edge_node_template.yaml
@@ -22,8 +22,6 @@ spec:
             - --name=$(NODE_NAME)
             - --http-server=https://{{server}}:10002
             - --websocket-server={{server}}:10000
-            - --alsologtostderr
-            - --v=2
           env:
             - name: NODE_NAME
               valueFrom:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
remove these 2 args  --alsologtostderr and  --v=2, because edgemark now do not support , these args make edgemark exit error

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE
