### PR TITLE
Automated cherry pick of #4960: enable cri config in containerd

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -128,6 +128,10 @@ jobs:
 
       - run: make test
 
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
+
       - run: make integrationtest
 
   e2e_test:
@@ -173,6 +177,10 @@ jobs:
       - name: docker load kubeedge/build-tools image
         run: |
           docker load < /home/runner/build-tools/build-tools.tar
+
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
 
       - run: |
           export PROTOCOL=${{ matrix.PROTOCOL }}
@@ -225,6 +233,10 @@ jobs:
         run: |
           docker load < /home/runner/build-tools/build-tools.tar
 
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service         
+
       - run: make keadm_deprecated_e2e
 
   keadm_e2e_test:
@@ -259,6 +271,10 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           version: v3.4.0
+
+      - name: enable cri config in containerd service
+        run: |
+          containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
 
       - run: make keadm_e2e
 


### PR DESCRIPTION
Cherry pick of #4960 on release-1.12.

#4960: enable cri config in containerd

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.