### PR TITLE
Supports high availability of router messages.

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -1,6 +1,7 @@
 package cloudhub
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -25,6 +26,7 @@ import (
 )
 
 var DoneTLSTunnelCerts = make(chan bool, 1)
+var sessionMgr *session.Manager
 
 type cloudHub struct {
 	enable               bool
@@ -58,6 +60,7 @@ func newCloudHub(enable bool) *cloudHub {
 		int(hubconfig.Config.KeepaliveInterval),
 		sessionManager, client.GetCRDClient(),
 		messageDispatcher, authorizer)
+	sessionMgr = sessionManager
 
 	ch := &cloudHub{
 		enable:         enable,
@@ -150,4 +153,11 @@ func getAuthConfig() authorization.Config {
 		AuthorizationModes:       authorizationModes,
 		VersionedInformerFactory: builtinInformerFactory,
 	}
+}
+
+func GetSessionManager() (*session.Manager, error) {
+	if sessionMgr != nil {
+		return sessionMgr, nil
+	}
+	return nil, errors.New("cloudhub not initialized")
 }

--- a/cloud/pkg/router/listener/http.go
+++ b/cloud/pkg/router/listener/http.go
@@ -1,18 +1,27 @@
 package listener
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/avast/retry-go"
 	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	routerConfig "github.com/kubeedge/kubeedge/cloud/pkg/router/config"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router/utils"
+	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/pkg/util"
 )
 
 const MaxMessageBytes = 12 * (1 << 20)
@@ -98,85 +107,132 @@ func (rh *RestHandler) matchedPath(uri string) (string, bool) {
 }
 
 func (rh *RestHandler) httpHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Transfer-Encoding", "chunked")
 	uriSections := strings.Split(r.RequestURI, "/")
 	if len(uriSections) < 2 {
 		// URL format incorrect
-		klog.Warningf("url format incorrect: %s", r.URL.String())
-		w.WriteHeader(http.StatusNotFound)
-		if _, err := w.Write([]byte("Request error")); err != nil {
-			klog.Errorf("Response write error: %s, %s", r.RequestURI, err.Error())
-		}
+		err := fmt.Errorf("url format incorrect: %s", r.URL.String())
+		writeErr(w, r, http.StatusNotFound, err)
 		return
 	}
 
