### PR TITLE
Add more metaserver non resources URIs support.

### DIFF
--- a/pkg/util/pass-through/pass_through.go
+++ b/pkg/util/pass-through/pass_through.go
@@ -3,11 +3,17 @@ package passthrough
 type passRequest string
 
 const (
-	versionRequest passRequest = "/version::get"
+	versionRequest  passRequest = "/version::get"
+	healthRequest   passRequest = "/healthz::get"
+	liveRequest     passRequest = "/livez::get"
+	readyRequest    passRequest = "/readyz::get"
 )
 
 var passThroughMap = map[passRequest]bool{
 	versionRequest: true,
+	healthRequest:  true,
+	liveRequest:    true,
+	readyRequest:   true,
 }
 
 // IsPassThroughPath determining whether the uri can be passed through

--- a/pkg/util/pass-through/pass_through_test.go
+++ b/pkg/util/pass-through/pass_through_test.go
@@ -10,11 +10,6 @@ func TestIsPassThroughPath(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "/healthz::get is not pass through path",
-			path: "/healthz",
-			verb: "get",
-			want: false,
-		}, {
 			name: "/version::post is not pass through path",
 			path: "/version",
 			verb: "post",
@@ -22,6 +17,36 @@ func TestIsPassThroughPath(t *testing.T) {
 		}, {
 			name: "/version::get is pass through path",
 			path: "/version",
+			verb: "get",
+			want: true,
+		}, {
+			name: "/healthz::update is not pass through path",
+			path: "/healthz",
+			verb: "update",
+			want: false,
+		}, {
+			name: "/healthz::get is pass through path",
+			path: "/healthz",
+			verb: "get",
+			want: true,
+		}, {
+			name: "/livez::create is not pass through path",
+			path: "/livez",
+			verb: "create",
+			want: false,
+		}, {
+			name: "/livez::get is pass through path",
+			path: "/livez",
+			verb: "get",
+			want: true,
+		}, {
+			name: "/readyz::delete is not pass through path",
+			path: "/readyz",
+			verb: "delete",
+			want: false,
+		}, {
+			name: "/readyz::get is pass through path",
+			path: "/readyz",
 			verb: "get",
 			want: true,
 		},


### PR DESCRIPTION
/kind feature
/kind api-change

**What this PR does / why we need it**:

Some applications check health periodically and commit suicide on failure.

https://github.com/kubeedge/kubeedge/issues/4844#issuecomment-1752276811

**Which issue(s) this PR fixes**:

Fixes #4844 

**Special notes for your reviewer**:

How are we going to deal with request with more complicated options, such as `127.0.0.1:10550/readyz?verbose`?
https://kubernetes.io/docs/reference/using-api/health-checks/#api-endpoints-for-health
https://github.com/kubeedge/kubeedge/issues/4844#issuecomment-1791972324

**Does this PR introduce a user-facing change?**:

```release-note
    Add support of getting healthz, livez, readyz for metaserver.
```
