### PR TITLE
Replace deprecated `io/ioutil` function

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/publish/http/client.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/publish/http/client.go
@@ -3,7 +3,7 @@ package http
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -61,7 +61,7 @@ func (pm *PushMethod) Push(data *common.DataModel) {
 		fmt.Println(err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// handle error
 		klog.Errorf("Publish device data by HTTP failed, err = %v", err)

--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/config/config.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/config/config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
@@ -61,7 +61,7 @@ func Parse() (c *Config, err error) {
 	}
 
 	c = &Config{}
-	cf, err := ioutil.ReadFile(configFile)
+	cf, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/httpserver/server.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/httpserver/server.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -74,7 +74,7 @@ func (rs *RestServer) StartServer() {
 		klog.V(3).Info("mtls communication, please provide client-key and client-cert to access service")
 		// Configure the server to trust TLS client cert issued by your CA.
 		certPool := x509.NewCertPool()
-		if caCertPEM, err := ioutil.ReadFile(rs.CaCertFilePath); err != nil {
+		if caCertPEM, err := os.ReadFile(rs.CaCertFilePath); err != nil {
 			klog.Errorf("Error loading ca certificate file: %v", err)
 			return
 		} else if ok := certPool.AppendCertsFromPEM(caCertPEM); !ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
As we upgrade to go 1.20, replace `io/ioutil` with `io` or `os`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
