### PR TITLE
update controller-runtime setup-envtest version to handle the CI failure 

### DIFF
--- a/cloud/test/integration/scripts/execute.sh
+++ b/cloud/test/integration/scripts/execute.sh
@@ -22,7 +22,7 @@ ENVTEST_BIN_DIR=""
 
 function do_preparation() {
     which setup-envtest &> /dev/null || {
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
         sudo cp $GOPATH/bin/setup-envtest /usr/bin/
     }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test


**What this PR does / why we need it**:

integration test always fail with the error as below:

![image](https://github.com/kubeedge/kubeedge/assets/48788150/dd7b139e-1fae-4ff4-be07-a951f7d92a68)

So we cannot use the latest version of controller-runtime setup-envtest, because it refers to a Go version that is too new. 

More details and disscussion: https://github.com/kubernetes-sigs/controller-runtime/issues/2720 



