### PR TITLE
Fix keadm upgrade command

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/edge/upgrade.go
@@ -51,7 +51,7 @@ func NewEdgeUpgrade() *cobra.Command {
 		Long:  "Upgrade edge components. Upgrade the edge node to the desired version.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// upgrade edgecore
-			return upgradeOptions.upgrade()
+			return upgradeOptions.Upgrade()
 		},
 	}
 
@@ -68,7 +68,8 @@ func NewUpgradeOptions() *UpgradeOptions {
 	return opts
 }
 
-func (up *UpgradeOptions) upgrade() error {
+// Upgrade handles upgrade command logic
+func (up *UpgradeOptions) Upgrade() error {
 	// get EdgeCore configuration from edgecore.yaml config file
 	data, err := os.ReadFile(up.Config)
 	if err != nil {

--- a/keadm/cmd/keadm/app/cmd/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/upgrade.go
@@ -13,6 +13,7 @@ Specify whether to upgrade the cloud or the edge through three-level commands.
 If no three-level command, it upgrades edge components.`
 )
 
+// NewUpgradeCommand creates a upgrade command instance and returns it.
 func NewUpgradeCommand() *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   "upgrade",
@@ -20,15 +21,15 @@ func NewUpgradeCommand() *cobra.Command {
 		Long:  upgradeLongDescription,
 	}
 
-	edgecmd := edge.NewEdgeUpgrade()
-
 	// Used for backward compatibility of the edgecore trigger the upgrade command
 	upgradeOptions := edge.NewUpgradeOptions()
+	cmds.RunE = func(cmd *cobra.Command, args []string) error {
+		return upgradeOptions.Upgrade()
+	}
 	edge.AddUpgradeFlags(cmds, upgradeOptions)
-	cmds.RunE = edgecmd.RunE
 
 	// Register three-level commands
-	cmds.AddCommand(edgecmd)
+	cmds.AddCommand(edge.NewEdgeUpgrade())
 	cmds.AddCommand(cloud.NewCloudUpgrade())
 	return cmds
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Sorry, the function reference I used earlier(https://github.com/kubeedge/kubeedge/pull/5374) caused a problem with the scope of the upgrade options. In the RunE, the upgradeOptions pointer variable refers to the upgradeOptions in the NewEdgeUpgrade(), it's just an instance initialized with default values.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
