### PR TITLE
Moving from standard lib to `stretchr/testify` for UT

### DIFF
--- a/cloud/pkg/router/messagelayer/util_test.go
+++ b/cloud/pkg/router/messagelayer/util_test.go
@@ -18,11 +18,14 @@ package messagelayer
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildResourceForRouter(t *testing.T) {
+	assert := assert.New(t)
+
 	type args struct {
 		namespace    string
 		resourceType string
@@ -79,13 +82,8 @@ func TestBuildResourceForRouter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotResource, err := BuildResourceForRouter(tt.args.namespace, tt.args.resourceType, tt.args.resourceID)
-			if !reflect.DeepEqual(err, tt.wantErr) {
-				t.Errorf("%v: BuildResourceForRouter() error = %v, wantErr %v", tt.name, err, tt.wantErr)
-				return
-			}
-			if gotResource != tt.wantResource {
-				t.Errorf("%v: BuildResourceForRouter() = %v, want %v", tt.name, gotResource, tt.wantResource)
-			}
+			assert.Equal(tt.wantErr, err)
+			assert.Equal(tt.wantResource, gotResource)
 		})
 	}
 }

--- a/edge/pkg/devicetwin/devicetwin_test.go
+++ b/edge/pkg/devicetwin/devicetwin_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kubeedge/beehive/pkg/common"
 	"github.com/kubeedge/beehive/pkg/core"
@@ -35,6 +36,8 @@ func init() {
 
 // TestName is function to test Name().
 func TestName(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name string
 		want string
@@ -47,15 +50,15 @@ func TestName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dt := &DeviceTwin{}
-			if got := dt.Name(); got != tt.want {
-				t.Errorf("DeviceTwin.Name() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(tt.want, dt.Name(), "DeviceTwin.Name() = %v, want %v", dt.Name(), tt.want)
 		})
 	}
 }
 
 // TestGroup is function to test Group().
 func TestGroup(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name string
 		want string
@@ -68,15 +71,15 @@ func TestGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dt := &DeviceTwin{}
-			if got := dt.Group(); got != tt.want {
-				t.Errorf("DeviceTwin.Group() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(tt.want, dt.Group(), "DeviceTwin.Group() = %v, want %v", dt.Group(), tt.want)
 		})
 	}
 }
 
 // TestStart is function to test Start().
 func TestStart(t *testing.T) {
+	assert := assert.New(t)
+
 	//test is for sending test messages from devicetwin module.
 	var test model.Message
 	// ormerMock is mocked Ormer implementation.
@@ -128,10 +131,7 @@ func TestStart(t *testing.T) {
 	// Sending a message from devicetwin module to the created fake module(TestModule) to check context is initialized properly.
 	beehiveContext.Send(TestModule, test)
 	_, err := beehiveContext.Receive(TestModule)
-	if err != nil {
-		t.Errorf("Error while receiving message: %v", err)
-		return
-	}
+	assert.NoError(err)
 	//Checking whether Mem,Twin,Device and Comm modules are registered and started successfully.
 	tests := []struct {
 		name       string
@@ -162,9 +162,7 @@ func TestStart(t *testing.T) {
 					if test.moduleName == module.Name {
 						moduleCheck = true
 						err := dt.DTContexts.HeartBeat(test.moduleName, "ping")
-						if err != nil {
-							t.Errorf("Heartbeat of module %v is expired and dtcontroller will start it again", test.moduleName)
-						}
+						assert.NoError(err, "Heartbeat of module %v is expired and dtcontroller will start it again", test.moduleName)
 						break
 					}
 				}
@@ -174,9 +172,7 @@ func TestStart(t *testing.T) {
 				time.Sleep(delay)
 				retry++
 			}
-			if retry >= maxRetries {
-				t.Errorf("Registration of module %v failed", test.moduleName)
-			}
+			assert.Less(retry, maxRetries, "Registration of module %v failed", test.moduleName)
 		})
 	}
 }

