### PR TITLE
remove pid namespace config in copy-resource

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -281,8 +281,6 @@ func (runtime *CRIRuntime) CopyResources(edgeImage string, files map[string]stri
 			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
 				NamespaceOptions: &runtimeapi.NamespaceOption{
 					Network: runtimeapi.NamespaceMode_POD,
-					Pid:     runtimeapi.NamespaceMode_CONTAINER,
-					Ipc:     runtimeapi.NamespaceMode_POD,
 				},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

Remove pid namespace config for it is unnecessary. But we still need to config network namespace config, otherwise we will join edgecore failed with the error as below

![image](https://github.com/kubeedge/kubeedge/assets/48788150/dcc38349-269f-4e3a-bbc9-040afc13ecd9)


**Which issue(s) this PR fixes**:

Fixes #5139


