### PR TITLE
Add a retry mechanism to the container runtime e2e test

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -90,7 +90,7 @@ verify_docker_installed() {
   # verify the docker installed
   command -v docker >/dev/null || {
     echo "must install the docker first"
-    exit 1
+    return 1
   }
 }
 
@@ -98,7 +98,7 @@ verify_cridockerd_installed() {
   # verify the cri-dockerd installed
   command -v cri-dockerd >/dev/null || {
     echo "must install the cri-dockerd first"
-    exit 1
+    return 1
   }
 }
 
@@ -106,7 +106,7 @@ verify_crio_installed() {
   # verify the cri-o installed
   command -v crio >/dev/null || {
     echo "must install the cri-o first"
-    exit 1
+    return 1
   }
 }
 
@@ -114,7 +114,7 @@ verify_isulad_installed() {
   # verify the isulad installed
   command -v isulad >/dev/null || {
     echo "must install the isulad first"
-    exit 1
+    return 1
   }
 }
 

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -31,13 +31,65 @@ fi
 export CLUSTER_CONTEXT="--name ${CLUSTER_NAME}"
 
 function install_cr() {
-  if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
-    install_docker
-  elif [[ "${CONTAINER_RUNTIME}" = "cri-o" ]]; then
-    install_crio
-  elif [[ "${CONTAINER_RUNTIME}" = "isulad" ]]; then
-    install_isulad
+  attempt_num=0
+  max_attempts=5
+
+  while [ $attempt_num -lt $max_attempts ]
+  do
+    if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
+      install_docker
+      verify_docker_installed
+      if [ $? -ne 0 ]; then
+        # docker was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install docker failed. Retrying..."
+        continue
+      fi
+      verify_cridockerd_installed
+      if [ $? -ne 0 ]; then
+        # cri-dockerd was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install cri-dockerd failed. Retrying..."
+        continue
+      fi
+      echo "docker has been downloaded successfully"
+      break
+
+    elif [[ "${CONTAINER_RUNTIME}" = "cri-o" ]]; then
+      install_crio
+      verify_crio_installed
+      if [ $? -ne 0 ]; then
+        # crio was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install cri-o failed. Retrying..."
+        continue
+      fi
+      echo "cri-o has been downloaded successfully"
+      break
+
+    elif [[ "${CONTAINER_RUNTIME}" = "isulad" ]]; then
+      install_isulad
+      verify_isulad_installed
+      if [ $? -ne 0 ]; then
+        # isulad was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install isulad failed. Retrying..."
+        continue
+      fi
+      echo "isulad has been downloaded successfully"
+      break
+    else
+      echo "No need to download container runtime"
+      break
+    fi
+  done
+
+  if [ $attempt_num -eq $max_attempts ]; then
+    # all retries failed
+    echo "Task failed after $max_attempts attempts."
+    exit 1
   fi
+
 }
 
 function check_prerequisites {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
As described in #5436 , the E2E test of the container runtime often fails due to network reasons, so we add a retry mechanism here to automatically retry when there is a network problem. It can improve the success rate of the E2E test.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5436 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
