### PR TITLE
add list/watch abac resources clusterrole for requireAuthorization feature

### DIFF
--- a/manifests/charts/cloudcore/templates/aggregation_rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/aggregation_rbac_cloudcore.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloudcore
+  {{- with .Values.cloudCore.labels }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac/aggregate-to-cloudcore: "true"
+rules: []
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- with .Values.cloudCore.labels }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: cloudcore
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloudcore
+  {{- with .Values.cloudCore.labels }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloudcore
+subjects:
+  - kind: ServiceAccount
+    name: cloudcore
+    namespace: {{ .Release.Namespace }}

--- a/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
@@ -9,6 +9,8 @@ data:
   cloudcore.yaml: |
     apiVersion: cloudcore.config.kubeedge.io/v1alpha2
     kind: CloudCore
+    featureGates:
+      requireAuthorization: {{ .Values.cloudCore.featureGates.requireAuthorization }}
     kubeAPIConfig:
       kubeConfig: ""
       master: ""

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
@@ -1,11 +1,9 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: cloudcore
-  {{- with .Values.cloudCore.labels }}
-  labels: {{- toYaml . | nindent 4 }}
-  {{- end }}
+  name: cloudcore-common
+  labels:
+    rbac/aggregate-to-cloudcore: "true"
 rules:
 - apiGroups: [""]
   resources: ["nodes", "nodes/status", "serviceaccounts/token", "configmaps", "pods", "pods/status", "secrets", "endpoints", "services", "persistentvolumes", "persistentvolumeclaims"]
@@ -40,31 +38,3 @@ rules:
 - apiGroups: ["operations.kubeedge.io"]
   resources: ["nodeupgradejobs", "nodeupgradejobs/status", "imageprepulljobs", "imageprepulljobs/status"]
   verbs: ["get", "list", "watch", "update", "patch"]
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  {{- with .Values.cloudCore.labels }}
-  labels: {{- toYaml . | nindent 4 }}
-  {{- end }}
-  name: cloudcore
-
---- 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cloudcore
-  {{- with .Values.cloudCore.labels }}
-  labels: {{- toYaml . | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cloudcore
-subjects:
-- kind: ServiceAccount
-  name: cloudcore
-  namespace: {{ .Release.Namespace }}
-
-

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore_feature.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore_feature.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.cloudCore.featureGates.requireAuthorization }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloudcore-feature
+  labels:
+    rbac/aggregate-to-cloudcore: "true"
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["list", "watch"]
+- apiGroups: ["policy.kubeedge.io"]
+  resources: ["serviceaccountaccesses"]
+  verbs: ["list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "clusterrolebindings", "rolebindings", "clusterroles"]
+  verbs: ["list", "watch"]
+{{- end }}

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -34,6 +34,8 @@ cloudCore:
       cpu: 100m
       memory: 512Mi
   strategy: {}
+  featureGates:
+    requireAuthorization: false
   modules:
     cloudHub:
       # Caution!: Leave this entry to empty will cause CloudCore to exit abnormally once KubeEdge is enabled.

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -34,6 +34,8 @@ cloudCore:
       cpu: 100m
       memory: 512Mi
   strategy: {}
+  featureGate:
+    requireAuthorization: false
   modules:
     cloudHub:
       advertiseAddress:   # Caution!: Leave this entry to empty will cause CloudCore to exit abnormally once KubeEdge is enabled.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

- add a new clusterrole for rbac feature 
- use aggregate clusterrole mode, when we enable requireAuthorization featuregate, the new clusterrole will be created and aggregate into the cloudcore clusterrole. 

**Which issue(s) this PR fixes**:


Fixes #5464 


