### PR TITLE
Fix throws nil runtime error when decode AdmissionReview failed

### DIFF
--- a/cloud/pkg/admissioncontroller/common.go
+++ b/cloud/pkg/admissioncontroller/common.go
@@ -94,10 +94,10 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 		responseAdmissionReview.Response = toAdmissionResponse(err)
 	} else {
 		responseAdmissionReview.Response = hook(requestedAdmissionReview)
+		// Return the same UID
+		responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
 	}
 
-	// Return the same UID
-	responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID
 	klog.V(4).Infof("sending response: %+v", responseAdmissionReview.Response)
 
 	respBytes, err := json.Marshal(responseAdmissionReview)

--- a/cloud/pkg/admissioncontroller/common_test.go
+++ b/cloud/pkg/admissioncontroller/common_test.go
@@ -1,0 +1,47 @@
+package admissioncontroller
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+
+	"github.com/kubeedge/kubeedge/cloud/test/httpfake"
+)
+
+func TestServe(t *testing.T) {
+	w := httpfake.NewResponseWriter()
+	hookfn := func(admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+		return &admissionv1.AdmissionResponse{Allowed: true}
+	}
+
+	t.Run("not json content-type", func(_ *testing.T) {
+		serve(w, &http.Request{
+			Header: map[string][]string{
+				"Content-Type": {"application/xml"},
+			},
+		}, hookfn)
+	})
+
+	t.Run("decode body failed", func(_ *testing.T) {
+		raw := "{"
+		serve(w, &http.Request{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
+		}, hookfn)
+	})
+
+	t.Run("handle hook func", func(_ *testing.T) {
+		raw := "{\"request\": {\"uid\": \"1\"}}"
+		serve(w, &http.Request{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
+		}, hookfn)
+	})
+}

--- a/cloud/test/httpfake/http_fake.go
+++ b/cloud/test/httpfake/http_fake.go
@@ -1,0 +1,28 @@
+package httpfake
+
+import "net/http"
+
+type ResponseWriter struct {
+	HTTPHeader http.Header
+	Status     int
+	Body       []byte
+}
+
+func NewResponseWriter() *ResponseWriter {
+	return &ResponseWriter{
+		HTTPHeader: make(http.Header),
+	}
+}
+
+func (f *ResponseWriter) Header() http.Header {
+	return f.HTTPHeader
+}
+
+func (f *ResponseWriter) Write(b []byte) (int, error) {
+	f.Body = b
+	return len(b), nil
+}
+
+func (f *ResponseWriter) WriteHeader(statusCode int) {
+	f.Status = statusCode
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When decode AdmissionReview fails, the `admissionv1.AdmissionReview.Request` is still nil, and the code `responseAdmissionReview.Response.UID = requestedAdmissionReview.Request.UID` will throw a runtime nil error.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
