### PR TITLE
Automated cherry pick of #5817: Make kubeedge time international

### DIFF
--- a/cloud/pkg/taskmanager/imageprepullcontroller/image_prepull_task.go
+++ b/cloud/pkg/taskmanager/imageprepullcontroller/image_prepull_task.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
-	"github.com/kubeedge/kubeedge/cloud/pkg/taskmanager/util"
 	fsmapi "github.com/kubeedge/kubeedge/pkg/apis/fsm/v1alpha1"
 	v1alpha12 "github.com/kubeedge/kubeedge/pkg/apis/fsm/v1alpha1"
 	"github.com/kubeedge/kubeedge/pkg/apis/operations/v1alpha1"
@@ -71,7 +70,7 @@ func updatePrePullNodeState(id, nodeName string, state v1alpha12.State, event fs
 					State:    state,
 					Event:    event.Type,
 					Action:   event.Action,
-					Time:     time.Now().Format(util.ISO8601UTC),
+					Time:     time.Now().UTC().Format(time.RFC3339),
 					Reason:   event.Msg,
 				},
 				ImageStatus: imagesStatus,
@@ -122,7 +121,7 @@ func updateUpgradeTaskState(id, _ string, state v1alpha12.State, event fsm.Event
 	status.Action = event.Action
 	status.Reason = event.Msg
 	status.State = state
-	status.Time = time.Now().Format(util.ISO8601UTC)
+	status.Time = time.Now().UTC().Format(time.RFC3339)
 
 	err := patchStatus(newTask, *status, client.GetCRDClient())
 

--- a/cloud/pkg/taskmanager/nodeupgradecontroller/upgrade_task.go
+++ b/cloud/pkg/taskmanager/nodeupgradecontroller/upgrade_task.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
-	"github.com/kubeedge/kubeedge/cloud/pkg/taskmanager/util"
 	fsmapi "github.com/kubeedge/kubeedge/pkg/apis/fsm/v1alpha1"
 	v1alpha12 "github.com/kubeedge/kubeedge/pkg/apis/fsm/v1alpha1"
 	"github.com/kubeedge/kubeedge/pkg/apis/operations/v1alpha1"
@@ -62,7 +61,7 @@ func updateUpgradeNodeState(id, nodeName string, state v1alpha12.State, event fs
 				State:    state,
 				Event:    event.Type,
 				Action:   event.Action,
-				Time:     time.Now().Format(util.ISO8601UTC),
+				Time:     time.Now().UTC().Format(time.RFC3339),
 				Reason:   event.Msg,
 			}
 			break
@@ -111,7 +110,7 @@ func updateUpgradeTaskState(id, _ string, state v1alpha12.State, event fsm.Event
 	status.Action = event.Action
 	status.Reason = event.Msg
 	status.State = state
-	status.Time = time.Now().Format(util.ISO8601UTC)
+	status.Time = time.Now().UTC().Format(time.RFC3339)
 
 	err := patchStatus(newTask, *status, client.GetCRDClient())
 

--- a/cloud/pkg/taskmanager/util/util.go
+++ b/cloud/pkg/taskmanager/util/util.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/distribution/distribution/v3/reference"
 	metav1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog/v2"
 
@@ -41,8 +41,6 @@ const (
 	TaskRollback = "rollback"
 	TaskBackup   = "backup"
 	TaskPrePull  = "prepull"
-
-	ISO8601UTC = "2006-01-02T15:04:05Z"
 )
 
 type TaskMessage struct {

--- a/edge/pkg/devicetwin/dtmanager/device.go
+++ b/edge/pkg/devicetwin/dtmanager/device.go
@@ -95,7 +95,7 @@ func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg in
 	default:
 		return nil
 	}
-	lastOnline := time.Now().Format("2006-01-02 15:04:05")
+	lastOnline := time.Now().UTC().Format(time.RFC3339)
 	for i := 1; i <= dtcommon.RetryTimes; i++ {
 		err = dtclient.UpdateDeviceFields(
 			device.ID,

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -47,7 +47,6 @@ import (
 	"github.com/kubeedge/kubeedge/common/constants"
 	commontypes "github.com/kubeedge/kubeedge/common/types"
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
-	"github.com/kubeedge/kubeedge/pkg/apis"
 	"github.com/kubeedge/kubeedge/pkg/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/util/fsm"
 	pkgversion "github.com/kubeedge/kubeedge/pkg/version"
@@ -654,7 +653,7 @@ func ReportTaskResult(config *v1alpha2.EdgeCoreConfig, taskType, taskID string, 
 		NodeName: config.Modules.Edged.HostnameOverride,
 		Event:    event.Type,
 		Action:   event.Action,
-		Time:     time.Now().Format(apis.ISO8601UTC),
+		Time:     time.Now().UTC().Format(time.RFC3339),
 		Reason:   event.Msg,
 	}
 	edgeHub := config.Modules.EdgeHub


### PR DESCRIPTION
Cherry pick of #5817 on release-1.17.

#5817: Make kubeedge time international

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.