### PR TITLE
Automated cherry pick of #5270: fix featuregates didn't take effect in edged config

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -166,6 +166,13 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	if !edgedconfig.Config.RegisterNode {
 		kubeletConfig.RegisterNode = false
 	}
+
+	// set feature gates from initial flags-based config
+	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(kubeletConfig.FeatureGates); err != nil {
+		return nil, fmt.Errorf("failed to set feature gates from initial flags-based config: %w", err)
+	}
+
+	// construct a KubeletServer from kubeletFlags and kubeletConfig
 	kubeletServer := kubeletoptions.KubeletServer{
 		KubeletFlags:         kubeletFlags,
 		KubeletConfiguration: kubeletConfig,


### PR DESCRIPTION
Cherry pick of #5270 on release-1.14.

#5270: fix featuregates

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.