### PR TITLE
Automated cherry pick of #5484: fix retrytimes in imageprepulljob

### DIFF
--- a/build/crd-samples/operations/imageprepulljob.yaml
+++ b/build/crd-samples/operations/imageprepulljob.yaml
@@ -10,5 +10,5 @@ spec:
       - busybox:latest
     nodes:
       - edgenode1 # Need to replaced with your own node name
-    timeoutSecondsOnEachNode: 300
+    timeoutSeconds: 300
     retryTimes: 1

--- a/edge/pkg/edgehub/task/taskexecutor/image_prepull.go
+++ b/edge/pkg/edgehub/task/taskexecutor/image_prepull.go
@@ -137,7 +137,7 @@ func prePullImages(prePullReq commontypes.ImagePrePullJobRequest, container util
 		prePullStatus := v1alpha1.ImageStatus{
 			Image: image,
 		}
-		for i := 0; i < int(prePullReq.RetryTimes); i++ {
+		for i := 0; i <= int(prePullReq.RetryTimes); i++ {
 			err = container.PullImage(image, authConfig, nil)
 			if err == nil {
 				break


### PR DESCRIPTION
Cherry pick of #5484 on release-1.16.

#5484: fix retrytimes in imageprepulljob

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.