### PR TITLE
Automated cherry pick of #5179: Fix copy resources from the image throws nil runtimg error

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -263,6 +263,13 @@ func (runtime *CRIRuntime) CopyResources(edgeImage string, files map[string]stri
 			Name:      KubeEdgeBinaryName,
 			Namespace: constants.SystemNamespace,
 		},
+		Linux: &runtimeapi.LinuxPodSandboxConfig{
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
+				NamespaceOptions: &runtimeapi.NamespaceOption{
+					Network: runtimeapi.NamespaceMode_POD,
+				},
+			},
+		},
 	}
 	if runtime.cgroupDriver == v1alpha2.CGroupDriverSystemd {
 		cgroupName := cm.NewCgroupName(cm.CgroupName{"kubeedge", "setup", "podcopyresource"})


### PR DESCRIPTION
Cherry pick of #5179 on release-1.13.

#5179: Fix copy resources from the image throws nil runtimg error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.