### PR TITLE
Automated cherry pick of #5141: Fix edgecore's metaserver panic when handling create, update,

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/serializer/serializer.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/serializer/serializer.go
@@ -31,6 +31,7 @@ func (f WithoutConversionCodecFactory) SupportedMediaTypes() []runtime.Serialize
 			EncodesAsText:    true,
 			Serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Pretty: false}),
 			PrettySerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Pretty: true}),
+			StrictSerializer: json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Strict: true}),
 			StreamSerializer: &runtime.StreamSerializerInfo{
 				EncodesAsText: true,
 				Serializer:    json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Pretty: false}),


### PR DESCRIPTION
Cherry pick of #5141 on release-1.14.

#5141: Fix edgecore's metaserver panic when handling create, update,

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.