### PR TITLE
Automated cherry pick of #5519: fix device mapper generate script error

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
+++ b/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
@@ -28,8 +28,14 @@ function entry() {
   cp "${ROOT_DIR}/go.sum" "${mapperPath}"
 
   mapperVar=$(echo "${mapperName}" | sed -e "s/\b\(.\)/\\u\1/g")
-  sed -i "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
-  sed -i "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  
+  if [ $(uname) = "Darwin" ]; then
+      sed -i "" "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
+      sed -i "" "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  else
+      sed -i "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
+      sed -i "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  fi
 
   empty_file_path="${MAPPER_DIR}/.empty"
   if [ -f "$empty_file_path" ]; then


### PR DESCRIPTION
Cherry pick of https://github.com/kubeedge/kubeedge/pull/5519 on release-1.15.

https://github.com/kubeedge/kubeedge/pull/5519: fix device mapper generate script error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