--- a/edge/pkg/devicetwin/dttype/types_helper_test.go
+++ b/edge/pkg/devicetwin/dttype/types_helper_test.go
@@ -19,11 +19,11 @@ package dttype
 import (
 	"encoding/json"
 	"errors"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtclient"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtcommon"
@@ -31,6 +31,8 @@ import (
 
 // TestUnmarshalMembershipDetail is function to test UnmarshalMembershipDetails()
 func TestUnmarshalMembershipDetail(t *testing.T) {
+	assert := assert.New(t)
+
 	var memDetail MembershipDetail
 	bytesMemDetail, _ := json.Marshal(memDetail)
 	tests := []struct {
@@ -56,25 +58,19 @@ func TestUnmarshalMembershipDetail(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := UnmarshalMembershipDetail(test.membershipDetail)
 			if err != nil {
-				if !reflect.DeepEqual(err.Error(), test.wantErr.Error()) {
-					t.Errorf("Error Got = %v,Want =%v", err.Error(), test.wantErr.Error())
-					return
-				}
+				assert.EqualError(err, test.wantErr.Error())
 			} else {
-				if !reflect.DeepEqual(err, test.wantErr) {
-					t.Errorf("Error Got = %v,Want =%v", err, test.wantErr)
-					return
-				}
+				assert.NoError(err)
 			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("UnmarshalMembershipDetail() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.want, got)
 		})
 	}
 }
 
 // TestUnmarshalMembershipUpdate is function to test UnmarshalMembershipUpdate().
 func TestUnmarshalMembershipUpdate(t *testing.T) {
+	assert := assert.New(t)
+
 	var memUpdate MembershipUpdate
 	bytesMemUpdate, _ := json.Marshal(memUpdate)
 	tests := []struct {
@@ -100,25 +96,19 @@ func TestUnmarshalMembershipUpdate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := UnmarshalMembershipUpdate(test.membershipUpdate)
 			if err != nil {
-				if !reflect.DeepEqual(err.Error(), test.wantErr.Error()) {
-					t.Errorf("Error Got = %v,Want =%v", err.Error(), test.wantErr.Error())
-					return
-				}
+				assert.EqualError(err, test.wantErr.Error())
 			} else {
-				if !reflect.DeepEqual(err, test.wantErr) {
-					t.Errorf("Error Got = %v,Want =%v", err, test.wantErr)
-					return
-				}
+				assert.NoError(err)
 			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("UnmarshalMembershipUpdate() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.want, got)
 		})
 	}
 }
 
 // TestUnmarshalBaseMessage is function to test UnmarshalBaseMessage().
 func TestUnmarshalBaseMessage(t *testing.T) {
+	assert := assert.New(t)
+
 	var baseMessage BaseMessage
 	bytesBaseMessage, _ := json.Marshal(baseMessage)
 	tests := []struct {
@@ -144,25 +134,19 @@ func TestUnmarshalBaseMessage(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := UnmarshalBaseMessage(test.baseMsg)
 			if err != nil {
-				if !reflect.DeepEqual(err.Error(), test.wantErr.Error()) {
-					t.Errorf("Error Got = %v,Want =%v", err.Error(), test.wantErr.Error())
-					return
-				}
+				assert.EqualError(err, test.wantErr.Error())
 			} else {
-				if !reflect.DeepEqual(err, test.wantErr) {
-					t.Errorf("Error Got = %v,Want =%v", err, test.wantErr)
-					return
-				}
+				assert.NoError(err)
 			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("UnmarshalBaseMessage() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.want, got)
 		})
 	}
 }
 
 // TestDeviceAttrToMsgAttr is function to test DeviceAttrtoMsgAttr().
 func TestDeviceAttrToMsgAttr(t *testing.T) {
+	assert := assert.New(t)
+
 	var devAttr []dtclient.DeviceAttr
 	attr := dtclient.DeviceAttr{
 		ID:          00,
@@ -199,23 +183,13 @@ func TestDeviceAttrToMsgAttr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := DeviceAttrToMsgAttr(tt.deviceAttrs)
-			if len(got) != len(tt.want) {
-				t.Errorf("DeviceAttrToMsgAttr failed due to wrong map size, Got Size = %v Want = %v", len(got), len(tt.want))
-			}
+			assert.Equal(len(tt.want), len(got), "DeviceAttrToMsgAttr failed due to wrong map size")
 			for gotKey, gotValue := range got {
-				keyPresent := false
-				for wantKey, wantValue := range tt.want {
-					if gotKey == wantKey {
-						keyPresent = true
-						if !reflect.DeepEqual(gotValue.Metadata, wantValue.Metadata) || !reflect.DeepEqual(gotValue.Optional, wantValue.Optional) || !reflect.DeepEqual(gotValue.Value, wantValue.Value) {
-							t.Errorf("Error in DeviceAttrToMsgAttr() Got wrong value for key %v", gotKey)
-							return
-						}
-					}
-				}
-				if !keyPresent {
-					t.Errorf("DeviceAttrToMsgAttr failed() due to wrong key %v", gotKey)
-				}
+				wantValue, keyPresent := tt.want[gotKey]
+				assert.True(keyPresent, "DeviceAttrToMsgAttr failed due to wrong key %v", gotKey)
+				assert.Equal(wantValue.Metadata, gotValue.Metadata, "Error in DeviceAttrToMsgAttr() Got wrong value for key %v", gotKey)
+				assert.Equal(wantValue.Optional, gotValue.Optional, "Error in DeviceAttrToMsgAttr() Got wrong value for key %v", gotKey)
+				assert.Equal(wantValue.Value, gotValue.Value, "Error in DeviceAttrToMsgAttr() Got wrong value for key %v", gotKey)
 			}
 		})
 	}
@@ -259,6 +233,8 @@ func createMessageTwinFromDeviceTwin(devTwin dtclient.DeviceTwin) map[string]*Ms
 
 // TestDeviceTwinToMsgTwin is function to test DeviceTwinToMsgTwin().
 func TestDeviceTwinToMsgTwin(t *testing.T) {
+	assert := assert.New(t)
+
 	devTwin := dtclient.DeviceTwin{
 		ID:              00,
 		DeviceID:        "DeviceA",
@@ -288,15 +264,15 @@ func TestDeviceTwinToMsgTwin(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DeviceTwinToMsgTwin(tt.deviceTwins); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DeviceTwinToMsgTwin() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(tt.want, DeviceTwinToMsgTwin(tt.deviceTwins))
 		})
 	}
 }
 
 // TestMsgAttrToDeviceAttr is function to test MsgAttrToDeviceAttr().
 func TestMsgAttrToDeviceAttr(t *testing.T) {
+	assert := assert.New(t)
+
 	optional := true
 	metadata := &TypeMetadata{
 		Type: "string",
@@ -326,15 +302,15 @@ func TestMsgAttrToDeviceAttr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MsgAttrToDeviceAttr(tt.attrname, tt.msgAttribute); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MsgAttrToDeviceAttr() = %v, want %v", got, tt.want)
-			}
+			assert.Equal(tt.want, MsgAttrToDeviceAttr(tt.attrname, tt.msgAttribute))
 		})
 	}
 }
 
 // TestCopyMsgTwin is function to test CopyMsgTwin().
 func TestCopyMsgTwin(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name      string
 		msgTwin   *MsgTwin
@@ -386,15 +362,16 @@ func TestCopyMsgTwin(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CopyMsgTwin(tt.msgTwin, tt.noVersion); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CopyMsgTwin() = %v, want %v", got, tt.want)
-			}
+			got := CopyMsgTwin(tt.msgTwin, tt.noVersion)
+			assert.Equal(tt.want, got)
 		})
 	}
 }
 
 // TestCopyMsgAttr is function to test CopyMsgAttr().
 func TestCopyMsgAttr(t *testing.T) {
+	assert := assert.New(t)
+
 	optional := true
 	metaData := TypeMetadata{Type: "Attribute"}
 	tests := []struct {
@@ -418,15 +395,16 @@ func TestCopyMsgAttr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CopyMsgAttr(tt.msgAttr); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CopyMsgAttr() = %v, want %v", got, tt.want)
-			}
+			got := CopyMsgAttr(tt.msgAttr)
+			assert.Equal(tt.want, got)
 		})
 	}
 }
 
 // TestMsgTwinToDeviceTwin is function to test MsgTwinToDeviceTwin().
 func TestMsgTwinToDeviceTwin(t *testing.T) {
+	assert := assert.New(t)
+
 	optional := true
 	metadata := TypeMetadata{Type: "Twin"}
 	tests := []struct {
@@ -451,15 +429,16 @@ func TestMsgTwinToDeviceTwin(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := MsgTwinToDeviceTwin(test.twinName, test.msgTwin); !reflect.DeepEqual(got, test.want) {
-				t.Errorf("MsgTwinToDeviceTwin() = %v, want %v", got, test.want)
-			}
+			got := MsgTwinToDeviceTwin(test.twinName, test.msgTwin)
+			assert.Equal(test.want, got)
 		})
 	}
 }
 
 // TestBuildDeviceState is function to test BuildDeviceCloudMsgState().
 func TestBuildDeviceState(t *testing.T) {
+	assert := assert.New(t)
+
 	baseMessage := BaseMessage{EventID: uuid.New().String(), Timestamp: time.Now().UnixNano() / 1e6}
 	device := Device{
 		Name:       "SensorTag",
@@ -494,19 +473,16 @@ func TestBuildDeviceState(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := BuildDeviceCloudMsgState(test.baseMessage, test.device)
-			if !reflect.DeepEqual(err, test.wantErr) {
-				t.Errorf("Error Got = %v,Want =%v", err, test.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildDeviceCloudMsgState() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.wantErr, err)
+			assert.Equal(test.want, got)
 		})
 	}
 }
 
 // TestBuildDeviceAttrUpdate is function to test BuildDeviceAttrUpdate().
 func TestBuildDeviceAttrUpdate(t *testing.T) {
+	assert := assert.New(t)
+
 	baseMessage := BaseMessage{
 		EventID:   uuid.New().String(),
 		Timestamp: time.Now().UnixNano() / 1e6,
@@ -552,13 +528,8 @@ func TestBuildDeviceAttrUpdate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := BuildDeviceAttrUpdate(test.baseMessage, test.attrs)
-			if !reflect.DeepEqual(err, test.wantErr) {
-				t.Errorf("Error Got = %v,Want =%v", err, test.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildDeviceAttrUpdate() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.wantErr, err)
+			assert.Equal(test.want, got)
 		})
 	}
 }
