### PR TITLE
Fix Metaserver Panic when Handling POST.

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/serializer/serializer.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/serializer/serializer.go
@@ -31,6 +31,7 @@ func (f WithoutConversionCodecFactory) SupportedMediaTypes() []runtime.Serialize
 			EncodesAsText:    true,
 			Serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Pretty: false}),
 			PrettySerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Pretty: true}),
+			StrictSerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Strict: true}),
 			StreamSerializer: &runtime.StreamSerializerInfo{
 				EncodesAsText: true,
 				Serializer:    json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Pretty: false}),


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Fix to the `edgecore` panic issue: https://github.com/kubeedge/kubeedge/issues/4844#issuecomment-1789997085.
The panic happens when any create/update/patch request is received by `metaserver`.

**Which issue(s) this PR fixes**:

Fixes #4844 

```release-note
    Fix edgecore's metaserver panic when handling create, update, and patch request issue.
```
