### PR TITLE
remove registerNodeNamespace in edged config

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -97,7 +97,7 @@ var _ core.Module = (*edged)(nil)
 // Register register edged
 func Register(e *v1alpha2.Edged) {
 	edgedconfig.InitConfigure(e)
-	edged, err := newEdged(e.Enable, e.HostnameOverride, e.RegisterNodeNamespace)
+	edged, err := newEdged(e.Enable, e.HostnameOverride, constants.DefaultRegisterNodeNamespace)
 	if err != nil {
 		klog.Errorf("init new edged error, %v", err)
 		os.Exit(1)

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -69,8 +69,7 @@ func NewDefaultEdgeCoreConfig() (config *EdgeCoreConfig) {
 					RegisterSchedulable:     true,
 					WindowsPriorityClass:    DefaultWindowsPriorityClass,
 				},
-				CustomInterfaceName:   "",
-				RegisterNodeNamespace: constants.DefaultRegisterNodeNamespace,
+				CustomInterfaceName: "",
 			},
 			EdgeHub: &EdgeHub{
 				Enable:            true,
@@ -200,8 +199,7 @@ func NewMinEdgeCoreConfig() (config *EdgeCoreConfig) {
 					RegisterSchedulable:     true,
 					WindowsPriorityClass:    DefaultWindowsPriorityClass,
 				},
-				CustomInterfaceName:   "",
-				RegisterNodeNamespace: constants.DefaultRegisterNodeNamespace,
+				CustomInterfaceName: "",
 			},
 			EdgeHub: &EdgeHub{
 				Heartbeat:         15,

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -109,9 +109,6 @@ type Edged struct {
 	// If this is not defined the IP address is obtained by the hostname.
 	// default ""
 	CustomInterfaceName string `json:"customInterfaceName,omitempty"`
-	// RegisterNodeNamespace indicates register node namespace
-	// default "default"
-	RegisterNodeNamespace string `json:"registerNodeNamespace,omitempty"`
 }
 
 // TailoredKubeletConfiguration indicates the tailored kubelet configuration.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup



**What this PR does / why we need it**:

Cause we don't support register node with other namespaces, we need to remove registernodenamespace to avoid confusing users  
