### PR TITLE
Change the print helm chart resources YAML command name keadm generate to keadm manifest.

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/manifest.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/manifest.go
@@ -31,27 +31,14 @@ import (
 
 var (
 	cloudManifestLongDescription = `
-"keadm manifest" command renders charts by using a list of set flags like helm.
-`
-
-	cloudManifestGenerateLongDescription = `
-"keadm manifest generate" command renders charts by using a list of set flags like helm, and generates kubernetes resources.
-`
-
-	cloudManifestExample = `
-keadm manifest
-- This command will render Kubernetes resources
-
-keadm generate --advertise-address=127.0.0.1 --profile version=v%s --kube-config=/root/.kube/config
-  - kube-config is the absolute path of kubeconfig which used to secure connectivity between cloudcore and kube-apiserver
-	- a list of helm style set flags like "--set key=value" can be implemented, ref: https://github.com/kubeedge/kubeedge/tree/master/manifests/charts/cloudcore/README.md
+"keadm manifest" command renders charts by using a list of set flags like helm, and generates kubernetes resources.
 `
 
 	cloudManifestGenerateExample = `
-keadm manifest generate
+keadm manifest
 - This command will render and generate Kubernetes resources
 
-keadm manifest generate --advertise-address=127.0.0.1 --profile version=v%s --kube-config=/root/.kube/config
+keadm manifest --advertise-address=127.0.0.1 --profile version=v%s --kube-config=/root/.kube/config
   - kube-config is the absolute path of kubeconfig which used to secure connectivity between cloudcore and kube-apiserver
 	- a list of helm style set flags like "--set key=value" can be implemented, ref: https://github.com/kubeedge/kubeedge/tree/master/manifests/charts/cloudcore/README.md
 `
@@ -64,9 +51,9 @@ func NewManifestGenerate() *cobra.Command {
 	flagVals := make(map[string]types.FlagData)
 
 	var generateCmd = &cobra.Command{
-		Use:     "generate",
+		Use:     "manifest",
 		Short:   "Checks and generate the manifests.",
-		Long:    cloudManifestGenerateLongDescription,
+		Long:    cloudManifestLongDescription,
 		Example: fmt.Sprintf(cloudManifestGenerateExample, types.DefaultKubeEdgeVersion),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			checkFlags := func(f *pflag.Flag) {
@@ -81,15 +68,7 @@ func NewManifestGenerate() *cobra.Command {
 	}
 
 	addManifestsGenerateJoinOtherFlags(generateCmd, opts)
-
-	var manifestCmd = &cobra.Command{
-		Use:     "manifest",
-		Short:   "Render the manifests by using a list of set flags like helm.",
-		Long:    cloudManifestLongDescription,
-		Example: fmt.Sprintf(cloudManifestExample, types.DefaultKubeEdgeVersion),
-	}
-	manifestCmd.AddCommand(generateCmd)
-	return manifestCmd
+	return generateCmd
 }
 
 func addManifestsGenerateJoinOtherFlags(cmd *cobra.Command, initOpts *types.InitOptions) {


### PR DESCRIPTION
… to keadm manifest.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
![image](https://github.com/kubeedge/kubeedge/assets/110345347/0bd8dbfd-3e61-4e4b-b35a-72a039e41269)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes A part of #5317

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
