### PR TITLE
bump `slsa-framework / slsa-github-generator` to v1.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
     with:
       base64-subjects: "${{ needs.combine_hashes.outputs.hashes }}"
       # Upload provenance to a new release
@@ -163,7 +163,7 @@ jobs:
       id-token: write # for creating OIDC tokens for signing.
       packages: write # for uploading attestations.
     if: startsWith(github.ref, 'refs/tags/')
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.4.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0
     with:
       image: kubeedge/${{ matrix.target }}
       registry-username: ${{ vars.DOCKERHUB_USER_NAME }}


### PR DESCRIPTION

**What type of PR is this?**


/kind bug



**What this PR does / why we need it**:

Bump `slsa-framework / slsa-github-generator` from v1.4.0 to v1.9.0.  

We signed images failed because the download from the cosign-releases GCS bucket was deprecated, cosign-installer need to be updated to v3.1.1 or later version, but `slsa-framework / slsa-github-generator` v1.4.0 still uses cosign-installer v2.8.1.  So we need to bump  `slsa-framework / slsa-github-generator`  to the newest version v1.9.0.

The blog about deprecated cosign-releases GCS bucket: https://blog.sigstore.dev/cosign-releases-bucket-deprecation/ 

The discussion about this pr:  https://github.com/slsa-framework/slsa-github-generator/issues/3006



