### PR TITLE
fix mutex unlock

### DIFF
--- a/edge/pkg/devicetwin/dmiserver/server.go
+++ b/edge/pkg/devicetwin/dmiserver/server.go
@@ -91,11 +91,8 @@ func (s *server) MapperRegister(ctx context.Context, in *pb.MapperRegisterReques
 	var deviceList []*pb.Device
 	var deviceModelList []*pb.DeviceModel
 	s.dmiCache.DeviceMu.Lock()
-	defer s.dmiCache.DeviceMu.Unlock()
 	for _, device := range s.dmiCache.DeviceList {
-		protocol := device.Spec.Protocol.ProtocolName
-
-		if protocol == in.Mapper.Protocol {
+		if device.Spec.Protocol.ProtocolName == in.Mapper.Protocol {
 			dev, err := dtcommon.ConvertDevice(device)
 			if err != nil {
 				klog.Errorf("fail to convert device %s with err: %v", device.Name, err)
@@ -118,6 +115,8 @@ func (s *server) MapperRegister(ctx context.Context, in *pb.MapperRegisterReques
 			deviceModelList = append(deviceModelList, dm)
 		}
 	}
+	s.dmiCache.DeviceMu.Unlock()
+
 	dmiclient.DMIClientsImp.CreateDMIClient(in.Mapper.Protocol, string(in.Mapper.Address))
 
 	return &pb.MapperRegisterResponse{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
We need to unlock the mutex after the loop ends, instead of defining defer when function ends.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
