### PR TITLE
Fix PersistentVolume data deleted at edge abnormally

### DIFF
--- a/edge/pkg/edged/kubeclientbridge/typed/core/v1/persistentvolume_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/core/v1/persistentvolume_bridge.go
@@ -41,5 +41,5 @@ type PersistentVolumesBridge struct {
 
 // Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
 func (c *PersistentVolumesBridge) Get(_ context.Context, name string, options metav1.GetOptions) (result *corev1.PersistentVolume, err error) {
-	return c.MetaClient.PersistentVolumes(metav1.NamespaceDefault).Get(name, options)
+	return c.MetaClient.PersistentVolumes().Get(name, options)
 }

--- a/edge/pkg/edged/kubeclientbridge/typed/storage/v1/volumeattachment_bridge_test.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/storage/v1/volumeattachment_bridge_test.go
@@ -57,15 +57,15 @@ func (f *mockMetaClient) VolumeAttachments(_ string) client.VolumeAttachmentsInt
 	return f.volumeAttachments
 }
 
-func (f *mockMetaClient) Pods(string) client.PodsInterface                           { return nil }
-func (f *mockMetaClient) PodStatus(string) client.PodStatusInterface                 { return nil }
-func (f *mockMetaClient) ConfigMaps(string) client.ConfigMapsInterface               { return nil }
-func (f *mockMetaClient) Nodes(string) client.NodesInterface                         { return nil }
-func (f *mockMetaClient) NodeStatus(string) client.NodeStatusInterface               { return nil }
-func (f *mockMetaClient) Secrets(string) client.SecretsInterface                     { return nil }
-func (f *mockMetaClient) ServiceAccountToken() client.ServiceAccountTokenInterface   { return nil }
-func (f *mockMetaClient) ServiceAccounts(string) client.ServiceAccountInterface      { return nil }
-func (f *mockMetaClient) PersistentVolumes(string) client.PersistentVolumesInterface { return nil }
+func (f *mockMetaClient) Pods(string) client.PodsInterface                         { return nil }
+func (f *mockMetaClient) PodStatus(string) client.PodStatusInterface               { return nil }
+func (f *mockMetaClient) ConfigMaps(string) client.ConfigMapsInterface             { return nil }
+func (f *mockMetaClient) Nodes(string) client.NodesInterface                       { return nil }
+func (f *mockMetaClient) NodeStatus(string) client.NodeStatusInterface             { return nil }
+func (f *mockMetaClient) Secrets(string) client.SecretsInterface                   { return nil }
+func (f *mockMetaClient) ServiceAccountToken() client.ServiceAccountTokenInterface { return nil }
+func (f *mockMetaClient) ServiceAccounts(string) client.ServiceAccountInterface    { return nil }
+func (f *mockMetaClient) PersistentVolumes() client.PersistentVolumesInterface     { return nil }
 func (f *mockMetaClient) PersistentVolumeClaims(string) client.PersistentVolumeClaimsInterface {
 	return nil
 }

--- a/edge/pkg/metamanager/client/metaclient.go
+++ b/edge/pkg/metamanager/client/metaclient.go
@@ -70,8 +70,8 @@ func (m *metaClient) PodStatus(namespace string) PodStatusInterface {
 }
 
 // New PersistentVolumes metaClient
-func (m *metaClient) PersistentVolumes(namespace string) PersistentVolumesInterface {
-	return newPersistentVolumes(namespace, m.send)
+func (m *metaClient) PersistentVolumes() PersistentVolumesInterface {
+	return newPersistentVolumes(m.send)
 }
 
 // New PersistentVolumeClaims metaClient

--- a/edge/pkg/metamanager/client/persistentvolume.go
+++ b/edge/pkg/metamanager/client/persistentvolume.go
@@ -10,11 +10,12 @@ import (
 	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	v2 "github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/v2"
 )
 
 // PersistentVolumesGetter is interface to get client PersistentVolumes
 type PersistentVolumesGetter interface {
-	PersistentVolumes(namespace string) PersistentVolumesInterface
+	PersistentVolumes() PersistentVolumesInterface
 }
 
 // PersistentVolumesInterface is interface for client PersistentVolumes
@@ -26,14 +27,12 @@ type PersistentVolumesInterface interface {
 }
 
 type persistentvolumes struct {
-	namespace string
-	send      SendInterface
+	send SendInterface
 }
 
-func newPersistentVolumes(n string, s SendInterface) *persistentvolumes {
+func newPersistentVolumes(s SendInterface) *persistentvolumes {
 	return &persistentvolumes{
-		namespace: n,
-		send:      s,
+		send: s,
 	}
 }
 
@@ -50,7 +49,7 @@ func (c *persistentvolumes) Delete(string) error {
 }
 
 func (c *persistentvolumes) Get(name string, _ metav1.GetOptions) (*api.PersistentVolume, error) {
-	resource := fmt.Sprintf("%s/%s/%s", c.namespace, "persistentvolume", name)
+	resource := fmt.Sprintf("%s/%s/%s", v2.NullNamespace, "persistentvolume", name)
 	pvMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
 	msg, err := c.send.SendSync(pvMsg)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:

SyncController  send delete persistentvolume msg to edge, causing persistentvolume data at edge deleted. When edge node restart, pod cannot query pv data successfully. 

**Reason**:

1. When edged query pv from cloud, mataclient sets a default ns in msg. 
2. In CloudHub https://github.com/kubeedge/kubeedge/blob/master/cloud/pkg/cloudhub/session/node_session.go#L381, it will be operated as a `NamespaceResource`,  CloudHub will create a corresponding objectSync for pv (ref: https://github.com/kubeedge/kubeedge/blob/master/cloud/pkg/cloudhub/session/node_session.go#L441).  But actually **it should create a clusterObjectSync for pv** because pv is a cluster resource. 
3. SyncController lists pv as a namespace resource but it cannot get pv by namespace, so it mistakenly thinking that the pv was deleted, and send a deletion msg to edge.   

**in this PR**:

set `null` namespace for pv msg

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/5060


