### PR TITLE
fix featuregates didn't take effect in edged config

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -168,6 +168,11 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 		kubeletConfig.RegisterNode = false
 	}
 
+	// set feature gates from initial flags-based config
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(kubeletConfig.FeatureGates); err != nil {
+		return nil, fmt.Errorf("failed to set feature gates from initial flags-based config: %w", err)
+	}
+
 	// construct a KubeletServer from kubeletFlags and kubeletConfig
 	kubeletServer := kubeletoptions.KubeletServer{
 		KubeletFlags:         kubeletFlags,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:

FeatureGates config need to be set into DefaultMutableFeatureGate Map, but we didn't set it, causing featureGate in edged config didn't take any effect in previous releases. 