### PR TITLE
update go version to 1.20.10 for docker build tool

### DIFF
--- a/build/docker/build-tools/build-tools.dockerfile
+++ b/build/docker/build-tools/build-tools.dockerfile
@@ -10,9 +10,9 @@ RUN apt-get autoremove -y &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/*
 
-RUN if [ "${ARCH}" = "amd64" ]; then wget -c https://dl.google.com/go/go1.19.12.linux-amd64.tar.gz -O - | tar -xz -C /usr/local; \
-    elif [ "${ARCH}" = "arm64" ]; then wget -c https://dl.google.com/go/go1.19.12.linux-arm64.tar.gz -O - | tar -xz -C /usr/local; \
-    elif [ "${ARCH}" = "arm" ]; then wget -c https://dl.google.com/go/go1.19.12.linux-armv6l.tar.gz -O - | tar -xz -C /usr/local; \
+RUN if [ "${ARCH}" = "amd64" ]; then wget -c https://dl.google.com/go/go1.20.10.linux-amd64.tar.gz -O - | tar -xz -C /usr/local; \
+    elif [ "${ARCH}" = "arm64" ]; then wget -c https://dl.google.com/go/go1.20.10.linux-arm64.tar.gz -O - | tar -xz -C /usr/local; \
+    elif [ "${ARCH}" = "arm" ]; then wget -c https://dl.google.com/go/go1.20.10.linux-armv6l.tar.gz -O - | tar -xz -C /usr/local; \
     fi
 
 ENV GO111MODULE=on

--- a/build/docker/build-tools/make-build-tools.sh
+++ b/build/docker/build-tools/make-build-tools.sh
@@ -6,7 +6,7 @@ REPOSITORY=${REPOSITORY:-"kubeedge/build-tools"}
 # image tag for build-tools image, including golang version and build-tools version
 # If there's some modifications for build-tools.dockerfile other than golang version, the build-tools version should be updated e.g. ke1, ke2.
 # If the golang version is updated in build-tools.dockerfile, the build-tools version should be started from ke1.
-IMAGE_TAG=${IMAGE_TAG:-"1.19.12-ke2"}
+IMAGE_TAG=${IMAGE_TAG:-"1.20.10-ke1"}
 WORK_DIR=$(cd "$(dirname "$0")";pwd)
 PUSH_TAG=${1}
 ARCHS=(amd64 arm64 arm)


### PR DESCRIPTION
**What type of PR is this?**


/kind feature



**What this PR does / why we need it**:

update go version to 1.20.10 for docker build tool

**Which issue(s) this PR fixes**:

Fixes #5122 

