### PR TITLE
Automated cherry pick of #5045: fix remove pod failed

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -288,15 +288,16 @@ func (e *edged) handlePod(op string, content []byte, updatesChan chan<- interfac
 	pods = append(pods, &pod)
 
 	if filterPodByNodeName(&pod, e.nodeName) {
+		var podOp kubelettypes.PodOperation
 		switch op {
-		case model.InsertOperation:
-			klog.V(4).InfoS("Receive message of adding new pods", "pods", klog.KObjs(pods))
-		case model.UpdateOperation:
-			klog.V(4).InfoS("Receive message of updating pods", "pods", klog.KObjs(pods))
+		case model.InsertOperation, model.UpdateOperation:
+			klog.V(4).InfoS("Receive message of add/update pods", "operation", op, "pods", klog.KObjs(pods))
+			podOp = kubelettypes.UPDATE
 		case model.DeleteOperation:
 			klog.V(4).InfoS("Receive message of deleting pods", "pods", klog.KObjs(pods))
+			podOp = kubelettypes.REMOVE
 		}
-		updates := &kubelettypes.PodUpdate{Op: kubelettypes.UPDATE, Pods: pods, Source: kubelettypes.ApiserverSource}
+		updates := &kubelettypes.PodUpdate{Op: podOp, Pods: pods, Source: kubelettypes.ApiserverSource}
 		updatesChan <- *updates
 	}
 


### PR DESCRIPTION
Cherry pick of #5045 on release-1.13.

#5045: fix remove pod failed

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.