### PR TITLE
Add the  image-repository  address of the container in keadm init/upgrade.

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -105,6 +105,9 @@ func addInitOtherFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 
 	cmd.Flags().StringVar(&initOpts.ExternalHelmRoot, types.FlagNameExternalHelmRoot, initOpts.ExternalHelmRoot,
 		"Add external helm root path to keadm.")
+
+	cmd.Flags().StringVar(&initOpts.ImageRepository, types.FlagNameImageRepository, initOpts.ImageRepository,
+		"Choose a container image repository to pull the image of the kubedge component.")
 }
 
 func addHelmValueOptionsFlags(cmd *cobra.Command, initOpts *types.InitOptions) {

--- a/keadm/cmd/keadm/app/cmd/cloud/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/upgrade.go
@@ -82,4 +82,7 @@ func addUpgradeOptionFlags(cmd *cobra.Command, opts *types.CloudUpgradeOptions) 
 
 	fs.BoolVar(&opts.PrintFinalValues, types.FlagNamePrintFinalValues, false,
 		"Print the final values configuration for debuging")
+
+	fs.StringVar(&opts.ImageRepository, types.FlagNameImageRepository, opts.ImageRepository,
+		"Choose a container image repository to pull the image of the kubedge component.")
 }

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -35,6 +35,7 @@ type CloudInitUpdateBase struct {
 	Force            bool
 	DryRun           bool
 	PrintFinalValues bool
+	ImageRepository  string
 }
 
 const requiredSetSplitLen = 2

--- a/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
+++ b/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
@@ -66,6 +66,7 @@ const (
 )
 
 var setsKeyImageTags = []string{"cloudCore.image.tag", "iptablesManager.image.tag", "controllerManager.image.tag"}
+var setsKeyImageRepositories = map[string]string{"cloudCore.image.repository": "cloudcore", "iptablesManager.image.repository": "iptables-manager", "controllerManager.image.repository": "controller-manager"}
 
 var helmSettings = helmcli.New()
 
@@ -290,6 +291,14 @@ func appendDefaultSets(version, advertiseAddress string, opts *types.CloudInitUp
 		for _, k := range setsKeyImageTags {
 			if !opts.HasSets(k) {
 				opts.Sets = append(opts.Sets, fmt.Sprintf("%s=%s", k, version))
+			}
+		}
+	}
+	if opts.ImageRepository != "" {
+		opts.ImageRepository = strings.TrimSuffix(opts.ImageRepository, "/")
+		for k, v := range setsKeyImageRepositories {
+			if !opts.HasSets(k) {
+				opts.Sets = append(opts.Sets, fmt.Sprintf("%s=%s", k, opts.ImageRepository+"/"+v))
 			}
 		}
 	}


### PR DESCRIPTION
Change the print helm chart resources YAML command name keadm generate to keadm manifest.

Add the  image-repository  address of the container in keadm init/upgrade.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
![image](https://github.com/kubeedge/kubeedge/assets/110345347/94e8a6e7-0253-4cd0-8017-0d6303f35cfe)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/5317

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
