### PR TITLE
Fixed the quic protocol handshake timeout when using the service

### DIFF
--- a/manifests/charts/cloudcore/templates/service_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/service_cloudcore.yaml
@@ -24,6 +24,7 @@ spec:
     name: cloudhub
   - port: 10001
     targetPort: 10001
+    protocol: UDP
     {{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}
     nodePort: {{ .Values.cloudCore.service.cloudhubQuicNodePort }}
     {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

The quic protocol handshake timeout when using the service.

```bash
I0531 13:33:36.847911   37090 quicclient.go:43] Quic start to connect Access
E0531 13:41:56.844772   37090 quic.go:98] failed dial addr <ip>:<port>, error:HandshakeTimeout: Crypto handshake did not complete in time.
E0531 13:41:56.844802   37090 quicclient.go:75] Init quic connection failed HandshakeTimeout: Crypto handshake did not complete in time.
F0531 13:41:56.844807   37090 main.go:26] HandshakeTimeout: Crypto handshake did not complete in time.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
