### PR TITLE
Automated cherry pick of #5091: update dependency tool version and cleanup unused images

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -193,6 +193,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: cleanup images
+        run: docker system prune -a -f
+
       - name: Retrieve saved kubeedge/build-tools image
         uses: actions/download-artifact@v3
         with:
@@ -256,6 +259,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: cleanup images
+        run: docker system prune -a -f
+
       - name: Retrieve saved kubeedge/build-tools image
         uses: actions/download-artifact@v3
         with:
@@ -309,6 +315,9 @@ jobs:
         run: |
           containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
 
+      - name: cleanup images
+        run: docker system prune -a -f
+
       - run: make keadm_e2e
 
   docker_build:
@@ -325,5 +334,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: cleanup images
+        run: docker system prune -a -f
 
       - run: make image

--- a/cloud/test/integration/scripts/execute.sh
+++ b/cloud/test/integration/scripts/execute.sh
@@ -22,7 +22,7 @@ ENVTEST_BIN_DIR=""
 
 function do_preparation() {
     which setup-envtest &> /dev/null || {
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20231013144025-0e9da2e3cab7
         sudo cp $GOPATH/bin/setup-envtest /usr/bin/
     }
 

--- a/tests/scripts/keadm_e2e.sh
+++ b/tests/scripts/keadm_e2e.sh
@@ -91,6 +91,10 @@ function start_kubeedge() {
       sleep 3
       kubectl get node | grep edge-node | grep -q -w Ready && break
   done
+
+  # cleanup unused images and packages
+  docker rmi kubeedge/cloudcore:$IMAGE_TAG kubeedge/installation-package:$IMAGE_TAG
+  rm cloudcore.tar installation-package.tar
 }
 
 function run_test() {


### PR DESCRIPTION
Cherry pick of #5091 on release-1.13.

#5091: update integration test tool version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.