### PR TITLE
Automated cherry pick of #5387: Fix keadm upgrade command

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/edge/upgrade.go
@@ -51,7 +51,7 @@ func NewEdgeUpgrade() *cobra.Command {
 		Long:  "Upgrade edge components. Upgrade the edge node to the desired version.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// upgrade edgecore
-			return upgradeOptions.upgrade()
+			return upgradeOptions.Upgrade()
 		},
 	}
 
@@ -68,7 +68,8 @@ func NewUpgradeOptions() *UpgradeOptions {
 	return opts
 }
 
-func (up *UpgradeOptions) upgrade() error {
+// Upgrade handles upgrade command logic
+func (up *UpgradeOptions) Upgrade() error {
 	// get EdgeCore configuration from edgecore.yaml config file
 	data, err := os.ReadFile(up.Config)
 	if err != nil {

--- a/keadm/cmd/keadm/app/cmd/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/upgrade.go
@@ -13,6 +13,7 @@ Specify whether to upgrade the cloud or the edge through three-level commands.
 If no three-level command, it upgrades edge components.`
 )
 
+// NewUpgradeCommand creates a upgrade command instance and returns it.
 func NewUpgradeCommand() *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   "upgrade",
@@ -20,15 +21,15 @@ func NewUpgradeCommand() *cobra.Command {
 		Long:  upgradeLongDescription,
 	}
 
-	edgecmd := edge.NewEdgeUpgrade()
-
 	// Used for backward compatibility of the edgecore trigger the upgrade command
 	upgradeOptions := edge.NewUpgradeOptions()
+	cmds.RunE = func(cmd *cobra.Command, args []string) error {
+		return upgradeOptions.Upgrade()
+	}
 	edge.AddUpgradeFlags(cmds, upgradeOptions)
-	cmds.RunE = edgecmd.RunE
 
 	// Register three-level commands
-	cmds.AddCommand(edgecmd)
+	cmds.AddCommand(edge.NewEdgeUpgrade())
 	cmds.AddCommand(cloud.NewCloudUpgrade())
 	return cmds
 }


### PR DESCRIPTION
Cherry pick of #5387 on release-1.16.

#5387: Fix keadm upgrade command

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.