### PR TITLE
Automated cherry pick of #5086: Determine whether to push device data from mapper to edgeCore

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
@@ -129,6 +129,7 @@ func dataHandler(ctx context.Context, dev *driver.CustomizedDev) {
 			VisitorConfig:   &visitorConfig,
 			Topic:           fmt.Sprintf(common.TopicTwinUpdate, dev.Instance.ID),
 			CollectCycle:    time.Duration(twin.Property.CollectCycle),
+			ReportToCloud:   twin.Property.ReportToCloud,
 		}
 		go twinData.Run(ctx)
 		// handle push method

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
@@ -26,6 +26,7 @@ type TwinData struct {
 	Topic           string
 	Results         interface{}
 	CollectCycle    time.Duration
+	ReportToCloud   bool
 }
 
 func (td *TwinData) GetPayLoad() ([]byte, error) {
@@ -87,6 +88,9 @@ func (td *TwinData) PushToEdgeCore() {
 }
 
 func (td *TwinData) Run(ctx context.Context) {
+	if !td.ReportToCloud {
+		return
+	}
 	if td.CollectCycle == 0 {
 		td.CollectCycle = 1 * time.Second
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
@@ -188,6 +188,7 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 			ModelName:    device.Spec.DeviceModelReference,
 			CollectCycle: pptv.GetCollectCycle(),
 			ReportCycle:  pptv.GetReportCycle(),
+			ReportToCloud: pptv.GetReportToCloud(),
 			Protocol:     protocolName,
 			Visitors:     visitorConfig,
 			PushMethod: common.PushMethodConfig{


### PR DESCRIPTION
Cherry pick of #5086 on release-1.15.

#5086: Determine whether to push device data from mapper to edgeCore

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.