### PR TITLE
Automated cherry pick of #5878: Specify the version for isulad. #5443: Add a retry mechanism to the container runtime e2e test #5800: changing apt source after multiple failures

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -90,7 +90,7 @@ verify_docker_installed() {
   # verify the docker installed
   command -v docker >/dev/null || {
     echo "must install the docker first"
-    exit 1
+    return 1
   }
 }
 
@@ -98,7 +98,7 @@ verify_cridockerd_installed() {
   # verify the cri-dockerd installed
   command -v cri-dockerd >/dev/null || {
     echo "must install the cri-dockerd first"
-    exit 1
+    return 1
   }
 }
 
@@ -106,7 +106,7 @@ verify_crio_installed() {
   # verify the cri-o installed
   command -v crio >/dev/null || {
     echo "must install the cri-o first"
-    exit 1
+    return 1
   }
 }
 
@@ -114,7 +114,7 @@ verify_isulad_installed() {
   # verify the isulad installed
   command -v isulad >/dev/null || {
     echo "must install the isulad first"
-    exit 1
+    return 1
   }
 }
 

--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -262,7 +262,7 @@ install_isulad() {
 
   # build lcr
   cd $BUILD_DIR
-  sudo git clone https://gitee.com/openeuler/lcr.git
+  sudo git clone https://gitee.com/openeuler/lcr.git -b v2.1.4
   cd lcr
   sudo mkdir build
   cd build
@@ -272,7 +272,7 @@ install_isulad() {
 
   # build and install clibcni
   cd $BUILD_DIR
-  sudo git clone https://gitee.com/openeuler/clibcni.git
+  sudo git clone https://gitee.com/openeuler/clibcni.git -b v2.1.0
   cd clibcni
   sudo mkdir build
   cd build
@@ -282,7 +282,7 @@ install_isulad() {
 
   # build and install iSulad
   cd $BUILD_DIR
-  sudo git clone https://gitee.com/openeuler/iSulad.git
+  sudo git clone https://gitee.com/openeuler/iSulad.git -b v2.1.5
   cd iSulad
   sudo mkdir build
   cd build

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -36,6 +36,11 @@ function install_cr() {
 
   while [ $attempt_num -lt $max_attempts ]
   do
+    if  [ $attempt_num -eq 3 ]; then
+      echo "Download failed multiple times, try to change apt source ..."
+      sudo sed -i 's@//.*archive.ubuntu.com@//mirrors.ustc.edu.cn@g' /etc/apt/sources.list
+      sudo apt-get update
+    fi
     if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
       install_docker
       verify_docker_installed

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -31,13 +31,65 @@ fi
 export CLUSTER_CONTEXT="--name ${CLUSTER_NAME}"
 
 function install_cr() {
-  if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
-    install_docker
-  elif [[ "${CONTAINER_RUNTIME}" = "cri-o" ]]; then
-    install_crio
-  elif [[ "${CONTAINER_RUNTIME}" = "isulad" ]]; then
-    install_isulad
+  attempt_num=0
+  max_attempts=5
+
+  while [ $attempt_num -lt $max_attempts ]
+  do
+    if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
+      install_docker
+      verify_docker_installed
+      if [ $? -ne 0 ]; then
+        # docker was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install docker failed. Retrying..."
+        continue
+      fi
+      verify_cridockerd_installed
+      if [ $? -ne 0 ]; then
+        # cri-dockerd was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install cri-dockerd failed. Retrying..."
+        continue
+      fi
+      echo "docker has been downloaded successfully"
+      break
+
+    elif [[ "${CONTAINER_RUNTIME}" = "cri-o" ]]; then
+      install_crio
+      verify_crio_installed
+      if [ $? -ne 0 ]; then
+        # crio was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install cri-o failed. Retrying..."
+        continue
+      fi
+      echo "cri-o has been downloaded successfully"
+      break
+
+    elif [[ "${CONTAINER_RUNTIME}" = "isulad" ]]; then
+      install_isulad
+      verify_isulad_installed
+      if [ $? -ne 0 ]; then
+        # isulad was not downloaded normally
+        attempt_num=$[$attempt_num+1]
+        echo "Install isulad failed. Retrying..."
+        continue
+      fi
+      echo "isulad has been downloaded successfully"
+      break
+    else
+      echo "No need to download container runtime"
+      break
+    fi
+  done
+
+  if [ $attempt_num -eq $max_attempts ]; then
+    # all retries failed
+    echo "Task failed after $max_attempts attempts."
+    exit 1
   fi
+
 }
 
 function check_prerequisites {


### PR DESCRIPTION
Cherry pick of #5878 #5443 #5800 on release-1.16.

#5878: Specify the version for isulad.
#5443: Add a retry mechanism to the container runtime e2e test
#5800: changing apt source after multiple failures

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.