### PR TITLE
fix device mapper generate script error

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
+++ b/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
@@ -29,8 +29,14 @@ function entry() {
   cp -r "${ROOT_DIR}/_template/mapper" "${mapperPath}"
 
   mapperVar=$(echo "${mapperName}" | sed -e "s/\b\(.\)/\\u\1/g")
-  sed -i "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
-  sed -i "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  
+  if [ $(uname) = "Darwin" ]; then
+      sed -i "" "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
+      sed -i "" "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  else
+      sed -i "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
+      sed -i "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  fi
 
   cd ${mapperPath} && go mod tidy
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Device mapper generate script don't support macOS.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
none
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
