### PR TITLE
Correct the server IP of quic on edge nodes.

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -155,4 +155,8 @@ const (
 
 	// DefaultManifestsDir edge node default static pod path
 	DefaultManifestsDir = "/etc/kubeedge/manifests"
+
+	// EdgeHub
+	DefaultWebSocketPort = 10000
+	DefaultQuicPort      = 10001
 )

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -100,6 +100,8 @@ const (
 	HelmInstallAction  = "install"
 	HelmManifestAction = "manifest"
 
+	HubProtocol = "hub-protocol"
+
 	CmdGetDNSIP         = "cat /etc/resolv.conf | grep nameserver | grep -v -E ':|#' | awk '{print $2}' | head -n1"
 	CmdGetStatusDocker  = "systemctl status docker |grep Active | awk '{print $2}'"
 	CmdPing             = "ping %s -w %d |grep 'packets transmitted' |awk '{print $6}'"

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -59,6 +59,7 @@ type JoinOptions struct {
 	Labels                []string
 	WithMQTT              bool
 	ImageRepository       string
+	HubProtocol           string
 }
 
 type CheckOptions struct {

--- a/keadm/cmd/keadm/app/cmd/deprecated/join.go
+++ b/keadm/cmd/keadm/app/cmd/deprecated/join.go
@@ -28,6 +28,7 @@ import (
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/edge"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+	"github.com/kubeedge/viaduct/pkg/api"
 )
 
 var (
@@ -84,6 +85,7 @@ func NewDeprecatedEdgeJoin() *cobra.Command {
 func newJoinOptions() *types.JoinOptions {
 	opts := &types.JoinOptions{}
 	opts.CertPath = types.DefaultCertPath
+	opts.HubProtocol = api.ProtocolTypeWS
 
 	return opts
 }
@@ -129,6 +131,7 @@ func Add2EdgeToolsList(toolList map[string]types.ToolsInstaller, flagData map[st
 		CGroupDriver:          joinOptions.CGroupDriver,
 		TarballPath:           joinOptions.TarballPath,
 		Labels:                joinOptions.Labels,
+		HubProtocol:           joinOptions.HubProtocol,
 	}
 
 	toolList["MQTT"] = &util.MQTTInstTool{}

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/viaduct/pkg/api"
 )
 
 var (
@@ -110,6 +111,7 @@ func newOption() *common.JoinOptions {
 	joinOptions.CertPath = common.DefaultCertPath
 	joinOptions.RuntimeType = kubetypes.RemoteContainerRuntime
 	joinOptions.RemoteRuntimeEndpoint = constants.DefaultRemoteRuntimeEndpoint
+	joinOptions.HubProtocol = api.ProtocolTypeWS
 	return joinOptions
 }
 

--- a/keadm/cmd/keadm/app/cmd/util/edgecoreinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/edgecoreinstaller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2/validation"
 	"github.com/kubeedge/kubeedge/pkg/util"
+	"github.com/kubeedge/viaduct/pkg/api"
 )
 
 // KubeEdgeInstTool embeds Common struct and contains cloud node ip:port information
@@ -45,6 +46,7 @@ type KubeEdgeInstTool struct {
 	CGroupDriver          string
 	TarballPath           string
 	Labels                []string
+	HubProtocol           string
 }
 
 // InstallTools downloads KubeEdge for the specified version
@@ -92,8 +94,6 @@ func (ku *KubeEdgeInstTool) createEdgeConfigFiles() error {
 	}
 
 	edgeCoreConfig := v1alpha2.NewDefaultEdgeCoreConfig()
-	edgeCoreConfig.Modules.EdgeHub.WebSocket.Server = ku.CloudCoreIP
-
 	if ku.EdgeNodeName != "" {
 		edgeCoreConfig.Modules.Edged.HostnameOverride = ku.EdgeNodeName
 	}
@@ -123,6 +123,21 @@ func (ku *KubeEdgeInstTool) createEdgeConfigFiles() error {
 		edgeCoreConfig.Modules.EdgeHub.HTTPServer = "https://" + cloudCoreIP + ":" + ku.CertPort
 	} else {
 		edgeCoreConfig.Modules.EdgeHub.HTTPServer = "https://" + cloudCoreIP + ":10002"
+	}
+
+	switch ku.HubProtocol {
+	case api.ProtocolTypeQuic:
+		edgeCoreConfig.Modules.EdgeHub.Quic.Enable = true
+		edgeCoreConfig.Modules.EdgeHub.WebSocket.Enable = false
+		edgeCoreConfig.Modules.EdgeHub.Quic.Server = ku.CloudCoreIP
+		edgeCoreConfig.Modules.EdgeHub.WebSocket.Server = net.JoinHostPort(cloudCoreIP, strconv.Itoa(constants.DefaultWebSocketPort))
+	case api.ProtocolTypeWS:
+		edgeCoreConfig.Modules.EdgeHub.Quic.Enable = false
+		edgeCoreConfig.Modules.EdgeHub.WebSocket.Enable = true
+		edgeCoreConfig.Modules.EdgeHub.Quic.Server = net.JoinHostPort(cloudCoreIP, strconv.Itoa(constants.DefaultQuicPort))
+		edgeCoreConfig.Modules.EdgeHub.WebSocket.Server = ku.CloudCoreIP
+	default:
+		return fmt.Errorf("unsupported hub of protocol: %s", ku.HubProtocol)
 	}
 	edgeCoreConfig.Modules.EdgeStream.TunnelServer = net.JoinHostPort(cloudCoreIP, strconv.Itoa(constants.DefaultTunnelPort))
 

--- a/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
@@ -32,12 +32,12 @@ data:
         websocket:
           address: 0.0.0.0
           enable: {{ .Values.cloudCore.modules.cloudHub.websocket.enable }}
-          port: 10000
+          port: {{ .Values.cloudCore.modules.cloudHub.websocket.port }}
         quic:
           address: 0.0.0.0
           enable: {{ .Values.cloudCore.modules.cloudHub.quic.enable }}
           maxIncomingStreams: {{ .Values.cloudCore.modules.cloudHub.quic.maxIncomingStreams }}
-          port: 10001
+          port: {{ .Values.cloudCore.modules.cloudHub.quic.port }}
         https:
           address: 0.0.0.0
           enable: {{ .Values.cloudCore.modules.cloudHub.https.enable }}

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -43,8 +43,10 @@ cloudCore:
         - ""
       nodeLimit: "1000"
       websocket:
+        port: 10000
         enable: true
       quic:
+        port: 10001
         enable: false
         maxIncomingStreams: "10000"
       https:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
It is found that the server IP of Quic on the edge node is currently the IP of the edge node, which is incorrect. Quic's server IP should be the IP of the cloud node, and the purpose of this PR is to correct Quic's server IP.
![quic](https://github.com/kubeedge/kubeedge/assets/110345347/9f00f7d5-8f5e-412a-900a-c2e25f898de5)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
@Shelley-BaoYue 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
