### PR TITLE
Automated cherry pick of #5519: fix device mapper generate script error

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
+++ b/staging/src/github.com/kubeedge/mapper-framework/hack/make-rules/generate.sh
@@ -29,8 +29,14 @@ function entry() {
   cp -r "${ROOT_DIR}/_template/mapper" "${mapperPath}"
 
   mapperVar=$(echo "${mapperName}" | sed -e "s/\b\(.\)/\\u\1/g")
-  sed -i "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
-  sed -i "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  
+  if [ $(uname) = "Darwin" ]; then
+      sed -i "" "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
+      sed -i "" "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  else
+      sed -i "s/Template/${mapperVar}/g" `grep Template -rl ${mapperPath}`
+      sed -i "s/kubeedge\/${mapperVar}/kubeedge\/${mapperNameLowercase}/g" `grep "kubeedge\/${mapperVar}" -rl $mapperPath`
+  fi
 
   cd ${mapperPath} && go mod tidy
 


### PR DESCRIPTION
Cherry pick of https://github.com/kubeedge/kubeedge/pull/5519 on release-1.16.

https://github.com/kubeedge/kubeedge/pull/5519: fix device mapper generate script error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.