### PR TITLE
Fix mapper-framework code which was used in example mapper

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
@@ -128,6 +128,7 @@ func dataHandler(ctx context.Context, dev *driver.CustomizedDev) {
 			VisitorConfig:   &visitorConfig,
 			Topic:           fmt.Sprintf(common.TopicTwinUpdate, dev.Instance.ID),
 			CollectCycle:    time.Duration(twin.Property.CollectCycle),
+			ReportToCloud:   twin.Property.ReportToCloud,
 		}
 		go twinData.Run(ctx)
 		// handle push method
@@ -252,7 +253,7 @@ func setVisitor(visitorConfig *driver.VisitorConfig, twin *common.Twin, dev *dri
 		klog.V(3).Infof("%s twin readonly property: %s", dev.Instance.Name, twin.PropertyName)
 		return nil
 	}
-	err := dev.CustomizedClient.SetDeviceData(twin, visitorConfig)
+	err = dev.CustomizedClient.SetDeviceData(twin, visitorConfig)
 	if err != nil {
 		return fmt.Errorf("%s set device data error: %v", twin.PropertyName, err)
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
@@ -109,7 +109,6 @@ func dataHandler(ctx context.Context, dev *driver.CustomizedDev) {
 		var visitorConfig driver.VisitorConfig
 
 		err := json.Unmarshal(twin.Property.Visitors, &visitorConfig)
-		visitorConfig.VisitorConfigData.DataType = strings.ToLower(visitorConfig.VisitorConfigData.DataType)
 		if err != nil {
 			klog.Errorf("Unmarshal VisitorConfig error: %v", err)
 			continue
@@ -129,7 +128,6 @@ func dataHandler(ctx context.Context, dev *driver.CustomizedDev) {
 			VisitorConfig:   &visitorConfig,
 			Topic:           fmt.Sprintf(common.TopicTwinUpdate, dev.Instance.ID),
 			CollectCycle:    time.Duration(twin.Property.CollectCycle),
-			ReportToCloud:   twin.Property.ReportToCloud,
 		}
 		go twinData.Run(ctx)
 		// handle push method
@@ -254,13 +252,7 @@ func setVisitor(visitorConfig *driver.VisitorConfig, twin *common.Twin, dev *dri
 		klog.V(3).Infof("%s twin readonly property: %s", dev.Instance.Name, twin.PropertyName)
 		return nil
 	}
-	klog.V(2).Infof("Convert type: %s, value: %s ", twin.Property.PProperty.DataType, twin.ObservedDesired.Value)
-	value, err := common.Convert(twin.Property.PProperty.DataType, twin.ObservedDesired.Value)
-	if err != nil {
-		klog.Errorf("Failed to convert value as %s : %v", twin.Property.PProperty.DataType, err)
-		return err
-	}
-	err = dev.CustomizedClient.SetDeviceData(value, visitorConfig)
+	err := dev.CustomizedClient.SetDeviceData(twin, visitorConfig)
 	if err != nil {
 		return fmt.Errorf("%s set device data error: %v", twin.PropertyName, err)
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-        "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/Template/driver"
 	"github.com/kubeedge/Template/pkg/common"
@@ -26,6 +26,7 @@ type TwinData struct {
 	Topic           string
 	Results         interface{}
 	CollectCycle    time.Duration
+	ReportToCloud   bool
 }
 
 func (td *TwinData) GetPayLoad() ([]byte, error) {
@@ -86,6 +87,9 @@ func (td *TwinData) PushToEdgeCore() {
 }
 
 func (td *TwinData) Run(ctx context.Context) {
+	if !td.ReportToCloud {
+		return
+	}
 	if td.CollectCycle == 0 {
 		td.CollectCycle = 1 * time.Second
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/devicetwin.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog/v2"
+        "k8s.io/klog/v2"
 
 	"github.com/kubeedge/Template/driver"
 	"github.com/kubeedge/Template/pkg/common"
@@ -26,12 +26,10 @@ type TwinData struct {
 	Topic           string
 	Results         interface{}
 	CollectCycle    time.Duration
-	ReportToCloud   bool
 }
 
 func (td *TwinData) GetPayLoad() ([]byte, error) {
 	var err error
-	td.VisitorConfig.VisitorConfigData.DataType = strings.ToLower(td.VisitorConfig.VisitorConfigData.DataType)
 	td.Results, err = td.Client.GetDeviceData(td.VisitorConfig)
 	if err != nil {
 		return nil, fmt.Errorf("get device data failed: %v", err)
@@ -88,9 +86,6 @@ func (td *TwinData) PushToEdgeCore() {
 }
 
 func (td *TwinData) Run(ctx context.Context) {
-	if !td.ReportToCloud {
-		return
-	}
 	if td.CollectCycle == 0 {
 		td.CollectCycle = 1 * time.Second
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/driver/devicetype.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/driver/devicetype.go
@@ -34,5 +34,4 @@ type VisitorConfig struct {
 
 type VisitorConfigData struct {
 	// TODO: add your visitor config data
-	DataType string `json:"dataType"`
 }

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/driver/driver.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/driver/driver.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"github.com/kubeedge/Template/pkg/common"
 	"sync"
 )
 
@@ -25,7 +26,7 @@ func (c *CustomizedClient) GetDeviceData(visitor *VisitorConfig) (interface{}, e
 	return nil, nil
 }
 
-func (c *CustomizedClient) SetDeviceData(data interface{}, visitor *VisitorConfig) error {
+func (c *CustomizedClient) SetDeviceData(twin *common.Twin, visitor *VisitorConfig) error {
 	// TODO: set device's data
 	// you can use c.ProtocolConfig and visitor
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Remove the code in mapper-framework that is only used in example mappers， to make the mapper project generated by mapper-framework more universal. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
