### PR TITLE
Resolve that users do not need to define the status module in device. yaml.

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
@@ -72,26 +72,18 @@ func BuildProtocolFromGrpc(device *dmiapi.Device) (common.ProtocolConfig, error)
 }
 
 func buildTwinsFromGrpc(device *dmiapi.Device) []common.Twin {
-	if len(device.Status.Twins) == 0 {
+	if len(device.Spec.Properties) == 0 {
 		return nil
 	}
-	res := make([]common.Twin, 0, len(device.Status.Twins))
-	for _, twin := range device.Status.Twins {
+	res := make([]common.Twin, 0, len(device.Spec.Properties))
+	for _, property := range device.Spec.Properties {
 		cur := common.Twin{
-			PropertyName: twin.PropertyName,
-
+			PropertyName: property.Name,
 			ObservedDesired: common.TwinProperty{
-				Value: twin.ObservedDesired.Value,
+				Value: property.Desired.Value,
 				Metadata: common.Metadata{
-					Timestamp: twin.ObservedDesired.Metadata["timestamp"],
-					Type:      twin.ObservedDesired.Metadata["type"],
-				},
-			},
-			Reported: common.TwinProperty{
-				Value: twin.Reported.Value,
-				Metadata: common.Metadata{
-					Timestamp: twin.ObservedDesired.Metadata["timestamp"],
-					Type:      twin.ObservedDesired.Metadata["type"],
+					Timestamp: property.Desired.Metadata["timestamp"],
+					Type:      property.Desired.Metadata["type"],
 				},
 			},
 		}
@@ -183,14 +175,14 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 
 		// get the final Properties
 		cur := common.DeviceProperty{
-			Name:         pptv.GetName(),
-			PropertyName: pptv.GetName(),
-			ModelName:    device.Spec.DeviceModelReference,
-			CollectCycle: pptv.GetCollectCycle(),
-			ReportCycle:  pptv.GetReportCycle(),
+			Name:          pptv.GetName(),
+			PropertyName:  pptv.GetName(),
+			ModelName:     device.Spec.DeviceModelReference,
+			CollectCycle:  pptv.GetCollectCycle(),
+			ReportCycle:   pptv.GetReportCycle(),
 			ReportToCloud: pptv.GetReportToCloud(),
-			Protocol:     protocolName,
-			Visitors:     visitorConfig,
+			Protocol:      protocolName,
+			Visitors:      visitorConfig,
 			PushMethod: common.PushMethodConfig{
 				MethodName:   pushMethodName,
 				MethodConfig: pushMethod,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug






Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
The current mapper requires users to define status and twist data in device, but this part of data should be obtained from the device based on the mapper, and should not be defined by the user. Therefore, this PR mainly solves the problem of users no longer defining status in device, and the mapper reconstructs the data structure of twist based on properties to report status.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
@wbc6080 @cl2017 
**Does this PR introduce a user-facing change?**:
Users no longer need to define the status module in device. yaml.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
