### PR TITLE
Fixed the k8s client impersonation for the authroization

### DIFF
--- a/cloud/pkg/common/client/impersonation_test.go
+++ b/cloud/pkg/common/client/impersonation_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	authenticationv1 "k8s.io/api/authentication/v1"
+
+	ctxutl "github.com/kubeedge/kubeedge/cloud/pkg/common/context"
+)
+
+type fakeNextRoundTripper struct {
+	enable bool
+}
+
+func (f *fakeNextRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if f.enable {
+		if vals := req.Header[authenticationv1.ImpersonateUserHeader]; len(vals) == 0 || vals[0] == "" {
+			return nil, fmt.Errorf("invalid request header %s", authenticationv1.ImpersonateUserHeader)
+		}
+		if vals := req.Header[authenticationv1.ImpersonateGroupHeader]; len(vals) == 0 || vals[0] == "" {
+			return nil, fmt.Errorf("invalid request header %s", authenticationv1.ImpersonateGroupHeader)
+		}
+	} else {
+		if vals := req.Header[authenticationv1.ImpersonateUserHeader]; len(vals) > 0 {
+			return nil, fmt.Errorf("invalid request header %s", authenticationv1.ImpersonateUserHeader)
+		}
+		if vals := req.Header[authenticationv1.ImpersonateGroupHeader]; len(vals) > 0 {
+			return nil, fmt.Errorf("invalid request header %s", authenticationv1.ImpersonateGroupHeader)
+		}
+	}
+	return nil, nil
+}
+
+func TestRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		enable bool
+	}{
+		{name: "enable impersonation", enable: true},
+		{name: "disable impersonation", enable: false},
+	}
+
+	url, err := url.Parse("http://localhost:6443/apis")
+	assert.NoError(t, err)
+	ctx := ctxutl.WithEdgeNode(context.TODO(), "test-node")
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := &http.Request{
+				Method: http.MethodGet,
+				URL:    url,
+				Header: make(http.Header),
+			}
+			r := &impersonationRoundTripper{
+				enable: c.enable,
+				rt:     &fakeNextRoundTripper{enable: c.enable},
+			}
+			_, err := r.RoundTrip(req.WithContext(ctx))
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

**What this PR does / why we need it**:

`request.Header.Set` only one value can be set, multiple values are not supported.
```
func (h Header) Set(key, value string) {
	textproto.MIMEHeader(h).Set(key, value)
}

func (h MIMEHeader) Set(key, value string) {
	h[CanonicalMIMEHeaderKey(key)] = []string{value}
}
```

Other:
1. Make error messages more clear.
2. Add some unit tests for `RoundTrip()` function.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
