### PR TITLE
Fixed stream tunnel access kubelet

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -255,7 +255,7 @@ func NegotiateTunnelPort() (*int, error) {
 }
 
 func negotiatePort(portRecord map[int]bool) int {
-	for port := constants.ServerPort; ; {
+	for port := constants.KubeletDefaultServerPort; ; {
 		port++
 		if _, found := portRecord[port]; !found {
 			return port

--- a/cloud/pkg/cloudstream/apiserverconnection.go
+++ b/cloud/pkg/cloudstream/apiserverconnection.go
@@ -6,11 +6,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
-const (
-	httpScheme        = "http"
-	defaultServerHost = "127.0.0.1"
-)
-
 // APIServerConnection indicates a connection request originally made by kube-apiserver to kubelet
 // There are basically three types of connection requests : containersLogs, containerExec, Metric
 // Cloudstream module first intercepts the connection request and then sends the request data through the tunnel (websocket) to edgestream module

--- a/cloud/pkg/cloudstream/containerattach_connection.go
+++ b/cloud/pkg/cloudstream/containerattach_connection.go
@@ -26,7 +26,6 @@ import (
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
@@ -81,8 +80,6 @@ func (ah *ContainerAttachConnection) SendConnection() (stream.EdgedConnection, e
 		URL:    *ah.r.Request.URL,
 		Header: ah.r.Request.Header,
 	}
-	connector.URL.Scheme = httpScheme
-	connector.URL.Host = net.JoinHostPort(defaultServerHost, fmt.Sprintf("%v", constants.ServerPort))
 	m, err := connector.CreateConnectMessage()
 	if err != nil {
 		return nil, err

--- a/cloud/pkg/cloudstream/containerexec_connection.go
+++ b/cloud/pkg/cloudstream/containerexec_connection.go
@@ -10,7 +10,6 @@ import (
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
@@ -65,8 +64,6 @@ func (c *ContainerExecConnection) SendConnection() (stream.EdgedConnection, erro
 		URL:    *c.r.Request.URL,
 		Header: c.r.Request.Header,
 	}
-	connector.URL.Scheme = httpScheme
-	connector.URL.Host = net.JoinHostPort(defaultServerHost, fmt.Sprintf("%v", constants.ServerPort))
 	m, err := connector.CreateConnectMessage()
 	if err != nil {
 		return nil, err

--- a/cloud/pkg/cloudstream/containerlog_connection.go
+++ b/cloud/pkg/cloudstream/containerlog_connection.go
@@ -20,12 +20,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
@@ -80,8 +78,6 @@ func (l *ContainerLogsConnection) SendConnection() (stream.EdgedConnection, erro
 		URL:    *l.r.Request.URL,
 		Header: l.r.Request.Header,
 	}
-	connector.URL.Scheme = httpScheme
-	connector.URL.Host = net.JoinHostPort(defaultServerHost, fmt.Sprintf("%v", constants.ServerPort))
 	m, err := connector.CreateConnectMessage()
 	if err != nil {
 		return nil, err

--- a/cloud/pkg/cloudstream/containermetrics_connection.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection.go
@@ -20,13 +20,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
-	"strconv"
 
 	"github.com/emicklei/go-restful"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
 
@@ -81,8 +78,6 @@ func (ms *ContainerMetricsConnection) SendConnection() (stream.EdgedConnection, 
 		URL:    *ms.r.Request.URL,
 		Header: ms.r.Request.Header,
 	}
-	connector.URL.Scheme = httpScheme
-	connector.URL.Host = net.JoinHostPort(defaultServerHost, strconv.Itoa(constants.ServerPort))
 	m, err := connector.CreateConnectMessage()
 	if err != nil {
 		return nil, err

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -21,9 +21,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/emicklei/go-restful"
@@ -183,7 +185,7 @@ func (s *StreamServer) getMetrics(r *restful.Request, w *restful.Response) {
 		if t := strings.Split(forwardedURI, "/"); strings.HasPrefix(forwardedURI, "/api/v1/nodes/") && len(t) > 6 {
 			sessionKey = t[4]
 			if ip, ok := s.tunnel.getNodeIP(sessionKey); ok {
-				r.Request.Host = fmt.Sprintf("%s:%d", ip, constants.ServerPort)
+				r.Request.Host = net.JoinHostPort(ip, strconv.Itoa(constants.KubeletDefaultServerPort))
 			}
 		}
 	}

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -135,10 +135,10 @@ const (
 	CSIOperationTypeControllerUnpublishVolume = "controllerunpublishvolume"
 	CSISyncMsgRespTimeout                     = 1 * time.Minute
 
-	ServerAddress = "127.0.0.1"
-	// ServerPort is the default port for the edgecore server on each host machine.
+	KubeletDefaultServerAddress = "127.0.0.1"
+	// KubeletDefaultServerPort is the default port for the edgecore server on each host machine.
 	// May be overridden by a flag at startup in the future.
-	ServerPort = 10350
+	KubeletDefaultServerPort = 10350
 
 	// MessageSuccessfulContent is the successful content value of Message struct
 	MessageSuccessfulContent string = "OK"

--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -3,7 +3,9 @@ package app
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 
 	ps "github.com/shirou/gopsutil/v3/process"
 	"github.com/spf13/cobra"
@@ -195,7 +197,8 @@ func registerModules(c *v1alpha2.EdgeCoreConfig) {
 	eventbus.Register(c.Modules.EventBus, c.Modules.Edged.HostnameOverride)
 	metamanager.Register(c.Modules.MetaManager)
 	servicebus.Register(c.Modules.ServiceBus)
-	edgestream.Register(c.Modules.EdgeStream, c.Modules.Edged.HostnameOverride, c.Modules.Edged.NodeIP)
+	kubeletHost := net.JoinHostPort(c.Modules.Edged.TailoredKubeletConfig.Address, strconv.Itoa(int(c.Modules.Edged.TailoredKubeletConfig.ReadOnlyPort)))
+	edgestream.Register(c.Modules.EdgeStream, c.Modules.Edged.HostnameOverride, c.Modules.Edged.NodeIP, kubeletHost)
 	test.Register(c.Modules.DBTest)
 	// Note: Need to put it to the end, and wait for all models to register before executing
 	dbm.InitDBConfig(c.DataBase.DriverName, c.DataBase.AliasName, c.DataBase.DataSource)

--- a/edge/pkg/edgestream/edgestream.go
+++ b/edge/pkg/edgestream/edgestream.go
@@ -40,11 +40,12 @@ type edgestream struct {
 	enable           bool
 	hostnameOverride string
 	nodeIP           string
+	kubeletHost      string
 }
 
 var _ core.Module = (*edgestream)(nil)
 
-func newEdgeStream(enable bool, hostnameOverride, nodeIP string) (*edgestream, error) {
+func newEdgeStream(enable bool, hostnameOverride, nodeIP string, kubeletHost string) (*edgestream, error) {
 	var err error
 	if nodeIP == "" {
 		nodeIP, err = util.GetLocalIP(util.GetHostname())
@@ -59,13 +60,14 @@ func newEdgeStream(enable bool, hostnameOverride, nodeIP string) (*edgestream, e
 		enable:           enable,
 		hostnameOverride: hostnameOverride,
 		nodeIP:           nodeIP,
+		kubeletHost:      kubeletHost,
 	}, nil
 }
 
 // Register register edgestream
-func Register(s *v1alpha2.EdgeStream, hostnameOverride, nodeIP string) {
+func Register(s *v1alpha2.EdgeStream, hostnameOverride, nodeIP string, kubeletHost string) {
 	config.InitConfigure(s)
-	edgeStream, err := newEdgeStream(s.Enable, hostnameOverride, nodeIP)
+	edgeStream, err := newEdgeStream(s.Enable, hostnameOverride, nodeIP, kubeletHost)
 	if err != nil {
 		klog.Errorf("init new edged error, %v", err)
 		os.Exit(1)
@@ -137,6 +139,6 @@ func (e *edgestream) TLSClientConnect(url url.URL, tlsConfig *tls.Config) error 
 		klog.Errorf("dial %v error %v", url.String(), err)
 		return err
 	}
-	session := NewTunnelSession(con)
+	session := NewTunnelSession(con, e.kubeletHost)
 	return session.Serve()
 }

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -35,7 +35,7 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 			APIVersion: path.Join(GroupName, APIVersion),
 		},
 		CommonConfig: &CommonConfig{
-			TunnelPort: constants.ServerPort,
+			TunnelPort: constants.KubeletDefaultServerPort,
 			MonitorServer: MonitorServer{
 				BindAddress:     "127.0.0.1:9091",
 				EnableProfiling: false,

--- a/pkg/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
+++ b/pkg/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
@@ -41,8 +41,8 @@ import (
 func SetDefaultsKubeletConfiguration(obj *TailoredKubeletConfiguration) {
 	obj.StaticPodPath = constants.DefaultManifestsDir
 	obj.SyncFrequency = metav1.Duration{Duration: 1 * time.Minute}
-	obj.Address = constants.ServerAddress
-	obj.ReadOnlyPort = constants.ServerPort
+	obj.Address = constants.KubeletDefaultServerAddress
+	obj.ReadOnlyPort = constants.KubeletDefaultServerPort
 	obj.ClusterDomain = constants.DefaultClusterDomain
 	obj.RegistryPullQPS = utilpointer.Int32(5)
 	obj.RegistryBurst = 10


### PR DESCRIPTION
…el access

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When we set the property `edged.tailoredKubeletConfig.readOnlyPort` to **10250**, that will changes the kubelet server port to **10250**, but the tunnel client still accesses `127.0.0.1:10350`.

We need to let the edgecore configuration determine the host for the stream tunnel access.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4952

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
