### PR TITLE
fix ci: update dependency tool version and cleanup unused images 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -193,6 +193,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: cleanup images
+        run: docker system prune -a -f
+
       - name: Retrieve saved kubeedge/build-tools image
         uses: actions/download-artifact@v3
         with:
@@ -252,6 +255,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: cleanup images
+        run: docker system prune -a -f
+
       - name: Retrieve saved kubeedge/build-tools image
         uses: actions/download-artifact@v3
         with:
@@ -305,6 +311,9 @@ jobs:
         run: |
           containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
 
+      - name: cleanup images
+        run: docker system prune -a -f
+
       - run: make keadm_e2e
 
   docker_build:
@@ -321,5 +330,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: cleanup images
+        run: docker system prune -a -f
 
       - run: make image

--- a/cloud/test/integration/scripts/execute.sh
+++ b/cloud/test/integration/scripts/execute.sh
@@ -22,7 +22,7 @@ ENVTEST_BIN_DIR=""
 
 function do_preparation() {
     which setup-envtest &> /dev/null || {
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20231013144025-0e9da2e3cab7
         sudo cp $GOPATH/bin/setup-envtest /usr/bin/
     }
 

--- a/tests/scripts/keadm_e2e.sh
+++ b/tests/scripts/keadm_e2e.sh
@@ -91,6 +91,10 @@ function start_kubeedge() {
       sleep 3
       kubectl get node | grep edge-node | grep -q -w Ready && break
   done
+
+  # cleanup unused images and packages
+  docker rmi kubeedge/cloudcore:$IMAGE_TAG kubeedge/installation-package:$IMAGE_TAG
+  rm cloudcore.tar installation-package.tar
 }
 
 function run_test() {


### PR DESCRIPTION
**What type of PR is this?**


/kind test

/kind failing-test



**What this PR does / why we need it**:

- update sigs.k8s.io/controller-runtime/tools/setup-envtest version to an old version. The latest version need go version  > 1.19,   while we upgrade golang to 1.19 from kubeedge v1.15.  
- cleanup unused images before ci to solve the disk pressure.
