### PR TITLE
Make NodeUpgradeJob enable through the helm

### DIFF
--- a/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
@@ -53,3 +53,5 @@ data:
       iptablesManager:
         enable: {{ .Values.iptablesManager.enable }}
         mode: {{ .Values.iptablesManager.mode }}
+      nodeUpgradeJobController:
+        enable: {{ .Values.cloudCore.modules.nodeUpgradeJobController.enable }}

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -55,6 +55,8 @@ cloudCore:
       enable: false
     router:
       enable: false
+    nodeUpgradeJobController:
+      enable: false
   service:
     enable: true
     type: "NodePort"

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -51,6 +51,8 @@ cloudCore:
       enable: false
     router:
       enable: false
+    nodeUpgradeJobController:
+      enable: false
   service:
     enable: false
     type: "NodePort"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When we want to enable the NodeUpgradeJob, we need to modify the Configmap of Cloudcore and restart the Cloudcore.
This change makes the NodeUpgradeJob to be enabled by configuring `values.yaml` of Cloudcore helm chart.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
