### PR TITLE
Make the timestamps of kubeedge resources support international time

### DIFF
--- a/cloud/pkg/taskmanager/imageprepullcontroller/image_prepull_task.go
+++ b/cloud/pkg/taskmanager/imageprepullcontroller/image_prepull_task.go
@@ -27,7 +27,6 @@ import (
 	v1alpha12 "github.com/kubeedge/api/apis/fsm/v1alpha1"
 	"github.com/kubeedge/api/apis/operations/v1alpha1"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
-	"github.com/kubeedge/kubeedge/cloud/pkg/taskmanager/util"
 	"github.com/kubeedge/kubeedge/pkg/util/fsm"
 )
 
@@ -71,7 +70,7 @@ func updatePrePullNodeState(id, nodeName string, state v1alpha12.State, event fs
 					State:    state,
 					Event:    event.Type,
 					Action:   event.Action,
-					Time:     time.Now().Format(util.ISO8601UTC),
+					Time:     time.Now().UTC().Format(time.RFC3339),
 					Reason:   event.Msg,
 				},
 				ImageStatus: imagesStatus,
@@ -122,7 +121,7 @@ func updateUpgradeTaskState(id, _ string, state v1alpha12.State, event fsm.Event
 	status.Action = event.Action
 	status.Reason = event.Msg
 	status.State = state
-	status.Time = time.Now().Format(util.ISO8601UTC)
+	status.Time = time.Now().UTC().Format(time.RFC3339)
 
 	err := patchStatus(newTask, *status, client.GetCRDClient())
 

--- a/cloud/pkg/taskmanager/nodeupgradecontroller/upgrade_task.go
+++ b/cloud/pkg/taskmanager/nodeupgradecontroller/upgrade_task.go
@@ -24,7 +24,6 @@ import (
 	v1alpha12 "github.com/kubeedge/api/apis/fsm/v1alpha1"
 	"github.com/kubeedge/api/apis/operations/v1alpha1"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
-	"github.com/kubeedge/kubeedge/cloud/pkg/taskmanager/util"
 	"github.com/kubeedge/kubeedge/pkg/util/fsm"
 )
 
@@ -62,7 +61,7 @@ func updateUpgradeNodeState(id, nodeName string, state v1alpha12.State, event fs
 				State:    state,
 				Event:    event.Type,
 				Action:   event.Action,
-				Time:     time.Now().Format(util.ISO8601UTC),
+				Time:     time.Now().UTC().Format(time.RFC3339),
 				Reason:   event.Msg,
 			}
 			break
@@ -111,7 +110,7 @@ func updateUpgradeTaskState(id, _ string, state v1alpha12.State, event fsm.Event
 	status.Action = event.Action
 	status.Reason = event.Msg
 	status.State = state
-	status.Time = time.Now().Format(util.ISO8601UTC)
+	status.Time = time.Now().UTC().Format(time.RFC3339)
 
 	err := patchStatus(newTask, *status, client.GetCRDClient())
 

--- a/cloud/pkg/taskmanager/util/util.go
+++ b/cloud/pkg/taskmanager/util/util.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/distribution/distribution/v3/reference"
 	metav1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
 
@@ -41,8 +41,6 @@ const (
 	TaskRollback = "rollback"
 	TaskBackup   = "backup"
 	TaskPrePull  = "prepull"
-
-	ISO8601UTC = "2006-01-02T15:04:05Z"
 )
 
 type TaskMessage struct {

--- a/common/constants/default.go
+++ b/common/constants/default.go
@@ -174,5 +174,3 @@ const (
 	// DeviceTwin
 	DefaultDMISockPath = "/etc/kubeedge/dmi.sock"
 )
-
-const ISO8601UTC = "2006-01-02T15:04:05Z"

--- a/edge/pkg/devicetwin/dtmanager/device.go
+++ b/edge/pkg/devicetwin/dtmanager/device.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/beehive/pkg/core/model"
-	common "github.com/kubeedge/kubeedge/common/constants"
 	messagepkg "github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtclient"
@@ -99,7 +98,7 @@ func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg in
 	}
 	var lastOnline string
 	if state == dtcommon.DeviceStatusOnline || state == dtcommon.DeviceStatusOK {
-		lastOnline = time.Now().Format(common.ISO8601UTC)
+		lastOnline = time.Now().UTC().Format(time.RFC3339)
 	}
 	for i := 1; i <= dtcommon.RetryTimes; i++ {
 		err = dtclient.UpdateDeviceFields(

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -653,7 +653,7 @@ func ReportTaskResult(config *v1alpha2.EdgeCoreConfig, taskType, taskID string, 
 		NodeName: config.Modules.Edged.HostnameOverride,
 		Event:    event.Type,
 		Action:   event.Action,
-		Time:     time.Now().Format(constants.ISO8601UTC),
+		Time:     time.Now().UTC().Format(time.RFC3339),
 		Reason:   event.Msg,
 	}
 	edgeHub := config.Modules.EdgeHub

--- a/staging/src/github.com/kubeedge/api/apis/common/constants/default.go
+++ b/staging/src/github.com/kubeedge/api/apis/common/constants/default.go
@@ -174,5 +174,3 @@ const (
 	// DeviceTwin
 	DefaultDMISockPath = "/etc/kubeedge/dmi.sock"
 )
-
-const ISO8601UTC = "2006-01-02T15:04:05Z"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Using "2006-01-02T15:04:05Z" layout to format the time zone is not utc, the time zone will be lost.
```golang
// The time with Asia/ShangHai time zone is 2024-08-26T17:24:00Z.
// We lost the time zone now.
pt, err := time.Parse("2006-01-02T15:04:05Z", "2024-08-26T17:24:00Z")
fmt.Println(pt) // 2024-08-26 17:24:00 +0000 UTC
```

At this point, we can no longer support international time. Therefore, we use a layout that contains the time zone.
```golang
time.Now().UTC().Format(time.RFC3339)  // 2024-08-26T17:24:00Z
time.Now().Format(time.RFC3339)  // 2024-08-26T17:24:00+08:00

pt, err := time.Parse(time.RFC3339, "2024-08-26T17:24:00+08:00")
fmt.Println(pt)  // 2024-08-26 17:24:00 +0800 CST
fmt.Println(pt.UTC())  // 2024-08-26 09:24:00 +0000 UTC
```

So, we need to format the time using `time.Now().UTC().Format(time.RFC3339)` to support international time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
