### PR TITLE
Fixed a null pointer error when PushMethod is not defined for device properties.

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
@@ -134,63 +134,65 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 		// get dbMethod filed by grpc device instance
 		var dbMethodName string
 		var dbconfig common.DBConfig
-		if pptv.PushMethod.DBMethod != nil {
-			dbMethodName, err = getDBMethodFromGrpc(pptv)
-			if err != nil {
-				klog.Errorf("err: %+v", err)
-				return nil
-			}
-			switch dbMethodName {
-			case "influx":
-				clientconfig, err := json.Marshal(pptv.PushMethod.DBMethod.Influxdb2.Influxdb2ClientConfig)
-				if err != nil {
-					klog.Errorf("err: %+v", err)
-					return nil
-				}
-				dataconfig, err := json.Marshal(pptv.PushMethod.DBMethod.Influxdb2.Influxdb2DataConfig)
-				if err != nil {
-					klog.Errorf("err: %+v", err)
-					return nil
-				}
-				dbconfig = common.DBConfig{
-					Influxdb2ClientConfig: clientconfig,
-					Influxdb2DataConfig:   dataconfig,
-				}
-			}
-		}
-
-		// get pushMethod filed by grpc device instance
-		pushMethodName, err := getPushMethodFromGrpc(pptv)
-		if err != nil {
-			klog.Errorf("err: %+v", err)
-			return nil
-		}
 		var pushMethod []byte
-		switch pushMethodName {
-		case "http":
-			pushMethod, err = json.Marshal(pptv.PushMethod.Http)
+		var pushMethodName string
+		if pptv.PushMethod != nil {
+			if pptv.PushMethod.DBMethod != nil {
+				dbMethodName, err = getDBMethodFromGrpc(pptv)
+				if err != nil {
+					klog.Errorf("err: %+v", err)
+					return nil
+				}
+				switch dbMethodName {
+				case "influx":
+					clientconfig, err := json.Marshal(pptv.PushMethod.DBMethod.Influxdb2.Influxdb2ClientConfig)
+					if err != nil {
+						klog.Errorf("err: %+v", err)
+						return nil
+					}
+					dataconfig, err := json.Marshal(pptv.PushMethod.DBMethod.Influxdb2.Influxdb2DataConfig)
+					if err != nil {
+						klog.Errorf("err: %+v", err)
+						return nil
+					}
+					dbconfig = common.DBConfig{
+						Influxdb2ClientConfig: clientconfig,
+						Influxdb2DataConfig:   dataconfig,
+					}
+				}
+			}
+			// get pushMethod filed by grpc device instance
+			pushMethodName, err = getPushMethodFromGrpc(pptv)
 			if err != nil {
 				klog.Errorf("err: %+v", err)
 				return nil
 			}
-		case "mqtt":
-			pushMethod, err = json.Marshal(pptv.PushMethod.Mqtt)
-			if err != nil {
-				klog.Errorf("err: %+v", err)
-				return nil
+			switch pushMethodName {
+			case "http":
+				pushMethod, err = json.Marshal(pptv.PushMethod.Http)
+				if err != nil {
+					klog.Errorf("err: %+v", err)
+					return nil
+				}
+			case "mqtt":
+				pushMethod, err = json.Marshal(pptv.PushMethod.Mqtt)
+				if err != nil {
+					klog.Errorf("err: %+v", err)
+					return nil
+				}
 			}
 		}
 
 		// get the final Properties
 		cur := common.DeviceProperty{
-			Name:         pptv.GetName(),
-			PropertyName: pptv.GetName(),
-			ModelName:    device.Spec.DeviceModelReference,
-			CollectCycle: pptv.GetCollectCycle(),
-			ReportCycle:  pptv.GetReportCycle(),
+			Name:          pptv.GetName(),
+			PropertyName:  pptv.GetName(),
+			ModelName:     device.Spec.DeviceModelReference,
+			CollectCycle:  pptv.GetCollectCycle(),
+			ReportCycle:   pptv.GetReportCycle(),
 			ReportToCloud: pptv.GetReportToCloud(),
-			Protocol:     protocolName,
-			Visitors:     visitorConfig,
+			Protocol:      protocolName,
+			Visitors:      visitorConfig,
 			PushMethod: common.PushMethodConfig{
 				MethodName:   pushMethodName,
 				MethodConfig: pushMethod,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When the device's properties do not define PushMethod, a null pointer error will be reported, such as pptv.PushMethod.DBMethod in the code reporting a null pointer exception. Therefore, this optimization is to avoid reporting null pointer exceptions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
@cl2017 @wbc6080 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
