### PR TITLE
Automated cherry pick of #5878: Specify the version for isulad. #5800: changing apt source after multiple failures

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -262,7 +262,7 @@ install_isulad() {
 
   # build lcr
   cd $BUILD_DIR
-  sudo git clone https://gitee.com/openeuler/lcr.git
+  sudo git clone https://gitee.com/openeuler/lcr.git -b v2.1.4
   cd lcr
   sudo mkdir build
   cd build
@@ -272,7 +272,7 @@ install_isulad() {
 
   # build and install clibcni
   cd $BUILD_DIR
-  sudo git clone https://gitee.com/openeuler/clibcni.git
+  sudo git clone https://gitee.com/openeuler/clibcni.git -b v2.1.0
   cd clibcni
   sudo mkdir build
   cd build
@@ -282,7 +282,7 @@ install_isulad() {
 
   # build and install iSulad
   cd $BUILD_DIR
-  sudo git clone https://gitee.com/openeuler/iSulad.git
+  sudo git clone https://gitee.com/openeuler/iSulad.git -b v2.1.5
   cd iSulad
   sudo mkdir build
   cd build

--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -36,6 +36,11 @@ function install_cr() {
 
   while [ $attempt_num -lt $max_attempts ]
   do
+    if  [ $attempt_num -eq 3 ]; then
+      echo "Download failed multiple times, try to change apt source ..."
+      sudo sed -i 's@//.*archive.ubuntu.com@//mirrors.ustc.edu.cn@g' /etc/apt/sources.list
+      sudo apt-get update
+    fi
     if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
       install_docker
       verify_docker_installed


### PR DESCRIPTION
Cherry pick of #5878 #5800 on release-1.17.

#5878: Specify the version for isulad.
#5800: changing apt source after multiple failures

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.