### PR TITLE
Automated cherry pick of #5196 upstream release 1.13

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -266,7 +266,7 @@ func (runtime *CRIRuntime) CopyResources(edgeImage string, files map[string]stri
 		Linux: &runtimeapi.LinuxPodSandboxConfig{
 			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
 				NamespaceOptions: &runtimeapi.NamespaceOption{
-					Network: runtimeapi.NamespaceMode_POD,
+					Network: runtimeapi.NamespaceMode_NODE,
 				},
 			},
 		},


### PR DESCRIPTION
Cherry pick of https://github.com/kubeedge/kubeedge/pull/5196 on release-1.13.

https://github.com/kubeedge/kubeedge/pull/5196: Supports installing edgecore without installing the CNI plugin.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.