### PR TITLE
Refactor the command reset to third-level commands, like: keamd reset

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/reset.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/reset.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/helm"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+var (
+	resetLongDescription = `
+keadm reset cloud command can be executed edge node
+In cloud node it shuts down the cloud processes of KubeEdge
+`
+	resetExample = `
+For cloud node:
+keadm reset cloud
+`
+)
+
+func NewCloudReset() *cobra.Command {
+	isEdgeNode := false
+	reset := util.NewResetOptions()
+
+	var cmd = &cobra.Command{
+		Use:     "cloud",
+		Short:   "Teardowns CloudCore component",
+		Long:    resetLongDescription,
+		Example: resetExample,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			whoRunning := util.CloudCoreRunningModuleV2(reset)
+			if whoRunning == common.NoneRunning {
+				fmt.Println("None of CloudCore components are running in this host, exit")
+				os.Exit(0)
+			}
+
+			if whoRunning == common.KubeEdgeEdgeRunning {
+				isEdgeNode = true
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !reset.Force {
+				fmt.Println("[reset] WARNING: Changes made to this host by 'keadm init' or 'keadm join' will be reverted.")
+				fmt.Print("[reset] Are you sure you want to proceed? [y/N]: ")
+				s := bufio.NewScanner(os.Stdin)
+				s.Scan()
+				if err := s.Err(); err != nil {
+					return err
+				}
+				if strings.ToLower(s.Text()) != "y" {
+					return fmt.Errorf("aborted reset operation")
+				}
+			}
+
+			// 1. kill cloudcore process.
+			if err := TearDownCloudCore(reset.Kubeconfig); err != nil {
+				return err
+			}
+
+			// 3. Clean stateful directories
+			if err := util.CleanDirectories(isEdgeNode); err != nil {
+				return err
+			}
+
+			//4. TODO: clean status information
+
+			return nil
+		},
+	}
+
+	addResetFlags(cmd, reset)
+	return cmd
+}
+
+// TearDownCloudCore will bring down cloud component,
+func TearDownCloudCore(kubeConfig string) error {
+	ke := &helm.KubeCloudHelmInstTool{
+		Common: util.Common{
+			KubeConfig: kubeConfig,
+		},
+	}
+
+	err := ke.TearDown()
+	if err != nil {
+		return fmt.Errorf("TearDown failed, err:%v", err)
+	}
+	return nil
+}
+
+func addResetFlags(cmd *cobra.Command, resetOpts *common.ResetOptions) {
+	cmd.Flags().StringVar(&resetOpts.Kubeconfig, common.FlagNameKubeConfig, common.DefaultKubeConfig,
+		"Use this key to set kube-config path, eg: $HOME/.kube/config")
+	cmd.Flags().BoolVar(&resetOpts.Force, "force", resetOpts.Force,
+		"Reset the node without prompting for confirmation")
+}

--- a/keadm/cmd/keadm/app/cmd/edge/reset_other.go
+++ b/keadm/cmd/keadm/app/cmd/edge/reset_other.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edge
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/reset"
+	utilsexec "k8s.io/utils/exec"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+var (
+	resetLongDescription = `
+keadm reset edge command can be executed edge node
+In edge node it shuts down the edge processes of KubeEdge
+`
+	resetExample = `
+For edge node edge:
+keadm reset edge
+`
+)
+
+func NewOtherEdgeReset() *cobra.Command {
+	isEdgeNode := false
+	reset := util.NewResetOptions()
+	var cmd = &cobra.Command{
+		Use:     "edge",
+		Short:   "Teardowns EdgeCore component",
+		Long:    resetLongDescription,
+		Example: resetExample,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			whoRunning := util.EdgeCoreRunningModuleV2(reset)
+			if whoRunning == common.NoneRunning {
+				fmt.Println("None of EdgeCore components are running in this host, exit")
+				os.Exit(0)
+			}
+
+			if whoRunning == common.KubeEdgeEdgeRunning {
+				isEdgeNode = true
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !reset.Force {
+				fmt.Println("[reset] WARNING: Changes made to this host by 'keadm init' or 'keadm join' will be reverted.")
+				fmt.Print("[reset] Are you sure you want to proceed? [y/N]: ")
+				s := bufio.NewScanner(os.Stdin)
+				s.Scan()
+				if err := s.Err(); err != nil {
+					return err
+				}
+				if strings.ToLower(s.Text()) != "y" {
+					return fmt.Errorf("aborted reset operation")
+				}
+			}
+
+			staticPodPath := ""
+			config, err := util.ParseEdgecoreConfig(common.EdgecoreConfigPath)
+			if err != nil {
+				fmt.Printf("failed to get edgecore's config with err:%v\n", err)
+			} else {
+				if reset.Endpoint == "" {
+					reset.Endpoint = config.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint
+				}
+				staticPodPath = config.Modules.Edged.TailoredKubeletConfig.StaticPodPath
+			}
+			// first cleanup edge node static pod directory to stop static and mirror pod
+			if staticPodPath != "" {
+				if err := phases.CleanDir(staticPodPath); err != nil {
+					fmt.Printf("Failed to delete static pod directory %s: %v\n", staticPodPath, err)
+				} else {
+					time.Sleep(1 * time.Second)
+					fmt.Printf("Static pod directory has been removed!\n")
+				}
+			}
+
+			// 1. kill edgecore process.
+			// For edgecore, don't delete node from K8S
+			if err := TearDownEdgeCore(); err != nil {
+				return err
+			}
+
+			// 2. Remove containers managed by KubeEdge. Only for edge node.
+			if err := util.RemoveContainers(reset.Endpoint, utilsexec.New()); err != nil {
+				fmt.Printf("Failed to remove containers: %v\n", err)
+			}
+
+			// 3. Clean stateful directories
+			if err := util.CleanDirectories(isEdgeNode); err != nil {
+				return err
+			}
+
+			//4. TODO: clean status information
+
+			return nil
+		},
+	}
+
+	addResetFlags(cmd, reset)
+	return cmd
+}
+
+// TearDownEdgeCore will bring down edge component,
+func TearDownEdgeCore() error {
+	ke := &util.KubeEdgeInstTool{Common: util.Common{}}
+	err := ke.TearDown()
+	if err != nil {
+		return fmt.Errorf("TearDown failed, err:%v", err)
+	}
+	return nil
+}
+
+func addResetFlags(cmd *cobra.Command, resetOpts *common.ResetOptions) {
+	cmd.Flags().BoolVar(&resetOpts.Force, "force", resetOpts.Force,
+		"Reset the node without prompting for confirmation")
+}

