### PR TITLE
fix: the container of mqtt can't be deleted when exec keadm reset

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -154,7 +154,7 @@ func (runtime *DockerRuntime) RemoveMQTT() error {
 		All: true,
 	}
 	options.Filters = filters.NewArgs()
-	options.Filters.Add("ancestor", constants.DefaultMosquittoImage)
+	options.Filters.Add("name", image.EdgeMQTT)
 
 	mqttContainers, err := runtime.Client.ContainerList(runtime.ctx, options)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

the container of mqtt can't be deleted when exec keadm reset, It turned out to be the way to filter containers using the label "ancestor=eclipse-mosquitto:1.6.15", but i found it can't find the currect container of mqtt, use the container name is a better way to handle this action

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
