### PR TITLE
[WIP]Fix deviceID in message parsing

### DIFF
--- a/cloud/pkg/common/messagelayer/util.go
+++ b/cloud/pkg/common/messagelayer/util.go
@@ -131,8 +131,9 @@ func BuildResourceForDevice(nodeID, resourceType, resourceID string) (resource s
 // GetDeviceID returns the ID of the device
 func GetDeviceID(resource string) (string, error) {
 	res := strings.Split(resource, "/")
-	if len(res) >= ResourceDeviceIDIndex+1 && res[ResourceDeviceIndex] == ResourceDevice {
-		return res[ResourceDeviceIDIndex], nil
+	// Because device id is device.namespace/device.name, we need to index two places backward
+	if len(res) >= ResourceDeviceIDIndex+2 && res[ResourceDeviceIndex] == ResourceDevice {
+		return pkgutil.GetResourceID(res[ResourceDeviceIDIndex], res[ResourceDeviceIDIndex+1]), nil
 	}
 	return "", errors.New("failed to get device id")
 }

--- a/cloud/pkg/common/messagelayer/util_test.go
+++ b/cloud/pkg/common/messagelayer/util_test.go
@@ -91,9 +91,9 @@ func TestGetDeviceID(t *testing.T) {
 		{
 			name: "TestGetDeviceID(): Case 1: success",
 			args: args{
-				resource: fmt.Sprintf("node/%s/%s/%s", "nid", ResourceDevice, "did"),
+				resource: fmt.Sprintf("node/%s/%s/%s/%s", "nid", ResourceDevice, "dns", "dnm"),
 			},
-			want:    "did",
+			want:    "dns/dnm",
 			wantErr: nil,
 		},
 		{

--- a/edge/pkg/devicetwin/process.go
+++ b/edge/pkg/devicetwin/process.go
@@ -212,7 +212,13 @@ func classifyMsg(message *dttype.DTMessage) bool {
 				return false
 			}
 		} else {
-			identity = splitString[idLoc]
+			// Because device id is device.namespace/device.name, we need to distinguish it
+			if strings.Compare(splitString[idLoc-1], "device") == 0 {
+				identity = splitString[idLoc] + "/" + splitString[idLoc+1]
+			} else {
+				identity = splitString[idLoc]
+			}
+
 			loc := strings.Index(topic, identity)
 			nextLoc := loc + len(identity)
 			prefix := topic[0:loc]

--- a/edge/pkg/devicetwin/process_test.go
+++ b/edge/pkg/devicetwin/process_test.go
@@ -397,7 +397,7 @@ func Test_classifyMsg(t *testing.T) {
 	otherTopic := "/membership/detail/result"
 	otherEncodedTopic := base64.URLEncoding.EncodeToString([]byte(otherTopic))
 	//Encoded eventbus resource
-	eventbusTopic := "$hw/events/device/+/state/update"
+	eventbusTopic := "$hw/events/device/device_namespace/device_name/state/update"
 	eventbusResource := base64.URLEncoding.EncodeToString([]byte(eventbusTopic))
 
 	content := testutil.GenerateAddDevicePalyloadMsg(t)

--- a/edge/pkg/eventbus/mqtt/client.go
+++ b/edge/pkg/eventbus/mqtt/client.go
@@ -42,8 +42,8 @@ var (
 	// SubTopics which edge-client should be sub
 	SubTopics = []string{
 		"$hw/events/upload/#",
-		"$hw/events/device/+/state/update",
-		"$hw/events/device/+/twin/+",
+		"$hw/events/device/+/+/state/update",
+		"$hw/events/device/+/+/twin/+",
 		"$hw/events/node/+/membership/get",
 		UploadTopic,
 		"+/user/#",

--- a/edge/pkg/eventbus/mqtt/filter_test.go
+++ b/edge/pkg/eventbus/mqtt/filter_test.go
@@ -25,7 +25,7 @@ func init() {
 
 func TestDispatch(t *testing.T) {
 	msg := packet.Message{
-		Topic:   "$hw/events/device/sampledevice/twin/test",
+		Topic:   "$hw/events/device/sampleNamespace/sampleDevice/twin/test",
 		Payload: []byte("device sample"),
 		QOS:     0,
 		Retain:  false,

--- a/edge/test/integration/device/device_suite_test.go
+++ b/edge/test/integration/device/device_suite_test.go
@@ -52,9 +52,9 @@ var (
 	//deviceupload topic
 	DeviceUpload = "$hw/events/upload/#"
 	//device status update topic "$hw/events/device/+/state/update"
-	DevicestatusUpdate = dtcommon.DeviceETPrefix + "+" + dtcommon.DeviceETStateUpdateSuffix
+	DevicestatusUpdate = dtcommon.DeviceETPrefix + "+/+" + dtcommon.DeviceETStateUpdateSuffix
 	//device twin update topic "$hw/events/device/+/twin/+"
-	DeviceTwinUpdate = dtcommon.DeviceETPrefix + "+" + dtcommon.DeviceTwinModule + "/+"
+	DeviceTwinUpdate = dtcommon.DeviceETPrefix + "+/+" + dtcommon.DeviceTwinModule + "/+"
 	//device membership update topic "$hw/events/node/+/membership/get"
 	DeviceMembershipUpdate = dtcommon.MemETPrefix + "+" + dtcommon.MemETGetSuffix
 	//upload record to cloud topic

--- a/edge/test/integration/device/device_test.go
+++ b/edge/test/integration/device/device_test.go
@@ -187,8 +187,7 @@ var _ = Describe("Event Bus Testing", func() {
 	Context("Publish on eventbus topics throgh MQTT internal broker", func() {
 		BeforeEach(func() {
 			common.Infof("Adding Mock device to edgenode !!")
-
-			DeviceIDN = GenerateDeviceID("kubeedge-device-")
+			DeviceIDN = GenerateDeviceID("default/kubeedge-device-")
 			DeviceN = CreateDevice(DeviceIDN, "edgedevice", "unknown")
 
 			ClientOpts = HubClientInit(ctx.Cfg.MqttEndpoint, ClientID, "", "")
@@ -311,7 +310,7 @@ var _ = Describe("Event Bus Testing", func() {
 		})
 		It("TC_TEST_EBUS_9: Add a sample device with device attributes to kubeedge node", func() {
 			//Generating Device ID
-			DeviceIDWithAttr = GenerateDeviceID("kubeedge-device-WithDeviceAttributes")
+			DeviceIDWithAttr = GenerateDeviceID("default/kubeedge-device-WithDeviceAttributes")
 			//Generate a Device
 			DeviceATT = CreateDevice(DeviceIDWithAttr, "DeviceATT", "unknown")
 			//Add Attribute to device
@@ -330,7 +329,7 @@ var _ = Describe("Event Bus Testing", func() {
 
 		It("TC_TEST_EBUS_10: Add a sample device with Twin attributes to kubeedge node", func() {
 			//Generating Device ID
-			DeviceIDWithTwin = GenerateDeviceID("kubeedge-device-WithTwinAttributes")
+			DeviceIDWithTwin = GenerateDeviceID("default/kubeedge-device-WithTwinAttributes")
 			//Generate a Device
 			DeviceTW = CreateDevice(DeviceIDWithTwin, "DeviceTW", "unknown")
 			//Add twin attribute


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Since we define deviceID as device.namespace/device.name, one more bit will be parsed during message parsing than before, resulting in message parsing errors that need to be corrected.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
