### PR TITLE
Solving the deployment order dependency of mapper and device

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -122,14 +122,14 @@ func (dw *DMIWorker) dealMetaDeviceOperation(context *dtcontext.DTContext, resou
 		}
 		switch message.GetOperation() {
 		case model.InsertOperation:
+			dw.dmiCache.DeviceMu.Lock()
+			dw.dmiCache.DeviceList[device.Name] = &device
+			dw.dmiCache.DeviceMu.Unlock()
 			err = dmiclient.DMIClientsImp.RegisterDevice(&device)
 			if err != nil {
 				klog.Errorf("add device %s failed with err: %v", device.Name, err)
 				return err
 			}
-			dw.dmiCache.DeviceMu.Lock()
-			dw.dmiCache.DeviceList[device.Name] = &device
-			dw.dmiCache.DeviceMu.Unlock()
 		case model.DeleteOperation:
 			err = dmiclient.DMIClientsImp.RemoveDevice(&device)
 			if err != nil {
@@ -140,14 +140,14 @@ func (dw *DMIWorker) dealMetaDeviceOperation(context *dtcontext.DTContext, resou
 			delete(dw.dmiCache.DeviceList, device.Name)
 			dw.dmiCache.DeviceMu.Unlock()
 		case model.UpdateOperation:
+			dw.dmiCache.DeviceMu.Lock()
+			dw.dmiCache.DeviceList[device.Name] = &device
+			dw.dmiCache.DeviceMu.Unlock()
 			err = dmiclient.DMIClientsImp.UpdateDevice(&device)
 			if err != nil {
 				klog.Errorf("udpate device %s failed with err: %v", device.Name, err)
 				return err
 			}
-			dw.dmiCache.DeviceMu.Lock()
-			dw.dmiCache.DeviceList[device.Name] = &device
-			dw.dmiCache.DeviceMu.Unlock()
 		default:
 			klog.Warningf("unsupported operation %s", message.GetOperation())
 		}
@@ -158,14 +158,14 @@ func (dw *DMIWorker) dealMetaDeviceOperation(context *dtcontext.DTContext, resou
 		}
 		switch message.GetOperation() {
 		case model.InsertOperation:
+			dw.dmiCache.DeviceModelMu.Lock()
+			dw.dmiCache.DeviceModelList[dm.Name] = &dm
+			dw.dmiCache.DeviceModelMu.Unlock()
 			err = dmiclient.DMIClientsImp.CreateDeviceModel(&dm)
 			if err != nil {
 				klog.Errorf("add device model %s failed with err: %v", dm.Name, err)
 				return err
 			}
-			dw.dmiCache.DeviceModelMu.Lock()
-			dw.dmiCache.DeviceModelList[dm.Name] = &dm
-			dw.dmiCache.DeviceModelMu.Unlock()
 		case model.DeleteOperation:
 			err = dmiclient.DMIClientsImp.RemoveDeviceModel(&dm)
 			if err != nil {
@@ -176,14 +176,14 @@ func (dw *DMIWorker) dealMetaDeviceOperation(context *dtcontext.DTContext, resou
 			delete(dw.dmiCache.DeviceModelList, dm.Name)
 			dw.dmiCache.DeviceModelMu.Unlock()
 		case model.UpdateOperation:
+			dw.dmiCache.DeviceModelMu.Lock()
+			dw.dmiCache.DeviceModelList[dm.Name] = &dm
+			dw.dmiCache.DeviceModelMu.Unlock()
 			err = dmiclient.DMIClientsImp.UpdateDeviceModel(&dm)
 			if err != nil {
 				klog.Errorf("update device model %s failed with err: %v", dm.Name, err)
 				return err
 			}
-			dw.dmiCache.DeviceModelMu.Lock()
-			dw.dmiCache.DeviceModelList[dm.Name] = &dm
-			dw.dmiCache.DeviceModelMu.Unlock()
 		default:
 			klog.Warningf("unsupported operation %s", message.GetOperation())
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug



**What this PR does / why we need it**:
bug:I found that if you deploy devicemodel and device first and then start mapper, it will always get stuck here:
start grpc server
Insecure communication,skiping server......
However, deploying mapper first and then deploying devicemodel and device is normal.
result:I have resolved the deployment order between mapper and device without dependencies.
**Which issue(s) this PR fixes**:
Fixes #5021

**Special notes for your reviewer**:
@wbc6080 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
