### PR TITLE
Automated cherry pick of #5721: fix func NewErrorMessage

### DIFF
--- a/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
@@ -251,7 +251,7 @@ func (msg *Message) NewRespByMessage(message *Message, content interface{}) *Mes
 
 // NewErrorMessage returns a new error message by a message received
 func NewErrorMessage(message *Message, errContent string) *Message {
-	return NewMessage(message.Header.ParentID).
+	return NewMessage(message.GetID()).
 		SetResourceOperation(message.Router.Resource, ResponseErrorOperation).
 		FillBody(errContent)
 }


### PR DESCRIPTION
Cherry pick of #5721 on release-1.16.

#5721: fix func NewErrorMessage

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.