### PR TITLE
Remove some unused constants in devicecontroller

### DIFF
--- a/cloud/pkg/devicecontroller/constants/device.go
+++ b/cloud/pkg/devicecontroller/constants/device.go
@@ -18,11 +18,6 @@ package constants
 
 // Constants for protocol, datatype, configmap, deviceProfile
 const (
-	OPCUA              = "opcua"
-	Modbus             = "modbus"
-	Bluetooth          = "bluetooth"
-	CustomizedProtocol = "customized-protocol"
-
 	DataTypeInt     = "int"
 	DataTypeInteger = "integer"
 	DataTypeString  = "string"
@@ -30,10 +25,6 @@ const (
 	DataTypeFloat   = "float"
 	DataTypeBoolean = "boolean"
 	DataTypeBytes   = "bytes"
-
-	DeviceProfileConfigPrefix = "device-profile-config-"
-
-	DeviceProfileJSON = "deviceProfile.json"
 
 	ResourceTypeDeviceModel  = "devicemodel"
 	ResourceTypeDevice       = "device"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
As we remove the built-in protocol fields in the device API, there are some constants in the `devicecontroller` that are not actually used. They are removed here.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