-	matchPath, exist := rh.matchedPath(r.RequestURI)
-	if !exist {
-		klog.Warningf("URL format incorrect: %s", r.RequestURI)
-		w.WriteHeader(http.StatusNotFound)
-		if _, err := w.Write([]byte("Request error")); err != nil {
-			klog.Errorf("Response write error: %s, %s", r.RequestURI, err.Error())
-		}
-		return
-	}
-	v, ok := rh.handlers.Load(matchPath)
-	if !ok {
-		klog.Warningf("No matched handler for path: %s", matchPath)
-		return
-	}
-	handle, ok := v.(Handle)
-	if !ok {
-		klog.Errorf("invalid convert to Handle. match path: %s", matchPath)
-		return
-	}
 	aReaderCloser := http.MaxBytesReader(w, r.Body, MaxMessageBytes)
 	b, err := io.ReadAll(aReaderCloser)
 	if err != nil {
-		klog.Errorf("request error, write result: %v", err)
-		w.WriteHeader(http.StatusBadRequest)
-		if _, err = w.Write([]byte("Request error,body is null")); err != nil {
-			klog.Errorf("Response write error: %s, %s", r.RequestURI, err.Error())
-		}
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 
-	if isNodeName(uriSections[1]) {
-		params := make(map[string]interface{})
-		msgID := uuid.New().String()
-		params["messageID"] = msgID
-		params["request"] = r
-		params["timeout"] = rh.restTimeout
-		params["data"] = b
-
-		v, err := handle(params)
-		if err != nil {
-			klog.Errorf("handle request error, msg id: %s, err: %v", msgID, err)
-			return
-		}
-		response, ok := v.(*http.Response)
-		if !ok {
-			klog.Errorf("response convert error, msg id: %s", msgID)
-			return
-		}
-		body, err := io.ReadAll(io.LimitReader(response.Body, MaxMessageBytes))
-		if err != nil {
-			klog.Errorf("response body read error, msg id: %s, reason: %v", msgID, err)
-			return
-		}
-		for key, values := range response.Header {
-			for _, value := range values {
-				w.Header().Add(key, value)
+	edgeNodeName := uriSections[1]
+	err = retry.Do(
+		func() error {
+			targetCloudCoreIP, err := GetEdgeToCloudCoreIP(r.Context(), edgeNodeName)
+			if err != nil {
+				return err
 			}
-		}
-		w.WriteHeader(response.StatusCode)
-		if _, err = w.Write(body); err != nil {
-			klog.Errorf("response body write error, msg id: %s, reason: %v", msgID, err)
-			return
-		}
-		klog.Infof("response to client, msg id: %s, write result: success", msgID)
-	} else {
-		w.WriteHeader(http.StatusNotFound)
-		_, err = w.Write([]byte("No rule match"))
-		klog.Infof("no rule match, write result: %v", err)
+
+			hostnameOverride := util.GetHostname()
+			localIP, err := util.GetLocalIP(hostnameOverride)
+			if err != nil {
+				return fmt.Errorf("failed to get cloudcore localIP with err:%v", err)
+			}
+			if targetCloudCoreIP != localIP {
+				var url string
+				if r.TLS != nil {
+					url = "https://" + targetCloudCoreIP
+				} else {
+					url = "http://" + targetCloudCoreIP
+				}
+				url += ":" + strconv.Itoa(rh.port) + r.RequestURI
+				reqBody := io.NopCloser(bytes.NewBuffer(b))
+				forwardReq, err := http.NewRequest(r.Method, url, reqBody)
+				if err != nil {
+					return fmt.Errorf("failed to create forward request: %v", err)
+				}
+
+				forwardReq.TLS = r.TLS
+				forwardReq.Header = make(http.Header)
+				for key, values := range r.Header {
+					forwardReq.Header[key] = values
+				}
+				return requestForward(targetCloudCoreIP, w, forwardReq)
+			}
+
+			matchPath, exist := rh.matchedPath(r.RequestURI)
+			if !exist {
+				klog.Warningf("URL format incorrect: %s", r.RequestURI)
+				w.WriteHeader(http.StatusNotFound)
+				if _, err := w.Write([]byte("Request error")); err != nil {
+					klog.Errorf("Response write error: %s, %s", r.RequestURI, err.Error())
+				}
+				return nil
+			}
+			v, ok := rh.handlers.Load(matchPath)
+			if !ok {
+				klog.Warningf("No matched handler for path: %s", matchPath)
+				return nil
+			}
+			handle, ok := v.(Handle)
+			if !ok {
+				klog.Errorf("invalid convert to Handle. match path: %s", matchPath)
+				return nil
+			}
+
+			if isNodeName(uriSections[1]) {
+				params := make(map[string]interface{})
+				msgID := uuid.New().String()
+				params["messageID"] = msgID
+				params["request"] = r
+				params["timeout"] = rh.restTimeout
+				params["data"] = b
+
+				v, err := handle(params)
+				if err != nil {
+					klog.Errorf("handle request error, msg id: %s, err: %v", msgID, err)
+					return nil
+				}
+				response, ok := v.(*http.Response)
+				if !ok {
+					klog.Errorf("response convert error, msg id: %s", msgID)
+					return nil
+				}
+				body, err := io.ReadAll(io.LimitReader(response.Body, MaxMessageBytes))
+				if err != nil {
+					klog.Errorf("response body read error, msg id: %s, reason: %v", msgID, err)
+					return nil
+				}
+				for key, values := range response.Header {
+					for _, value := range values {
+						w.Header().Add(key, value)
+					}
+				}
+
+				if response.StatusCode != http.StatusOK {
+					errMsg := string(body)
+					return errors.New(errMsg)
+				}
+
+				w.WriteHeader(response.StatusCode)
+				if _, err = w.Write(body); err != nil {
+					klog.Errorf("response body write error, msg id: %s, reason: %v", msgID, err)
+					return nil
+				}
+				klog.Infof("response to client, msg id: %s, write result: success", msgID)
+				return nil
+			}
+			w.WriteHeader(http.StatusNotFound)
+			_, err = w.Write([]byte("No rule match"))
+			klog.Infof("no rule match, write result: %v", err)
+			return nil
+		},
+		retry.Delay(1*time.Second),
+		retry.Attempts(3),
+		retry.DelayType(retry.FixedDelay),
+	)
+
+	if err != nil {
+		writeErr(w, r, http.StatusInternalServerError, err)
+		return
 	}
 }
 
@@ -195,4 +251,62 @@ func (rh *RestHandler) IsMatch(key interface{}, message interface{}) bool {
 // TODO: check node name
 func isNodeName(_ string) bool {
 	return true
+}
+
+func GetEdgeToCloudCoreIP(ctx context.Context, nodeName string) (string, error) {
+	node, err := client.GetKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get node:%s,err:%v", nodeName, err)
+	}
+	cloudCoreIP, ok := node.Annotations[constants.EdgeMappingCloudKey]
+	if !ok {
+		return "", fmt.Errorf("no corresponding cloudcore was found for edgeNode:%s", nodeName)
+	}
+	return cloudCoreIP, nil
+}
+
+func requestForward(targetCloudCoreIP string, w http.ResponseWriter, forwardReq *http.Request) error {
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(forwardReq)
+	if err != nil {
+		return fmt.Errorf("failed to forward request: %v", err)
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			klog.Errorf("failed to close resp.Body with err:%v", err)
+		}
+	}(resp.Body)
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("error reading body:%v", err)
+		}
+		errMsg := string(bodyBytes)
+		return errors.New(errMsg)
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy resp.Body to writer with err:%v", err)
+	}
+
+	klog.Infof("forwarded request to %s successfully", targetCloudCoreIP)
+	return nil
+}
+
+func writeErr(w http.ResponseWriter, r *http.Request, statusCode int, err error) {
+	klog.Errorf(err.Error())
+	w.WriteHeader(statusCode)
+	if _, err := w.Write([]byte(err.Error())); err != nil {
+		klog.Errorf("Response write error: %s, %s", r.RequestURI, err.Error())
+	}
 }

