### PR TITLE
Automated cherry pick of #5144: remove pid config in copy resource

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -281,8 +281,6 @@ func (runtime *CRIRuntime) CopyResources(edgeImage string, files map[string]stri
 			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
 				NamespaceOptions: &runtimeapi.NamespaceOption{
 					Network: runtimeapi.NamespaceMode_POD,
-					Pid:     runtimeapi.NamespaceMode_CONTAINER,
-					Ipc:     runtimeapi.NamespaceMode_POD,
 				},
 			},
 		},


### PR DESCRIPTION
Cherry pick of #5144 on release-1.15.

#5144: remove pid config in copy resource

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.