### PR TITLE
Add a timeout option to the golangci-lint command

### DIFF
--- a/hack/lib/lint.sh
+++ b/hack/lib/lint.sh
@@ -73,9 +73,9 @@ kubeedge::lint::check() {
     set -o pipefail
 
     echo "check any issue by golangci-lint ..."
-    GOOS="linux" golangci-lint run -v
+    GOOS="linux" golangci-lint run -v --timeout=12m
 
     # check codes under staging dir, this will also use .golangci.yaml in the {KUBEEDGE_ROOT} dir
-    cd "${KUBEEDGE_ROOT}/staging/src/github.com/kubeedge/beehive" && GOOS="linux" golangci-lint run -v
-    cd "${KUBEEDGE_ROOT}/staging/src/github.com/kubeedge/viaduct" && GOOS="linux" golangci-lint run -v
+    cd "${KUBEEDGE_ROOT}/staging/src/github.com/kubeedge/beehive" && GOOS="linux" golangci-lint run -v --timeout=1m
+    cd "${KUBEEDGE_ROOT}/staging/src/github.com/kubeedge/viaduct" && GOOS="linux" golangci-lint run -v --timeout=1m
 }

--- a/tests/scripts/keadm_e2e.sh
+++ b/tests/scripts/keadm_e2e.sh
@@ -72,7 +72,6 @@ function start_kubeedge() {
   export MASTER_IP=`kubectl get node test-control-plane -o jsonpath={.status.addresses[0].address}`
   export KUBECONFIG=$HOME/.kube/config
   docker run --rm kubeedge/installation-package:$IMAGE_TAG cat /usr/local/bin/keadm > /usr/local/bin/keadm && chmod +x /usr/local/bin/keadm
-
   /usr/local/bin/keadm init --advertise-address=$MASTER_IP --profile version=$KUBEEDGE_VERSION --set cloudCore.service.enable=false --kube-config=$KUBECONFIG --force
   
   # ensure tokensecret is generated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Sometime the lint CI job will have a timeout error when executing golangci-lint, and now the `/retest` comment cannot be executed to re-execute CI, this will result in frequent close-reopen the PR to pass the CI check.

This fix sets the kubeedge repository's golangci-lint timeout option to 12min to reduce the probability of failure, the beehive and viaduct repository's golangci-lint execute quickly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
