### PR TITLE
[release-1.12]fixed mqtt would not start when using custom registry

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -171,5 +171,7 @@ const (
 	EdgeNodeRoleValue = ""
 
 	DeafultMosquittoContainerName = "mqtt-kubeedge"
-	DeployMqttContainerEnv        = "DEPLOY_MQTT_CONTAINER"
+
+	DeployMqttContainerEnv      = "DEPLOY_MQTT_CONTAINER"
+	DeployMqttContainerImageEnv = "DEPLOY_MQTT_CONTAINER_IMAGE"
 )

--- a/edge/pkg/metamanager/dao/meta.go
+++ b/edge/pkg/metamanager/dao/meta.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/common/dbm"
 )
 
-//constant metatable name reference
+// constant metatable name reference
 const (
 	MetaTableName = "meta"
 )
@@ -109,7 +109,7 @@ func QueryAllMeta(key string, condition string) (*[]Meta, error) {
 
 // SaveMQTTMeta saves mqtt container data in sqlites
 // When egdecore starts, edged will start mqtt container
-func SaveMQTTMeta(nodeName string) error {
+func SaveMQTTMeta(nodeName, image string) error {
 	flag := true
 	mqttData := coreV1.Pod{
 		TypeMeta: metaV1.TypeMeta{
@@ -124,8 +124,9 @@ func SaveMQTTMeta(nodeName string) error {
 		Spec: coreV1.PodSpec{
 			Containers: []coreV1.Container{
 				{
-					Name:  "mqtt",
-					Image: "eclipse-mosquitto:1.6.15",
+					Name:            "mqtt",
+					Image:           image,
+					ImagePullPolicy: coreV1.PullIfNotPresent,
 					Ports: []coreV1.ContainerPort{
 						{
 							ContainerPort: 1883,

--- a/keadm/cmd/keadm/app/cmd/common/content.go
+++ b/keadm/cmd/keadm/app/cmd/common/content.go
@@ -34,15 +34,28 @@ ExecStart=%s
 Restart=always
 RestartSec=10
 Environment=%s
+Environment=%s
 
 [Install]
 WantedBy=multi-user.target
 `
 
-func GenerateServiceFile(process string, execStartCmd string, withMqtt bool) error {
-	filename := fmt.Sprintf("%s.service", process)
+type GenerateServiceFileOpts struct {
+	Process      string
+	ExecStartCmd string
+	WithMqtt     bool
+	MqttImage    string
+}
 
-	content := fmt.Sprintf(serviceFileTemplate, process, execStartCmd, fmt.Sprintf("%s=%t", constants.DeployMqttContainerEnv, withMqtt))
+func GenerateServiceFile(opts GenerateServiceFileOpts) error {
+	filename := fmt.Sprintf("%s.service", opts.Process)
+
+	content := fmt.Sprintf(serviceFileTemplate,
+		opts.Process,
+		opts.ExecStartCmd,
+		fmt.Sprintf("%s=%t", constants.DeployMqttContainerEnv, opts.WithMqtt),
+		fmt.Sprintf("%s=%s", constants.DeployMqttContainerImageEnv, opts.MqttImage),
+	)
 	serviceFilePath := fmt.Sprintf("/etc/systemd/system/%s", filename)
 	return os.WriteFile(serviceFilePath, []byte(content), os.ModePerm)
 }

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2/validation"
+	"github.com/kubeedge/kubeedge/pkg/image"
 	pkgutil "github.com/kubeedge/kubeedge/pkg/util"
 )
 
@@ -173,12 +174,18 @@ func join(opt *common.JoinOptions, step *common.Step) error {
 
 	// Do not create any files in the management directory,
 	// you need to mount the contents of the mirror first.
-	if err := request(opt, step); err != nil {
+	imageSet, err := request(opt, step)
+	if err != nil {
 		return err
 	}
 
 	step.Printf("Generate systemd service file")
-	if err := common.GenerateServiceFile(util.KubeEdgeBinaryName, filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName), opt.WithMQTT); err != nil {
+	if err := common.GenerateServiceFile(common.GenerateServiceFileOpts{
+		Process:      util.KubeEdgeBinaryName,
+		ExecStartCmd: filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName),
+		WithMqtt:     opt.WithMQTT,
+		MqttImage:    imageSet.Get(image.EdgeMQTT),
+	}); err != nil {
 		return fmt.Errorf("create systemd service file failed: %v", err)
 	}
 
@@ -188,7 +195,10 @@ func join(opt *common.JoinOptions, step *common.Step) error {
 	}
 
 	step.Printf("Run EdgeCore daemon")
-	return runEdgeCore(opt.WithMQTT)
+	if err := runEdgeCore(opt.WithMQTT, imageSet.Get(image.EdgeMQTT)); err != nil {
+		return fmt.Errorf("start edgecore failed: %v", err)
+	}
+	return err
 }
 
 func createDirs() error {
@@ -290,7 +300,7 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 	return common.Write2File(configFilePath, edgeCoreConfig)
 }
 
-func runEdgeCore(withMqtt bool) error {
+func runEdgeCore(withMqtt bool, mqttImage string) error {
 	systemdExist := util.HasSystemd()
 
 	var binExec, tip string
@@ -301,9 +311,11 @@ func runEdgeCore(withMqtt bool) error {
 			common.EdgeCore, common.EdgeCore)
 	} else {
 		tip = fmt.Sprintf("KubeEdge edgecore is running, For logs visit: %s%s.log", util.KubeEdgeLogPath, util.KubeEdgeBinaryName)
-		err := os.Setenv(constants.DeployMqttContainerEnv, strconv.FormatBool(withMqtt))
-		if err != nil {
+		if err := os.Setenv(constants.DeployMqttContainerEnv, strconv.FormatBool(withMqtt)); err != nil {
 			klog.Errorf("Set Environment %s failed, err: %v", constants.DeployMqttContainerEnv, err)
+		}
+		if err := os.Setenv(constants.DeployMqttContainerImageEnv, mqttImage); err != nil {
+			klog.Errorf("Set Environment %s failed, err: %v", constants.DeployMqttContainerImageEnv, err)
 		}
 		binExec = fmt.Sprintf(
 			"%s > %skubeedge/edge/%s.log 2>&1 &",

--- a/keadm/cmd/keadm/app/cmd/edge/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/edge/upgrade.go
@@ -246,14 +246,16 @@ func (up *Upgrade) Process() error {
 	// set withMqtt to false during upgrading edgecore, it will not affect the MQTT container. This is a temporary workaround and will be modified in v1.15.
 	// generate edgecore.service
 	if util.HasSystemd() {
-		err = common.GenerateServiceFile(util.KubeEdgeBinaryName, fmt.Sprintf("%s --config %s", filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName), up.ConfigFilePath), false)
-		if err != nil {
+		if err := common.GenerateServiceFile(common.GenerateServiceFileOpts{
+			Process:      util.KubeEdgeBinaryName,
+			ExecStartCmd: fmt.Sprintf("%s --config %s", filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName), up.ConfigFilePath),
+		}); err != nil {
 			return fmt.Errorf("failed to create edgecore.service file: %v", err)
 		}
 	}
 
 	// start new edgecore service
-	err = runEdgeCore(false)
+	err = runEdgeCore(false, "")
 	if err != nil {
 		return fmt.Errorf("failed to start edgecore: %v", err)
 	}
@@ -288,14 +290,16 @@ func (up *Upgrade) Rollback() error {
 
 	// generate edgecore.service
 	if util.HasSystemd() {
-		err = common.GenerateServiceFile(util.KubeEdgeBinaryName, fmt.Sprintf("%s --config %s", filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName), up.ConfigFilePath), false)
-		if err != nil {
+		if err := common.GenerateServiceFile(common.GenerateServiceFileOpts{
+			Process:      util.KubeEdgeBinaryName,
+			ExecStartCmd: fmt.Sprintf("%s --config %s", filepath.Join(util.KubeEdgeUsrBinPath, util.KubeEdgeBinaryName), up.ConfigFilePath),
+		}); err != nil {
 			return fmt.Errorf("failed to create edgecore.service file: %v", err)
 		}
 	}
 
 	// start edgecore
-	err = runEdgeCore(false)
+	err = runEdgeCore(false, "")
 	if err != nil {
 		return fmt.Errorf("failed to start origin edgecore: %v", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

If the image of the `mqtt` uses a custom registry, the container of the `mqtt` will not start properly.

```bash
keadm join --cloudcore-ipport=<"THE-EXPOSED-IP":10000> --token=<token>  --image-repository=<custom registry>/kubeedg

# The edgecore will have an error
start failed in pod mqtt-kubeedge_default(93205b92-a7fe-46a9-b899-c4eaa43ef339): ErrImageNeverPull: Container image "eclipse-mosquitto:1.6.15" is not present with pull policy of Never
10月 17 17:06:14 zdk1 edgecore[23420]: E1017 17:06:14.588945   23420 pod_workers.go:962] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"mqtt\" with ErrImageNeverPull: \"Container image \\\"eclipse-mosquitto:1.6.15\\\" is not present with pull policy of Never\"" pod="default/mqtt-kubeedge" podUID=93205b92-a7fe-46a9-b899-c4eaa43ef339
```

This is because the `keadm` only pull the custom image `<custom registry>/kubeedg/eclipse-mosquitto:1.6.15`, not the default image `eclipse-mosquitto:1.6.15`, and the `kubelet` image pull policy is used `Never` when the image pull policy is empty.

This pr is fixed:
- Set the default image pull policy to `PullIfNotPresent`;
- Align the image of the `mqtt` with the image pulled by the `keadm`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
