### PR TITLE
Automated cherry pick of #5506: fix device status problem with device's namespace in kubeege v1.16.0

### DIFF
--- a/cloud/pkg/common/messagelayer/util.go
+++ b/cloud/pkg/common/messagelayer/util.go
@@ -36,8 +36,8 @@ const (
 	ResourceResourceTypeIndex = 3
 	ResourceResourceNameIndex = 4
 
-	ResourceDeviceIndex   = 2
-	ResourceDeviceIDIndex = 3
+	ResourceDeviceIndex          = 2
+	ResourceDeviceNamespaceIndex = 3
 
 	ResourceDevice               = "device"
 	ResourceTypeTwinEdgeUpdated  = "twin/edge_updated"
@@ -128,11 +128,11 @@ func BuildResourceForDevice(nodeID, resourceType, resourceID string) (resource s
 	return
 }
 
-// GetDeviceID returns the ID of the device
+// GetDeviceID returns the ID of the device,resource's format:$hw/events/device/{namespace}/{deviceName}
 func GetDeviceID(resource string) (string, error) {
 	res := strings.Split(resource, "/")
-	if len(res) >= ResourceDeviceIDIndex+1 && res[ResourceDeviceIndex] == ResourceDevice {
-		return res[ResourceDeviceIDIndex], nil
+	if len(res) >= ResourceDeviceNamespaceIndex+2 && res[ResourceDeviceIndex] == ResourceDevice {
+		return res[ResourceDeviceNamespaceIndex] + "/" + res[ResourceDeviceNamespaceIndex+1], nil
 	}
 	return "", errors.New("failed to get device id")
 }

--- a/cloud/pkg/common/messagelayer/util_test.go
+++ b/cloud/pkg/common/messagelayer/util_test.go
@@ -91,15 +91,15 @@ func TestGetDeviceID(t *testing.T) {
 		{
 			name: "TestGetDeviceID(): Case 1: success",
 			args: args{
-				resource: fmt.Sprintf("node/%s/%s/%s", "nid", ResourceDevice, "did"),
+				resource: fmt.Sprintf("node/%s/%s/%s/%s", "nid", ResourceDevice, "ns", "did"),
 			},
-			want:    "did",
+			want:    "ns/did",
 			wantErr: nil,
 		},
 		{
-			name: "TestGetDeviceID(): Case 2: length less then 4",
+			name: "TestGetDeviceID(): Case 2: length less then 5",
 			args: args{
-				resource: fmt.Sprintf("node/%s/%s", "nid", ResourceDevice),
+				resource: fmt.Sprintf("node/%s/%s/%s", "nid", ResourceDevice, "ns"),
 			},
 			want:    "",
 			wantErr: fmt.Errorf("failed to get device id"),

--- a/edge/pkg/devicetwin/process.go
+++ b/edge/pkg/devicetwin/process.go
@@ -214,7 +214,11 @@ func classifyMsg(message *dttype.DTMessage) bool {
 		} else {
 			identity = splitString[idLoc]
 			loc := strings.Index(topic, identity)
-			nextLoc := loc + len(identity)
+			var nextLoc int
+			if strings.Contains(topic, dtcommon.DeviceETPrefix) {
+				identity = identity + "/" + splitString[idLoc+1]
+			}
+			nextLoc = loc + len(identity)
 			prefix := topic[0:loc]
 			suffix := topic[nextLoc:]
 			klog.Infof("%s %s", prefix, suffix)

--- a/edge/pkg/devicetwin/process_test.go
+++ b/edge/pkg/devicetwin/process_test.go
@@ -397,7 +397,7 @@ func Test_classifyMsg(t *testing.T) {
 	otherTopic := "/membership/detail/result"
 	otherEncodedTopic := base64.URLEncoding.EncodeToString([]byte(otherTopic))
 	//Encoded eventbus resource
-	eventbusTopic := "$hw/events/device/+/state/update"
+	eventbusTopic := "$hw/events/device/+/+/state/update"
 	eventbusResource := base64.URLEncoding.EncodeToString([]byte(eventbusTopic))
 
 	content := testutil.GenerateAddDevicePalyloadMsg(t)

--- a/edge/pkg/eventbus/mqtt/client.go
+++ b/edge/pkg/eventbus/mqtt/client.go
@@ -42,8 +42,8 @@ var (
 	// SubTopics which edge-client should be sub
 	SubTopics = []string{
 		"$hw/events/upload/#",
-		"$hw/events/device/+/state/update",
-		"$hw/events/device/+/twin/+",
+		"$hw/events/device/+/+/state/update",
+		"$hw/events/device/+/+/twin/+",
 		"$hw/events/node/+/membership/get",
 		UploadTopic,
 		"+/user/#",

--- a/edge/test/integration/utils/helpers/helpers.go
+++ b/edge/test/integration/utils/helpers/helpers.go
@@ -82,7 +82,7 @@ type TwinAttribute struct {
 }
 
 func GenerateDeviceID(deviceSuffix string) string {
-	return deviceSuffix + edge.GetRandomString(10)
+	return "default/" + deviceSuffix + edge.GetRandomString(10)
 }
 
 // Function to Generate Device


### PR DESCRIPTION
Cherry pick of https://github.com/kubeedge/kubeedge/pull/5506 on release-1.16.

https://github.com/kubeedge/kubeedge/pull/5506: fix device status problem with device's namespace in kubeege v1.16.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.