### PR TITLE
Support to config log level for edgemark

### DIFF
--- a/edge/cmd/edgemark/hollow_edgecore.go
+++ b/edge/cmd/edgemark/hollow_edgecore.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/cli/globalflag"
 	"k8s.io/component-base/featuregate"
 	kubeletapp "k8s.io/kubernetes/cmd/kubelet/app"
 	kubeletoptions "k8s.io/kubernetes/cmd/kubelet/app/options"
@@ -96,6 +97,7 @@ func newHollowEdgeNodeCommand() *cobra.Command {
 
 	fs := cmd.Flags()
 	fs.AddGoFlagSet(flag.CommandLine) // for flags like --docker-only
+	globalflag.AddGlobalFlags(fs, cmd.Name())
 	s.addFlags(fs)
 
 	return cmd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
/kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
The component edgemark under edge doesn't support config log level. So registered a flag of klog in edgemark component.

Fixes #4990 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
<br>

Signed-off-by: Akshat Khanna [khannakshat7@gmail.com](mailto:khannakshat7@gmail.com)