### PR TITLE
Automated cherry pick of #4960: enable cri config in containerd

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -153,6 +153,9 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
 
       - run: make integrationtest
 
@@ -199,6 +202,10 @@ jobs:
       - name: docker load kubeedge/build-tools image
         run: |
           docker load < /home/runner/build-tools/build-tools.tar
+
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
 
       # for QUIC protocol, we will use docker as edgecore container runtime
       # for WebSocket protocol, we will use containerd as edgecore container runtime
@@ -259,6 +266,10 @@ jobs:
         run: |
           docker load < /home/runner/build-tools/build-tools.tar
 
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service         
+
       - run: make keadm_deprecated_e2e
 
   keadm_e2e_test:
@@ -293,6 +304,10 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.4.0
+
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
 
       - run: make keadm_e2e
 


### PR DESCRIPTION
Cherry pick of #4960 on release-1.13.

#4960: enable cri config in containerd

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.