### PR TITLE
fix device mapper data collecting cycle calculation error

### DIFF
--- a/docs/proposals/device-crd-v1beta1.md
+++ b/docs/proposals/device-crd-v1beta1.md
@@ -342,8 +342,8 @@ spec:
   nodeName: worker-node1
   properties:
     - name: temp
-      collectCycle: 2000
-      reportCycle: 2000
+      collectCycle: 2000      # 2000 stands for 2000 milliseconds (2 seconds)
+      reportCycle: 2000       # 2000 stands for 2000 milliseconds (2 seconds)
       desired:
         value: "30"
       reportToCloud: true

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/influxdb2/handler.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/influxdb2/handler.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
-
 	"github.com/kubeedge/Template/driver"
 	"github.com/kubeedge/mapper-framework/pkg/common"
 )
@@ -37,7 +36,7 @@ func DataHandler(ctx context.Context, twin *common.Twin, client *driver.Customiz
 		klog.Errorf("init database client err: %v", err)
 		return
 	}
-	reportCycle := time.Duration(twin.Property.ReportCycle)
+	reportCycle := time.Millisecond * time.Duration(twin.Property.ReportCycle)
 	if reportCycle == 0 {
 		reportCycle = common.DefaultReportCycle
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/redis/handler.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/redis/handler.go
@@ -37,7 +37,7 @@ func DataHandler(ctx context.Context, twin *common.Twin, client *driver.Customiz
 		klog.Errorf("init redis database client err: %v", err)
 		return
 	}
-	reportCycle := time.Duration(twin.Property.ReportCycle)
+	reportCycle := time.Millisecond * time.Duration(twin.Property.ReportCycle)
 	if reportCycle == 0 {
 		reportCycle = common.DefaultReportCycle
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/tdengine/handler.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/tdengine/handler.go
@@ -37,7 +37,7 @@ func DataHandler(ctx context.Context, twin *common.Twin, client *driver.Customiz
 		klog.Errorf("init database client err: %v", err)
 		return
 	}
-	reportCycle := time.Duration(twin.Property.ReportCycle)
+	reportCycle := time.Millisecond * time.Duration(twin.Property.ReportCycle)
 	if reportCycle == 0 {
 		reportCycle = common.DefaultReportCycle
 	}

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
@@ -145,7 +145,7 @@ func dataHandler(ctx context.Context, dev *driver.CustomizedDev) {
 			ObservedDesired: twin.ObservedDesired,
 			VisitorConfig:   &visitorConfig,
 			Topic:           fmt.Sprintf(common.TopicTwinUpdate, dev.Instance.ID),
-			CollectCycle:    time.Duration(twin.Property.CollectCycle),
+			CollectCycle:    time.Millisecond * time.Duration(twin.Property.CollectCycle),
 			ReportToCloud:   twin.Property.ReportToCloud,
 		}
 		go twinData.Run(ctx)
@@ -196,7 +196,7 @@ func pushHandler(ctx context.Context, twin *common.Twin, client *driver.Customiz
 		klog.Errorf("init publish method err: %v", err)
 		return
 	}
-	reportCycle := time.Duration(twin.Property.ReportCycle)
+	reportCycle := time.Millisecond * time.Duration(twin.Property.ReportCycle)
 	if reportCycle == 0 {
 		reportCycle = common.DefaultReportCycle
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
The device mapper data collecting cycle is too short, causing the mapper to crash.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
