### PR TITLE
Fix upgrade time layout and lost time value issue

### DIFF
--- a/cloud/pkg/nodeupgradejobcontroller/controller/downstream.go
+++ b/cloud/pkg/nodeupgradejobcontroller/controller/downstream.go
@@ -210,7 +210,7 @@ func (dc *DownstreamController) processUpgrade(node string, upgrade *v1alpha1.No
 		State:    v1alpha1.Upgrading,
 		History: v1alpha1.History{
 			HistoryID:   upgradeReq.HistoryID,
-			UpgradeTime: time.Now().String(),
+			UpgradeTime: time.Now().Format(ISO8601UTC),
 		},
 	}
 	err = patchNodeUpgradeJobStatus(dc.crdClient, upgrade, status)

--- a/cloud/pkg/nodeupgradejobcontroller/controller/util_test.go
+++ b/cloud/pkg/nodeupgradejobcontroller/controller/util_test.go
@@ -107,23 +107,23 @@ func TestUpdateUpgradeStatus(t *testing.T) {
 					NodeName: "edge-node",
 					State:    v1alpha1.Completed,
 					History: v1alpha1.History{
-						Reason: "the first upgrade",
+						Reason:      "the first upgrade",
+						UpgradeTime: "2023-09-22T17:33:00Z",
 					},
 				},
 			},
 		},
 	}
 	upgrade2 := upgrade.DeepCopy()
-	upgrade2.Status.Status[0].History = v1alpha1.History{
-		Reason: "the second upgrade",
-	}
+	upgrade2.Status.Status[0].History.Reason = "the second upgrade"
 
 	upgrade3 := upgrade.DeepCopy()
 	upgrade3.Status.Status = append(upgrade3.Status.Status, v1alpha1.UpgradeStatus{
 		NodeName: "edge-node2",
 		State:    v1alpha1.Completed,
 		History: v1alpha1.History{
-			Reason: "the first upgrade",
+			Reason:      "the first upgrade",
+			UpgradeTime: "2023-09-22T17:35:00Z",
 		},
 	})
 
@@ -140,7 +140,8 @@ func TestUpdateUpgradeStatus(t *testing.T) {
 				NodeName: "edge-node",
 				State:    v1alpha1.Completed,
 				History: v1alpha1.History{
-					Reason: "the first upgrade",
+					Reason:      "the first upgrade",
+					UpgradeTime: "2023-09-22T17:33:00Z",
 				},
 			},
 			expected: upgrade.DeepCopy(),
@@ -152,7 +153,8 @@ func TestUpdateUpgradeStatus(t *testing.T) {
 				NodeName: "edge-node2",
 				State:    v1alpha1.Completed,
 				History: v1alpha1.History{
-					Reason: "the first upgrade",
+					Reason:      "the first upgrade",
+					UpgradeTime: "2023-09-22T17:35:00Z",
 				},
 			},
 			expected: upgrade3,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

1. The upgrade time initial value is returned by the `String()` function of the time struct, like `2023-09-22 16:07:13.505954202 +0800 CST m=+19903.570598396`, this time format is difficult to be handle, the k8s's various time format layouts are `2006-01-02T15:04:05Z`, so we need to use that format layout as well;
2. When the upgrade status is updated again after the first update, the upgrade time is lost. The `upgradeTime` of parameter `status` has no value in `UpdateNodeUpgradeJobStatus(..)` function, so we need set the generated upgrade time of old upgrade status to the new value. If generated upgrade time is empty, we initialize it with the current time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
