### PR TITLE
update default kubeedge version in keadm

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -120,7 +120,7 @@ const (
 	DefaultK8SMinimumVersion = 11
 
 	// DefaultKubeEdgeVersion is the default KubeEdge version, it must have no prefix 'v'
-	DefaultKubeEdgeVersion = "1.15.1"
+	DefaultKubeEdgeVersion = "1.18.0"
 
 	// Helm action
 	HelmInstallAction  = "install"

--- a/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
+++ b/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
@@ -124,7 +124,7 @@ func (c *CloudCoreHelmTool) Install(opts *types.InitOptions) error {
 		return fmt.Errorf("failed to verify k8s component installed, err: %v", err)
 	}
 
-	fmt.Println("Kubernetes version verification passed, KubeEdge installation will start...")
+	fmt.Printf("Kubernetes version verification passed, KubeEdge %s installation will start...\n", opts.KubeEdgeVersion)
 
 	appendDefaultSets(opts.KubeEdgeVersion, opts.AdvertiseAddress, &opts.CloudInitUpdateBase)
 	// Load profile values, and merges the sets flag


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind bug

**What this PR does / why we need it**:

When keadm runs without specifying a KubeEdge version, it defaults to installing version v1.15.1, which is outdated.

I suggest updating the default version to v1.18.0. Although the code will be released in v1.19.0, I believe v1.18.0 is more appropriate as it is more stable.



Test: all help information use v1.18.0
![image](https://github.com/user-attachments/assets/4a88a998-2f3b-41e0-83a2-a738c1995e5d)

Test:  In scenarios where both the  client version and the remote version provided by the KubeEdge website are unavailable, use the v1.18.0

![image](https://github.com/user-attachments/assets/c16e5efe-ff0c-48b1-b0bf-f8b36a94d175)

Test: mock remote verison fail suition , use client verison 
![image](https://github.com/user-attachments/assets/9e194a34-7d74-4507-a545-b437816d8a28)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/5851

**Special notes for your reviewer**:

When the remote version provided by the KubeEdge website is functioning, the KubeEdge version defaults to v1.15.1 if no specific version is specified.  but the condition will change after the https://github.com/kubeedge/website/pull/638 merge

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
