### PR TITLE
Automated cherry pick of #5063: fix start edgecore failed when using systemd cgroupdriver

### DIFF
--- a/edge/pkg/edgehub/upgrade/upgrade.go
+++ b/edge/pkg/edgehub/upgrade/upgrade.go
@@ -112,7 +112,7 @@ func (*keadmUpgrade) Upgrade(upgradeReq *commontypes.NodeUpgradeJobRequest) erro
 
 	// install the requested installer keadm from docker image
 	klog.Infof("Begin to download version %s keadm", upgradeReq.Version)
-	container, err := util.NewContainerRuntime(config.Modules.Edged.ContainerRuntime, config.Modules.Edged.RemoteRuntimeEndpoint)
+	container, err := util.NewContainerRuntime(config.Modules.Edged.ContainerRuntime, config.Modules.Edged.RemoteRuntimeEndpoint, config.Modules.Edged.TailoredKubeletConfig.CgroupDriver)
 	if err != nil {
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}

--- a/keadm/cmd/keadm/app/cmd/config.go
+++ b/keadm/cmd/keadm/app/cmd/config.go
@@ -120,7 +120,7 @@ func newCmdConfigImagesPull() *cobra.Command {
 			cfg.KubeEdgeVersion = ver
 
 			images := GetKubeEdgeImages(cfg)
-			return pullImages(cfg.RuntimeType, cfg.RemoteRuntimeEndpoint, images)
+			return pullImages(cfg.RuntimeType, cfg.RemoteRuntimeEndpoint, "", images)
 		},
 		Args: cobra.NoArgs,
 	}
@@ -129,8 +129,8 @@ func newCmdConfigImagesPull() *cobra.Command {
 	return cmd
 }
 
-func pullImages(runtimeType string, endpoint string, images []string) error {
-	runtime, err := util.NewContainerRuntime(runtimeType, endpoint)
+func pullImages(runtimeType, endpoint, cgroupDriver string, images []string) error {
+	runtime, err := util.NewContainerRuntime(runtimeType, endpoint, cgroupDriver)
 	if err != nil {
 		return err
 	}

--- a/keadm/cmd/keadm/app/cmd/edge/image.go
+++ b/keadm/cmd/keadm/app/cmd/edge/image.go
@@ -30,7 +30,7 @@ func request(opt *common.JoinOptions, step *common.Step) error {
 	imageSet := image.EdgeSet(opt.ImageRepository, opt.KubeEdgeVersion)
 	images := imageSet.List()
 
-	runtime, err := util.NewContainerRuntime(opt.RuntimeType, opt.RemoteRuntimeEndpoint)
+	runtime, err := util.NewContainerRuntime(opt.RuntimeType, opt.RemoteRuntimeEndpoint, opt.CGroupDriver)
 	if err != nil {
 		return err
 	}

--- a/keadm/cmd/keadm/app/cmd/edge/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/edge/upgrade.go
@@ -179,7 +179,8 @@ func (up *Upgrade) PreProcess() error {
 	// download the request version edgecore
 	klog.Infof("Begin to download version %s edgecore", up.ToVersion)
 	upgradePath := filepath.Join(util.KubeEdgeUpgradePath, up.ToVersion)
-	container, err := util.NewContainerRuntime(up.EdgeCoreConfig.Modules.Edged.ContainerRuntime, up.EdgeCoreConfig.Modules.Edged.RemoteRuntimeEndpoint)
+	container, err := util.NewContainerRuntime(up.EdgeCoreConfig.Modules.Edged.ContainerRuntime, up.EdgeCoreConfig.Modules.Edged.RemoteRuntimeEndpoint,
+		up.EdgeCoreConfig.Modules.Edged.TailoredKubeletConfig.CgroupDriver)
 	if err != nil {
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}

--- a/keadm/cmd/keadm/app/cmd/reset.go
+++ b/keadm/cmd/keadm/app/cmd/reset.go
@@ -107,7 +107,7 @@ func NewKubeEdgeReset() *cobra.Command {
 			}
 
 			// cleanup mqtt container
-			if err := RemoveMqttContainer(reset.RuntimeType, reset.Endpoint); err != nil {
+			if err := RemoveMqttContainer(reset.RuntimeType, reset.Endpoint, ""); err != nil {
 				fmt.Printf("Failed to remove MQTT container: %v\n", err)
 			}
 			//4. TODO: clean status information
@@ -120,8 +120,8 @@ func NewKubeEdgeReset() *cobra.Command {
 	return cmd
 }
 
-func RemoveMqttContainer(runtimeType string, endpoint string) error {
-	runtime, err := util.NewContainerRuntime(runtimeType, endpoint)
+func RemoveMqttContainer(runtimeType, endpoint, cgroupDriver string) error {
+	runtime, err := util.NewContainerRuntime(runtimeType, endpoint, cgroupDriver)
 	if err != nil {
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}


### PR DESCRIPTION
Cherry pick of #5063 on release-1.12.

#5063: fix cgroupdriver systemd

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.