### PR TITLE
Allow configuration of dmi.sock path

### DIFF
--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -156,4 +156,7 @@ const (
 	// EdgeHub
 	DefaultWebSocketPort = 10000
 	DefaultQuicPort      = 10001
+
+	// DeviceTwin
+	DefaultDMISockPath = "/etc/kubeedge/dmi.sock"
 )

--- a/edge/pkg/devicetwin/dmiserver/server.go
+++ b/edge/pkg/devicetwin/dmiserver/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubeedge/kubeedge/common/constants"
 	messagepkg "github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	deviceconfig "github.com/kubeedge/kubeedge/edge/pkg/devicetwin/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dmiclient"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtcommon"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao"
@@ -168,13 +169,19 @@ func CreateMessageTwinUpdate(twin *pb.Twin) ([]byte, error) {
 }
 
 func StartDMIServer(cache *DMICache) {
-	err := initSock(SockPath)
+	var DMISockPath string
+	if deviceconfig.Get().DeviceTwin.DMISockPath != "" {
+		DMISockPath = deviceconfig.Get().DeviceTwin.DMISockPath
+	} else {
+		DMISockPath = SockPath
+	}
+	err := initSock(DMISockPath)
 	if err != nil {
 		klog.Fatalf("failed to remove uds socket with err: %v", err)
 		return
 	}
 
-	lis, err := net.Listen(deviceconst.UnixNetworkType, SockPath)
+	lis, err := net.Listen(deviceconst.UnixNetworkType, DMISockPath)
 	if err != nil {
 		klog.Errorf("failed to start DMI Server with err: %v", err)
 		return

--- a/edge/test/integration/utils/test_setup.go
+++ b/edge/test/integration/utils/test_setup.go
@@ -40,6 +40,7 @@ func CreateEdgeCoreConfigFile(nodeName string) error {
 	c.Modules.EdgeHub.TLSCAFile = "/tmp/edgecore/rootCA.crt"
 	c.Modules.EdgeHub.TLSCertFile = "/tmp/edgecore/kubeedge.crt"
 	c.Modules.EdgeHub.TLSPrivateKeyFile = "/tmp/edgecore/kubeedge.key"
+	c.Modules.DeviceTwin.DMISockPath = "/etc/kubeedge/dmi.sock"
 	c.Modules.EventBus.Enable = true
 	c.Modules.EventBus.MqttMode = edgecore.MqttModeInternal
 	c.Modules.DBTest.Enable = true

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -142,7 +142,8 @@ func NewDefaultEdgeCoreConfig() (config *EdgeCoreConfig) {
 				Timeout: 60,
 			},
 			DeviceTwin: &DeviceTwin{
-				Enable: true,
+				Enable:      true,
+				DMISockPath: constants.DefaultDMISockPath,
 			},
 			DBTest: &DBTest{
 				Enable: false,
@@ -179,6 +180,9 @@ func NewMinEdgeCoreConfig() (config *EdgeCoreConfig) {
 			DataSource: DataBaseDataSource,
 		},
 		Modules: &Modules{
+			DeviceTwin: &DeviceTwin{
+				DMISockPath: constants.DefaultDMISockPath,
+			},
 			Edged: &Edged{
 				Enable:                true,
 				TailoredKubeletConfig: &defaultTailedKubeletConfig,

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -1023,6 +1023,9 @@ type DeviceTwin struct {
 	// if set to false (for debugging etc.), skip checking other DeviceTwin configs.
 	// default true
 	Enable bool `json:"enable"`
+	// DMISockPath sets the path to dmi.sock
+	// default "/etc/kubeedge/dmi.sock"
+	DMISockPath string `json:"dmiSockPath,omitempty"`
 }
 
 // DBTest indicates the DBTest module config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Based on the situation encountered in the issue #5323 , We add the configuration field for the dmi.sock path in edgecore.yaml to allow customization of the dmi.sock path. For example, in the local-up script, the original path /etc/kubeedge.dmi.sock will become /tmp/etc/kubeedge/dmi.sock
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5323 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
