### PR TITLE
Let the podSendboxImage supports custom repository

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/join_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_others.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -314,6 +315,10 @@ func createV1alpha1EdgeConfigFiles(opt *common.JoinOptions) error {
 
 	if len(opt.Labels) > 0 {
 		edgeCoreConfig.Modules.Edged.Labels = setEdgedNodeLabels(opt)
+	}
+
+	if opt.ImageRepository != "" {
+		edgeCoreConfig.Modules.Edged.PodSandboxImage = path.Join(opt.ImageRepository, constants.DefaultPodSandboxImage)
 	}
 
 	if errs := validationv1alpha1.ValidateEdgeCoreConfiguration(edgeCoreConfig); len(errs) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

If the edge node can only use the private image registry, the pod sndbox cannot run properly,  because it cannot pull the kubeedge/pause:3.6 image from the docker hub

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
