### PR TITLE
fix device status problem

### DIFF
--- a/cloud/pkg/devicecontroller/controller/upstream.go
+++ b/cloud/pkg/devicecontroller/controller/upstream.go
@@ -135,7 +135,7 @@ func (uc *UpstreamController) updateDeviceStatus() {
 			}
 			deviceStatus := &DeviceStatus{Status: cacheDevice.Status}
 			for twinName, twin := range msgTwin.Twin {
-				deviceTwin := findTwinByName(twinName, &deviceStatus.Status.Twins)
+				deviceTwin := findTwinByName(twinName, deviceStatus.Status.Twins)
 				if deviceTwin != nil {
 					if twin.Actual != nil && twin.Actual.Value != nil {
 						reported := v1beta1.TwinProperty{}
@@ -226,10 +226,10 @@ func NewUpstreamController(dc *DownstreamController) (*UpstreamController, error
 	return uc, nil
 }
 
-func findTwinByName(twinName string, twins *[]v1beta1.Twin) *v1beta1.Twin {
-	for _, twin := range *twins {
-		if twinName == twin.PropertyName {
-			return &twin
+func findTwinByName(twinName string, twins []v1beta1.Twin) *v1beta1.Twin {
+	for i := range twins {
+		if twinName == twins[i].PropertyName {
+			return &twins[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
As described in #5327 , since we return the address of the index variable, not the address of `devicestatus.twin`, updating the status of devicetwin will fail. This PR returns the correct address of `devicestatus.twin`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5327 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
