### PR TITLE
fix mapper framework generate.sh to build image successfully

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/tdengine/client.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/tdengine/client.go
@@ -4,12 +4,14 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/kubeedge/Template/pkg/common"
-	_ "github.com/taosdata/driver-go/v3/taosRestful"
-	"k8s.io/klog/v2"
 	"os"
 	"strings"
 	"time"
+
+	_ "github.com/taosdata/driver-go/v3/taosRestful"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/Template/pkg/common"
 )
 
 var (

--- a/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
+++ b/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
@@ -31,6 +31,8 @@ function entry() {
   sed -i "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
   sed -i "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
 
+  cd ${mapperPath} && go mod tidy
+ 
   empty_file_path="${MAPPER_DIR}/.empty"
   if [ -f "$empty_file_path" ]; then
       rm "$empty_file_path"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Fix the mapper generate.sh to successfully build the images refer to #5287 
I tried adding the database dependency package in go.mod of mapper-framework, but when I executed `make verify` at the end, the package I added was automatically removed. It seems that go mod cannot correctly identify the dependency reference under the _template file. So I executed `go mod tidy` in the generate.sh to re-import the database dependencies.
By the way, I also corrected the import order of tdengine.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5287 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