@@ -614,6 +585,8 @@ func createMembershipGetResult(message BaseMessage) MembershipGetResult {
 
 // TestBuildMembershipGetResult is function to test BuildMembershipGetResult().
 func TestBuildMembershipGetResult(t *testing.T) {
+	assert := assert.New(t)
+
 	baseMessage := BaseMessage{EventID: uuid.New().String(), Timestamp: time.Now().UnixNano() / 1e6}
 	devices := createDevice()
 	memGetResult := createMembershipGetResult(baseMessage)
@@ -636,13 +609,8 @@ func TestBuildMembershipGetResult(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := BuildMembershipGetResult(test.baseMessage, test.devices)
-			if !reflect.DeepEqual(err, test.wantErr) {
-				t.Errorf("BuildMembershipGetResult() error = %v, wantErr %v", err, test.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildMembershipGetResult() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.wantErr, err)
+			assert.Equal(test.want, got)
 		})
 	}
 }
@@ -682,6 +650,8 @@ func createDeviceTwinResult(baseMessage BaseMessage) DeviceTwinResult {
 
 // TestBuildDeviceTwinResult is function to test BuildDeviceTwinResult().
 func TestBuildDeviceTwinResult(t *testing.T) {
+	assert := assert.New(t)
+
 	baseMessage := BaseMessage{EventID: uuid.New().String(), Timestamp: time.Now().UnixNano() / 1e6}
 	msgTwins := createMessageTwin()
 	devTwinResultDealType0 := createDeviceTwinResultDealTypeGet(baseMessage)
@@ -716,19 +686,16 @@ func TestBuildDeviceTwinResult(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := BuildDeviceTwinResult(test.baseMessage, test.twins, test.dealType)
-			if !reflect.DeepEqual(err, test.wantErr) {
-				t.Errorf("BuildDeviceTwinResult() error = %v, wantErr %v", err, test.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildDeviceTwinResult() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.wantErr, err)
+			assert.Equal(test.want, got)
 		})
 	}
 }
 
 // TestBuildErrorResult is function to test BuildErrorResult().
 func TestBuildErrorResult(t *testing.T) {
+	assert := assert.New(t)
+
 	result := Result{BaseMessage: BaseMessage{
 		EventID: ""},
 		Code:   1,
@@ -749,29 +716,20 @@ func TestBuildErrorResult(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := BuildErrorResult(test.para)
-			gotResult := Result{}
+			var gotResult Result
 			json.Unmarshal(got, &gotResult)
-			if !reflect.DeepEqual(err, test.wantErr) {
-				t.Errorf("BuildErrorResult() error = %v, wantErr %v", err, test.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(gotResult.EventID, test.want.EventID) {
-				t.Errorf("BuildErrorResult() error EventID = %v, want = %v", gotResult.EventID, test.want.EventID)
-				return
-			}
-			if !reflect.DeepEqual(gotResult.Reason, test.want.Reason) {
-				t.Errorf("BuildErrorResult() error Reason = %v, want = %v", gotResult.Reason, test.want.Reason)
-				return
-			}
-			if !reflect.DeepEqual(gotResult.Code, test.want.Code) {
-				t.Errorf("BuildErrorResult() error Code = %v, want = %v", gotResult.Code, test.want.Code)
-			}
+			assert.Equal(test.wantErr, err)
+			assert.Equal(test.want.EventID, gotResult.EventID)
+			assert.Equal(test.want.Reason, gotResult.Reason)
+			assert.Equal(test.want.Code, gotResult.Code)
 		})
 	}
 }
 
 // TestUnmarshalDeviceUpdate is function to test UnmarshalDeviceUpdate().
 func TestUnmarshalDeviceUpdate(t *testing.T) {
+	assert := assert.New(t)
+
 	var devUpdate DeviceUpdate
 	bytesDevUpdate, _ := json.Marshal(devUpdate)
 	tests := []struct {
@@ -790,13 +748,8 @@ func TestUnmarshalDeviceUpdate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := UnmarshalDeviceUpdate(test.payload)
-			if !reflect.DeepEqual(err, test.wantErr) {
-				t.Errorf("UnmarshalDeviceUpdate() error = %v, wantErr %v", err, test.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("UnmarshalDeviceUpdate() = %v, want %v", got, test.want)
-			}
+			assert.Equal(test.wantErr, err)
+			assert.Equal(test.want, got)
 		})
 	}
 }
