### PR TITLE
modify parameters for ginkgo v2

### DIFF
--- a/build/conformance/e2e-runner/run.go
+++ b/build/conformance/e2e-runner/run.go
@@ -36,7 +36,8 @@ const (
 	dryRunEnvKey        = "E2E_DRYRUN"
 	skipEnvKey          = "E2E_SKIP"
 	focusEnvKey         = "E2E_FOCUS"
-	ginkgoEnvKey        = "GINKGO_BIN"
+	ginkgoPathEnvKey    = "GINKGO_BIN"
+	ginkgoTimeoutEnvKey = "GINKGO_TIMEOUT"
 	testBinEnvKey       = "TEST_BIN"
 	resultsDirEnvKey    = "RESULTS_DIR"
 	reportPrefixEnvKey  = "REPORT_PREFIX"
@@ -45,6 +46,7 @@ const (
 	kubeConfigEnvKey    = "KUBECONFIG"
 	logFileName         = "e2e.log"
 	defaultFocus        = "\\[Conformance\\]"
+	defaultTimeout      = "2h"
 	extraArgsEnvKey     = "E2E_EXTRA_ARGS"
 	defaultResultsDir   = "/tmp/results"
 	defaultReportPrefix = "conformance"
@@ -128,7 +130,10 @@ func makeCmd(w io.Writer) (*exec.Cmd, error) {
 
 	focusEnvValue := util.GetEnvWithDefault(focusEnvKey, defaultFocus)
 	ginkgoArgs = append(ginkgoArgs, "--focus="+focusEnvValue)
-	ginkgoArgs = append(ginkgoArgs, "--noColor=true")
+	ginkgoArgs = append(ginkgoArgs, "--no-color=true")
+
+	timeoutEnvValue := util.GetEnvWithDefault(ginkgoTimeoutEnvKey, defaultTimeout)
+	ginkgoArgs = append(ginkgoArgs, "--timeout="+timeoutEnvValue)
 
 	if len(util.GetEnvWithDefault(dryRunEnvKey, "")) > 0 {
 		ginkgoArgs = append(ginkgoArgs, "--dryRun=true")
@@ -152,7 +157,7 @@ func makeCmd(w io.Writer) (*exec.Cmd, error) {
 	args = append(args, "--")
 	args = append(args, extraArgs...)
 
-	cmd := exec.Command(util.GetEnvWithDefault(ginkgoEnvKey, defaultGinkgoBinary), args...)
+	cmd := exec.Command(util.GetEnvWithDefault(ginkgoPathEnvKey, defaultGinkgoBinary), args...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	return cmd, nil

--- a/build/conformance/kubernetes/edge_skip_case.yaml
+++ b/build/conformance/kubernetes/edge_skip_case.yaml
@@ -18,3 +18,5 @@
 - codename: should call prestop when killing a pod
 - codename: should support sysctls
 - codename: Should recreate evicted statefulset
+- codename: should execute poststart exec hook properly
+- codename: should execute prestop exec hook properly

--- a/build/conformance/node-e2e-runner/run.go
+++ b/build/conformance/node-e2e-runner/run.go
@@ -36,7 +36,8 @@ const (
 	dryRunEnvKey        = "E2E_DRYRUN"
 	skipEnvKey          = "E2E_SKIP"
 	focusEnvKey         = "E2E_FOCUS"
-	ginkgoEnvKey        = "GINKGO_BIN"
+	ginkgoPathEnvKey    = "GINKGO_BIN"
+	ginkgoTimeoutEnvKey = "GINKGO_TIMEOUT"
 	testBinEnvKey       = "TEST_BIN"
 	resultsDirEnvKey    = "RESULTS_DIR"
 	reportPrefixEnvKey  = "REPORT_PREFIX"
@@ -45,6 +46,7 @@ const (
 	kubeConfigEnvKey    = "KUBECONFIG"
 	logFileName         = "e2e.log"
 	defaultFocus        = "\\[sig-node\\].*Conformance"
+	defaultTimeout      = "2h"
 	extraArgsEnvKey     = "E2E_EXTRA_ARGS"
 	defaultResultsDir   = "/tmp/results"
 	defaultReportPrefix = "conformance"
@@ -128,7 +130,10 @@ func makeCmd(w io.Writer) (*exec.Cmd, error) {
 
 	focusEnvValue := util.GetEnvWithDefault(focusEnvKey, defaultFocus)
 	ginkgoArgs = append(ginkgoArgs, "--focus="+focusEnvValue)
-	ginkgoArgs = append(ginkgoArgs, "--noColor=true")
+	ginkgoArgs = append(ginkgoArgs, "--no-color=true")
+
+	timeoutEnvValue := util.GetEnvWithDefault(ginkgoTimeoutEnvKey, defaultTimeout)
+	ginkgoArgs = append(ginkgoArgs, "--timeout="+timeoutEnvValue)
 
 	if len(util.GetEnvWithDefault(dryRunEnvKey, "")) > 0 {
 		ginkgoArgs = append(ginkgoArgs, "--dryRun=true")
@@ -152,7 +157,7 @@ func makeCmd(w io.Writer) (*exec.Cmd, error) {
 	args = append(args, "--")
 	args = append(args, extraArgs...)
 
-	cmd := exec.Command(util.GetEnvWithDefault(ginkgoEnvKey, defaultGinkgoBinary), args...)
+	cmd := exec.Command(util.GetEnvWithDefault(ginkgoPathEnvKey, defaultGinkgoBinary), args...)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	return cmd, nil

--- a/build/conformance/util/util.go
+++ b/build/conformance/util/util.go
@@ -121,7 +121,7 @@ var updateTaintBackoff = wait.Backoff{
 	Jitter:   1.0,
 }
 
-// beforeRunConformance do prepare work before run conformance
+// BeforeRunConformance do prepare work before run conformance
 func BeforeRunConformance() error {
 	kubeClient, err := getKubeClient()
 	if err != nil {

--- a/edge/test/integration/utils/common/log.go
+++ b/edge/test/integration/utils/common/log.go
@@ -49,11 +49,11 @@ func Infof(format string, args ...interface{}) {
 // PrintTestcaseNameandStatus to print the test case name and status of execution
 func PrintTestcaseNameandStatus() {
 	var Status string
-	testSpecReport := ginkgo.CurrentGinkgoTestDescription()
-	if testSpecReport.Failed {
+	testSpecReport := ginkgo.CurrentSpecReport()
+	if testSpecReport.Failed() {
 		Status = "FAILED"
 	} else {
 		Status = "PASSED"
 	}
-	Infof("TestCase:%40s     Status=%s", testSpecReport.TestText, Status)
+	Infof("TestCase:%40s     Status=%s", testSpecReport.LeafNodeText, Status)
 }

--- a/tests/e2e/apps/deployment.go
+++ b/tests/e2e/apps/deployment.go
@@ -42,7 +42,7 @@ var DeploymentTestTimerGroup = utils.NewTestTimerGroup()
 var _ = GroupDescribe("Application deployment test in E2E scenario", func() {
 	var UID string
 	var testTimer *utils.TestTimer
-	var testSpecReport ginkgo.GinkgoTestDescription
+	var testSpecReport ginkgo.SpecReport
 
 	var clientSet clientset.Interface
 
@@ -53,9 +53,9 @@ var _ = GroupDescribe("Application deployment test in E2E scenario", func() {
 	ginkgo.Context("Test application deployment and delete deployment using deployment spec", func() {
 		ginkgo.BeforeEach(func() {
 			// Get current test SpecReport
-			testSpecReport = ginkgo.CurrentGinkgoTestDescription()
+			testSpecReport = ginkgo.CurrentSpecReport()
 			// Start test timer
-			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 
 		ginkgo.AfterEach(func() {
@@ -122,9 +122,9 @@ var _ = GroupDescribe("Application deployment test in E2E scenario", func() {
 	ginkgo.Context("Test application deployment using Pod spec", func() {
 		ginkgo.BeforeEach(func() {
 			// Get current test SpecReport
-			testSpecReport = ginkgo.CurrentGinkgoTestDescription()
+			testSpecReport = ginkgo.CurrentSpecReport()
 			// Start test timer
-			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 		ginkgo.AfterEach(func() {
 			// End test timer
@@ -229,9 +229,9 @@ var _ = GroupDescribe("Application deployment test in E2E scenario", func() {
 	ginkgo.Context("StatefulSet lifecycle test in edge node", func() {
 		ginkgo.BeforeEach(func() {
 			// Get current test SpecReport
-			testSpecReport = ginkgo.CurrentGinkgoTestDescription()
+			testSpecReport = ginkgo.CurrentSpecReport()
 			// Start test timer
-			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 
 		ginkgo.AfterEach(func() {

--- a/tests/e2e/device/device.go
+++ b/tests/e2e/device/device.go
@@ -36,7 +36,7 @@ const (
 // Run Test cases
 var _ = GroupDescribe("Device Management test in E2E scenario", func() {
 	var testTimer *utils.TestTimer
-	var testSpecReport ginkgo.GinkgoTestDescription
+	var testSpecReport ginkgo.SpecReport
 	var edgeClientSet edgeclientset.Interface
 
 	ginkgo.BeforeEach(func() {
@@ -53,9 +53,9 @@ var _ = GroupDescribe("Device Management test in E2E scenario", func() {
 				gomega.Expect(err).To(gomega.BeNil())
 			}
 			// Get current test SpecReport
-			testSpecReport = ginkgo.CurrentGinkgoTestDescription()
+			testSpecReport = ginkgo.CurrentSpecReport()
 			// Start test timer
-			testTimer = utils.CRDTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = utils.CRDTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 		ginkgo.AfterEach(func() {
 			// End test timer
@@ -121,9 +121,9 @@ var _ = GroupDescribe("Device Management test in E2E scenario", func() {
 			}
 			utils.TwinResult = utils.DeviceTwinResult{}
 			// Get current test SpecReport
-			testSpecReport = ginkgo.CurrentGinkgoTestDescription()
+			testSpecReport = ginkgo.CurrentSpecReport()
 			// Start test timer
-			testTimer = utils.CRDTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = utils.CRDTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 		ginkgo.AfterEach(func() {
 			// End test timer

--- a/tests/e2e/rule/rule.go
+++ b/tests/e2e/rule/rule.go
@@ -16,7 +16,7 @@ import (
 
 var _ = GroupDescribe("Rule Management test in E2E scenario", func() {
 	var testTimer *utils.TestTimer
-	var testSpecReport ginkgo.GinkgoTestDescription
+	var testSpecReport ginkgo.SpecReport
 	var edgeClientSet edgeclientset.Interface
 
 	ginkgo.BeforeEach(func() {
@@ -41,9 +41,9 @@ var _ = GroupDescribe("Rule Management test in E2E scenario", func() {
 				gomega.Expect(err).To(gomega.BeNil())
 			}
 			// Get current test SpecReport
-			testSpecReport = ginkgo.CurrentGinkgoTestDescription()
+			testSpecReport = ginkgo.CurrentSpecReport()
 			// Start test timer
-			testTimer = utils.CRDTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = utils.CRDTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 		ginkgo.AfterEach(func() {
 			// End test timer

--- a/tests/e2e/utils/log.go
+++ b/tests/e2e/utils/log.go
@@ -55,11 +55,11 @@ func Infof(format string, args ...interface{}) {
 // PrintTestcaseNameandStatus print the test case name and status of execution
 func PrintTestcaseNameandStatus() {
 	var Status string
-	testSpecReport := ginkgo.CurrentGinkgoTestDescription()
-	if testSpecReport.Failed {
+	testSpecReport := ginkgo.CurrentSpecReport()
+	if testSpecReport.Failed() {
 		Status = "FAILED"
 	} else {
 		Status = "PASSED"
 	}
-	Infof("TestCase:%40s     Status=%s", testSpecReport.TestText, Status)
+	Infof("TestCase:%40s     Status=%s", testSpecReport.LeafNodeText, Status)
 }

--- a/tests/e2e_edgesite/edgesite_test.go
+++ b/tests/e2e_edgesite/edgesite_test.go
@@ -39,7 +39,7 @@ var DeploymentTestTimerGroup = utils.NewTestTimerGroup()
 var _ = Describe("Application deployment test in E2E scenario using EdgeSite", func() {
 	var UID string
 	var testTimer *utils.TestTimer
-	var testSpecReport GinkgoTestDescription
+	var testSpecReport SpecReport
 
 	var clientSet clientset.Interface
 
@@ -50,9 +50,9 @@ var _ = Describe("Application deployment test in E2E scenario using EdgeSite", f
 	Context("Test application deployment and delete deployment using deployment spec", func() {
 		BeforeEach(func() {
 			// Get current test SpecReport
-			testSpecReport = CurrentGinkgoTestDescription()
+			testSpecReport = CurrentSpecReport()
 			// Start test timer
-			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 
 		AfterEach(func() {
@@ -118,9 +118,9 @@ var _ = Describe("Application deployment test in E2E scenario using EdgeSite", f
 	Context("Test application deployment using Pod spec using EdgeSite", func() {
 		BeforeEach(func() {
 			// Get current test SpecReport
-			testSpecReport = CurrentGinkgoTestDescription()
+			testSpecReport = CurrentSpecReport()
 			// Start test timer
-			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 
 		AfterEach(func() {

--- a/tests/e2e_keadm/keadm_test.go
+++ b/tests/e2e_keadm/keadm_test.go
@@ -34,7 +34,7 @@ var DeploymentTestTimerGroup = utils.NewTestTimerGroup()
 // Run Test cases
 var _ = Describe("Application deployment test in keadm E2E scenario", func() {
 	var testTimer *utils.TestTimer
-	var testSpecReport GinkgoTestDescription
+	var testSpecReport SpecReport
 
 	var clientSet clientset.Interface
 
@@ -45,9 +45,9 @@ var _ = Describe("Application deployment test in keadm E2E scenario", func() {
 	Context("Test application deployment using Pod spec", func() {
 		BeforeEach(func() {
 			// Get current test SpecReport
-			testSpecReport = CurrentGinkgoTestDescription()
+			testSpecReport = CurrentSpecReport()
 			// Start test timer
-			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.TestText)
+			testTimer = DeploymentTestTimerGroup.NewTestTimer(testSpecReport.LeafNodeText)
 		})
 		AfterEach(func() {
 			// End test timer


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

/kind test


**What this PR does / why we need it**:

- add parameter 'timeout' for ginkgo v2. ginkgo v2 changes timeout default to 1h, while the conformance test takes 1h-1.5h. The ginkgo v1 default timeout value is 24h. 
- add two skip cases, for we don't support them now.
- --noColor has been changed to --no-color in ginkgo v2
- CurrentGinkgoTestDescription() is deprecated in Ginkgo V2.  Use CurrentSpecReport() instead.