### PR TITLE
fix: remove short flag Signed-off-by: Qaplagzy <qaplagzy@gmail.com>

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -22,7 +22,7 @@ function check_kubectl {
     echo "kubectl not installed, exiting."
     exit 1
   else
-    echo -n "found kubectl, " && kubectl version --short --client
+    echo -n "found kubectl, " && kubectl version --client
   fi
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
> Flag --short has been deprecated, and will be removed in the future. The --short output will become the default.

To maintain compatibility and support for the current version of kubectl.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/4164
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```