### PR TITLE
fix e2e test when push doc related PR 

### DIFF
--- a/.github/workflows/main-doc.yaml
+++ b/.github/workflows/main-doc.yaml
@@ -70,9 +70,19 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        PROTOCOL:
-          - WebSocket
-          - QUIC
+        cases:
+          - protocol: WebSocket
+            version: v1.24.0
+          - protocol: WebSocket
+            version: v1.23.0
+          - protocol: WebSocket
+            version: v1.22.0
+          - protocol: QUIC
+            version: v1.24.0
+          - protocol: QUIC
+            version: v1.23.0
+          - protocol: QUIC
+            version: v1.22.0
     timeout-minutes: 30
     name: E2e test
     needs: image-prepare


### PR DESCRIPTION

**What type of PR is this?**


/kind bug



**What this PR does / why we need it**: PR

e2e tests has been modified with PR: #4939. However, when pushing the PR related to documentation, the main-doc is still running outdated e2e tests. This PR aims to fix it.

