### PR TITLE
fix some bug in framework

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"encoding/json"
+
 	"k8s.io/klog/v2"
 
 	dmiapi "github.com/kubeedge/kubeedge/pkg/apis/dmi/v1beta1"
@@ -147,7 +148,6 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 			default:
 				klog.Errorf("get DBMethod err: Unsupported database type")
 			}
-
 		}
 		if pptv.PushMethod != nil {
 			//parse pushmethod filed

--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/util/parse/grpc.go
@@ -2,8 +2,6 @@ package parse
 
 import (
 	"encoding/json"
-	"errors"
-
 	"k8s.io/klog/v2"
 
 	dmiapi "github.com/kubeedge/kubeedge/pkg/apis/dmi/v1beta1"
@@ -17,27 +15,6 @@ type TwinResultResponse struct {
 
 func getProtocolNameFromGrpc(device *dmiapi.Device) (string, error) {
 	return device.Spec.Protocol.ProtocolName, nil
-}
-
-func getPushMethodFromGrpc(visitor *dmiapi.DeviceProperty) (string, error) {
-	if visitor.PushMethod != nil && visitor.PushMethod.Http != nil {
-		return common.PushMethodHTTP, nil
-	}
-	if visitor.PushMethod != nil && visitor.PushMethod.Mqtt != nil {
-		return common.PushMethodMQTT, nil
-	}
-	return "", errors.New("can not parse publish method")
-}
-
-func getDBMethodFromGrpc(visitor *dmiapi.DeviceProperty) (string, error) {
-	if visitor.PushMethod.DBMethod.Influxdb2 != nil {
-		return "influx", nil
-	} else if visitor.PushMethod.DBMethod.Redis != nil {
-		return "redis", nil
-	} else if visitor.PushMethod.DBMethod.Tdengine != nil {
-		return "tdengine", nil
-	}
-	return "", errors.New("can not parse dbMethod")
 }
 
 func BuildProtocolFromGrpc(device *dmiapi.Device) (common.ProtocolConfig, error) {
@@ -123,19 +100,16 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 			return nil
 		}
 
-		// get dbMethod filed by grpc device instance
+		// get the whole pushmethod filed by grpc device instance
 		var dbMethodName string
 		var dbconfig common.DBConfig
 		var pushMethod []byte
 		var pushMethodName string
 		if pptv.PushMethod != nil && pptv.PushMethod.DBMethod != nil {
-			dbMethodName, err = getDBMethodFromGrpc(pptv)
-			if err != nil {
-				klog.Errorf("get DBMethod err: %+v", err)
-				return nil
-			}
-			switch dbMethodName {
-			case "influx":
+			//parse dbmethod filed
+			switch {
+			case pptv.PushMethod.DBMethod.Influxdb2 != nil:
+				dbMethodName = "influx"
 				clientconfig, err := json.Marshal(pptv.PushMethod.DBMethod.Influxdb2.Influxdb2ClientConfig)
 				if err != nil {
 					klog.Errorf("influx client config err: %+v", err)
@@ -150,7 +124,8 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 					Influxdb2ClientConfig: clientconfig,
 					Influxdb2DataConfig:   dataconfig,
 				}
-			case "redis":
+			case pptv.PushMethod.DBMethod.Redis != nil:
+				dbMethodName = "redis"
 				clientConfig, err := json.Marshal(pptv.PushMethod.DBMethod.Redis.RedisClientConfig)
 				if err != nil {
 					klog.Errorf("redis config err: %+v", err)
@@ -159,7 +134,8 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 				dbconfig = common.DBConfig{
 					RedisClientConfig: clientConfig,
 				}
-			case "tdengine":
+			case pptv.PushMethod.DBMethod.Tdengine != nil:
+				dbMethodName = "tdengine"
 				clientConfig, err := json.Marshal(pptv.PushMethod.DBMethod.Tdengine.TdEngineClientConfig)
 				if err != nil {
 					klog.Errorf("tdengine config err: %+v", err)
@@ -168,27 +144,30 @@ func buildPropertiesFromGrpc(device *dmiapi.Device) []common.DeviceProperty {
 				dbconfig = common.DBConfig{
 					TDEngineClientConfig: clientConfig,
 				}
+			default:
+				klog.Errorf("get DBMethod err: Unsupported database type")
 			}
-		}
 
-		// get pushMethod filed by grpc device instance
-		pushMethodName, err = getPushMethodFromGrpc(pptv)
-		if err != nil {
-			klog.Errorf("err: %+v", err)
-			return nil
 		}
-		switch pushMethodName {
-		case common.PushMethodHTTP:
-			pushMethod, err = json.Marshal(pptv.PushMethod.Http)
-			if err != nil {
-				klog.Errorf("err: %+v", err)
-				return nil
-			}
-		case common.PushMethodMQTT:
-			pushMethod, err = json.Marshal(pptv.PushMethod.Mqtt)
-			if err != nil {
-				klog.Errorf("err: %+v", err)
-				return nil
+		if pptv.PushMethod != nil {
+			//parse pushmethod filed
+			switch {
+			case pptv.PushMethod.Http != nil:
+				pushMethodName = common.PushMethodHTTP
+				pushMethod, err = json.Marshal(pptv.PushMethod.Http)
+				if err != nil {
+					klog.Errorf("err: %+v", err)
+					return nil
+				}
+			case pptv.PushMethod.Mqtt != nil:
+				pushMethodName = common.PushMethodMQTT
+				pushMethod, err = json.Marshal(pptv.PushMethod.Mqtt)
+				if err != nil {
+					klog.Errorf("err: %+v", err)
+					return nil
+				}
+			default:
+				klog.Errorf("get PushMethod err: Unsupported pushmethod type")
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
1. In the previous PR, we removed the protocol field, but it was not fixed in the grpcserver/device.go file, resulting in incorrect function parameters and needs to be corrected.

2. When parsing the Property field in the parse/grpc.go file, if dbMethod or pushMethod is empty, the entire Property field will be directly returned as nil. This is unreasonable and will cause other Property field information to be lost. Here we change that if dbMethod or pushMethod is empty, just change this field to nil, which will not affect the parsing of other fields.

![xzzq](https://github.com/kubeedge/kubeedge/assets/48212997/d66da94b-0122-4757-b455-876062ec5440)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
@cl2017 @WillardHu 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
