### PR TITLE
Fix edgecore's metaserver panic due to nil initializers in request scope.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters-settings:
   misspell:
     ignore-words:
       - mosquitto
+      - creater
 
 linters:
   disable-all: true


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Sorry that I didn't succeed in fixing panic problem thoroughly in pull request 5313.
This PR fill schemes for elements not initialized in request scope which lead to new panic issues.

**Special notes for your reviewer**:

Related tickets:
https://github.com/kubeedge/kubeedge/issues/4844
https://github.com/kubeedge/kubeedge/issues/5350
https://github.com/kubeedge/kubeedge/pull/5313

**Does this PR introduce a user-facing change?**:

 No.
