### PR TITLE
Automated cherry pick of #4881: fix the bug in local-up mode that causes cni to not launch

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -96,12 +96,74 @@ verify_docker_installed(){
 
 # install CNI plugins
 function install_cni_plugins() {
+  CNI_DOWNLOAD_ADDR=${CNI_DOWNLOAD_ADDR:-"https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz"}
+  CNI_PKG=${CNI_DOWNLOAD_ADDR##*/}
+  CNI_CONF_OVERWRITE=${CNI_CONF_OVERWRITE:-"true"}
+  echo -e "The installation of the cni plugin will overwrite the cni config file. Use export CNI_CONFIG_FILE=false to disable it."
+
   # install CNI plugins if not exist
   if [ ! -f "/opt/cni/bin/loopback" ]; then
-    echo -e "install CNI plugins..."
-    mkdir -p /opt/cni/bin
-    wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
-    tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
+    echo -e "start installing CNI plugins..."
+    sudo mkdir -p /opt/cni/bin
+    wget ${CNI_DOWNLOAD_ADDR}
+    if [ ! -f ${CNI_PKG} ]; then
+      echo -e "cni plugins package does not exits"
+      exit 1
+    fi
+    sudo tar Cxzvf /opt/cni/bin ${CNI_PKG}
+    rm -rf ${CNI_PKG}
+    if [ ! -f "/opt/cni/bin/loopback" ]; then
+      echo -e "the ${CNI_PKG} package does not contain a loopback file."
+      exit 1
+    fi
+
+    # create CNI netconf file
+    CNI_CONFIG_FILE="/etc/cni/net.d/10-containerd-net.conflist"
+    if [ -f ${CNI_CONFIG_FILE} ]; then
+      if [ ${CNI_CONF_OVERWRITE} == "false" ]; then
+        echo -e "CNI netconf file already exist and will no overwrite"
+        return
+      fi
+      echo -e "Configuring cni, ${CNI_CONFIG_FILE} already exists, will be backup as ${CNI_CONFIG_FILE}-bak ..."
+      sudo mv ${CNI_CONFIG_FILE} ${CNI_CONFIG_FILE}-bak
+    fi
+    sudo mkdir -p "/etc/cni/net.d/"
+    sudo sh -c 'cat > '${CNI_CONFIG_FILE}' <<EOF
+{
+  "cniVersion": "1.0.0",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{
+            "subnet": "10.88.0.0/16"
+          }],
+          [{
+            "subnet": "2001:db8:4860::/64"
+          }]
+        ],
+        "routes": [
+          { "dst": "0.0.0.0/0" },
+          { "dst": "::/0" }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF'
+    sudo systemctl restart containerd
+    sleep 2
   else
     echo "CNI plugins already installed and no need to install"
   fi

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -21,6 +21,7 @@ LOG_LEVEL=${LOG_LEVEL:-2}
 TIMEOUT=${TIMEOUT:-60}s
 PROTOCOL=${PROTOCOL:-"WebSocket"}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"remote"}
+echo -e "The installation of the cni plugin will overwrite the cni config file. Use export CNI_CONFIG_FILE=false to disable it."
 
 if [[ "${CLUSTER_NAME}x" == "x" ]];then
     CLUSTER_NAME="test"
@@ -256,12 +257,6 @@ build_edgecore
 
 kind_up_cluster
 
-# install CNI plugins
-if [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
-  # we need to install CNI plugins only when we use remote(containerd) as edgecore container runtime
-  install_cni_plugins
-fi
-
 export KUBECONFIG=$HOME/.kube/config
 
 check_control_plane_ready
@@ -279,6 +274,12 @@ create_serviceaccountaccess_crd
 generate_streamserver_cert
 
 start_cloudcore
+
+# install CNI plugins
+if [[ "${CONTAINER_RUNTIME}" = "remote" ]]; then
+# we need to install CNI plugins only when we use remote(containerd) as edgecore container runtime
+install_cni_plugins
+fi
 
 sleep 2
 


### PR DESCRIPTION
Cherry pick of #4881 on release-1.14.

#4881: fix the bug in local-up mode that causes cni to not launch

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.