### PR TITLE
Skip kube-proxy during restarting edgecore.

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -185,10 +185,7 @@ func environmentCheck(skipCheck bool) error {
 		}
 		switch processName {
 		case "kubelet": // if kubelet is running, return error
-			return errors.New("kubelet should not running on edge node when running edgecore")
-		case "kube-proxy":
-			// kube-proxy pod does not conflict with edgecore, proceed to restart edgecore
-			klog.Infof("kube-proxy is running when restarting edgecore")
+			return errors.New("kubelet should not be running on edge node when starting edgecore")
 		}
 	}
 

--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -186,8 +186,9 @@ func environmentCheck(skipCheck bool) error {
 		switch processName {
 		case "kubelet": // if kubelet is running, return error
 			return errors.New("kubelet should not running on edge node when running edgecore")
-		case "kube-proxy": // if kube-proxy is running, return error
-			return errors.New("kube-proxy should not running on edge node when running edgecore")
+		case "kube-proxy":
+			// kube-proxy pod does not conflict with edgecore, proceed to restart edgecore
+			klog.Infof("kube-proxy is running when restarting edgecore")
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR is minor fix to skip checking `kube-proxy` when it restarts the edgecore.
Since `edgecore` and `kube-proxy` does not conflict each other, and lifecycle is not dependent, proceed to restart the edgecore.

**Which issue(s) this PR fixes**:

Fixes #5865 
