### PR TITLE
Automated cherry pick of #5800: Change apt source to fix container runtime CI failures

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -36,6 +36,11 @@ function install_cr() {
 
   while [ $attempt_num -lt $max_attempts ]
   do
+    if  [ $attempt_num -eq 3 ]; then
+      echo "Download failed multiple times, try to change apt source ..."
+      sudo sed -i 's@//.*archive.ubuntu.com@//mirrors.ustc.edu.cn@g' /etc/apt/sources.list
+      sudo apt-get update
+    fi
     if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
       install_docker
       verify_docker_installed


### PR DESCRIPTION
Cherry pick of https://github.com/kubeedge/kubeedge/pull/5800 on release-1.18.

https://github.com/kubeedge/kubeedge/pull/5800: Change apt source to fix container runtime CI failures

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.