### PR TITLE
Automated cherry pick of #5085: fix keadm upgrade If edgecore is stopped, the keadm process

### DIFF
--- a/edge/pkg/edgehub/upgrade/upgrade.go
+++ b/edge/pkg/edgehub/upgrade/upgrade.go
@@ -138,8 +138,8 @@ func (*keadmUpgrade) Upgrade(upgradeReq *commontypes.NodeUpgradeJobRequest) erro
 		upgradeReq.UpgradeID, upgradeReq.HistoryID, version.Get(), upgradeReq.Version, opts.ConfigFile, image)
 
 	// run upgrade cmd to upgrade edge node
-	// use setsid command and nohup command to start a separate progress
-	command := fmt.Sprintf("setsid nohup %s &", upgradeCmd)
+	// use nohup command to start a child progress
+	command := fmt.Sprintf("nohup %s &", upgradeCmd)
 	cmd := exec.Command("bash", "-c", command)
 	s, err := cmd.CombinedOutput()
 	if err != nil {

--- a/keadm/cmd/keadm/app/cmd/common/content.go
+++ b/keadm/cmd/keadm/app/cmd/common/content.go
@@ -34,6 +34,7 @@ ExecStart=%s
 Restart=always
 RestartSec=10
 Environment=%s
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Cherry pick of #5085 on release-1.14.

#5085: fix keadm upgrade If edgecore is stopped, the keadm process

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.