@@ -845,6 +798,8 @@ func createMessageTwinAndDeltaWithSameValues() (map[string]*MsgTwin, map[string]
 
 // TestBuildDeviceTwinDelta is function to test BuildDeviceTwinDelta().
 func TestBuildDeviceTwinDelta(t *testing.T) {
+	assert := assert.New(t)
+
 	baseMessage := BaseMessage{EventID: "Event1", Timestamp: time.Now().UnixNano() / 1e6}
 	msgTwins := createMessageTwinWithDiffValues(baseMessage)
 	delta := make(map[string]string)
@@ -877,19 +832,17 @@ func TestBuildDeviceTwinDelta(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, got1 := BuildDeviceTwinDelta(test.baseMessage, test.twins)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildDeviceTwinDelta() got = %v, want %v", got, test.want)
-			}
-			if got1 != test.wantBool {
-				t.Errorf("BuildDeviceTwinDelta() got1 = %v, want %v", got1, test.wantBool)
-			}
+			got, gotBool := BuildDeviceTwinDelta(test.baseMessage, test.twins)
+			assert.Equal(test.want, got)
+			assert.Equal(test.wantBool, gotBool)
 		})
 	}
 }
 
 // TestBuildDeviceTwinDocument is function to test BuildDeviceTwinDocument().
 func TestBuildDeviceTwinDocument(t *testing.T) {
+	assert := assert.New(t)
+
 	twinDoc := make(map[string]*TwinDoc)
 	doc := TwinDoc{
 		LastState:    generateTwinActualExpected(dtcommon.TypeUpdated, "", ""),
@@ -923,12 +876,8 @@ func TestBuildDeviceTwinDocument(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got, gotBool := BuildDeviceTwinDocument(test.baseMessage, test.twins)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("BuildDeviceTwinDocument() got = %v, want %v", got, test.want)
-			}
-			if gotBool != test.wantBool {
-				t.Errorf("BuildDeviceTwinDocument() gotBool = %v, want %v", gotBool, test.wantBool)
-			}
+			assert.Equal(test.want, got, "BuildDeviceTwinDocument() got = %v, want %v", got, test.want)
+			assert.Equal(test.wantBool, gotBool, "BuildDeviceTwinDocument() gotBool = %v, want %v", gotBool, test.wantBool)
 		})
 	}
 }

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/validation/validation_test.go
@@ -19,42 +19,36 @@ package validation
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/cloudcore/v1alpha1"
 )
 
 func TestValidateCloudCoreConfiguration(t *testing.T) {
-	dir := t.TempDir()
+	assert := assert.New(t)
 
+	dir := t.TempDir()
 	ef, err := os.CreateTemp(dir, "existFile")
-	if err != nil {
-		t.Errorf("create temp file failed: %v", err)
-		return
-	}
+	assert.NoError(err)
 
 	config := v1alpha1.NewDefaultCloudCoreConfig()
 	config.Modules.CloudHub.UnixSocket.Address = "unix://" + ef.Name()
 	config.KubeAPIConfig.KubeConfig = ef.Name()
 
 	errList := ValidateCloudCoreConfiguration(config)
-	if len(errList) > 0 {
-		t.Errorf("cloudcore configuration is not correct: %v", errList)
-	}
+	assert.Empty(errList)
 }
 
 func TestValidateModuleCloudHub(t *testing.T) {
+	assert := assert.New(t)
 	dir := t.TempDir()
 
 	ef, err := os.CreateTemp(dir, "existFile")
-	if err != nil {
-		t.Errorf("create temp file failed: %v", err)
-		return
-	}
+	assert.NoError(err)
 	unixAddr := "unix://" + ef.Name()
 
 	cases := []struct {
@@ -228,13 +222,14 @@ func TestValidateModuleCloudHub(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleCloudHub(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
-		}
+		result := ValidateModuleCloudHub(c.input)
+		assert.Equal(c.expected, result, c.name)
 	}
 }
 
 func TestValidateModuleEdgeController(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		name     string
 		input    v1alpha1.EdgeController
@@ -268,13 +263,14 @@ func TestValidateModuleEdgeController(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleEdgeController(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
-		}
+		result := ValidateModuleEdgeController(c.input)
+		assert.Equal(c.expected, result, c.name)
 	}
 }
 
 func TestValidateModuleDeviceController(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		name     string
 		input    v1alpha1.DeviceController
@@ -297,13 +293,14 @@ func TestValidateModuleDeviceController(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleDeviceController(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
-		}
+		result := ValidateModuleDeviceController(c.input)
+		assert.Equal(c.expected, result, c.name)
 	}
 }
 
 func TestValidateModuleSyncController(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		name     string
 		input    v1alpha1.SyncController
@@ -326,13 +323,14 @@ func TestValidateModuleSyncController(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleSyncController(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
-		}
+		result := ValidateModuleSyncController(c.input)
+		assert.Equal(c.expected, result, c.name)
 	}
 }
 
 func TestValidateModuleDynamicController(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		name     string
 		input    v1alpha1.DynamicController
@@ -355,20 +353,17 @@ func TestValidateModuleDynamicController(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleDynamicController(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
-		}
+		result := ValidateModuleDynamicController(c.input)
+		assert.Equal(c.expected, result, c.name)
 	}
 }
 
 func TestValidateModuleCloudStream(t *testing.T) {
-	dir := t.TempDir()
+	assert := assert.New(t)
 
+	dir := t.TempDir()
 	ef, err := os.CreateTemp(dir, "existFile")
-	if err != nil {
-		t.Errorf("create temp file failed: %v", err)
-		return
-	}
+	assert.NoError(err)
 
 	nonexistentDir := filepath.Join(dir, "not_exist_dir")
 	notExistFile := filepath.Join(nonexistentDir, "not_exist_file")
@@ -431,20 +426,19 @@ func TestValidateModuleCloudStream(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleCloudStream(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
-		}
+		result := ValidateModuleCloudStream(c.input)
+		assert.Equal(c.expected, result, c.name)
 	}
 }
 
 func TestValidateKubeAPIConfig(t *testing.T) {
+	assert := assert.New(t)
+
 	dir := t.TempDir()
 
 	ef, err := os.CreateTemp(dir, "existFile")
-	if err != nil {
-		t.Errorf("create temp file failed: %v", err)
-		return
-	}
+	assert.NoError(err)
+	defer ef.Close()
 
 	nonexistentDir := filepath.Join(dir, "not_exist_dir")
 	notExistFile := filepath.Join(nonexistentDir, "not_exist_file")
@@ -480,13 +474,14 @@ func TestValidateKubeAPIConfig(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if result := ValidateKubeAPIConfig(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
-		}
+		result := ValidateKubeAPIConfig(c.input)
+		assert.Equal(c.expected, result, c.name)
 	}
 }
 
 func TestValidateCommonConfig(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name         string
 		commonConfig v1alpha1.CommonConfig
@@ -523,12 +518,10 @@ func TestValidateCommonConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			errList := ValidateCommonConfig(tt.commonConfig)
-			if len(errList) == 0 && tt.expectedErr {
-				t.Errorf("ValidateCommonConfig expected get err, but errList is nil")
-			}
-
-			if len(errList) != 0 && !tt.expectedErr {
-				t.Errorf("ValidateCommonConfig expected get no err, but errList is not nil")
+			if tt.expectedErr {
+				assert.NotEmpty(errList, "ValidateCommonConfig expected to get an error, but errList is empty")
+			} else {
+				assert.Empty(errList, "ValidateCommonConfig expected to get no error, but errList is not empty")
 			}
 		})
 	}

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -1,14 +1,17 @@
 package image
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
 
 func TestEdgeSet(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name string
 		args common.JoinOptions
@@ -76,14 +79,15 @@ func TestEdgeSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := EdgeSet(&tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("EdgeSet() = %v, want %v", got, tt.want)
-			}
+			got := EdgeSet(&tt.args)
+			assert.Equal(tt.want, got)
 		})
 	}
 }
 
 func TestCloudSet(t *testing.T) {
+	assert := assert.New(t)
+
 	type args struct {
 		imageRepository string
 		version         string
@@ -148,14 +152,15 @@ func TestCloudSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CloudSet(tt.args.imageRepository, tt.args.version); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CloudSet() = %v, want %v", got, tt.want)
-			}
+			got := CloudSet(tt.args.imageRepository, tt.args.version)
+			assert.Equal(tt.want, got)
 		})
 	}
 }
 
 func TestSet_Get(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name string
 		s    Set
@@ -171,14 +176,15 @@ func TestSet_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.s.Get(tt.args); got != tt.want {
-				t.Errorf("Set.Get() = %v, want %v", got, tt.want)
-			}
+			got := tt.s.Get(tt.args)
+			assert.Equal(tt.want, got)
 		})
 	}
 }
 
 func TestSet_List(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name string
 		s    Set
@@ -202,14 +208,14 @@ func TestSet_List(t *testing.T) {
 			for _, v := range tt.want {
 				wantMap[v] = ""
 			}
-			if !reflect.DeepEqual(gotMap, wantMap) {
-				t.Errorf("Set.List() = %v, but want %v", got, tt.want)
-			}
+			assert.Equal(wantMap, gotMap)
 		})
 	}
 }
 
 func TestSet_Merge(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name string
 		s    Set
@@ -237,14 +243,15 @@ func TestSet_Merge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.s.Merge(tt.args); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Set.Merge() = %v, want %v", got, tt.want)
-			}
+			got := tt.s.Merge(tt.args)
+			assert.Equal(tt.want, got)
 		})
 	}
 }
 
 func TestSet_Remove(t *testing.T) {
+	assert := assert.New(t)
+
 	tests := []struct {
 		name string
 		s    Set
@@ -263,9 +270,8 @@ func TestSet_Remove(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.s.Remove(EdgeMQTT); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Set.Remove() = %v, want %v", got, tt.want)
-			}
+			got := tt.s.Remove(EdgeMQTT)
+			assert.Equal(tt.want, got)
 		})
 	}
 }

