### PR TITLE
Fixed the mqtt would not start when using custom registry

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -151,7 +151,9 @@ const (
 	EdgeNodeRoleValue = ""
 
 	DeafultMosquittoContainerName = "mqtt-kubeedge"
-	DeployMqttContainerEnv        = "DEPLOY_MQTT_CONTAINER"
+
+	DeployMqttContainerEnv      = "DEPLOY_MQTT_CONTAINER"
+	DeployMqttContainerImageEnv = "DEPLOY_MQTT_CONTAINER_IMAGE"
 
 	// DefaultManifestsDir edge node default static pod path
 	DefaultManifestsDir = "/etc/kubeedge/manifests"

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -121,12 +121,20 @@ func (e *edged) Enable() bool {
 func (e *edged) Start() {
 	klog.Info("Starting edged...")
 
-	// edged saves the data of mqtt container in sqlite3 and starts it. This is a temporary workaround and will be modified in v1.15.
-	withMqtt, err := strconv.ParseBool(os.Getenv(constants.DeployMqttContainerEnv))
-	if err == nil && withMqtt {
-		err := dao.SaveMQTTMeta(e.nodeName)
-		if err != nil {
-			klog.ErrorS(err, "Start mqtt container failed")
+	// edged saves the data of mqtt container in sqlite3 and starts it.
+	// This is a temporary workaround and will be modified in v1.15.
+	if deployMqtt := os.Getenv(constants.DeployMqttContainerEnv); deployMqtt != "" {
+		if withMqtt, err := strconv.ParseBool(deployMqtt); err == nil && withMqtt {
+			image := constants.DefaultMosquittoImage
+			if customimg := os.Getenv(constants.DeployMqttContainerImageEnv); customimg != "" {
+				image = customimg
+			}
+			err := dao.SaveMQTTMeta(e.nodeName, image)
+			if err != nil {
+				klog.ErrorS(err, "Start mqtt container failed")
+			}
+		} else if err != nil {
+			klog.Errorf("parse Environment %s failed, err: %v", constants.DeployMqttContainerImageEnv, err)
 		}
 	}
 

--- a/edge/pkg/metamanager/dao/meta.go
+++ b/edge/pkg/metamanager/dao/meta.go
@@ -120,7 +120,7 @@ func QueryAllMeta(key string, condition string) (*[]Meta, error) {
 
 // SaveMQTTMeta saves mqtt container data in sqlites
 // When egdecore starts, edged will start mqtt container
-func SaveMQTTMeta(nodeName string) error {
+func SaveMQTTMeta(nodeName, image string) error {
 	flag := true
 	mqttData := coreV1.Pod{
 		TypeMeta: metaV1.TypeMeta{
@@ -135,8 +135,9 @@ func SaveMQTTMeta(nodeName string) error {
 		Spec: coreV1.PodSpec{
 			Containers: []coreV1.Container{
 				{
-					Name:  "mqtt",
-					Image: constants.DefaultMosquittoImage,
+					Name:            "mqtt",
+					Image:           image,
+					ImagePullPolicy: coreV1.PullIfNotPresent,
 					Ports: []coreV1.ContainerPort{
 						{
 							ContainerPort: 1883,

--- a/keadm/cmd/keadm/app/cmd/common/content.go
+++ b/keadm/cmd/keadm/app/cmd/common/content.go
@@ -34,15 +34,28 @@ ExecStart=%s
 Restart=always
 RestartSec=10
 Environment=%s
+Environment=%s
 
 [Install]
 WantedBy=multi-user.target
 `
 
-func GenerateServiceFile(process string, execStartCmd string, withMqtt bool) error {
-	filename := fmt.Sprintf("%s.service", process)
+type GenerateServiceFileOpts struct {
+	Process      string
+	ExecStartCmd string
+	WithMqtt     bool
+	MqttImage    string
+}
 
-	content := fmt.Sprintf(serviceFileTemplate, process, execStartCmd, fmt.Sprintf("%s=%t", constants.DeployMqttContainerEnv, withMqtt))
+func GenerateServiceFile(opts GenerateServiceFileOpts) error {
+	filename := fmt.Sprintf("%s.service", opts.Process)
+
+	content := fmt.Sprintf(serviceFileTemplate,
+		opts.Process,
+		opts.ExecStartCmd,
+		fmt.Sprintf("%s=%t", constants.DeployMqttContainerEnv, opts.WithMqtt),
+		fmt.Sprintf("%s=%s", constants.DeployMqttContainerImageEnv, opts.MqttImage),
+	)
 	serviceFilePath := fmt.Sprintf("/etc/systemd/system/%s", filename)
 	return os.WriteFile(serviceFilePath, []byte(content), os.ModePerm)
 }

--- a/keadm/cmd/keadm/app/cmd/edge/image.go
+++ b/keadm/cmd/keadm/app/cmd/edge/image.go
@@ -26,18 +26,18 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/image"
 )
 
-func request(opt *common.JoinOptions, step *common.Step) error {
+func request(opt *common.JoinOptions, step *common.Step) (image.Set, error) {
 	imageSet := image.EdgeSet(opt)
 	images := imageSet.List()
 
 	runtime, err := util.NewContainerRuntime(opt.RuntimeType, opt.RemoteRuntimeEndpoint, opt.CGroupDriver)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	step.Printf("Pull Images")
 	if err := runtime.PullImages(images); err != nil {
-		return fmt.Errorf("pull Images failed: %v", err)
+		return nil, fmt.Errorf("pull Images failed: %v", err)
 	}
 
 	step.Printf("Copy resources from the image to the management directory")
@@ -45,16 +45,16 @@ func request(opt *common.JoinOptions, step *common.Step) error {
 		filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName): filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName),
 	}
 	if err := runtime.CopyResources(imageSet.Get(image.EdgeCore), files); err != nil {
-		return fmt.Errorf("copy resources failed: %v", err)
+		return nil, fmt.Errorf("copy resources failed: %v", err)
 	}
 
 	if opt.WithMQTT {
 		step.Printf("Start the default mqtt service")
 		if err := createMQTTConfigFile(); err != nil {
-			return fmt.Errorf("create MQTT config file failed: %v", err)
+			return nil, fmt.Errorf("create MQTT config file failed: %v", err)
 		}
 	}
-	return nil
+	return imageSet, nil
 }
 
 func createMQTTConfigFile() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

If the image of the `mqtt` uses a custom registry, the container of the `mqtt` will not start properly.

```bash
keadm join --cloudcore-ipport=<"THE-EXPOSED-IP":10000> --token=<token>  --image-repository=<custom registry>/kubeedg

# The edgecore will have an error
start failed in pod mqtt-kubeedge_default(93205b92-a7fe-46a9-b899-c4eaa43ef339): ErrImageNeverPull: Container image "eclipse-mosquitto:1.6.15" is not present with pull policy of Never
10月 17 17:06:14 zdk1 edgecore[23420]: E1017 17:06:14.588945   23420 pod_workers.go:962] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"mqtt\" with ErrImageNeverPull: \"Container image \\\"eclipse-mosquitto:1.6.15\\\" is not present with pull policy of Never\"" pod="default/mqtt-kubeedge" podUID=93205b92-a7fe-46a9-b899-c4eaa43ef339
```

This is because the `keadm` only pull the custom image `<custom registry>/kubeedg/eclipse-mosquitto:1.6.15`, not the default image `eclipse-mosquitto:1.6.15`, and the `kubelet` image pull policy is used `Never` when the image pull policy is empty.

This pr is fixed:
- Set the default image pull policy to `PullIfNotPresent`;
- Align the image of the `mqtt` with the image pulled by the `keadm`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
