### PR TITLE
[WIP]Add delay to fix docker e2e test

### DIFF
--- a/tests/scripts/execute.sh
+++ b/tests/scripts/execute.sh
@@ -54,4 +54,6 @@ export GINKGO_TESTING_RESULT=0
 
 trap cleanup EXIT
 
+sleep 10
+
 bash -x ${curpath}/tests/scripts/fast_test.sh ${compilemodule}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
The current failure rate of docker e2e testing is high. The possible reason is that the test is performed immediately after starting the kubeedge cluster, but some components in the cluster have not yet been started. Therefore, this PR adds a delay to avoid this problem.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
