### PR TITLE
Automated cherry pick of #5254: fix default staticPodPath in windows

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -152,7 +152,4 @@ const (
 
 	DeafultMosquittoContainerName = "mqtt-kubeedge"
 	DeployMqttContainerEnv        = "DEPLOY_MQTT_CONTAINER"
-
-	// DefaultManifestsDir edge node default static pod path
-	DefaultManifestsDir = "/etc/kubeedge/manifests"
 )

--- a/common/constants/default_others.go
+++ b/common/constants/default_others.go
@@ -30,4 +30,7 @@ const (
 	DefaultCNIBinDir             = "/opt/cni/bin"
 	DefaultCNICacheDir           = "/var/lib/cni/cache"
 	DefaultVolumePluginDir       = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+
+	// DefaultManifestsDir edge node default static pod path
+	DefaultManifestsDir = "/etc/kubeedge/manifests"
 )

--- a/common/constants/default_windows.go
+++ b/common/constants/default_windows.go
@@ -33,4 +33,7 @@ const (
 	DefaultCNIBinDir             = "c:\\opt\\cni\\bin"
 	DefaultCNICacheDir           = "c:\\var\\lib\\cni\\cache"
 	DefaultVolumePluginDir       = "C:\\usr\\libexec\\kubernetes\\kubelet-plugins\\volume\\exec\\"
+
+	// DefaultManifestsDir edge node default static pod path
+	DefaultManifestsDir = "c:\\etc\\kubeedge\\manifests\\"
 )


### PR DESCRIPTION
Cherry pick of #5254 on release-1.15.

#5254: fix default staticPodPath in windows

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.