--- a/keadm/cmd/keadm/app/cmd/util/common_others.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_others.go
@@ -84,7 +84,14 @@ func HasSystemd() bool {
 // RunningModuleV2 identifies cloudcore/edgecore running or not.
 // only used for cloudcore container install and edgecore binary install
 func RunningModuleV2(opt *types.ResetOptions) types.ModuleRunning {
-	osType := GetOSInterface()
+	result := CloudCoreRunningModuleV2(opt)
+	if result == types.KubeEdgeCloudRunning {
+		return result
+	}
+	return EdgeCoreRunningModuleV2(opt)
+}
+
+func CloudCoreRunningModuleV2(opt *types.ResetOptions) types.ModuleRunning {
 	cloudCoreRunning, err := IsCloudcoreContainerRunning(constants.SystemNamespace, opt.Kubeconfig)
 	if err != nil {
 		// just log the error, maybe we do not care
@@ -93,7 +100,11 @@ func RunningModuleV2(opt *types.ResetOptions) types.ModuleRunning {
 	if cloudCoreRunning {
 		return types.KubeEdgeCloudRunning
 	}
+	return types.NoneRunning
+}
 
+func EdgeCoreRunningModuleV2(opt *types.ResetOptions) types.ModuleRunning {
+	osType := GetOSInterface()
 	edgeCoreRunning, err := osType.IsKubeEdgeProcessRunning(KubeEdgeBinaryName)
 	if err != nil {
 		// just log the error, maybe we do not care

--- a/keadm/cmd/keadm/app/cmd/util/reset.go
+++ b/keadm/cmd/keadm/app/cmd/util/reset.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	phases "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/reset"
+	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
+	utilsexec "k8s.io/utils/exec"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+func NewResetOptions() *common.ResetOptions {
+	opts := &common.ResetOptions{}
+	return opts
+}
+
+func RemoveMqttContainer(endpoint, cgroupDriver string) error {
+	runtime, err := NewContainerRuntime(endpoint, cgroupDriver)
+	if err != nil {
+		return fmt.Errorf("failed to new container runtime: %v", err)
+	}
+
+	return runtime.RemoveMQTT()
+}
+
+// RemoveContainers removes all Kubernetes-managed containers
+func RemoveContainers(criSocketPath string, execer utilsexec.Interface) error {
+	if criSocketPath == "" {
+		var err error
+		criSocketPath, err = utilruntime.DetectCRISocket()
+		if err != nil {
+			return fmt.Errorf("failed to get crisocket with err:%v", err)
+		}
+	}
+
+	containerRuntime, err := utilruntime.NewContainerRuntime(execer, criSocketPath)
+	if err != nil {
+		return err
+	}
+
+	containers, err := containerRuntime.ListKubeContainers()
+	if err != nil {
+		return err
+	}
+
+	return containerRuntime.RemoveContainers(containers)
+}
+
+func CleanDirectories(isEdgeNode bool) error {
+	var dirToClean = []string{
+		KubeEdgePath,
+		KubeEdgeLogPath,
+		KubeEdgeSocketPath,
+		EdgeRootDir,
+	}
+
+	if isEdgeNode {
+		dirToClean = append(dirToClean, "/var/lib/dockershim", "/var/run/kubernetes", "/var/lib/cni")
+	}
+
+	for _, dir := range dirToClean {
+		if err := phases.CleanDir(dir); err != nil {
+			fmt.Printf("Failed to delete directory %s: %v\n", dir, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
cloud and keadm reset edge. If uses keadm rest, both the cloud and the edge will be reset.`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
![image](https://github.com/kubeedge/kubeedge/assets/110345347/8934892a-7dbc-470b-8059-ec55ce66aa32)
![image](https://github.com/kubeedge/kubeedge/assets/110345347/6bce7535-34f9-4b4f-a4f0-b21fb5c44515)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes : A part of issue  https://github.com/kubeedge/kubeedge/issues/5317

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
