### PR TITLE
Automated cherry pick of #4702: edgehub process send twin msg to twingroup directly to avoid

### DIFF
--- a/edge/pkg/devicetwin/process.go
+++ b/edge/pkg/devicetwin/process.go
@@ -52,8 +52,10 @@ func (dt *DeviceTwin) distributeMsg(m interface{}) error {
 		klog.Infof("Send msg to the %s module in twin", dtcommon.CommModule)
 		confirmMsg := dttype.DTMessage{Msg: model.NewMessage(message.Msg.GetParentID()), Action: dtcommon.Confirm}
 		if err := dt.DTContexts.CommTo(dtcommon.CommModule, &confirmMsg); err != nil {
+			klog.Errorf("fail to send msg %s to CommModule with err: %+v", confirmMsg.Msg.Header.ID, err)
 			return err
 		}
+		return nil
 	}
 	if !classifyMsg(&message) {
 		return errors.New("not found action")

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -73,6 +73,14 @@ func (*defaultHandler) Process(message *model.Message, clientHub clients.Adapter
 		md = modules.BusGroup
 	}
 
+	// TODO: just for a temporary fix.
+	// The code related to device twin message transmission will be reconstructed
+	//  by using sendSync function instead of send function.
+	if group == messagepkg.TwinGroupName {
+		beehiveContext.SendToGroup(md, *message)
+		return nil
+	}
+
 	isResponse := isSyncResponse(message.GetParentID())
 	if isResponse {
 		beehiveContext.SendResp(*message)


### PR DESCRIPTION
Cherry pick of #4702 on release-1.14.

#4702: edgehub process send twin msg to twingroup directly to avoid

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.