--- a/cloud/pkg/router/provider/eventbus/eventbus.go
+++ b/cloud/pkg/router/provider/eventbus/eventbus.go
@@ -9,6 +9,7 @@ import (
 
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router/constants"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router/listener"
@@ -143,6 +144,14 @@ func (eb *EventBus) GoToTarget(data map[string]interface{}, _ chan struct{}) (in
 	msg.SetResourceOperation(resource, publishOperation)
 	msg.FillBody(string(body))
 	msg.SetRoute(modules.RouterSourceEventBus, modules.UserGroup)
+
+	sessionMgr, err := cloudhub.GetSessionManager()
+	if err != nil {
+		return nil, err
+	}
+	if _, exists := sessionMgr.GetSession(nodeName); !exists {
+		return nil, fmt.Errorf("cloudcore doesn't have session for node:%s", nodeName)
+	}
 	beehiveContext.Send(modules.CloudHubModuleName, *msg)
 	return nil, nil
 }

--- a/cloud/pkg/router/provider/servicebus/servicebus.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus.go
@@ -12,6 +12,7 @@ import (
 
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router/constants"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router/listener"
@@ -146,6 +147,14 @@ func (sb *ServiceBus) GoToTarget(data map[string]interface{}, stop chan struct{}
 	msg.SetResourceOperation(resource, request.Method)
 	msg.FillBody(request)
 	msg.SetRoute(modules.RouterSourceServiceBus, modules.UserGroup)
+
+	sessionMgr, err := cloudhub.GetSessionManager()
+	if err != nil {
+		return nil, err
+	}
+	if _, exists := sessionMgr.GetSession(nodeName); !exists {
+		return nil, fmt.Errorf("cloudcore doesn't have session for node:%s", nodeName)
+	}
 	beehiveContext.Send(modules.CloudHubModuleName, *msg)
 	if stop != nil {
 		listener.MessageHandlerInstance.SetCallback(messageID, func(message *model.Message) {

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -16,7 +16,8 @@ const (
 	SystemName      = "kubeedge"
 	SystemNamespace = SystemName
 
-	CloudConfigMapName = "cloudcore"
+	CloudConfigMapName  = "cloudcore"
+	EdgeMappingCloudKey = "cloudcore"
 
 	// runtime
 	DockerContainerRuntime = "docker"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When Cloudcore adopts high availability, the RouterManager needs to support high availability functionality. When messages are sent from the cloud to edge nodes, it makes it difficult to determine whether they are being processed correctly by Cloudcore.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubeedge/kubeedge/issues/5561

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
