### PR TITLE
normalize the hostname in fucntion GetHostname

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	golang.org/x/text v0.13.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/component-helpers v0.0.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3
 )
 
@@ -259,7 +260,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/cloud-provider v0.27.7 // indirect
 	k8s.io/cluster-bootstrap v0.27.7 // indirect
-	k8s.io/component-helpers v0.0.0 // indirect
 	k8s.io/controller-manager v0.0.0 // indirect
 	k8s.io/csi-translation-lib v0.27.7 // indirect
 	k8s.io/dynamic-resource-allocation v0.0.0 // indirect

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	nodeutil "k8s.io/component-helpers/node/util"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 
 	"github.com/kubeedge/kubeedge/common/constants"
@@ -131,7 +132,7 @@ func SpliceErrors(errors []error) string {
 
 // GetHostname returns a reasonable hostname
 func GetHostname() string {
-	hostnameOverride, err := os.Hostname()
+	hostnameOverride, err := nodeutil.GetHostname("")
 	if err != nil {
 		return constants.DefaultHostnameOverride
 	}


### PR DESCRIPTION
Because hostname is case-insensitive, normalize it before coverting to a DNS subdomain name.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Kubeedge generates default node name by hostname if it is a valid DNS subdomain. The default node name will be `default-edge-node` if hostname contains uppercase letters, which may lead to compatibility issues when nodes are migrated from kubelet to kubeedge.

**Which issue(s) this PR fixes**：

Fixes #5391

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
yes
```release-note
The default name of node which has a uppercase hostname is changed from `default-edge-node` to lowercase hostname.
```
