### PR TITLE
Automated cherry pick of #5632: fix keadm init profile in v1.17.0 for keadm_e2e test.

### DIFF
--- a/tests/scripts/keadm_compatibility_e2e.sh
+++ b/tests/scripts/keadm_compatibility_e2e.sh
@@ -77,7 +77,7 @@ function start_kubeedge() {
   export MASTER_IP=`kubectl get node test-control-plane -o jsonpath={.status.addresses[0].address}`
   export KUBECONFIG=$HOME/.kube/config
   docker run --rm kubeedge/installation-package:$IMAGE_TAG cat /usr/local/bin/keadm > /usr/local/bin/keadm && chmod +x /usr/local/bin/keadm
-  /usr/local/bin/keadm init --advertise-address=$MASTER_IP --profile version --set cloudCore.service.enable=false --kube-config=$KUBECONFIG --force
+  /usr/local/bin/keadm init --advertise-address=$MASTER_IP --kubeedge-version $CLOUD_EDGE_VERSION --set cloudCore.service.enable=false --kube-config=$KUBECONFIG --force
 
   # ensure tokensecret is generated
   while true; do

--- a/tests/scripts/keadm_e2e.sh
+++ b/tests/scripts/keadm_e2e.sh
@@ -75,7 +75,7 @@ function start_kubeedge() {
   export MASTER_IP=`kubectl get node test-control-plane -o jsonpath={.status.addresses[0].address}`
   export KUBECONFIG=$HOME/.kube/config
   docker run --rm kubeedge/installation-package:$IMAGE_TAG cat /usr/local/bin/keadm > /usr/local/bin/keadm && chmod +x /usr/local/bin/keadm
-  /usr/local/bin/keadm init --advertise-address=$MASTER_IP --profile version --set cloudCore.service.enable=false --kube-config=$KUBECONFIG --force
+  /usr/local/bin/keadm init --advertise-address=$MASTER_IP --kubeedge-version $KUBEEDGE_VERSION --set cloudCore.service.enable=false --kube-config=$KUBECONFIG --force
   
   # ensure tokensecret is generated
   while true; do


### PR DESCRIPTION
Cherry pick of #5632 on release-1.17.

#5632: fix keadm init profile in v1.17.0 for keadm_e2e test.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.