### PR TITLE
Determine whether to push device data from mapper to edgeCore based on ReportToCloud.

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
@@ -129,6 +129,7 @@ func dataHandler(ctx context.Context, dev *driver.CustomizedDev) {
 			VisitorConfig:   &visitorConfig,
 			Topic:           fmt.Sprintf(common.TopicTwinUpdate, dev.Instance.ID),
 			CollectCycle:    time.Duration(twin.Property.CollectCycle),
+			ReportToCloud:   twin.Property.ReportToCloud,
 		}
 		go twinData.Run(ctx)
 		// handle push method

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
@@ -26,6 +26,7 @@ type TwinData struct {
 	Topic           string
 	Results         interface{}
 	CollectCycle    time.Duration
+	ReportToCloud   bool
 }
 
 func (td *TwinData) GetPayLoad() ([]byte, error) {
@@ -87,6 +88,9 @@ func (td *TwinData) PushToEdgeCore() {
 }
 
 func (td *TwinData) Run(ctx context.Context) {
+	if !td.ReportToCloud {
+		return
+	}
 	if td.CollectCycle == 0 {
 		td.CollectCycle = 1 * time.Second
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
@@ -188,6 +188,7 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 			ModelName:    device.Spec.DeviceModelReference,
 			CollectCycle: pptv.GetCollectCycle(),
 			ReportCycle:  pptv.GetReportCycle(),
+			ReportToCloud: pptv.GetReportToCloud(),
 			Protocol:     protocolName,
 			Visitors:     visitorConfig,
 			PushMethod: common.PushMethodConfig{


### PR DESCRIPTION
…n ReportToCloud.



**What type of PR is this?**
/kind feature



**What this PR does / why we need it**:

The current Mapper Template does not use the ReportToCloud field for judgment, so now all device data is reported to the cloud. If edge device business data does not need to be reported to the cloud, we should use ReportToCloud to determine whether to push the data to edgecore, so that the device's business data will not also be pushed to the cloud.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

@wbc6080 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
