### PR TITLE
Automated cherry pick of #5063: fix start edgecore failed when using systemd cgroupdriver

### DIFF
--- a/edge/pkg/edgehub/upgrade/upgrade.go
+++ b/edge/pkg/edgehub/upgrade/upgrade.go
@@ -112,7 +112,7 @@ func (*keadmUpgrade) Upgrade(upgradeReq *commontypes.NodeUpgradeJobRequest) erro
 
 	// install the requested installer keadm from docker image
 	klog.Infof("Begin to download version %s keadm", upgradeReq.Version)
-	container, err := util.NewContainerRuntime(config.Modules.Edged.ContainerRuntime, config.Modules.Edged.RemoteRuntimeEndpoint)
+	container, err := util.NewContainerRuntime(config.Modules.Edged.ContainerRuntime, config.Modules.Edged.RemoteRuntimeEndpoint, config.Modules.Edged.TailoredKubeletConfig.CgroupDriver)
 	if err != nil {
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}

--- a/keadm/cmd/keadm/app/cmd/config.go
+++ b/keadm/cmd/keadm/app/cmd/config.go
@@ -120,7 +120,7 @@ func newCmdConfigImagesPull() *cobra.Command {
 			cfg.KubeEdgeVersion = ver
 
 			images := GetKubeEdgeImages(cfg)
-			return pullImages(cfg.RuntimeType, cfg.RemoteRuntimeEndpoint, images)
+			return pullImages(cfg.RuntimeType, cfg.RemoteRuntimeEndpoint, "", images)
 		},
 		Args: cobra.NoArgs,
 	}
@@ -129,8 +129,8 @@ func newCmdConfigImagesPull() *cobra.Command {
 	return cmd
 }
 
-func pullImages(runtimeType string, endpoint string, images []string) error {
-	runtime, err := util.NewContainerRuntime(runtimeType, endpoint)
+func pullImages(runtimeType, endpoint, cgroupDriver string, images []string) error {
+	runtime, err := util.NewContainerRuntime(runtimeType, endpoint, cgroupDriver)
 	if err != nil {
 		return err
 	}

--- a/keadm/cmd/keadm/app/cmd/edge/image.go
+++ b/keadm/cmd/keadm/app/cmd/edge/image.go
@@ -30,7 +30,7 @@ func request(opt *common.JoinOptions, step *common.Step) error {
 	imageSet := image.EdgeSet(opt.ImageRepository, opt.KubeEdgeVersion)
 	images := imageSet.List()
 
-	runtime, err := util.NewContainerRuntime(opt.RuntimeType, opt.RemoteRuntimeEndpoint)
+	runtime, err := util.NewContainerRuntime(opt.RuntimeType, opt.RemoteRuntimeEndpoint, opt.CGroupDriver)
 	if err != nil {
 		return err
 	}

--- a/keadm/cmd/keadm/app/cmd/edge/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/edge/upgrade.go
@@ -179,7 +179,8 @@ func (up *Upgrade) PreProcess() error {
 	// download the request version edgecore
 	klog.Infof("Begin to download version %s edgecore", up.ToVersion)
 	upgradePath := filepath.Join(util.KubeEdgeUpgradePath, up.ToVersion)
-	container, err := util.NewContainerRuntime(up.EdgeCoreConfig.Modules.Edged.ContainerRuntime, up.EdgeCoreConfig.Modules.Edged.RemoteRuntimeEndpoint)
+	container, err := util.NewContainerRuntime(up.EdgeCoreConfig.Modules.Edged.ContainerRuntime, up.EdgeCoreConfig.Modules.Edged.RemoteRuntimeEndpoint,
+		up.EdgeCoreConfig.Modules.Edged.TailoredKubeletConfig.CgroupDriver)
 	if err != nil {
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}

--- a/keadm/cmd/keadm/app/cmd/reset.go
+++ b/keadm/cmd/keadm/app/cmd/reset.go
@@ -107,7 +107,7 @@ func NewKubeEdgeReset() *cobra.Command {
 			}
 
 			// cleanup mqtt container
-			if err := RemoveMqttContainer(reset.RuntimeType, reset.Endpoint); err != nil {
+			if err := RemoveMqttContainer(reset.RuntimeType, reset.Endpoint, ""); err != nil {
 				fmt.Printf("Failed to remove MQTT container: %v\n", err)
 			}
 			//4. TODO: clean status information
@@ -120,8 +120,8 @@ func NewKubeEdgeReset() *cobra.Command {
 	return cmd
 }
 
-func RemoveMqttContainer(runtimeType string, endpoint string) error {
-	runtime, err := util.NewContainerRuntime(runtimeType, endpoint)
+func RemoveMqttContainer(runtimeType, endpoint, cgroupDriver string) error {
+	runtime, err := util.NewContainerRuntime(runtimeType, endpoint, cgroupDriver)
 	if err != nil {
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}

--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -31,10 +31,12 @@ import (
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/cri/remote"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 
 	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/image"
 )
 
@@ -48,7 +50,7 @@ type ContainerRuntime interface {
 	RemoveMQTT() error
 }
 
-func NewContainerRuntime(runtimeType string, endpoint string) (ContainerRuntime, error) {
+func NewContainerRuntime(runtimeType, endpoint, cgroupDriver string) (ContainerRuntime, error) {
 	var runtime ContainerRuntime
 	switch runtimeType {
 	case kubetypes.DockerContainerRuntime:
@@ -75,6 +77,7 @@ func NewContainerRuntime(runtimeType string, endpoint string) (ContainerRuntime,
 		}
 		runtime = &CRIRuntime{
 			endpoint:            endpoint,
+			cgroupDriver:        cgroupDriver,
 			ImageManagerService: imageService,
 			RuntimeService:      runtimeService,
 		}
@@ -228,6 +231,7 @@ func (runtime *DockerRuntime) CopyResources(image string, files map[string]strin
 
 type CRIRuntime struct {
 	endpoint            string
+	cgroupDriver        string
 	ImageManagerService internalapi.ImageManagerService
 	RuntimeService      internalapi.RuntimeService
 }
@@ -259,6 +263,10 @@ func (runtime *CRIRuntime) CopyResources(edgeImage string, files map[string]stri
 			Name:      KubeEdgeBinaryName,
 			Namespace: constants.SystemNamespace,
 		},
+	}
+	if runtime.cgroupDriver == v1alpha2.CGroupDriverSystemd {
+		cgroupName := cm.NewCgroupName(cm.CgroupName{"kubeedge", "setup", "podcopyresource"})
+		psc.Linux.CgroupParent = cgroupName.ToSystemd()
 	}
 	sandbox, err := runtime.RuntimeService.RunPodSandbox(psc, "")
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #5063 on release-1.13.

#5063: fix cgroupdriver systemd

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.