### PR TITLE
Get the ConfigMap and Secret from the edge node

### DIFF
--- a/edge/pkg/metamanager/client/configmap.go
+++ b/edge/pkg/metamanager/client/configmap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao"
 )
 
 // ConfigMapsGetter has a method to return a ConfigMapInterface.
@@ -51,39 +52,38 @@ func (c *configMaps) Delete(string) error {
 
 func (c *configMaps) Get(name string) (*api.ConfigMap, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeConfigmap, name)
-	configMapMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(configMapMsg)
-	if err != nil {
-		return nil, fmt.Errorf("get configmap from metaManager failed, err: %v", err)
-	}
-	errContent, ok := msg.GetContent().(error)
-	if ok {
-		return nil, errContent
-	}
-	content, err := msg.GetContentData()
-	if err != nil {
-		return nil, fmt.Errorf("parse message to configmap failed, err: %v", err)
+	remoteGet := func() (*api.ConfigMap, error) {
+		configMapMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
+		msg, err := c.send.SendSync(configMapMsg)
+		if err != nil {
+			return nil, fmt.Errorf("get configmap from metaManager failed, err: %v", err)
+		}
+		errContent, ok := msg.GetContent().(error)
+		if ok {
+			return nil, errContent
+		}
+		content, err := msg.GetContentData()
+		if err != nil {
+			return nil, fmt.Errorf("parse message to configmap failed, err: %v", err)
+		}
+		return handleConfigMapFromMetaManager(content)
 	}
 
-	if msg.GetOperation() == model.ResponseOperation && msg.GetSource() == modules.MetaManagerModuleName {
-		return handleConfigMapFromMetaDB(content)
+	metas, err := dao.QueryMeta("key", resource)
+	if err != nil || len(*metas) == 0 {
+		return remoteGet()
 	}
-	return handleConfigMapFromMetaManager(content)
+
+	return handleConfigMapFromMetaDB(metas)
 }
 
-func handleConfigMapFromMetaDB(content []byte) (*api.ConfigMap, error) {
-	var lists []string
-	err := json.Unmarshal(content, &lists)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshal message to ConfigMap list from db failed, err: %v", err)
-	}
-
-	if len(lists) != 1 {
-		return nil, fmt.Errorf("ConfigMap length from meta db is %d", len(lists))
+func handleConfigMapFromMetaDB(lists *[]string) (*api.ConfigMap, error) {
+	if len(*lists) != 1 {
+		return nil, fmt.Errorf("ConfigMap length from meta db is %d", len(*lists))
 	}
 
 	var configMap api.ConfigMap
-	err = json.Unmarshal([]byte(lists[0]), &configMap)
+	err := json.Unmarshal([]byte((*lists)[0]), &configMap)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal message to ConfigMap from db failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/secret.go
+++ b/edge/pkg/metamanager/client/secret.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao"
 )
 
 // SecretsGetter is interface to get client secrets
@@ -51,39 +52,36 @@ func (c *secrets) Delete(string) error {
 func (c *secrets) Get(name string) (*api.Secret, error) {
 	resource := fmt.Sprintf("%s/%s/%s", c.namespace, model.ResourceTypeSecret, name)
 	secretMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
-	msg, err := c.send.SendSync(secretMsg)
-	if err != nil {
-		return nil, fmt.Errorf("get secret from metaManager failed, err: %v", err)
-	}
-	errContent, ok := msg.GetContent().(error)
-	if ok {
-		return nil, errContent
-	}
-	content, err := msg.GetContentData()
-	if err != nil {
-		return nil, fmt.Errorf("parse message to secret failed, err: %v", err)
+	remoteGet := func() (*api.Secret, error) {
+		msg, err := c.send.SendSync(secretMsg)
+		if err != nil {
+			return nil, fmt.Errorf("get secret from metaManager failed, err: %v", err)
+		}
+		errContent, ok := msg.GetContent().(error)
+		if ok {
+			return nil, errContent
+		}
+		content, err := msg.GetContentData()
+		if err != nil {
+			return nil, fmt.Errorf("parse message to secret failed, err: %v", err)
+		}
+		return handleSecretFromMetaManager(content)
 	}
 
-	if msg.GetOperation() == model.ResponseOperation && msg.GetSource() == modules.MetaManagerModuleName {
-		return handleSecretFromMetaDB(content)
+	metas, err := dao.QueryMeta("key", resource)
+	if err != nil || len(*metas) == 0 {
+		return remoteGet()
 	}
-	//else
-	return handleSecretFromMetaManager(content)
+	return handleSecretFromMetaDB(metas)
 }
 
-func handleSecretFromMetaDB(content []byte) (*api.Secret, error) {
-	var lists []string
-	err := json.Unmarshal(content, &lists)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshal message to secret list from db failed, err: %v", err)
-	}
-
-	if len(lists) != 1 {
-		return nil, fmt.Errorf("secret length from meta db is %d", len(lists))
+func handleSecretFromMetaDB(lists *[]string) (*api.Secret, error) {
+	if len(*lists) != 1 {
+		return nil, fmt.Errorf("secret length from meta db is %d", len(*lists))
 	}
 
 	var secret api.Secret
-	err = json.Unmarshal([]byte(lists[0]), &secret)
+	err := json.Unmarshal([]byte((*lists)[0]), &secret)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal message to secret from db failed, err: %v", err)
 	}

--- a/edge/pkg/metamanager/client/secret_test.go
+++ b/edge/pkg/metamanager/client/secret_test.go
@@ -54,43 +54,35 @@ func TestHandleSecretFromMetaDB(t *testing.T) {
 		Type: api.SecretTypeOpaque,
 	}
 	secretJSON, _ := json.Marshal(secret)
-	content, _ := json.Marshal([]string{string(secretJSON)})
+	content := []string{string(secretJSON)}
 
-	result, err := handleSecretFromMetaDB(content)
+	result, err := handleSecretFromMetaDB(&content)
 	assert.NoError(err)
 	assert.Equal(secret, result)
 
 	// Test case 2: Empty list
-	emptyList, _ := json.Marshal([]string{})
+	var emptyList []string
 
-	result, err = handleSecretFromMetaDB(emptyList)
+	result, err = handleSecretFromMetaDB(&emptyList)
 	assert.Error(err)
 	assert.Nil(result)
 	assert.Contains(err.Error(), "secret length from meta db is 0")
 
 	// Test case 3: List with multiple elements
-	multipleSecrets, _ := json.Marshal([]string{string(secretJSON), string(secretJSON)})
+	multipleSecrets := []string{string(secretJSON), string(secretJSON)}
 
-	result, err = handleSecretFromMetaDB(multipleSecrets)
+	result, err = handleSecretFromMetaDB(&multipleSecrets)
 	assert.Error(err)
 	assert.Nil(result)
 	assert.Contains(err.Error(), "secret length from meta db is 2")
 
 	// Test case 4: Invalid JSON in the list
-	invalidJSON := []byte(`["{invalid json}"]`)
+	invalidJSON := []string{"{invalid json}"}
 
-	result, err = handleSecretFromMetaDB(invalidJSON)
+	result, err = handleSecretFromMetaDB(&invalidJSON)
 	assert.Error(err)
 	assert.Nil(result)
 	assert.Contains(err.Error(), "unmarshal message to secret from db failed")
-
-	// Test case 5: Invalid outer JSON (not a list)
-	invalidOuterJSON := []byte(`{"not": "a list"}`)
-
-	result, err = handleSecretFromMetaDB(invalidOuterJSON)
-	assert.Error(err)
-	assert.Nil(result)
-	assert.Contains(err.Error(), "unmarshal message to secret list from db failed")
 }
 
 func TestHandleSecretFromMetaManager(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When the cloud edge network is not good, starting a pod to obtain the `configmap` from the cloud will result in a longer delay in pod startup, so it is necessary to directly obtain the configmap from the edge nodes.

![image](https://github.com/user-attachments/assets/fd152220-66df-4f61-b914-5b7b25c6032b)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