--- a/pkg/metaserver/key_test.go
+++ b/pkg/metaserver/key_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestKeyFuncObj(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		// group version kind namespace name
 		attr      []string
@@ -56,17 +59,15 @@ func TestKeyFuncObj(t *testing.T) {
 			obj.SetName(test.attr[4])
 
 			key, err := KeyFuncObj(&obj)
-			if err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			if test.stdResult != key {
-				t.Errorf("KeyFuncObj Case failed,wanted result:%+v,acctual result:%+v", test.stdResult, key)
-			}
+			assert.NoError(err)
+			assert.Equal(test.stdResult, key)
 		})
 	}
 }
 
 func TestKeyFuncReq(t *testing.T) {
+	assert := assert.New(t)
+
 	namespaceAll := metav1.NamespaceAll
 	Cases := []struct { //copy by requestinfo_test.go
 		method              string
@@ -156,21 +157,15 @@ func TestKeyFuncReq(t *testing.T) {
 	for k, v := range Cases {
 		t.Run("parseKey", func(t *testing.T) {
 			req, err := http.NewRequest(v.method, v.url, nil)
-			if err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
+			assert.NoError(err)
+
 			apiRequestInfo, err := resolver.NewRequestInfo(req)
-			if err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
+			assert.NoError(err)
+
 			ctx := request.WithRequestInfo(context.TODO(), apiRequestInfo)
 			key, err := KeyFuncReq(ctx, "")
-			if err != nil {
-				t.Errorf("Unexpected error %v", err)
-			}
-			if key != stdResult[k] {
-				t.Errorf("failed to parse req context, wanted(%v),get(%v)", stdResult[k], key)
-			}
+			assert.NoError(err)
+			assert.Equal(stdResult[k], key)
 		})
 	}
 }
@@ -183,6 +178,8 @@ func newTestRequestInfoResolver() *request.RequestInfoFactory {
 
 // TestSaveMeta is function to initialize all global variable and test SaveMeta
 func TestParseKey(t *testing.T) {
+	assert := assert.New(t)
+
 	type result struct {
 		gvr       schema.GroupVersionResource
 		namespace string
@@ -292,9 +289,7 @@ func TestParseKey(t *testing.T) {
 		t.Run("parseKey", func(t *testing.T) {
 			gvr, ns, name := ParseKey(test.key)
 			parseResult := result{gvr, ns, name}
-			if test.stdResult != parseResult {
-				t.Errorf("ParseKey Case failed, key:%v,wanted result:%+v,acctual result:%+v", test.key, test.stdResult, parseResult)
-			}
+			assert.Equal(test.stdResult, parseResult)
 		})
 	}
 }

--- a/pkg/util/pass-through/pass_through_test.go
+++ b/pkg/util/pass-through/pass_through_test.go
@@ -1,9 +1,15 @@
 package passthrough
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestIsPassThroughPath(t *testing.T) {
-	tests := []struct {
+	assert := assert.New(t)
+
+	testcases := []struct {
 		name string
 		path string
 		verb string
@@ -14,48 +20,54 @@ func TestIsPassThroughPath(t *testing.T) {
 			path: "/version",
 			verb: "post",
 			want: false,
-		}, {
+		},
+		{
 			name: "/version::get is pass through path",
 			path: "/version",
 			verb: "get",
 			want: true,
-		}, {
+		},
+		{
 			name: "/healthz::put is not pass through path",
 			path: "/healthz",
 			verb: "put",
 			want: false,
-		}, {
+		},
+		{
 			name: "/healthz::get is pass through path",
 			path: "/healthz",
 			verb: "get",
 			want: true,
-		}, {
+		},
+		{
 			name: "/livez::patch is not pass through path",
 			path: "/livez",
 			verb: "patch",
 			want: false,
-		}, {
+		},
+		{
 			name: "/livez::get is pass through path",
 			path: "/livez",
 			verb: "get",
 			want: true,
-		}, {
+		},
+		{
 			name: "/readyz::delete is not pass through path",
 			path: "/readyz",
 			verb: "delete",
 			want: false,
-		}, {
+		},
+		{
 			name: "/readyz::get is pass through path",
 			path: "/readyz",
 			verb: "get",
 			want: true,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsPassThroughPath(tt.path, tt.verb); got != tt.want {
-				t.Errorf("IsPassThroughPath() = %v, want %v", got, tt.want)
-			}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			assert.Equal(IsPassThroughPath(testcase.path, testcase.verb), testcase.want, "Path: %s Verb: %s", testcase.path, testcase.verb)
 		})
 	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateNodeIP(t *testing.T) {
+	assert := assert.New(t)
+
 	hostnameOverride := GetHostname()
 	localIP, _ := GetLocalIP(hostnameOverride)
 
@@ -56,13 +59,13 @@ func TestValidateNodeIP(t *testing.T) {
 	}
 	for _, c := range cases {
 		err := ValidateNodeIP(c.ip)
-		if !reflect.DeepEqual(err, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, err)
-		}
+		assert.Equal(c.expected, err, c.name)
 	}
 }
 
 func TestCommand(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		name     string
 		command  string
@@ -82,34 +85,34 @@ func TestCommand(t *testing.T) {
 	for _, c := range cases {
 		_, err := Command(c.command, nil)
 		isSuccess := err == nil
-		if isSuccess != c.expected {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, isSuccess)
-		}
+		assert.Equal(c.expected, isSuccess, c.name)
 	}
 }
 
 func TestGetCurPath(t *testing.T) {
+	assert := assert.New(t)
+
 	path := GetCurPath()
-	if path == "" {
-		t.Errorf("failed to get current path")
-	}
+	assert.NotEmpty(path)
 }
 
 func TestGetHostname(t *testing.T) {
+	assert := assert.New(t)
+
 	name := GetHostname()
-	if name == "" {
-		t.Errorf("get host name failed")
-	}
+	assert.NotEmpty(name)
 }
 
 func TestGetLocalIP(t *testing.T) {
+	assert := assert.New(t)
+
 	_, err := GetLocalIP(GetHostname())
-	if err != nil {
-		t.Errorf("get local ip failed")
-	}
+	assert.NoError(err)
 }
 
 func TestSpliceErrors(t *testing.T) {
+	assert := assert.New(t)
+
 	err1 := errors.New("this is error 1")
 	err2 := errors.New("this is error 2")
 	err3 := errors.New("this is error 3")
@@ -121,22 +124,19 @@ func TestSpliceErrors(t *testing.T) {
 	const tail = "]\n"
 
 	sliceOutput := SpliceErrors([]error{err1, err2, err3})
-	if strings.Index(sliceOutput, head) != 0 ||
-		strings.Index(sliceOutput, line1) != len(head) ||
-		strings.Index(sliceOutput, line2) != len(head+line1) ||
-		strings.Index(sliceOutput, line3) != len(head+line1+line2) ||
-		strings.Index(sliceOutput, tail) != len(head+line1+line2+line3) {
-		t.Error("the func format the multiple elements error slice unexpected")
-		return
-	}
+	assert.True(strings.HasPrefix(sliceOutput, head))
+	assert.True(strings.Contains(sliceOutput, line1))
+	assert.True(strings.Contains(sliceOutput, line2))
+	assert.True(strings.Contains(sliceOutput, line3))
+	assert.True(strings.HasSuffix(sliceOutput, tail))
 
-	if SpliceErrors([]error{}) != "" || SpliceErrors(nil) != "" {
-		t.Error("the func format the zero-length error slice unexpected")
-		return
-	}
+	assert.Equal("", SpliceErrors([]error{}))
+	assert.Equal("", SpliceErrors(nil))
 }
 
 func TestConcatStrings(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		args   []string
 		expect string
@@ -154,12 +154,8 @@ func TestConcatStrings(t *testing.T) {
 			expect: "ab",
 		},
 	}
-	var s string
-	for _, c := range cases {
-		s = ConcatStrings(c.args...)
-		if s != c.expect {
-			t.Errorf("the func return failed. expect: %s, actual: %s\n", c.expect, s)
-			return
-		}
+	for _, testcase := range cases {
+		s := ConcatStrings(testcase.args...)
+		assert.Equal(testcase.expect, s)
 	}
 }

--- a/pkg/util/validation/check_test.go
+++ b/pkg/util/validation/check_test.go
@@ -4,22 +4,23 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileIsExist(t *testing.T) {
+	assert := assert.New(t)
+
 	dir := t.TempDir()
 
 	ef, err := os.CreateTemp(dir, "CheckFileIsExist")
-	if err == nil {
-		if !FileIsExist(ef.Name()) {
-			t.Fatalf("file %v should exist", ef.Name())
-		}
-	}
+	assert.NoError(err, "Error creating temporary file")
+	defer os.Remove(ef.Name())
+
+	assert.True(FileIsExist(ef.Name()), "file %v should exist", ef.Name())
 
 	nonexistentDir := filepath.Join(dir, "not_exist_dir")
 	notExistFile := filepath.Join(nonexistentDir, "not_exist_file")
 
-	if FileIsExist(notExistFile) {
-		t.Fatalf("file %v should not exist", notExistFile)
-	}
+	assert.False(FileIsExist(notExistFile), "file %v should not exist", notExistFile)
 }

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -1,11 +1,14 @@
 package validation
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsValidIP(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		Name   string
 		IP     string
@@ -42,14 +45,14 @@ func TestIsValidIP(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			v := IsValidIP(c.IP)
 			get := len(v) == 0
-			if get != c.Expect {
-				t.Errorf("Input %s Expect %v while get %v", c.IP, c.Expect, v)
-			}
+			assert.Equal(get, c.Expect)
 		})
 	}
 }
 
 func TestIsValidPortNum(t *testing.T) {
+	assert := assert.New(t)
+
 	cases := []struct {
 		Name   string
 		Port   int
@@ -80,17 +83,15 @@ func TestIsValidPortNum(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			v := IsValidPortNum(c.Port)
-			if !reflect.DeepEqual(v, c.Expect) {
-				t.Errorf("Input %d Expect %v while get %v", c.Port, c.Expect, v)
-			}
+			assert.Equal(v, c.Expect)
 		})
 	}
 }
 
 func TestInclusiveRangeError(t *testing.T) {
+	assert := assert.New(t)
+
 	result := InclusiveRangeError(1, 65535)
 	expect := "must be between 1 and 65535, inclusive"
-	if !reflect.DeepEqual(result, expect) {
-		t.Errorf("Expected %v while get %v", expect, result)
-	}
+	assert.Equal(result, expect)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind feature


**What this PR does / why we need it**:

I [discussed ](https://github.com/kubeedge/kubeedge/pull/5675#discussion_r1643681405) this with @Shelley-BaoYue that we could move existing UTs from standard lib to an assertion lib like "testify/assert". This removes much boilerplate from the tests, and improves speed and quality of understanding and modifying them. there are negligible downsides.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4403

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
