### PR TITLE
Add an action in the conformance CI to increase available disk space 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -420,7 +420,6 @@ jobs:
 
         - name: Install dependencies
           run: |
-            command -v ginkgo || go install github.com/onsi/ginkgo/v2/ginkgo@${{ env.GINKGO_VERSION }}
             go install sigs.k8s.io/kind@v0.22.0
             curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.29.5/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
@@ -428,9 +427,6 @@ jobs:
           uses: actions/checkout@v4
           with:
             fetch-depth: 0
-
-        - name: Cleanup images
-          run: docker system prune -a -f
 
         - name: Retrieve saved kubeedge/build-tools image
           uses: actions/download-artifact@v4
@@ -441,10 +437,22 @@ jobs:
         - name: Docker load kubeedge/build-tools image
           run: |
             docker load < /home/runner/build-tools/build-tools.tar
+            rm -rf /home/runner/build-tools/build-tools.tar
 
         - name: Enable cri config in containerd service
           run: |
             containerd config default | sudo tee /etc/containerd/config.toml && sudo systemctl restart containerd.service
+
+        - name: Free Disk Space
+          uses: jlumbroso/free-disk-space@main
+          with:
+            tool-cache: false
+            android: true
+            dotnet: true
+            haskell: true
+            large-packages: true
+            docker-images: true
+            swap-storage: true
 
         - name: Run conformance e2e
           run: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Add an action in the conformance CI to increase available disk space to prevent test execution failures due to insufficient disk capacity.

ref #5774
https://github.com/kubeedge/kubeedge/actions/runs/11026517530/job/30634159887?pr=5774

As follows, there may be issues with test failures due to disk pressure：
```yaml
status:
            conditions:
            - lastProbeTime: null
              lastTransitionTime: "2024-09-25T05:44:10Z"
              message: '0/2 nodes are available: 1 node(s) had untolerated taint {node.kubeedge.io/conformance:
                remove-when-completed}, 1 node(s) had untolerated taint {node.kubernetes.io/disk-pressure:
                }. preemption: 0/2 nodes are available: 2 Preemption is not helpful for scheduling.'
              reason: Unschedulable
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Before cleanup:
```bash
$ dh -h /

Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   54G   20G  74% /
```

After cleanup:
```bash
+ df -Th
Filesystem     Type   Size  Used Avail Use% Mounted on
/dev/root      ext4    73G   28G   45G  39% /
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
