### PR TITLE
Automated cherry pick of #5840: fix keadm lack of flag remote-runtime-endpoint

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/reset_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/reset_others.go
@@ -136,4 +136,6 @@ func TearDownEdgeCore() error {
 func addResetFlags(cmd *cobra.Command, resetOpts *common.ResetOptions) {
 	cmd.Flags().BoolVar(&resetOpts.Force, "force", resetOpts.Force,
 		"Reset the node without prompting for confirmation")
+	cmd.Flags().StringVar(&resetOpts.Endpoint, "remote-runtime-endpoint", resetOpts.Endpoint,
+		"Use this key to set container runtime endpoint")
 }

--- a/keadm/cmd/keadm/app/cmd/reset_others.go
+++ b/keadm/cmd/keadm/app/cmd/reset_others.go
@@ -145,6 +145,8 @@ func addResetFlags(cmd *cobra.Command, resetOpts *common.ResetOptions) {
 		"Use this key to set kube-config path, eg: $HOME/.kube/config")
 	cmd.Flags().BoolVar(&resetOpts.Force, "force", resetOpts.Force,
 		"Reset the node without prompting for confirmation")
+	cmd.Flags().StringVar(&resetOpts.Endpoint, "remote-runtime-endpoint", resetOpts.Endpoint,
+		"Use this key to set container runtime endpoint")
 }
 
 // TearDownKubeEdge will bring down either cloud or edge components,


### PR DESCRIPTION
Cherry pick of https://github.com/kubeedge/kubeedge/pull/5840 on release-1.18.

https://github.com/kubeedge/kubeedge/pull/5840: fix keadm lack of flag remote-runtime-endpoint

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.