### PR TITLE
Automated cherry pick of #5107: Fix error logs for nodegroupx

### DIFF
--- a/cloud/pkg/controllermanager/nodegroup/nodegroupcontroller.go
+++ b/cloud/pkg/controllermanager/nodegroup/nodegroupcontroller.go
@@ -358,7 +358,7 @@ func (c *Controller) addOrUpdateNodeLabel(ctx context.Context, node *corev1.Node
 		return nil
 	}
 	if ok && v != nodeGroupName {
-		return fmt.Errorf("node %s has already belonged to NodeGroup %s", node.Name, nodeGroupName)
+		return fmt.Errorf("node %s has already belonged to NodeGroup %s", node.Name, v)
 	}
 
 	// !ok


### PR DESCRIPTION
Cherry pick of #5107 on release-1.13.

#5107: Fix error logs for nodegroupx

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.