### PR TITLE
Support offline-operations of data surface resources

### DIFF
--- a/LICENSES/vendor/github.com/fatih/camelcase/LICENSE
+++ b/LICENSES/vendor/github.com/fatih/camelcase/LICENSE
@@ -1,0 +1,24 @@
+= vendor/github.com/fatih/camelcase licensed under: =
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+= vendor/github.com/fatih/camelcase/LICENSE.md 4c59b216ce25dc182cdb837e07ba07c0

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -123,3 +123,14 @@ type NodeUpgradeConfirmResponse struct {
 	ErrMessages []string `json:"errMessages,omitempty"`
 	LogMessages []string `json:"logMessages,omitempty"`
 }
+
+type LogsResponse struct {
+	ErrMessages []string `json:"errMessages,omitempty"`
+	LogMessages []string `json:"logMessages,omitempty"`
+}
+
+type ExecResponse struct {
+	ErrMessages    []string `json:"errMessages,omitempty"`
+	RunOutMessages []string `json:"runOutMessages,omitempty"`
+	RunErrMessages []string `json:"runErrMessages,omitempty"`
+}

--- a/edge/pkg/devicetwin/process.go
+++ b/edge/pkg/devicetwin/process.go
@@ -270,7 +270,7 @@ func classifyMsg(message *dttype.DTMessage) bool {
 			return true
 		}
 		return false
-	} else if strings.Compare(msgSource, "meta") == 0 {
+	} else if strings.Compare(msgSource, "meta") == 0 || strings.Compare(msgSource, "metamanager") == 0 {
 		switch message.Msg.Content.(type) {
 		case []byte:
 			klog.Info("Message content type is []byte, no need to marshal again")

--- a/edge/pkg/metamanager/metaserver/common/types.go
+++ b/edge/pkg/metamanager/metaserver/common/types.go
@@ -4,3 +4,27 @@ type RestartInfo struct {
 	Namespace string
 	PodNames  []string
 }
+
+type LogsInfo struct {
+	Namespace                    string `query:"-"`
+	PodName                      string `query:"-"`
+	ContainerName                string `query:"-"`
+	TailLines                    string `query:"tailLines"`
+	Follow                       string `query:"follow"`
+	InsecureSkipTLSVerifyBackend string `query:"insecureSkipTLSVerifyBackend"`
+	LimitBytes                   string `query:"limitBytes"`
+	Pretty                       string `query:"pretty"`
+	SinceSeconds                 string `query:"sinceSeconds"`
+	Timestamps                   string `query:"timestamps"`
+}
+
+type ExecInfo struct {
+	Namespace string
+	PodName   string
+	Container string
+	Commands  []string
+	Stdin     bool
+	Stdout    bool
+	Stderr    bool
+	TTY       bool
+}

--- a/edge/pkg/metamanager/metaserver/handlerfactory/ext_handler.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/ext_handler.go
@@ -1,11 +1,15 @@
 package handlerfactory
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os/exec"
 
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/common/types"
@@ -15,6 +19,10 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/upgradedb"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/common"
 	"github.com/kubeedge/kubeedge/pkg/version"
+)
+
+const (
+	trueStr = "true"
 )
 
 func (f *Factory) Restart(namespace string) http.Handler {
@@ -52,6 +60,7 @@ func (f *Factory) Restart(namespace string) http.Handler {
 	})
 	return h
 }
+
 func (f *Factory) ConfirmUpgrade() http.Handler {
 	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		klog.Info("Begin to run upgrade command")
@@ -84,6 +93,143 @@ func (f *Factory) ConfirmUpgrade() http.Handler {
 		err = upgradedb.DeleteNodeUpgradeJobRequestFromMetaV2()
 		if err != nil {
 			klog.Errorf("Failed to delete NodeUpgradeJobRequest%s", err.Error())
+		}
+	})
+	return h
+}
+
+func (f *Factory) Logs(request *request.RequestInfo) http.Handler {
+	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		queryParams := req.URL.Query()
+
+		containerName := queryParams.Get("container")
+		follow := queryParams.Get("follow")
+		tailLines := queryParams.Get("tailLines")
+		insecureSkipTLSVerifyBackend := queryParams.Get("insecureSkipTLSVerifyBackend")
+		limitBytes := queryParams.Get("limitBytes")
+		pretty := queryParams.Get("pretty")
+		sinceSeconds := queryParams.Get("sinceSeconds")
+		timestamps := queryParams.Get("timestamps")
+
+		logsInfo := common.LogsInfo{
+			PodName:                      request.Name,
+			Namespace:                    request.Namespace,
+			ContainerName:                containerName,
+			Follow:                       follow,
+			TailLines:                    tailLines,
+			InsecureSkipTLSVerifyBackend: insecureSkipTLSVerifyBackend,
+			LimitBytes:                   limitBytes,
+			Pretty:                       pretty,
+			SinceSeconds:                 sinceSeconds,
+			Timestamps:                   timestamps,
+		}
+
+		logsResponse, res := f.storage.Logs(req.Context(), logsInfo)
+		if res == nil {
+			http.Error(w, "Failed to get logs from edged", http.StatusInternalServerError)
+			return
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			http.Error(w, fmt.Sprintf("Unexpected status code from edged: %d", res.StatusCode), http.StatusInternalServerError)
+			return
+		}
+
+		if logsInfo.Follow != "true" {
+			buf := &bytes.Buffer{}
+			if _, err := io.Copy(buf, res.Body); err != nil {
+				errMessage := fmt.Sprintf("failed to read logs with err:%v\n", err)
+				klog.Warningf("[metaserver/logs] %v", errMessage)
+				logsResponse.ErrMessages = append(logsResponse.ErrMessages, errMessage)
+			}
+
+			logsResponse.LogMessages = append(logsResponse.LogMessages, buf.String())
+
+			logsResBytes, err := json.Marshal(logsResponse)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(logsResBytes)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			// Logs are streamed
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Transfer-Encoding", "chunked")
+			w.WriteHeader(http.StatusOK)
+
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+				return
+			}
+
+			scanner := bufio.NewScanner(res.Body)
+			for scanner.Scan() {
+				fmt.Fprintln(w, scanner.Text())
+				flusher.Flush()
+			}
+
+			if err := scanner.Err(); err != nil {
+				http.Error(w, fmt.Sprintf("Error reading logs: %v", err), http.StatusInternalServerError)
+				return
+			}
+		}
+	})
+	return h
+}
+
+func (f *Factory) Exec(request *request.RequestInfo) http.Handler {
+	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		queryparams := req.URL.Query()
+
+		commands := queryparams["command"]
+		container := queryparams.Get("container")
+		stdinStr := queryparams.Get("stdin")
+		stdoutStr := queryparams.Get("stdout")
+		stderrStr := queryparams.Get("stderr")
+		ttyStr := queryparams.Get("tty")
+
+		stdin := stdinStr == trueStr
+		stdout := stdoutStr == trueStr
+		stderr := stderrStr == trueStr
+		tty := ttyStr == trueStr
+
+		execInfo := common.ExecInfo{
+			Namespace: request.Namespace,
+			PodName:   request.Name,
+			Container: container,
+			Commands:  commands,
+			Stdin:     stdin,
+			Stdout:    stdout,
+			Stderr:    stderr,
+			TTY:       tty,
+		}
+
+		execResponse, handler := f.storage.Exec(req.Context(), execInfo)
+
+		if handler != nil {
+			handler.ServeHTTP(w, req)
+		} else {
+			execResBytes, err := json.Marshal(execResponse)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(execResBytes)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 		}
 	})
 	return h

--- a/edge/pkg/metamanager/metaserver/handlerfactory/ext_handler_test.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/ext_handler_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlerfactory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/common"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage"
+)
+
+func TestLogs(t *testing.T) {
+	type testCase struct {
+		requestInfo            *request.RequestInfo
+		queryParams            string
+		isGetLogsFail          bool
+		isUnexpectedStatusCode bool
+		isStreamingErr         bool
+	}
+
+	cases := testCase{}
+
+	patch := gomonkey.NewPatches()
+	defer patch.Reset()
+
+	f := NewFactory()
+
+	patch.ApplyMethod(reflect.TypeOf(f.storage), "Logs", func(s *storage.REST, ctx context.Context, info common.LogsInfo) (*types.LogsResponse, *http.Response) {
+		if cases.isGetLogsFail {
+			return &types.LogsResponse{
+				LogMessages: []string{},
+				ErrMessages: []string{"failed to get logs for container"},
+			}, nil
+		}
+		if cases.isUnexpectedStatusCode {
+			return &types.LogsResponse{}, &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+			}
+		}
+
+		if cases.queryParams == "follow=true" {
+			if cases.isStreamingErr {
+				return &types.LogsResponse{}, &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+				}
+			}
+			return &types.LogsResponse{}, &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("log line 1\nlog line 2\n")),
+			}
+		}
+		return &types.LogsResponse{
+				LogMessages: []string{},
+				ErrMessages: []string{},
+			}, &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewBufferString("log line 1\nlog line 2\n")),
+			}
+	})
+
+	tests := []struct {
+		name           string
+		cases          testCase
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name: "Logs with success response",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams: "",
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"logMessages":["log line 1\nlog line 2\n"],"errMessages":null}`,
+		},
+		{
+			name: "Logs(follow) with success response",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams: "follow=true",
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "log line 1\nlog line 2\n",
+		},
+		{
+			name: "Logs with get logs fail",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams:   "",
+				isGetLogsFail: true,
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "Failed to get logs from edged\n",
+		},
+		{
+			name: "Logs with unexpected status code",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams:            "",
+				isUnexpectedStatusCode: true,
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   fmt.Sprintf("Unexpected status code from edged: %d\n", http.StatusInternalServerError),
+		},
+		{
+			name: "Logs with streaming error",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams:    "follow=true",
+				isStreamingErr: true,
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/logs?"+tt.cases.queryParams, nil)
+			w := httptest.NewRecorder()
+
+			cases = tt.cases
+
+			handler := f.Logs(tt.cases.requestInfo)
+			handler.ServeHTTP(w, req)
+
+			resp := w.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+			if tt.expectedStatus == http.StatusOK && tt.cases.queryParams == "follow=true" {
+				assert.Equal(t, tt.expectedBody, string(body))
+			} else if tt.expectedStatus == http.StatusInternalServerError {
+				assert.Equal(t, tt.expectedBody, string(body))
+			} else {
+				var logsResponse types.LogsResponse
+				err := json.Unmarshal(body, &logsResponse)
+				assert.NoError(t, err)
+				expectedResponse := types.LogsResponse{}
+				if err = json.Unmarshal([]byte(tt.expectedBody), &expectedResponse); err != nil {
+					t.Errorf("failed to unmarshal expected body: %v", err)
+				}
+				assert.Equal(t, expectedResponse, logsResponse)
+			}
+		})
+	}
+}
+
+func TestExec(t *testing.T) {
+	type testCase struct {
+		requestInfo    *request.RequestInfo
+		queryParams    string
+		isExecFail     bool
+		isHandlerExist bool
+	}
+
+	cases := testCase{}
+
+	patch := gomonkey.NewPatches()
+	defer patch.Reset()
+
+	f := NewFactory()
+
+	patch.ApplyMethod(reflect.TypeOf(f.storage), "Exec", func(s *storage.REST, ctx context.Context, info common.ExecInfo) (*types.ExecResponse, http.Handler) {
+		if cases.isExecFail {
+			return &types.ExecResponse{
+				ErrMessages: []string{"failed to exec command in container"},
+			}, nil
+		}
+		if cases.isHandlerExist {
+			return &types.ExecResponse{}, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("handler response"))
+			})
+		}
+		return &types.ExecResponse{
+			ErrMessages:    []string{},
+			RunOutMessages: []string{"exec output"},
+			RunErrMessages: []string{},
+		}, nil
+	})
+
+	tests := []struct {
+		name           string
+		cases          testCase
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name: "Exec with success response",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams: "command=ls&container=test-container&stdout=true",
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"runOutMessages":["exec output"], "runErrMessages":null, "errMessages":null}`,
+		},
+		{
+			name: "Exec with handler response",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams:    "command=ls&container=test-container&stdout=true&tty=true&stdin=true",
+				isHandlerExist: true,
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   "handler response",
+		},
+		{
+			name: "Exec with exec fail",
+			cases: testCase{
+				requestInfo: &request.RequestInfo{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				queryParams: "command=ls&container=test-container&stdout=true",
+				isExecFail:  true,
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"runOutMessages":null,"runErrMessages":null,"errMessages":["failed to exec command in container"]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/exec?"+tt.cases.queryParams, nil)
+			w := httptest.NewRecorder()
+
+			cases = tt.cases
+
+			handler := f.Exec(tt.cases.requestInfo)
+			handler.ServeHTTP(w, req)
+
+			resp := w.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+
+			assert.Equal(t, tt.expectedStatus, resp.StatusCode)
+			if tt.expectedStatus == http.StatusOK && tt.cases.isHandlerExist {
+				assert.Equal(t, tt.expectedBody, string(body))
+			} else if tt.expectedStatus == http.StatusInternalServerError {
+				assert.Equal(t, tt.expectedBody, string(body))
+			} else {
+				var execResponse types.ExecResponse
+				err := json.Unmarshal(body, &execResponse)
+				assert.NoError(t, err)
+				expectedResponse := types.ExecResponse{}
+				if err = json.Unmarshal([]byte(tt.expectedBody), &expectedResponse); err != nil {
+					t.Errorf("failed to unmarshal expected body: %v", err)
+				}
+				assert.Equal(t, expectedResponse, execResponse)
+			}
+		})
+	}
+}

--- a/edge/pkg/metamanager/metaserver/handlerfactory/handler.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/handler.go
@@ -2,8 +2,10 @@ package handlerfactory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -21,6 +23,11 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/constants"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/fakers"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/scope"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage"
@@ -101,6 +108,10 @@ func (f *Factory) getHandler(key string) (http.Handler, bool) {
 }
 
 func (f *Factory) Update(req *request.RequestInfo) http.Handler {
+	if req.Resource == "devices" {
+		h := updateEdgeDevice()
+		return h
+	}
 	s := scope.NewRequestScope()
 	s.Kind = schema.GroupVersionKind{
 		Group:   req.APIGroup,
@@ -108,6 +119,56 @@ func (f *Factory) Update(req *request.RequestInfo) http.Handler {
 		Kind:    util.UnsafeResourceToKind(req.Resource),
 	}
 	h := handlers.UpdateResource(f.storage, s, fakers.NewAlwaysAdmit())
+	return h
+}
+
+func updateEdgeDevice() http.Handler {
+	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		var device *v1beta1.Device
+		if err := json.Unmarshal(body, &device); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		source := modules.MetaManagerModuleName
+		target := modules.DeviceTwinModuleName
+		resourece := device.Namespace + "/device/updated"
+
+		operation := model.UpdateOperation
+
+		device.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   v1beta1.GroupName,
+			Version: v1beta1.Version,
+			Kind:    constants.KindTypeDevice,
+		})
+		modelMsg := model.NewMessage("").
+			SetResourceVersion(device.ResourceVersion).
+			FillBody(device)
+		modelMsg.BuildRouter(source, target, resourece, operation)
+		resp, err := beehiveContext.SendSync(source, *modelMsg, 1*time.Minute)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		respData, err := resp.GetContentData()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(respData)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
 	return h
 }
 

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/restful/request.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/restful/request.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restful
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strconv"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/edged/config"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/common"
+)
+
+const (
+	CONTAINERLOGS string = "/containerLogs"
+)
+
+type Request struct {
+	Method string
+	Path   string
+	Body   io.Reader
+}
+
+func LogsRequest(namespace string, podName string, containerName string, logsInfo common.LogsInfo) *Request {
+	queryString, err := structToQueryString(logsInfo)
+	if err != nil {
+		return nil
+	}
+	return &Request{
+		Method: http.MethodGet,
+		Path:   "/" + CONTAINERLOGS + "/" + namespace + "/" + podName + "/" + containerName + "?" + queryString,
+	}
+}
+
+// structToQueryString converts a struct to a query string
+func structToQueryString(s interface{}) (string, error) {
+	v := reflect.ValueOf(s)
+	t := reflect.TypeOf(s)
+
+	values := url.Values{}
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+		tag := fieldType.Tag.Get("query")
+
+		if fieldType.Name == "Namespace" || fieldType.Name == "PodName" || fieldType.Name == "ContainerName" {
+			continue
+		}
+
+		if field.IsZero() {
+			continue
+		}
+
+		switch field.Kind() {
+		case reflect.String:
+			values.Add(tag, field.String())
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			values.Add(tag, strconv.FormatInt(field.Int(), 10))
+		}
+	}
+	return values.Encode(), nil
+}
+
+func (req *Request) RestfulRequest() (*http.Response, error) {
+	var client http.Client
+	edgedAddress := config.Config.Edged.TailoredKubeletConfig.Address
+	edgedPort := config.Config.Edged.TailoredKubeletConfig.ReadOnlyPort
+	port := strconv.Itoa(int(edgedPort))
+
+	url := "http://" + edgedAddress + ":" + port
+	client = http.Client{}
+
+	request, err := http.NewRequest(req.Method, url+req.Path, req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("restful format failed with err: %v", err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("restful request failed with err: %v", err)
+	}
+	return response, nil
+}

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/storage_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/storage_test.go
@@ -4,19 +4,30 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/agiledragon/gomonkey"
+	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	cri "k8s.io/cri-api/pkg/apis"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cri/remote"
 
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/common/types"
 	connect "github.com/kubeedge/kubeedge/edge/pkg/common/cloudconnection"
+	"github.com/kubeedge/kubeedge/edge/pkg/edged/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/agent"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/common"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/restful"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator"
 	fakeclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake"
 	"github.com/kubeedge/kubeedge/pkg/metaserver"
@@ -125,4 +136,570 @@ func TestREST_PassThrough(t *testing.T) {
 			}
 		})
 	}
+}
+func TestREST_Exec(t *testing.T) {
+	type testCase struct {
+		execInfo               common.ExecInfo
+		isEdgedEnabled         bool
+		isRemoteRuntimeService bool
+		isListContainersFailed bool
+		isExecSyncFailed       bool
+		isExecFailed           bool
+		isParseExecURLFailed   bool
+		expectedExecResponse   *types.ExecResponse
+		expectedHandlerNotNil  bool
+	}
+
+	cases := testCase{}
+
+	patch := gomonkey.NewPatches()
+	defer patch.Reset()
+
+	patch.ApplyGlobalVar(&config.Config, config.Configure{
+		Edged: v1alpha2.Edged{
+			Enable: true,
+			TailoredKubeletConfig: &v1alpha2.TailoredKubeletConfiguration{
+				ContainerRuntimeEndpoint: "",
+			},
+		},
+	}).ApplyFunc(remote.NewRemoteRuntimeService, func(endpoint string, timeout time.Duration, tracerProvider trace.TracerProvider) (cri.RuntimeService, error) {
+		if !cases.isRemoteRuntimeService {
+			return nil, fmt.Errorf("err in NewRemoteRuntimeService")
+		}
+		return &fakeRuntimeService{
+			ListContainersF: func(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+				if cases.isListContainersFailed {
+					return nil, fmt.Errorf("err in ListContainers")
+				}
+				return []*runtimeapi.Container{
+					{
+						Id: "container-id",
+						Metadata: &runtimeapi.ContainerMetadata{
+							Name: "container-name",
+						},
+					},
+				}, nil
+			},
+			ExecSyncF: func(ctx context.Context, containerID string, cmd []string, timeout time.Duration) ([]byte, []byte, error) {
+				if cases.isExecSyncFailed {
+					return nil, nil, fmt.Errorf("err in ExecSync")
+				}
+				return []byte("stdout"), []byte("stderr"), nil
+			},
+			ExecF: func(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+				if cases.isExecFailed {
+					return nil, fmt.Errorf("err in Exec")
+				}
+				return &runtimeapi.ExecResponse{
+					Url: "http://localhost:8080/exec",
+				}, nil
+			},
+		}, nil
+	}).ApplyFunc(url.Parse, func(rawURL string) (*url.URL, error) {
+		if cases.isParseExecURLFailed {
+			return nil, fmt.Errorf("err in Parse")
+		}
+		return &url.URL{}, nil
+	})
+
+	var tests = []struct {
+		name    string
+		rest    *REST
+		cases   testCase
+		want    *types.ExecResponse
+		wantErr bool
+	}{
+		{
+			name: "test commands not specified",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+				},
+				isEdgedEnabled: true,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{"You must specify at least one command for the container"},
+					RunOutMessages: []string{},
+					RunErrMessages: []string{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test remote runtime service failed",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+					Commands:  []string{"ls"},
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: false,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{"new remote runtimeservice with err: err in NewRemoteRuntimeService"},
+					RunOutMessages: []string{},
+					RunErrMessages: []string{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test list containers failed",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+					Commands:  []string{"ls"},
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				isListContainersFailed: true,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{"failed to list containers: err in ListContainers"},
+					RunOutMessages: []string{},
+					RunErrMessages: []string{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test exec sync failed",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+					Commands:  []string{"ls"},
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				isExecSyncFailed:       true,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{"failed to exec command [ls] for container container-name for pod \"/default/pod-name\" with err:err in ExecSync"},
+					RunOutMessages: []string{},
+					RunErrMessages: []string{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test exec failed",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+					Commands:  []string{"ls"},
+					TTY:       true,
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				isExecFailed:           true,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{"failed to exec command [ls] for container container-name for pod \"/default/pod-name\" with err:err in Exec"},
+					RunOutMessages: []string{},
+					RunErrMessages: []string{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test parse exec url failed",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+					Commands:  []string{"ls"},
+					TTY:       true,
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				isParseExecURLFailed:   true,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{"failed to parse exec url with err:err in Parse"},
+					RunOutMessages: []string{},
+					RunErrMessages: []string{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "test exec sync success",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+					Commands:  []string{"ls"},
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{},
+					RunOutMessages: []string{"stdout"},
+					RunErrMessages: []string{"stderr"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test exec success",
+			cases: testCase{
+				execInfo: common.ExecInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+					Container: "container-name",
+					Commands:  []string{"ls"},
+					TTY:       true,
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				expectedExecResponse: &types.ExecResponse{
+					ErrMessages:    []string{},
+					RunOutMessages: []string{},
+					RunErrMessages: []string{},
+				},
+				expectedHandlerNotNil: true,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rest := &REST{}
+			cases = tt.cases
+			got, handler := rest.Exec(context.TODO(), tt.cases.execInfo)
+			if !reflect.DeepEqual(got, tt.cases.expectedExecResponse) {
+				t.Errorf("Exec() got = %v, want %v", got, tt.cases.expectedExecResponse)
+			}
+			if (handler != nil) != tt.cases.expectedHandlerNotNil {
+				t.Errorf("Exec() handler = %v, want %v", handler != nil, tt.cases.expectedHandlerNotNil)
+			}
+		})
+	}
+}
+
+func TestREST_Logs(t *testing.T) {
+	type testCase struct {
+		logsInfo                common.LogsInfo
+		isEdgedEnabled          bool
+		isRemoteRuntimeService  bool
+		isListContainersFailed  bool
+		isNoContainersFound     bool
+		isRestfulRequestFailed  bool
+		expectedLogsResponse    *types.LogsResponse
+		expectedHTTPResponseNil bool
+	}
+
+	cases := testCase{}
+
+	patch := gomonkey.NewPatches()
+	defer patch.Reset()
+
+	req := &restful.Request{}
+
+	patch.ApplyGlobalVar(&config.Config, config.Configure{
+		Edged: v1alpha2.Edged{
+			Enable: true,
+			TailoredKubeletConfig: &v1alpha2.TailoredKubeletConfiguration{
+				ContainerRuntimeEndpoint: "",
+			},
+		},
+	}).ApplyFunc(remote.NewRemoteRuntimeService, func(endpoint string, timeout time.Duration, tracerProvider trace.TracerProvider) (cri.RuntimeService, error) {
+		if !cases.isRemoteRuntimeService {
+			return nil, fmt.Errorf("err in NewRemoteRuntimeService")
+		}
+		return &fakeRuntimeService{
+			ListContainersF: func(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+				if cases.isListContainersFailed {
+					return nil, fmt.Errorf("err in ListContainers")
+				}
+				if cases.isNoContainersFound {
+					return []*runtimeapi.Container{}, nil
+				}
+				return []*runtimeapi.Container{
+					{
+						Id: "container-id",
+						Metadata: &runtimeapi.ContainerMetadata{
+							Name: "container-name",
+						},
+					},
+				}, nil
+			},
+		}, nil
+	}).ApplyMethod(reflect.TypeOf(req), "RestfulRequest", func(_ *restful.Request) (*http.Response, error) {
+		if cases.isRestfulRequestFailed {
+			return nil, fmt.Errorf("err in RestfulRequest")
+		}
+		return &http.Response{}, nil
+	})
+
+	var tests = []struct {
+		name    string
+		rest    *REST
+		cases   testCase
+		want    *types.LogsResponse
+		wantErr bool
+	}{
+		{
+			name: "test remote runtime service failed",
+			cases: testCase{
+				logsInfo: common.LogsInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: false,
+				expectedLogsResponse: &types.LogsResponse{
+					ErrMessages: []string{"new remote runtimeservice with err: err in NewRemoteRuntimeService"},
+					LogMessages: []string{},
+				},
+				expectedHTTPResponseNil: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "test list containers failed",
+			cases: testCase{
+				logsInfo: common.LogsInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				isListContainersFailed: true,
+				expectedLogsResponse: &types.LogsResponse{
+					ErrMessages: []string{"failed to list containers: err in ListContainers"},
+					LogMessages: []string{},
+				},
+				expectedHTTPResponseNil: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "test no containers found",
+			cases: testCase{
+				logsInfo: common.LogsInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				isNoContainersFound:    true,
+				expectedLogsResponse: &types.LogsResponse{
+					ErrMessages: []string{"not found pod:\"/default/pod-name\""},
+					LogMessages: []string{},
+				},
+				expectedHTTPResponseNil: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "test restful request failed",
+			cases: testCase{
+				logsInfo: common.LogsInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				isRestfulRequestFailed: true,
+				expectedLogsResponse: &types.LogsResponse{
+					ErrMessages: []string{"failed to get logs for container container-name for pod \"/default/pod-name\" with err:err in RestfulRequest"},
+					LogMessages: []string{},
+				},
+				expectedHTTPResponseNil: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "test logs success",
+			cases: testCase{
+				logsInfo: common.LogsInfo{
+					Namespace: "default",
+					PodName:   "pod-name",
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				expectedLogsResponse: &types.LogsResponse{
+					ErrMessages: []string{},
+					LogMessages: []string{},
+				},
+				expectedHTTPResponseNil: false,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rest := &REST{}
+			cases = tt.cases
+			got, res := rest.Logs(context.TODO(), tt.cases.logsInfo)
+			if !reflect.DeepEqual(got, tt.cases.expectedLogsResponse) {
+				t.Errorf("Logs() got = %v, want %v", got, tt.cases.expectedLogsResponse)
+			}
+			if (res == nil) != tt.cases.expectedHTTPResponseNil {
+				t.Errorf("Logs() res = %v, want %v", res == nil, tt.cases.expectedHTTPResponseNil)
+			}
+		})
+	}
+}
+
+type fakeRuntimeService struct {
+	VersionF                  func(ctx context.Context, apiVersion string) (*runtimeapi.VersionResponse, error)
+	CreateContainerF          func(ctx context.Context, podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
+	StartContainerF           func(ctx context.Context, containerID string) error
+	StopContainerF            func(ctx context.Context, containerID string, timeout int64) error
+	RemoveContainerF          func(ctx context.Context, containerID string) error
+	ListContainersF           func(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
+	ContainerStatusF          func(ctx context.Context, containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error)
+	UpdateContainerResourcesF func(ctx context.Context, containerID string, resources *runtimeapi.ContainerResources) error
+	ExecSyncF                 func(ctx context.Context, containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error)
+	ExecF                     func(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error)
+	AttachF                   func(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error)
+	ReopenContainerLogF       func(ctx context.Context, ContainerID string) error
+	CheckpointContainerF      func(ctx context.Context, options *runtimeapi.CheckpointContainerRequest) error
+	GetContainerEventsF       func(containerEventsCh chan *runtimeapi.ContainerEventResponse) error
+	RunPodSandboxF            func(ctx context.Context, config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error)
+	StopPodSandboxF           func(ctx context.Context, podSandboxID string) error
+	RemovePodSandboxF         func(ctx context.Context, podSandboxID string) error
+	PodSandboxStatusF         func(ctx context.Context, podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error)
+	ListPodSandboxF           func(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error)
+	PortForwardF              func(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error)
+	ContainerStatsF           func(ctx context.Context, containerID string) (*runtimeapi.ContainerStats, error)
+	ListContainerStatsF       func(ctx context.Context, filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error)
+	PodSandboxStatsF          func(ctx context.Context, podSandboxID string) (*runtimeapi.PodSandboxStats, error)
+	ListPodSandboxStatsF      func(ctx context.Context, filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error)
+	ListMetricDescriptorsF    func(ctx context.Context) ([]*runtimeapi.MetricDescriptor, error)
+	ListPodSandboxMetricsF    func(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error)
+	UpdateRuntimeConfigF      func(ctx context.Context, runtimeConfig *runtimeapi.RuntimeConfig) error
+	StatusF                   func(ctx context.Context, verbose bool) (*runtimeapi.StatusResponse, error)
+	RuntimeConfigF            func(ctx context.Context) (*runtimeapi.RuntimeConfigResponse, error)
+	ImageFsInfoF              func(ctx context.Context) (*runtimeapi.ImageFsInfoResponse, error)
+}
+
+func (f *fakeRuntimeService) Version(ctx context.Context, apiVersion string) (*runtimeapi.VersionResponse, error) {
+	return f.VersionF(ctx, apiVersion)
+}
+
+func (f *fakeRuntimeService) CreateContainer(ctx context.Context, podSandboxID string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) (string, error) {
+	return f.CreateContainerF(ctx, podSandboxID, config, sandboxConfig)
+}
+
+func (f *fakeRuntimeService) StartContainer(ctx context.Context, containerID string) error {
+	return f.StartContainerF(ctx, containerID)
+}
+
+func (f *fakeRuntimeService) StopContainer(ctx context.Context, containerID string, timeout int64) error {
+	return f.StopContainerF(ctx, containerID, timeout)
+}
+
+func (f *fakeRuntimeService) RemoveContainer(ctx context.Context, containerID string) error {
+	return f.RemoveContainerF(ctx, containerID)
+}
+
+func (f *fakeRuntimeService) ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	return f.ListContainersF(ctx, filter)
+}
+
+func (f *fakeRuntimeService) ContainerStatus(ctx context.Context, containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error) {
+	return f.ContainerStatusF(ctx, containerID, verbose)
+}
+
+func (f *fakeRuntimeService) UpdateContainerResources(ctx context.Context, containerID string, resources *runtimeapi.ContainerResources) error {
+	return f.UpdateContainerResourcesF(ctx, containerID, resources)
+}
+
+func (f *fakeRuntimeService) ExecSync(ctx context.Context, containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
+	return f.ExecSyncF(ctx, containerID, cmd, timeout)
+}
+
+func (f *fakeRuntimeService) Exec(ctx context.Context, req *runtimeapi.ExecRequest) (*runtimeapi.ExecResponse, error) {
+	return f.ExecF(ctx, req)
+}
+
+func (f *fakeRuntimeService) Attach(ctx context.Context, req *runtimeapi.AttachRequest) (*runtimeapi.AttachResponse, error) {
+	return f.AttachF(ctx, req)
+}
+
+func (f *fakeRuntimeService) ReopenContainerLog(ctx context.Context, ContainerID string) error {
+	return f.ReopenContainerLogF(ctx, ContainerID)
+}
+
+func (f *fakeRuntimeService) CheckpointContainer(ctx context.Context, options *runtimeapi.CheckpointContainerRequest) error {
+	return f.CheckpointContainerF(ctx, options)
+}
+
+func (f *fakeRuntimeService) GetContainerEvents(containerEventsCh chan *runtimeapi.ContainerEventResponse) error {
+	return f.GetContainerEventsF(containerEventsCh)
+}
+
+func (f *fakeRuntimeService) RunPodSandbox(ctx context.Context, config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
+	return f.RunPodSandboxF(ctx, config, runtimeHandler)
+}
+
+func (f *fakeRuntimeService) StopPodSandbox(ctx context.Context, podSandboxID string) error {
+	return f.StopPodSandboxF(ctx, podSandboxID)
+}
+
+func (f *fakeRuntimeService) RemovePodSandbox(ctx context.Context, podSandboxID string) error {
+	return f.RemovePodSandboxF(ctx, podSandboxID)
+}
+
+func (f *fakeRuntimeService) PodSandboxStatus(ctx context.Context, podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error) {
+	return f.PodSandboxStatusF(ctx, podSandboxID, verbose)
+}
+
+func (f *fakeRuntimeService) ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+	return f.ListPodSandboxF(ctx, filter)
+}
+
+func (f *fakeRuntimeService) PortForward(ctx context.Context, req *runtimeapi.PortForwardRequest) (*runtimeapi.PortForwardResponse, error) {
+	return f.PortForwardF(ctx, req)
+}
+
+func (f *fakeRuntimeService) ContainerStats(ctx context.Context, containerID string) (*runtimeapi.ContainerStats, error) {
+	return f.ContainerStatsF(ctx, containerID)
+}
+
+func (f *fakeRuntimeService) ListContainerStats(ctx context.Context, filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
+	return f.ListContainerStatsF(ctx, filter)
+}
+
+func (f *fakeRuntimeService) PodSandboxStats(ctx context.Context, podSandboxID string) (*runtimeapi.PodSandboxStats, error) {
+	return f.PodSandboxStatsF(ctx, podSandboxID)
+}
+
+func (f *fakeRuntimeService) ListPodSandboxStats(ctx context.Context, filter *runtimeapi.PodSandboxStatsFilter) ([]*runtimeapi.PodSandboxStats, error) {
+	return f.ListPodSandboxStatsF(ctx, filter)
+}
+
+func (f *fakeRuntimeService) ListMetricDescriptors(ctx context.Context) ([]*runtimeapi.MetricDescriptor, error) {
+	return f.ListMetricDescriptorsF(ctx)
+}
+
+func (f *fakeRuntimeService) ListPodSandboxMetrics(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error) {
+	return f.ListPodSandboxMetricsF(ctx)
+}
+
+func (f *fakeRuntimeService) UpdateRuntimeConfig(ctx context.Context, runtimeConfig *runtimeapi.RuntimeConfig) error {
+	return f.UpdateRuntimeConfigF(ctx, runtimeConfig)
+}
+
+func (f *fakeRuntimeService) Status(ctx context.Context, verbose bool) (*runtimeapi.StatusResponse, error) {
+	return f.StatusF(ctx, verbose)
+}
+
+func (f *fakeRuntimeService) RuntimeConfig(ctx context.Context) (*runtimeapi.RuntimeConfigResponse, error) {
+	return f.RuntimeConfigF(ctx)
+}
+
+func (f *fakeRuntimeService) ImageFsInfo(ctx context.Context) (*runtimeapi.ImageFsInfoResponse, error) {
+	return f.ImageFsInfoF(ctx)
 }

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -58,6 +58,18 @@ func sendToCloud(message *model.Message) {
 	beehiveContext.SendToGroup(string(metaManagerConfig.Config.ContextSendGroup), *message)
 }
 
+func sendToTwin(message *model.Message) {
+	beehiveContext.Send(modules.DeviceTwinModuleName, *message)
+}
+
+func sentToMetamanager(message *model.Message, sync bool) {
+	if sync {
+		beehiveContext.SendResp(*message)
+	} else {
+		beehiveContext.Send(modules.MetaManagerModuleName, *message)
+	}
+}
+
 // Resource format: <namespace>/<restype>[/resid]
 // return <reskey, restype, resid>
 func parseResource(message *model.Message) (string, string, string) {
@@ -255,6 +267,12 @@ func (m *metaManager) processUpdate(message model.Message) {
 	case cloudmodules.PolicyControllerModuleName:
 		resp := message.NewRespByMessage(&message, OK)
 		sendToCloud(resp)
+	case modules.MetaManagerModuleName:
+		// Process the update message from MetaManager(MetaServer)
+		// which is used to update the device in edge node.
+		sendToTwin(&message)
+		resp := message.NewRespByMessage(&message, OK)
+		sentToMetamanager(resp, message.IsSync())
 	default:
 		klog.Errorf("unsupport message source, %s", msgSource)
 	}

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,10 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 )
 
-require github.com/distribution/reference v0.5.0 // indirect
+require (
+	github.com/distribution/reference v0.5.0 // indirect
+	github.com/fatih/camelcase v1.0.0 // indirect
+)
 
 require (
 	cloud.google.com/go/compute v1.24.0 // indirect
@@ -194,7 +197,7 @@ require (
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
-	github.com/moby/term v0.0.0-20221205130635-1aeaba878587 // indirect
+	github.com/moby/term v0.0.0-20221205130635-1aeaba878587
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1073,6 +1073,8 @@ github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJ
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
+github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -282,8 +282,21 @@ var (
 )
 
 const (
-	FlagNameNamespace     = "namespace"
-	FlagNameAllNamespaces = "all-namespaces"
-	FlagNameOutput        = "output"
-	FlagNameLabelSelector = "selector"
+	FlagNameNamespace                    = "namespace"
+	FlagNameAllNamespaces                = "all-namespaces"
+	FlagNameOutput                       = "output"
+	FlagNameLabelSelector                = "selector"
+	FlagNameContainer                    = "container"
+	FlagNameFollow                       = "follow"
+	FlagNamePrevious                     = "previous"
+	FlagNameSinceSecond                  = "since-second"
+	FlagNameSinceTime                    = "since-time"
+	FlagNameTimestamps                   = "timestamps"
+	FlagNameTailLines                    = "tail"
+	FlagNameLimitBytes                   = "limit-bytes"
+	FlagNameInsecureSkipTLSVerifyBackend = "insecure-skip-tls-verify-backend"
+	FlagNameStdin                        = "stdin"
+	FlagNameTTY                          = "tty"
+	FlagNameShowEvents                   = "show-events"
+	FlagNameChunkSize                    = "chunk-size"
 )

--- a/keadm/cmd/keadm/app/cmd/ctl/client/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/client/device.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	"github.com/kubeedge/api/client/clientset/versioned/scheme"
+)
+
+type DeviceRequest struct {
+	Namespace     string
+	DeviceName    string
+	LabelSelector string
+	AllNamespaces bool
+}
+
+func (deviceRequest *DeviceRequest) GetDevice(ctx context.Context) (*v1beta1.Device, error) {
+	versionedClient, err := VersionedKubeClient()
+	if err != nil {
+		return nil, err
+	}
+	device, err := versionedClient.DevicesV1beta1().Devices(deviceRequest.Namespace).Get(ctx, deviceRequest.DeviceName, metaV1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return device, nil
+}
+
+func (deviceRequest *DeviceRequest) GetDevices(ctx context.Context) (*v1beta1.DeviceList, error) {
+	versionedClient, err := VersionedKubeClient()
+	if err != nil {
+		return nil, err
+	}
+	if deviceRequest.AllNamespaces {
+		deviceList, err := versionedClient.DevicesV1beta1().Devices(metaV1.NamespaceAll).List(ctx, metaV1.ListOptions{
+			LabelSelector: deviceRequest.LabelSelector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list devices: %v", err)
+		}
+		return deviceList, nil
+	}
+
+	deviceList, err := versionedClient.DevicesV1beta1().Devices(deviceRequest.Namespace).List(ctx, metaV1.ListOptions{
+		LabelSelector: deviceRequest.LabelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list devices: %v", err)
+	}
+	return deviceList, nil
+}
+
+func (deviceRequest *DeviceRequest) UpdateDevice(ctx context.Context, device *v1beta1.Device) (*rest.Result, error) {
+	versionedClient, err := VersionedKubeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	res := versionedClient.DevicesV1beta1().RESTClient().
+		Put().
+		Namespace(deviceRequest.Namespace).
+		Resource("devices").
+		Name(device.Name).
+		VersionedParams(&metaV1.UpdateOptions{}, scheme.ParameterCodec).
+		Body(device).
+		Do(ctx)
+	return &res, nil
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/client/request.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/client/request.go
@@ -24,12 +24,13 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/kubeedge/api/client/clientset/versioned"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 	keadutil "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 )
 
 func KubeClient() (*kubernetes.Clientset, error) {
-	kubeConfig, err := getKubeConfig()
+	kubeConfig, err := GetKubeConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +41,7 @@ func KubeClient() (*kubernetes.Clientset, error) {
 	return kubeClient, nil
 }
 
-func getKubeConfig() (*restclient.Config, error) {
+func GetKubeConfig() (*restclient.Config, error) {
 	config, err := keadutil.ParseEdgecoreConfig(common.EdgecoreConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("get edge config failed with err:%v", err)
@@ -73,4 +74,16 @@ func getKubeConfig() (*restclient.Config, error) {
 	}
 	kubeConfig.Timeout = 1 * time.Minute
 	return kubeConfig, nil
+}
+
+func VersionedKubeClient() (*versioned.Clientset, error) {
+	kubeConfig, err := GetKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	versionedClient, err := versioned.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return versionedClient, nil
 }

--- a/keadm/cmd/keadm/app/cmd/ctl/ctl.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/ctl.go
@@ -20,13 +20,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/confirm"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/describe"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/edit"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/exec"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/get"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/logs"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/restart"
 )
 
-var (
-	ctlShortDescription = `Commands operating on the data plane at edge`
-)
+var ctlShortDescription = `Commands operating on the data plane at edge`
 
 // NewCtl returns KubeEdge edge pod command.
 func NewCtl() *cobra.Command {
@@ -39,5 +41,9 @@ func NewCtl() *cobra.Command {
 	cmd.AddCommand(get.NewEdgeGet())
 	cmd.AddCommand(restart.NewEdgeRestart())
 	cmd.AddCommand(confirm.NewEdgeConfirm())
+	cmd.AddCommand(logs.NewEdgePodLogs())
+	cmd.AddCommand(exec.NewEdgePodExec())
+	cmd.AddCommand(describe.NewEdgeDescribe())
+	cmd.AddCommand(edit.NewEdgeEdit())
 	return cmd
 }

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/describe.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/describe.go
@@ -14,23 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package get
+package describe
 
 import "github.com/spf13/cobra"
 
-var (
-	edgeGetShortDescription = `Get resources in edge node`
-)
+var edgeDescribeShortDescription = `Show details of a specific resource`
 
-// NewEdgeGet returns KubeEdge edge resources get command.
-func NewEdgeGet() *cobra.Command {
+// NewEdgeDescribe returns KubeEdge edge resources describe command.
+func NewEdgeDescribe() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: edgeGetShortDescription,
-		Long:  edgeGetShortDescription,
+		Use:   "describe",
+		Short: edgeDescribeShortDescription,
+		Long:  edgeDescribeShortDescription,
 	}
 
-	cmd.AddCommand(NewEdgePodGet())
-	cmd.AddCommand(NewEdgeDeviceGet())
+	cmd.AddCommand(NewEdgeDescribePod())
+	cmd.AddCommand(NewEdgeDescribeDevice())
 	return cmd
 }

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/device.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/describe"
+
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+var edgeDescribeDeviceShortDescription = `Describe device in edge node`
+
+type DeviceDescribeOptions struct {
+	Namespace     string
+	LabelSelector string
+	AllNamespaces bool
+	// ShowEvents is true if events should be included in the description. Default is false.
+	ShowEvents bool
+	// ChunkSize is the number of bytes to include in a chunk. Default is 500.
+	ChunkSize int64
+	genericiooptions.IOStreams
+}
+
+// NewEdgeDescribeDevice returns KubeEdge describe edge device command.
+func NewEdgeDescribeDevice() *cobra.Command {
+	describeDeviceOptions := NewDescribeDeviceOptions()
+	cmd := &cobra.Command{
+		Use:   "device",
+		Short: edgeDescribeDeviceShortDescription,
+		Long:  edgeDescribeDeviceShortDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.CheckErr(describeDeviceOptions.describeDevice(args))
+			return nil
+		},
+	}
+	AddDescribeDeviceFlags(cmd, describeDeviceOptions)
+	return cmd
+}
+
+func NewDescribeDeviceOptions() *DeviceDescribeOptions {
+	return &DeviceDescribeOptions{
+		IOStreams: genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+	}
+}
+
+func AddDescribeDeviceFlags(cmd *cobra.Command, options *DeviceDescribeOptions) {
+	cmd.Flags().StringVarP(&options.Namespace, common.FlagNameNamespace, "n", "default", "If present, the namespace scope for this CLI request")
+	cmd.Flags().StringVar(&options.LabelSelector, common.FlagNameLabelSelector, "", "Selector (label query) to filter on")
+	cmd.Flags().BoolVarP(&options.AllNamespaces, common.FlagNameAllNamespaces, "A", false, "If present, list the requested object(s) across all namespaces")
+	cmd.Flags().BoolVar(&options.ShowEvents, common.FlagNameShowEvents, false, "If present, list the requested object(s) across all namespaces")
+	cmd.Flags().Int64Var(&options.ChunkSize, common.FlagNameChunkSize, 500, "If non-zero, split output into chunks of this many bytes")
+}
+
+func (o *DeviceDescribeOptions) describeDevice(args []string) error {
+	config, err := util.ParseEdgecoreConfig(common.EdgecoreConfigPath)
+	if err != nil {
+		return fmt.Errorf("get edge config failed with err:%v", err)
+	}
+	nodeName := config.Modules.Edged.HostnameOverride
+
+	ctx := context.Background()
+
+	var deviceListFilter *v1beta1.DeviceList
+
+	if len(args) > 0 {
+		deviceListFilter = &v1beta1.DeviceList{
+			Items: make([]v1beta1.Device, 0, len(args)),
+		}
+
+		var deviceRequest *client.DeviceRequest
+		for _, deviceName := range args {
+			deviceRequest = &client.DeviceRequest{
+				Namespace:  o.Namespace,
+				DeviceName: deviceName,
+			}
+			device, err := deviceRequest.GetDevice(ctx)
+			if err != nil {
+				klog.Error(err.Error())
+				continue
+			}
+			if device.Spec.NodeName == nodeName {
+				deviceListFilter.Items = append(deviceListFilter.Items, *device)
+			} else {
+				klog.Errorf("can't query device: \"%s\" for node: \"%s\"", device.Name, device.Spec.NodeName)
+			}
+		}
+	} else {
+		deviceRequest := &client.DeviceRequest{
+			Namespace:     o.Namespace,
+			LabelSelector: o.LabelSelector,
+			AllNamespaces: o.AllNamespaces,
+		}
+
+		deviceList, err := deviceRequest.GetDevices(ctx)
+		if err != nil {
+			return err
+		}
+
+		deviceListFilter = &v1beta1.DeviceList{
+			Items: make([]v1beta1.Device, 0, len(deviceList.Items)),
+		}
+
+		for _, device := range deviceList.Items {
+			if device.Spec.NodeName == nodeName {
+				deviceListFilter.Items = append(deviceListFilter.Items, device)
+			}
+		}
+	}
+
+	if len(deviceListFilter.Items) == 0 {
+		if len(args) > 0 {
+			return nil
+		}
+
+		if o.AllNamespaces {
+			klog.Info("No resources found in all namespaces.")
+		} else {
+			klog.Infof("No resources found in %s namespaces.", o.Namespace)
+		}
+
+		return nil
+	}
+
+	NamespaceToDeviceName := make(map[string][]string)
+
+	for _, device := range deviceListFilter.Items {
+		if _, ok := NamespaceToDeviceName[device.Namespace]; !ok {
+			NamespaceToDeviceName[device.Namespace] = make([]string, 0)
+		}
+		NamespaceToDeviceName[device.Namespace] = append(NamespaceToDeviceName[device.Namespace], device.Name)
+	}
+
+	m := &meta.RESTMapping{
+		Resource:         v1beta1.SchemeGroupVersion.WithResource("devices"),
+		GroupVersionKind: v1beta1.SchemeGroupVersion.WithKind("Device"),
+		Scope:            meta.RESTScopeNamespace,
+	}
+	c, err := client.GetKubeConfig()
+	if err != nil {
+		return err
+	}
+	d, ok := describe.GenericDescriberFor(m, c)
+	if !ok {
+		return fmt.Errorf("unable to find describer for %v", m)
+	}
+
+	first := true
+	for namespace, deviceNameList := range NamespaceToDeviceName {
+		for _, deviceName := range deviceNameList {
+			settings := describe.DescriberSettings{
+				ShowEvents: o.ShowEvents,
+				ChunkSize:  o.ChunkSize,
+			}
+			s, err := d.Describe(namespace, deviceName, settings)
+			if err != nil {
+				return err
+			}
+
+			if first {
+				first = false
+				klog.Info(s)
+			} else {
+				klog.Infof("\n\n%s", s)
+			}
+		}
+	}
+
+	return nil
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/pod.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/pod.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/describe"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	k8s_v1_api "k8s.io/kubernetes/pkg/apis/core/v1"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+var edgeDescribePodShortDescription = `Describe pod in edge node`
+
+type PodDescribeOptions struct {
+	Namespace     string
+	LabelSelector string
+	AllNamespaces bool
+	// ShowEvents is true if events should be included in the description. Default is false.
+	ShowEvents bool
+	// ChunkSize is the number of bytes to include in a chunk. Default is 500.
+	ChunkSize int64
+	genericiooptions.IOStreams
+}
+
+// NewEdgeDescribePod returns KubeEdge describe edge pod command.
+func NewEdgeDescribePod() *cobra.Command {
+	describePodOptions := NewDescribePodOptions()
+	cmd := &cobra.Command{
+		Use:   "pod",
+		Short: edgeDescribePodShortDescription,
+		Long:  edgeDescribePodShortDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.CheckErr(describePodOptions.describePod(args))
+			return nil
+		},
+	}
+	AddDescribePodFlags(cmd, describePodOptions)
+	return cmd
+}
+
+func NewDescribePodOptions() *PodDescribeOptions {
+	return &PodDescribeOptions{
+		IOStreams: genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+	}
+}
+
+func AddDescribePodFlags(cmd *cobra.Command, options *PodDescribeOptions) {
+	cmd.Flags().StringVarP(&options.Namespace, common.FlagNameNamespace, "n", "default", "If present, the namespace scope for this CLI request")
+	cmd.Flags().StringVarP(&options.LabelSelector, common.FlagNameLabelSelector, "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	cmd.Flags().BoolVarP(&options.AllNamespaces, common.FlagNameAllNamespaces, "A", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().BoolVar(&options.ShowEvents, common.FlagNameShowEvents, false, "If present, display events related to the described object.")
+	cmd.Flags().Int64Var(&options.ChunkSize, common.FlagNameChunkSize, 500, "If non-zero, split the output into chunks where each chunk contains N items")
+}
+
+func (o *PodDescribeOptions) describePod(args []string) error {
+	config, err := util.ParseEdgecoreConfig(common.EdgecoreConfigPath)
+	if err != nil {
+		return fmt.Errorf("get edge config failed with err:%v", err)
+	}
+	nodeName := config.Modules.Edged.HostnameOverride
+
+	ctx := context.Background()
+
+	var podListFilter *api.PodList
+
+	if len(args) > 0 {
+		podListFilter = &api.PodList{
+			Items: make([]api.Pod, 0, len(args)),
+		}
+
+		var podRequest *client.PodRequest
+		for _, podName := range args {
+			podRequest = &client.PodRequest{
+				Namespace: o.Namespace,
+				PodName:   podName,
+			}
+			pod, err := podRequest.GetPod(ctx)
+			if err != nil {
+				klog.Error(err.Error())
+				continue
+			}
+
+			if pod.Spec.NodeName == nodeName {
+				var apiPod api.Pod
+				if err := k8s_v1_api.Convert_v1_Pod_To_core_Pod(pod, &apiPod, nil); err != nil {
+					klog.Errorf("failed to convert pod with err:%v\n", err)
+					continue
+				}
+				podListFilter.Items = append(podListFilter.Items, apiPod)
+			} else {
+				klog.Errorf("can't to query pod: \"%s\" for node: \"%s\"\n", pod.Name, pod.Spec.NodeName)
+			}
+		}
+	} else {
+		podRequest := &client.PodRequest{
+			Namespace:     o.Namespace,
+			AllNamespaces: o.AllNamespaces,
+			LabelSelector: o.LabelSelector,
+		}
+		podList, err := podRequest.GetPods(ctx)
+		if err != nil {
+			return err
+		}
+		podListFilter = &api.PodList{
+			Items: make([]api.Pod, 0, len(podList.Items)),
+		}
+
+		for _, pod := range podList.Items {
+			if pod.Spec.NodeName == nodeName {
+				var apiPod api.Pod
+				if err := k8s_v1_api.Convert_v1_Pod_To_core_Pod(&pod, &apiPod, nil); err != nil {
+					return err
+				}
+				podListFilter.Items = append(podListFilter.Items, apiPod)
+			}
+		}
+	}
+
+	if len(podListFilter.Items) == 0 {
+		if len(args) > 0 {
+			return nil
+		}
+		if o.AllNamespaces {
+			klog.Info("No resources found in all namespaces.")
+		} else {
+			klog.Infof("No resources found in %s namespaces.", o.Namespace)
+		}
+		return nil
+	}
+
+	NamespaceToPodName := make(map[string][]string)
+
+	for _, pod := range podListFilter.Items {
+		if _, ok := NamespaceToPodName[pod.Namespace]; !ok {
+			NamespaceToPodName[pod.Namespace] = make([]string, 0)
+		}
+		NamespaceToPodName[pod.Namespace] = append(NamespaceToPodName[pod.Namespace], pod.Name)
+	}
+
+	c, err := client.KubeClient()
+	if err != nil {
+		return err
+	}
+
+	d := describe.PodDescriber{Interface: c}
+
+	first := true
+	for namespace, podName := range NamespaceToPodName {
+		for _, podName := range podName {
+			settings := describe.DescriberSettings{
+				ShowEvents: o.ShowEvents,
+				ChunkSize:  o.ChunkSize,
+			}
+			s, err := d.Describe(namespace, podName, settings)
+			if err != nil {
+				return err
+			}
+
+			if first {
+				first = false
+				klog.Info(s)
+			} else {
+				klog.Infof("\n\n%s", s)
+			}
+		}
+	}
+	return nil
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/device.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+var edgeEditDeviceShortDescription = `Edit a device in edge node`
+
+type DeviceEditOptions struct {
+	Namespace string
+
+	genericiooptions.IOStreams
+	editPrinterOptions *editPrinterOptions
+}
+
+type editPrinterOptions struct {
+	printFlags *genericclioptions.PrintFlags
+	ext        string
+	addHeader  bool
+}
+
+// NewEdgeEditDevice returns KubeEdge edit edge device command.
+func NewEdgeEditDevice() *cobra.Command {
+	editDeviceOptions := NewEditDeviceOpts()
+	cmd := &cobra.Command{
+		Use:   "device",
+		Short: edgeEditDeviceShortDescription,
+		Long:  edgeEditDeviceShortDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.CheckErr(editDeviceOptions.editDevice(args))
+			return nil
+		},
+	}
+	AddEditDeviceFlags(cmd, editDeviceOptions)
+	return cmd
+}
+
+func NewEditDeviceOpts() *DeviceEditOptions {
+	return &DeviceEditOptions{
+		IOStreams: genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+		editPrinterOptions: &editPrinterOptions{
+			printFlags: (&genericclioptions.PrintFlags{
+				JSONYamlPrintFlags: genericclioptions.NewJSONYamlPrintFlags(),
+			}).WithDefaultOutput("yaml"),
+			ext:       ".yaml",
+			addHeader: false,
+		},
+	}
+}
+
+func (o *DeviceEditOptions) editDevice(args []string) error {
+	config, err := util.ParseEdgecoreConfig(common.EdgecoreConfigPath)
+	if err != nil {
+		return fmt.Errorf("get edge config failed with err:%v", err)
+	}
+	nodeName := config.Modules.Edged.HostnameOverride
+
+	ctx := context.Background()
+
+	if len(args) == 1 {
+		deviceRequest := &client.DeviceRequest{
+			Namespace:  o.Namespace,
+			DeviceName: args[0],
+		}
+
+		device, err := deviceRequest.GetDevice(ctx)
+		if err != nil {
+			return err
+		}
+
+		if device.Spec.NodeName == nodeName {
+			if err = o.edit(device); err != nil {
+				return err
+			}
+			klog.Infof("Send update message to DeviceTwin")
+		} else {
+			klog.Errorf("Can't query device: \"%s\" for node: \"%s\"", device.Name, device.Spec.NodeName)
+		}
+	} else {
+		return fmt.Errorf("too many args, edit one device at once")
+	}
+
+	return nil
+}
+
+func (e *editPrinterOptions) PrintObj(obj *v1beta1.Device, out io.Writer) error {
+	// TODO: only yaml format is supported to print information,
+	// and other formats such as json are to be implemented
+	obj.GetObjectKind().SetGroupVersionKind(v1beta1.SchemeGroupVersion.WithKind("Device"))
+
+	jsonData, _ := json.Marshal(*obj)
+	data, err := yaml.JSONToYAML(jsonData)
+	if err != nil {
+		return err
+	}
+
+	_, err = out.Write(data)
+	return err
+}
+
+func (o *DeviceEditOptions) edit(dl *v1beta1.Device) error {
+	edit := editor.NewDefaultEditor([]string{
+		"KUBE_EDITOR",
+		"EDITOR",
+	})
+	buf := &bytes.Buffer{}
+	var w io.Writer = buf
+
+	if err := o.editPrinterOptions.PrintObj(dl, w); err != nil {
+		return err
+	}
+	original := buf.Bytes()
+	edited, file, err := edit.LaunchTempFile(fmt.Sprintf("%s-edit-", filepath.Base(os.Args[0])), "", buf)
+	if err != nil {
+		return preservedFile(err, file)
+	}
+
+	if bytes.Equal(cmdutil.StripComments(original), cmdutil.StripComments(edited)) {
+		os.Remove(file)
+		klog.Info("Edit cancelled, no changes made.")
+		return fmt.Errorf("no changes made")
+	}
+
+	jsonEdited := cmdutil.StripComments(edited)
+
+	var editedDevice v1beta1.Device
+	err = json.Unmarshal(jsonEdited, &editedDevice)
+	if err != nil {
+		return preservedFile(err, file)
+	}
+
+	deviceRequest := &client.DeviceRequest{
+		Namespace:  dl.Namespace,
+		DeviceName: dl.Name,
+	}
+
+	_, err = deviceRequest.UpdateDevice(context.Background(), &editedDevice)
+	if err != nil {
+		return preservedFile(err, file)
+	}
+
+	return nil
+}
+
+func preservedFile(err error, path string) error {
+	if len(path) > 0 {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			klog.Infof("A copy of your changes has been stored to %q", path)
+		}
+	}
+	return err
+}
+
+func AddEditDeviceFlags(cmd *cobra.Command, o *DeviceEditOptions) {
+	cmd.Flags().StringVarP(&o.Namespace, common.FlagNameNamespace, "n", "default", "If present, the namespace scope for this CLI request")
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/edit.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/edit.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,24 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-package get
+package edit
 
 import "github.com/spf13/cobra"
 
-var (
-	edgeGetShortDescription = `Get resources in edge node`
-)
+var edgeEditShortDescription = `Edit a specific resource`
 
-// NewEdgeGet returns KubeEdge edge resources get command.
-func NewEdgeGet() *cobra.Command {
+// NewEdgeEdit returns KubeEdge edit edge resources command.
+func NewEdgeEdit() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: edgeGetShortDescription,
-		Long:  edgeGetShortDescription,
+		Use:   "edit",
+		Short: edgeEditShortDescription,
+		Long:  edgeEditShortDescription,
 	}
-
-	cmd.AddCommand(NewEdgePodGet())
-	cmd.AddCommand(NewEdgeDeviceGet())
+	cmd.AddCommand(NewEdgeEditDevice())
 	return cmd
 }

--- a/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/moby/term"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+)
+
+// PodExecOptions defines the options for executing command in edge pod
+type PodExecOptions struct {
+	Namespace string
+	Container string
+
+	// Stdin is true if stdin is to be passed to the container
+	Stdin bool
+	// Stdout is true if output is passed to stdout
+	Stdout bool
+	// Stderr is true if output is passed to stderr
+	Stderr bool
+
+	// TTY is true if stdin is a TTY
+	TTY bool
+}
+
+var edgePodExecShortDescription = `Execute command in edge pod`
+
+// NewEdgePodExec returns KubeEdge exec edge pod command.
+func NewEdgePodExec() *cobra.Command {
+	execOpts := NewEdgePodExecOpts()
+	cmd := &cobra.Command{
+		Use:   "exec",
+		Short: edgePodExecShortDescription,
+		Long:  edgePodExecShortDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("no pod specified for exec")
+			}
+			cmdutil.CheckErr(execOpts.execPod(args))
+			return nil
+		},
+	}
+	AddPodExecFlags(cmd, execOpts)
+	return cmd
+}
+
+func NewEdgePodExecOpts() *PodExecOptions {
+	podExecOptions := &PodExecOptions{}
+	return podExecOptions
+}
+
+func AddPodExecFlags(cmd *cobra.Command, execOpts *PodExecOptions) {
+	cmd.Flags().StringVarP(&execOpts.Namespace, common.FlagNameNamespace, "n", "default", "Namespace of the pod")
+	cmd.Flags().StringVarP(&execOpts.Container, common.FlagNameContainer, "c", "", "Container name")
+	cmd.Flags().BoolVarP(&execOpts.Stdin, common.FlagNameStdin, "i", false, "Pass stdin to the container")
+	cmd.Flags().BoolVarP(&execOpts.TTY, common.FlagNameTTY, "t", false, "Allocate a TTY")
+}
+
+func (o *PodExecOptions) execPod(args []string) error {
+	kubeClient, err := client.KubeClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	pod := args[0]
+	commands := args[1:]
+
+	execResponse, err := podExec(ctx, kubeClient, pod, commands, o)
+	if err != nil {
+		return err
+	}
+	if execResponse == nil {
+		return nil
+	}
+
+	for _, runOutMsg := range execResponse.RunOutMessages {
+		klog.Info(runOutMsg)
+	}
+	for _, runErrMsg := range execResponse.RunErrMessages {
+		klog.Info(runErrMsg)
+	}
+	for _, errMsg := range execResponse.ErrMessages {
+		klog.Info(errMsg)
+	}
+	return nil
+}
+
+func podExec(ctx context.Context, clientSet *kubernetes.Clientset, pod string, commands []string, o *PodExecOptions) (*types.ExecResponse, error) {
+	exexRequest := clientSet.CoreV1().RESTClient().
+		Post().
+		Namespace(o.Namespace).
+		Resource("pods").
+		Name(pod).
+		SubResource("exec")
+	req := addQueryParams(exexRequest, o)
+
+	for _, cmd := range commands {
+		req.Param("command", cmd)
+	}
+
+	config, err := client.GetKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if o.TTY {
+		stdFd := os.Stdin.Fd()
+
+		restoreFunc, err := disableEcho(stdFd)
+		if err != nil {
+			return nil, fmt.Errorf("failed to disable echo: %v", err)
+		}
+		defer restoreFunc()
+
+		exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create executor: %v", err)
+		}
+
+		err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+			Stdin:  os.Stdin,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+			Tty:    true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error in Stream: %v", err)
+		}
+
+		return nil, nil
+	}
+
+	result := req.Do(ctx)
+	if result.Error() != nil {
+		return nil, result.Error()
+	}
+
+	statusCode := -1
+	result.StatusCode(&statusCode)
+	if statusCode != 200 {
+		return nil, fmt.Errorf("failed to exec command in pod %s, status code: %d", pod, statusCode)
+	}
+
+	body, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+
+	var execResponse types.ExecResponse
+	err = json.Unmarshal(body, &execResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &execResponse, nil
+}
+
+func addQueryParams(req *rest.Request, o *PodExecOptions) *rest.Request {
+	if o.Container != "" {
+		req.Param("container", o.Container)
+	}
+	if o.Stdin {
+		req.Param("stdin", "true")
+	}
+	if o.Stdout {
+		req.Param("stdout", "true")
+	}
+	if o.Stderr {
+		req.Param("stderr", "true")
+	}
+	if o.TTY {
+		req.Param("stdin", "true")
+		req.Param("stdout", "true")
+		req.Param("tty", "true")
+	}
+	return req
+}
+
+// disableEcho disables echo for the terminal in order to avoid echoing the input characters.
+func disableEcho(fd uintptr) (func(), error) {
+	state, err := term.MakeRaw(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	return func() {
+		_ = term.RestoreTerminal(fd, state)
+	}, nil
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/get/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/get/device.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/cmd/get"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+var edgeDeviceGetShortDescription = `Get devices in edge node`
+
+type DeviceGetOptions struct {
+	Namespace     string
+	LabelSelector string
+	AllNamespaces bool
+	Output        string
+	// PrintFlags holds the flags for printing resources
+	PrintFlags *get.PrintFlags
+}
+
+// NewEdgeDeviceGet returns KubeEdge get edge device command.
+func NewEdgeDeviceGet() *cobra.Command {
+	deviceGetOptions := NewDeviceGetOpts()
+	cmd := &cobra.Command{
+		Use:   "device",
+		Short: edgeDeviceGetShortDescription,
+		Long:  edgeDeviceGetShortDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.CheckErr(deviceGetOptions.getDevices(args))
+			return nil
+		},
+	}
+
+	AddGetDeviceFlags(cmd, deviceGetOptions)
+	return cmd
+}
+
+func (o *DeviceGetOptions) getDevices(args []string) error {
+	config, err := util.ParseEdgecoreConfig(common.EdgecoreConfigPath)
+	if err != nil {
+		return fmt.Errorf("get edge config failed with err:%v", err)
+	}
+	nodeName := config.Modules.Edged.HostnameOverride
+
+	ctx := context.Background()
+	var deviceListFilter *v1beta1.DeviceList
+
+	if len(args) > 0 {
+		deviceListFilter = &v1beta1.DeviceList{
+			Items: make([]v1beta1.Device, 0, len(args)),
+		}
+
+		var deviceRequest *client.DeviceRequest
+
+		for _, deviceName := range args {
+			deviceRequest = &client.DeviceRequest{
+				Namespace:  o.Namespace,
+				DeviceName: deviceName,
+			}
+
+			device, err := deviceRequest.GetDevice(ctx)
+			if err != nil {
+				klog.Error(err.Error())
+				continue
+			}
+
+			if device.Spec.NodeName == nodeName {
+				deviceListFilter.Items = append(deviceListFilter.Items, *device)
+			} else {
+				klog.Errorf("can't query device: \"%s\" for node: \"%s\"", device.Name, device.Spec.NodeName)
+			}
+		}
+	} else {
+		deviceRequest := &client.DeviceRequest{
+			Namespace:     o.Namespace,
+			LabelSelector: o.LabelSelector,
+			AllNamespaces: o.AllNamespaces,
+		}
+
+		deviceList, err := deviceRequest.GetDevices(ctx)
+		if err != nil {
+			return err
+		}
+
+		deviceListFilter = &v1beta1.DeviceList{
+			Items: make([]v1beta1.Device, 0, len(deviceList.Items)),
+		}
+
+		for _, device := range deviceList.Items {
+			if device.Spec.NodeName == nodeName {
+				deviceListFilter.Items = append(deviceListFilter.Items, device)
+			}
+		}
+	}
+
+	if len(deviceListFilter.Items) == 0 {
+		if len(args) > 0 {
+			return nil
+		}
+		if o.AllNamespaces {
+			klog.Info("No resources found in all namespaces.")
+		} else {
+			klog.Infof("No resources found in %s namespace.", o.Namespace)
+		}
+		return nil
+	}
+
+	if o.AllNamespaces {
+		if err := o.PrintFlags.EnsureWithNamespace(); err != nil {
+			return err
+		}
+	}
+
+	o.PrintFlags.SetKind(v1beta1.SchemeGroupVersion.WithKind("DeviceList").GroupKind())
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	printer, err = printers.NewTypeSetter(scheme.Scheme).WrapToPrinter(printer, nil)
+	if err != nil {
+		return nil
+	}
+
+	var deviceObjectList runtime.Object = deviceListFilter
+	deviceObjectList.GetObjectKind().SetGroupVersionKind(v1beta1.SchemeGroupVersion.WithKind("DeviceList"))
+
+	return printer.PrintObj(deviceObjectList, os.Stdout)
+}
+
+func NewDeviceGetOpts() *DeviceGetOptions {
+	deviceGetOptions := &DeviceGetOptions{}
+	deviceGetOptions.Namespace = "default"
+	deviceGetOptions.PrintFlags = get.NewGetPrintFlags()
+	deviceGetOptions.PrintFlags.OutputFormat = &deviceGetOptions.Output
+	return deviceGetOptions
+}
+
+func AddGetDeviceFlags(cmd *cobra.Command, deviceGetOptions *DeviceGetOptions) {
+	cmd.Flags().StringVarP(&deviceGetOptions.Namespace, common.FlagNameNamespace, "n", deviceGetOptions.Namespace,
+		"Specify a namespace")
+	cmd.Flags().StringVarP(&deviceGetOptions.LabelSelector, common.FlagNameLabelSelector, "l", deviceGetOptions.LabelSelector,
+		"Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	cmd.Flags().BoolVarP(&deviceGetOptions.AllNamespaces, common.FlagNameAllNamespaces, "A", deviceGetOptions.AllNamespaces,
+		"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace")
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+)
+
+var edgePodLogsShortDescription = `Get pod logs in edge node`
+
+// PodLogsOptions defines the options for getting logs of edge pod
+type PodLogsOptions struct {
+	Namespace string
+	Container string
+	// Follow is true if the logs should be streamed
+	Follow bool
+	// Previous is true if print the logs for the previous instance of the container in a pod(if it exists).
+	Previous bool
+	// SinceSecond is the duration in seconds for which to return logs newer than a relative duration like 5s, 2m, or 3h. Only one of sinceSeconds or sinceTime may be specified.
+	SinceSecond string
+	// SinceTime is the RFC3339 date for which to return logs newer than this date. Only one of sinceSeconds or sinceTime may be specified.
+	SinceTime string
+	// Timestamps is true if include timestamps on each line in the log output
+	Timestamps bool
+	// TailLines is the lines of recent log file to display.
+	TailLines string
+	// LimitBytes is the maximum bytes of logs to return.
+	LimitBytes string
+	// InsecureSkipTLSVerifyBackend is true if the server's certificate will not be checked for validity.
+	InsecureSkipTLSVerifyBackend bool
+}
+
+func NewEdgePodLogs() *cobra.Command {
+	logsOpts := NewLogsPodOpts()
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: edgePodLogsShortDescription,
+		Long:  edgePodLogsShortDescription,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("no pod specified for logs")
+			}
+			cmdutil.CheckErr(logsOpts.getPodLogs(args))
+			return nil
+		},
+	}
+	AddLogsPodFlags(cmd, logsOpts)
+	return cmd
+}
+
+func NewLogsPodOpts() *PodLogsOptions {
+	podLogsOptions := &PodLogsOptions{}
+	podLogsOptions.Namespace = "default"
+	return podLogsOptions
+}
+
+func AddLogsPodFlags(cmd *cobra.Command, podLogsOptions *PodLogsOptions) {
+	cmd.Flags().StringVarP(&podLogsOptions.Namespace, common.FlagNameNamespace, "n", podLogsOptions.Namespace, "If present, the namespace scope for this CLI request")
+	cmd.Flags().StringVarP(&podLogsOptions.Container, common.FlagNameContainer, "c", "", "Print the logs of this container")
+	cmd.Flags().BoolVarP(&podLogsOptions.Follow, common.FlagNameFollow, "f", false, "Specify if the logs should be streamed")
+	cmd.Flags().BoolVarP(&podLogsOptions.Previous, common.FlagNamePrevious, "p", false, "If true, print the logs for the previous instance of the container in a pod if it exists")
+	cmd.Flags().StringVar(&podLogsOptions.SinceSecond, common.FlagNameSinceSecond, "0", "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.")
+	cmd.Flags().StringVar(&podLogsOptions.SinceTime, common.FlagNameSinceTime, "", "Only return logs after a specific date (RFC3339). Defaults to all logs.")
+	cmd.Flags().BoolVar(&podLogsOptions.Timestamps, common.FlagNameTimestamps, false, "Include timestamps on each line in the log output")
+	cmd.Flags().StringVar(&podLogsOptions.TailLines, common.FlagNameTailLines, "-1", "Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided.")
+	cmd.Flags().StringVar(&podLogsOptions.LimitBytes, common.FlagNameLimitBytes, "-1", "Maximum bytes of logs to return. Defaults to no limit.")
+	cmd.Flags().BoolVar(&podLogsOptions.InsecureSkipTLSVerifyBackend, common.FlagNameInsecureSkipTLSVerifyBackend, false, "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.")
+}
+
+func (o *PodLogsOptions) getPodLogs(args []string) error {
+	kubeClient, err := client.KubeClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	logsResponse, err := logsPod(ctx, kubeClient, args[0], o)
+	if err != nil {
+		return err
+	}
+
+	for _, logMsg := range logsResponse.LogMessages {
+		klog.Info(logMsg)
+	}
+
+	for _, errMsg := range logsResponse.ErrMessages {
+		klog.Info(errMsg)
+	}
+
+	return nil
+}
+
+func logsPod(ctx context.Context, clientSet *kubernetes.Clientset, pod string, o *PodLogsOptions) (*types.LogsResponse, error) {
+	logRequest := clientSet.CoreV1().RESTClient().
+		Get().
+		Namespace(o.Namespace).
+		Resource("pods").
+		Name(pod).
+		SubResource("log")
+
+	req := addQueryParams(logRequest, o)
+
+	if o.Follow {
+		// Stream logs
+		logStream, err := req.Stream(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		defer logStream.Close()
+
+		if _, err := io.Copy(os.Stdout, logStream); err != nil {
+			return nil, err
+		}
+	}
+	result := req.Do(ctx)
+
+	if result.Error() != nil {
+		return nil, result.Error()
+	}
+
+	statusCode := -1
+	result.StatusCode(&statusCode)
+	if statusCode != 200 {
+		return nil, fmt.Errorf("failed to get logs for pod %s, status code: %d", pod, statusCode)
+	}
+
+	body, err := result.Raw()
+	if err != nil {
+		return nil, err
+	}
+
+	var logsResponse types.LogsResponse
+	err = json.Unmarshal(body, &logsResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logsResponse, nil
+}
+
+func addQueryParams(req *rest.Request, o *PodLogsOptions) *rest.Request {
+	if o.Container != "" {
+		req.Param("container", o.Container)
+	}
+	if o.Follow {
+		req.Param("follow", fmt.Sprintf("%v", o.Follow))
+	}
+	if o.Previous {
+		req.Param("previous", fmt.Sprintf("%v", o.Previous))
+	}
+	if o.SinceSecond != "0" {
+		req.Param("sinceSeconds", fmt.Sprintf("%v", o.SinceSecond))
+	}
+	if o.SinceTime != "" {
+		req.Param("sinceTime", fmt.Sprintf("%v", o.SinceTime))
+	}
+	if o.Timestamps {
+		req.Param("timestamps", fmt.Sprintf("%v", o.Timestamps))
+	}
+	if o.TailLines != "-1" {
+		req.Param("tailLines", fmt.Sprintf("%v", o.TailLines))
+	}
+	if o.LimitBytes != "-1" {
+		req.Param("limitBytes", fmt.Sprintf("%v", o.LimitBytes))
+	}
+	if o.InsecureSkipTLSVerifyBackend {
+		req.Param("insecureSkipTLSVerifyBackend", fmt.Sprintf("%v", o.InsecureSkipTLSVerifyBackend))
+	}
+
+	return req
+}

--- a/vendor/github.com/fatih/camelcase/.travis.yml
+++ b/vendor/github.com/fatih/camelcase/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go: 1.x
+

--- a/vendor/github.com/fatih/camelcase/LICENSE.md
+++ b/vendor/github.com/fatih/camelcase/LICENSE.md
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/fatih/camelcase/README.md
+++ b/vendor/github.com/fatih/camelcase/README.md
@@ -1,0 +1,58 @@
+# CamelCase [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/camelcase) [![Build Status](http://img.shields.io/travis/fatih/camelcase.svg?style=flat-square)](https://travis-ci.org/fatih/camelcase)
+
+CamelCase is a Golang (Go) package to split the words of a camelcase type
+string into a slice of words. It can be used to convert a camelcase word (lower
+or upper case) into any type of word.
+
+## Splitting rules:
+
+1. If string is not valid UTF-8, return it without splitting as
+   single item array.
+2. Assign all unicode characters into one of 4 sets: lower case
+   letters, upper case letters, numbers, and all other characters.
+3. Iterate through characters of string, introducing splits
+   between adjacent characters that belong to different sets.
+4. Iterate through array of split strings, and if a given string
+   is upper case:
+   * if subsequent string is lower case:
+     * move last character of upper case string to beginning of
+       lower case string
+
+## Install
+
+```bash
+go get github.com/fatih/camelcase
+```
+
+## Usage and examples
+
+```go
+splitted := camelcase.Split("GolangPackage")
+
+fmt.Println(splitted[0], splitted[1]) // prints: "Golang", "Package"
+```
+
+Both lower camel case and upper camel case are supported. For more info please
+check: [http://en.wikipedia.org/wiki/CamelCase](http://en.wikipedia.org/wiki/CamelCase)
+
+Below are some example cases:
+
+```
+"" =>                     []
+"lowercase" =>            ["lowercase"]
+"Class" =>                ["Class"]
+"MyClass" =>              ["My", "Class"]
+"MyC" =>                  ["My", "C"]
+"HTML" =>                 ["HTML"]
+"PDFLoader" =>            ["PDF", "Loader"]
+"AString" =>              ["A", "String"]
+"SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+"vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+"GL11Version" =>          ["GL", "11", "Version"]
+"99Bottles" =>            ["99", "Bottles"]
+"May5" =>                 ["May", "5"]
+"BFG9000" =>              ["BFG", "9000"]
+"BöseÜberraschung" =>     ["Böse", "Überraschung"]
+"Two  spaces" =>          ["Two", "  ", "spaces"]
+"BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+```

--- a/vendor/github.com/fatih/camelcase/camelcase.go
+++ b/vendor/github.com/fatih/camelcase/camelcase.go
@@ -1,0 +1,90 @@
+// Package camelcase is a micro package to split the words of a camelcase type
+// string into a slice of words.
+package camelcase
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Split splits the camelcase word and returns a list of words. It also
+// supports digits. Both lower camel case and upper camel case are supported.
+// For more info please check: http://en.wikipedia.org/wiki/CamelCase
+//
+// Examples
+//
+//   "" =>                     [""]
+//   "lowercase" =>            ["lowercase"]
+//   "Class" =>                ["Class"]
+//   "MyClass" =>              ["My", "Class"]
+//   "MyC" =>                  ["My", "C"]
+//   "HTML" =>                 ["HTML"]
+//   "PDFLoader" =>            ["PDF", "Loader"]
+//   "AString" =>              ["A", "String"]
+//   "SimpleXMLParser" =>      ["Simple", "XML", "Parser"]
+//   "vimRPCPlugin" =>         ["vim", "RPC", "Plugin"]
+//   "GL11Version" =>          ["GL", "11", "Version"]
+//   "99Bottles" =>            ["99", "Bottles"]
+//   "May5" =>                 ["May", "5"]
+//   "BFG9000" =>              ["BFG", "9000"]
+//   "BöseÜberraschung" =>     ["Böse", "Überraschung"]
+//   "Two  spaces" =>          ["Two", "  ", "spaces"]
+//   "BadUTF8\xe2\xe2\xa1" =>  ["BadUTF8\xe2\xe2\xa1"]
+//
+// Splitting rules
+//
+//  1) If string is not valid UTF-8, return it without splitting as
+//     single item array.
+//  2) Assign all unicode characters into one of 4 sets: lower case
+//     letters, upper case letters, numbers, and all other characters.
+//  3) Iterate through characters of string, introducing splits
+//     between adjacent characters that belong to different sets.
+//  4) Iterate through array of split strings, and if a given string
+//     is upper case:
+//       if subsequent string is lower case:
+//         move last character of upper case string to beginning of
+//         lower case string
+func Split(src string) (entries []string) {
+	// don't split invalid utf8
+	if !utf8.ValidString(src) {
+		return []string{src}
+	}
+	entries = []string{}
+	var runes [][]rune
+	lastClass := 0
+	class := 0
+	// split into fields based on class of unicode character
+	for _, r := range src {
+		switch true {
+		case unicode.IsLower(r):
+			class = 1
+		case unicode.IsUpper(r):
+			class = 2
+		case unicode.IsDigit(r):
+			class = 3
+		default:
+			class = 4
+		}
+		if class == lastClass {
+			runes[len(runes)-1] = append(runes[len(runes)-1], r)
+		} else {
+			runes = append(runes, []rune{r})
+		}
+		lastClass = class
+	}
+	// handle upper case -> lower case sequences, e.g.
+	// "PDFL", "oader" -> "PDF", "Loader"
+	for i := 0; i < len(runes)-1; i++ {
+		if unicode.IsUpper(runes[i][0]) && unicode.IsLower(runes[i+1][0]) {
+			runes[i+1] = append([]rune{runes[i][len(runes[i])-1]}, runes[i+1]...)
+			runes[i] = runes[i][:len(runes[i])-1]
+		}
+	}
+	// construct []string from results
+	for _, s := range runes {
+		if len(s) > 0 {
+			entries = append(entries, string(s))
+		}
+	}
+	return
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/util/editor/crlf/crlf.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/util/editor/crlf/crlf.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crlf
+
+import (
+	"bytes"
+	"io"
+)
+
+type crlfWriter struct {
+	io.Writer
+}
+
+// NewCRLFWriter implements a CR/LF line ending writer used for normalizing
+// text for Windows platforms.
+func NewCRLFWriter(w io.Writer) io.Writer {
+	return crlfWriter{w}
+}
+
+func (w crlfWriter) Write(b []byte) (n int, err error) {
+	for i, written := 0, 0; ; {
+		next := bytes.Index(b[i:], []byte("\n"))
+		if next == -1 {
+			n, err := w.Writer.Write(b[i:])
+			return written + n, err
+		}
+		next = next + i
+		n, err := w.Writer.Write(b[i:next])
+		if err != nil {
+			return written + n, err
+		}
+		written += n
+		n, err = w.Writer.Write([]byte("\r\n"))
+		if err != nil {
+			if n > 1 {
+				n = 1
+			}
+			return written + n, err
+		}
+		written++
+		i = next + 1
+	}
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -1,0 +1,919 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package editor
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	goruntime "runtime"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/cmd/util/editor/crlf"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/slice"
+)
+
+var SupportedSubresources = []string{"status"}
+
+// EditOptions contains all the options for running edit cli command.
+type EditOptions struct {
+	resource.FilenameOptions
+	RecordFlags *genericclioptions.RecordFlags
+
+	PrintFlags *genericclioptions.PrintFlags
+	ToPrinter  func(string) (printers.ResourcePrinter, error)
+
+	OutputPatch        bool
+	WindowsLineEndings bool
+
+	cmdutil.ValidateOptions
+	ValidationDirective string
+
+	OriginalResult *resource.Result
+
+	EditMode EditMode
+
+	CmdNamespace    string
+	ApplyAnnotation bool
+	ChangeCause     string
+
+	managedFields map[types.UID][]metav1.ManagedFieldsEntry
+
+	genericiooptions.IOStreams
+
+	Recorder            genericclioptions.Recorder
+	f                   cmdutil.Factory
+	editPrinterOptions  *editPrinterOptions
+	updatedResultGetter func(data []byte) *resource.Result
+
+	FieldManager string
+
+	Subresource string
+}
+
+// NewEditOptions returns an initialized EditOptions instance
+func NewEditOptions(editMode EditMode, ioStreams genericiooptions.IOStreams) *EditOptions {
+	return &EditOptions{
+		RecordFlags: genericclioptions.NewRecordFlags(),
+
+		EditMode: editMode,
+
+		PrintFlags: genericclioptions.NewPrintFlags("edited").WithTypeSetter(scheme.Scheme),
+
+		editPrinterOptions: &editPrinterOptions{
+			// create new editor-specific PrintFlags, with all
+			// output flags disabled, except json / yaml
+			printFlags: (&genericclioptions.PrintFlags{
+				JSONYamlPrintFlags: genericclioptions.NewJSONYamlPrintFlags(),
+			}).WithDefaultOutput("yaml"),
+			ext:       ".yaml",
+			addHeader: true,
+		},
+
+		WindowsLineEndings: goruntime.GOOS == "windows",
+
+		Recorder: genericclioptions.NoopRecorder{},
+
+		IOStreams: ioStreams,
+	}
+}
+
+type editPrinterOptions struct {
+	printFlags *genericclioptions.PrintFlags
+	ext        string
+	addHeader  bool
+}
+
+func (e *editPrinterOptions) Complete(fromPrintFlags *genericclioptions.PrintFlags) error {
+	if e.printFlags == nil {
+		return fmt.Errorf("missing PrintFlags in editor printer options")
+	}
+
+	// bind output format from existing printflags
+	if fromPrintFlags != nil && len(*fromPrintFlags.OutputFormat) > 0 {
+		e.printFlags.OutputFormat = fromPrintFlags.OutputFormat
+	}
+
+	// prevent a commented header at the top of the user's
+	// default editor if presenting contents as json.
+	if *e.printFlags.OutputFormat == "json" {
+		e.addHeader = false
+		e.ext = ".json"
+		return nil
+	}
+
+	// we default to yaml if check above is false, as only json or yaml are supported
+	e.addHeader = true
+	e.ext = ".yaml"
+	return nil
+}
+
+func (e *editPrinterOptions) PrintObj(obj runtime.Object, out io.Writer) error {
+	p, err := e.printFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	return p.PrintObj(obj, out)
+}
+
+// Complete completes all the required options
+func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Command) error {
+	var err error
+
+	o.RecordFlags.Complete(cmd)
+	o.Recorder, err = o.RecordFlags.ToRecorder()
+	if err != nil {
+		return err
+	}
+
+	if o.EditMode != NormalEditMode && o.EditMode != EditBeforeCreateMode && o.EditMode != ApplyEditMode {
+		return fmt.Errorf("unsupported edit mode %q", o.EditMode)
+	}
+
+	o.editPrinterOptions.Complete(o.PrintFlags)
+
+	if o.OutputPatch && o.EditMode != NormalEditMode {
+		return fmt.Errorf("the edit mode doesn't support output the patch")
+	}
+
+	cmdNamespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+	b := f.NewBuilder().
+		Unstructured()
+	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
+		// when do normal edit or apply edit we need to always retrieve the latest resource from server
+		b = b.ResourceTypeOrNameArgs(true, args...).Latest()
+	}
+	r := b.NamespaceParam(cmdNamespace).DefaultNamespace().
+		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		Subresource(o.Subresource).
+		ContinueOnError().
+		Flatten().
+		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
+	o.OriginalResult = r
+
+	o.updatedResultGetter = func(data []byte) *resource.Result {
+		// resource builder to read objects from edited data
+		return f.NewBuilder().
+			Unstructured().
+			Stream(bytes.NewReader(data), "edited-file").
+			Subresource(o.Subresource).
+			ContinueOnError().
+			Flatten().
+			Do()
+	}
+
+	o.ToPrinter = func(operation string) (printers.ResourcePrinter, error) {
+		o.PrintFlags.NamePrintFlags.Operation = operation
+		return o.PrintFlags.ToPrinter()
+	}
+
+	o.ValidationDirective, err = cmdutil.GetValidationDirective(cmd)
+	if err != nil {
+		return err
+	}
+
+	o.CmdNamespace = cmdNamespace
+	o.f = f
+
+	return nil
+}
+
+// Validate checks the EditOptions to see if there is sufficient information to run the command.
+func (o *EditOptions) Validate() error {
+	if len(o.Subresource) > 0 && !slice.ContainsString(SupportedSubresources, o.Subresource, nil) {
+		return fmt.Errorf("invalid subresource value: %q. Must be one of %v", o.Subresource, SupportedSubresources)
+	}
+	return nil
+}
+
+// Run performs the execution
+func (o *EditOptions) Run() error {
+	edit := NewDefaultEditor(editorEnvs())
+	// editFn is invoked for each edit session (once with a list for normal edit, once for each individual resource in a edit-on-create invocation)
+	editFn := func(infos []*resource.Info) error {
+		var (
+			results  = editResults{}
+			original = []byte{}
+			edited   = []byte{}
+			file     string
+			err      error
+		)
+
+		containsError := false
+		// loop until we succeed or cancel editing
+		for {
+			// get the object we're going to serialize as input to the editor
+			var originalObj runtime.Object
+			switch len(infos) {
+			case 1:
+				originalObj = infos[0].Object
+			default:
+				l := &unstructured.UnstructuredList{
+					Object: map[string]interface{}{
+						"kind":       "List",
+						"apiVersion": "v1",
+						"metadata":   map[string]interface{}{},
+					},
+				}
+				for _, info := range infos {
+					l.Items = append(l.Items, *info.Object.(*unstructured.Unstructured))
+				}
+				originalObj = l
+			}
+
+			// generate the file to edit
+			buf := &bytes.Buffer{}
+			var w io.Writer = buf
+			if o.WindowsLineEndings {
+				w = crlf.NewCRLFWriter(w)
+			}
+
+			if o.editPrinterOptions.addHeader {
+				results.header.writeTo(w, o.EditMode)
+			}
+
+			if !containsError {
+				if err := o.extractManagedFields(originalObj); err != nil {
+					return preservedFile(err, results.file, o.ErrOut)
+				}
+
+				if err := o.editPrinterOptions.PrintObj(originalObj, w); err != nil {
+					return preservedFile(err, results.file, o.ErrOut)
+				}
+				original = buf.Bytes()
+			} else {
+				// In case of an error, preserve the edited file.
+				// Remove the comments (header) from it since we already
+				// have included the latest header in the buffer above.
+				buf.Write(cmdutil.ManualStrip(edited))
+			}
+
+			// launch the editor
+			editedDiff := edited
+			edited, file, err = edit.LaunchTempFile(fmt.Sprintf("%s-edit-", filepath.Base(os.Args[0])), o.editPrinterOptions.ext, buf)
+			if err != nil {
+				return preservedFile(err, results.file, o.ErrOut)
+			}
+
+			// If we're retrying the loop because of an error, and no change was made in the file, short-circuit
+			if containsError && bytes.Equal(cmdutil.StripComments(editedDiff), cmdutil.StripComments(edited)) {
+				return preservedFile(fmt.Errorf("%s", "Edit cancelled, no valid changes were saved."), file, o.ErrOut)
+			}
+			// cleanup any file from the previous pass
+			if len(results.file) > 0 {
+				os.Remove(results.file)
+			}
+			klog.V(4).Infof("User edited:\n%s", string(edited))
+
+			// Apply validation
+			schema, err := o.f.Validator(o.ValidationDirective)
+			if err != nil {
+				return preservedFile(err, file, o.ErrOut)
+			}
+			err = schema.ValidateBytes(cmdutil.StripComments(edited))
+			if err != nil {
+				results = editResults{
+					file: file,
+				}
+				containsError = true
+				fmt.Fprintln(o.ErrOut, results.addError(apierrors.NewInvalid(corev1.SchemeGroupVersion.WithKind("").GroupKind(),
+					"", field.ErrorList{field.Invalid(nil, "The edited file failed validation", fmt.Sprintf("%v", err))}), infos[0]))
+				continue
+			}
+
+			// Compare content without comments
+			if bytes.Equal(cmdutil.StripComments(original), cmdutil.StripComments(edited)) {
+				os.Remove(file)
+				fmt.Fprintln(o.ErrOut, "Edit cancelled, no changes made.")
+				return nil
+			}
+
+			lines, err := hasLines(bytes.NewBuffer(edited))
+			if err != nil {
+				return preservedFile(err, file, o.ErrOut)
+			}
+			if !lines {
+				os.Remove(file)
+				fmt.Fprintln(o.ErrOut, "Edit cancelled, saved file was empty.")
+				return nil
+			}
+
+			results = editResults{
+				file: file,
+			}
+
+			// parse the edited file
+			updatedInfos, err := o.updatedResultGetter(edited).Infos()
+			if err != nil {
+				// syntax error
+				containsError = true
+				results.header.reasons = append(results.header.reasons, editReason{head: fmt.Sprintf("The edited file had a syntax error: %v", err)})
+				continue
+			}
+
+			// not a syntax error as it turns out...
+			containsError = false
+			updatedVisitor := resource.InfoListVisitor(updatedInfos)
+
+			// we need to add back managedFields to both updated and original object
+			if err := o.restoreManagedFields(updatedInfos); err != nil {
+				return preservedFile(err, file, o.ErrOut)
+			}
+			if err := o.restoreManagedFields(infos); err != nil {
+				return preservedFile(err, file, o.ErrOut)
+			}
+
+			// need to make sure the original namespace wasn't changed while editing
+			if err := updatedVisitor.Visit(resource.RequireNamespace(o.CmdNamespace)); err != nil {
+				return preservedFile(err, file, o.ErrOut)
+			}
+
+			// iterate through all items to apply annotations
+			if err := o.visitAnnotation(updatedVisitor); err != nil {
+				return preservedFile(err, file, o.ErrOut)
+			}
+
+			switch o.EditMode {
+			case NormalEditMode:
+				err = o.visitToPatch(infos, updatedVisitor, &results)
+			case ApplyEditMode:
+				err = o.visitToApplyEditPatch(infos, updatedVisitor)
+			case EditBeforeCreateMode:
+				err = o.visitToCreate(updatedVisitor)
+			default:
+				err = fmt.Errorf("unsupported edit mode %q", o.EditMode)
+			}
+			if err != nil {
+				return preservedFile(err, results.file, o.ErrOut)
+			}
+
+			// Handle all possible errors
+			//
+			// 1. retryable: propose kubectl replace -f
+			// 2. notfound: indicate the location of the saved configuration of the deleted resource
+			// 3. invalid: retry those on the spot by looping ie. reloading the editor
+			if results.retryable > 0 {
+				fmt.Fprintf(o.ErrOut, "You can run `%s replace -f %s` to try this update again.\n", filepath.Base(os.Args[0]), file)
+				return cmdutil.ErrExit
+			}
+			if results.notfound > 0 {
+				fmt.Fprintf(o.ErrOut, "The edits you made on deleted resources have been saved to %q\n", file)
+				return cmdutil.ErrExit
+			}
+
+			if len(results.edit) == 0 {
+				if results.notfound == 0 {
+					os.Remove(file)
+				} else {
+					fmt.Fprintf(o.Out, "The edits you made on deleted resources have been saved to %q\n", file)
+				}
+				return nil
+			}
+
+			if len(results.header.reasons) > 0 {
+				containsError = true
+			}
+		}
+	}
+
+	switch o.EditMode {
+	// If doing normal edit we cannot use Visit because we need to edit a list for convenience. Ref: #20519
+	case NormalEditMode:
+		infos, err := o.OriginalResult.Infos()
+		if err != nil {
+			return err
+		}
+		if len(infos) == 0 {
+			return errors.New("edit cancelled, no objects found")
+		}
+		return editFn(infos)
+	case ApplyEditMode:
+		infos, err := o.OriginalResult.Infos()
+		if err != nil {
+			return err
+		}
+		var annotationInfos []*resource.Info
+		for i := range infos {
+			data, err := util.GetOriginalConfiguration(infos[i].Object)
+			if err != nil {
+				return err
+			}
+			if data == nil {
+				continue
+			}
+
+			tempInfos, err := o.updatedResultGetter(data).Infos()
+			if err != nil {
+				return err
+			}
+			annotationInfos = append(annotationInfos, tempInfos[0])
+		}
+		if len(annotationInfos) == 0 {
+			return errors.New("no last-applied-configuration annotation found on resources, to create the annotation, use command `kubectl apply set-last-applied --create-annotation`")
+		}
+		return editFn(annotationInfos)
+	// If doing an edit before created, we don't want a list and instead want the normal behavior as kubectl create.
+	case EditBeforeCreateMode:
+		return o.OriginalResult.Visit(func(info *resource.Info, err error) error {
+			return editFn([]*resource.Info{info})
+		})
+	default:
+		return fmt.Errorf("unsupported edit mode %q", o.EditMode)
+	}
+}
+
+func (o *EditOptions) extractManagedFields(obj runtime.Object) error {
+	o.managedFields = make(map[types.UID][]metav1.ManagedFieldsEntry)
+	if meta.IsListType(obj) {
+		err := meta.EachListItem(obj, func(obj runtime.Object) error {
+			uid, mf, err := clearManagedFields(obj)
+			if err != nil {
+				return err
+			}
+			o.managedFields[uid] = mf
+			return nil
+		})
+		return err
+	}
+	uid, mf, err := clearManagedFields(obj)
+	if err != nil {
+		return err
+	}
+	o.managedFields[uid] = mf
+	return nil
+}
+
+func clearManagedFields(obj runtime.Object) (types.UID, []metav1.ManagedFieldsEntry, error) {
+	metaObjs, err := meta.Accessor(obj)
+	if err != nil {
+		return "", nil, err
+	}
+	mf := metaObjs.GetManagedFields()
+	metaObjs.SetManagedFields(nil)
+	return metaObjs.GetUID(), mf, nil
+}
+
+func (o *EditOptions) restoreManagedFields(infos []*resource.Info) error {
+	for _, info := range infos {
+		metaObjs, err := meta.Accessor(info.Object)
+		if err != nil {
+			return err
+		}
+		mf := o.managedFields[metaObjs.GetUID()]
+		metaObjs.SetManagedFields(mf)
+	}
+	return nil
+}
+
+func (o *EditOptions) visitToApplyEditPatch(originalInfos []*resource.Info, patchVisitor resource.Visitor) error {
+	err := patchVisitor.Visit(func(info *resource.Info, incomingErr error) error {
+		editObjUID, err := meta.NewAccessor().UID(info.Object)
+		if err != nil {
+			return err
+		}
+
+		var originalInfo *resource.Info
+		for _, i := range originalInfos {
+			originalObjUID, err := meta.NewAccessor().UID(i.Object)
+			if err != nil {
+				return err
+			}
+			if editObjUID == originalObjUID {
+				originalInfo = i
+				break
+			}
+		}
+		if originalInfo == nil {
+			return fmt.Errorf("no original object found for %#v", info.Object)
+		}
+
+		originalJS, err := encodeToJSON(originalInfo.Object.(runtime.Unstructured))
+		if err != nil {
+			return err
+		}
+
+		editedJS, err := encodeToJSON(info.Object.(runtime.Unstructured))
+		if err != nil {
+			return err
+		}
+
+		if reflect.DeepEqual(originalJS, editedJS) {
+			printer, err := o.ToPrinter("skipped")
+			if err != nil {
+				return err
+			}
+			return printer.PrintObj(info.Object, o.Out)
+		}
+		err = o.annotationPatch(info)
+		if err != nil {
+			return err
+		}
+
+		printer, err := o.ToPrinter("edited")
+		if err != nil {
+			return err
+		}
+		return printer.PrintObj(info.Object, o.Out)
+	})
+	return err
+}
+
+func (o *EditOptions) annotationPatch(update *resource.Info) error {
+	patch, _, patchType, err := GetApplyPatch(update.Object.(runtime.Unstructured))
+	if err != nil {
+		return err
+	}
+	mapping := update.ResourceMapping()
+	client, err := o.f.UnstructuredClientForMapping(mapping)
+	if err != nil {
+		return err
+	}
+	helper := resource.NewHelper(client, mapping).
+		WithFieldManager(o.FieldManager).
+		WithFieldValidation(o.ValidationDirective).
+		WithSubresource(o.Subresource)
+	_, err = helper.Patch(o.CmdNamespace, update.Name, patchType, patch, nil)
+	return err
+}
+
+// GetApplyPatch is used to get and apply patches
+func GetApplyPatch(obj runtime.Unstructured) ([]byte, []byte, types.PatchType, error) {
+	beforeJSON, err := encodeToJSON(obj)
+	if err != nil {
+		return nil, []byte(""), types.MergePatchType, err
+	}
+	objCopy := obj.DeepCopyObject()
+	accessor := meta.NewAccessor()
+	annotations, err := accessor.Annotations(objCopy)
+	if err != nil {
+		return nil, beforeJSON, types.MergePatchType, err
+	}
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[corev1.LastAppliedConfigAnnotation] = string(beforeJSON)
+	accessor.SetAnnotations(objCopy, annotations)
+	afterJSON, err := encodeToJSON(objCopy.(runtime.Unstructured))
+	if err != nil {
+		return nil, beforeJSON, types.MergePatchType, err
+	}
+	patch, err := jsonpatch.CreateMergePatch(beforeJSON, afterJSON)
+	return patch, beforeJSON, types.MergePatchType, err
+}
+
+func encodeToJSON(obj runtime.Unstructured) ([]byte, error) {
+	serialization, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	js, err := yaml.ToJSON(serialization)
+	if err != nil {
+		return nil, err
+	}
+	return js, nil
+}
+
+func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor resource.Visitor, results *editResults) error {
+	err := patchVisitor.Visit(func(info *resource.Info, incomingErr error) error {
+		editObjUID, err := meta.NewAccessor().UID(info.Object)
+		if err != nil {
+			return err
+		}
+
+		var originalInfo *resource.Info
+		for _, i := range originalInfos {
+			originalObjUID, err := meta.NewAccessor().UID(i.Object)
+			if err != nil {
+				return err
+			}
+			if editObjUID == originalObjUID {
+				originalInfo = i
+				break
+			}
+		}
+		if originalInfo == nil {
+			return fmt.Errorf("no original object found for %#v", info.Object)
+		}
+
+		originalJS, err := encodeToJSON(originalInfo.Object.(runtime.Unstructured))
+		if err != nil {
+			return err
+		}
+
+		editedJS, err := encodeToJSON(info.Object.(runtime.Unstructured))
+		if err != nil {
+			return err
+		}
+
+		if reflect.DeepEqual(originalJS, editedJS) {
+			// no edit, so just skip it.
+			printer, err := o.ToPrinter("skipped")
+			if err != nil {
+				return err
+			}
+			return printer.PrintObj(info.Object, o.Out)
+		}
+
+		preconditions := []mergepatch.PreconditionFunc{
+			mergepatch.RequireKeyUnchanged("apiVersion"),
+			mergepatch.RequireKeyUnchanged("kind"),
+			mergepatch.RequireMetadataKeyUnchanged("name"),
+			mergepatch.RequireKeyUnchanged("managedFields"),
+		}
+
+		// Create the versioned struct from the type defined in the mapping
+		// (which is the API version we'll be submitting the patch to)
+		versionedObject, err := scheme.Scheme.New(info.Mapping.GroupVersionKind)
+		var patchType types.PatchType
+		var patch []byte
+		switch {
+		case runtime.IsNotRegisteredError(err):
+			// fall back to generic JSON merge patch
+			patchType = types.MergePatchType
+			patch, err = jsonpatch.CreateMergePatch(originalJS, editedJS)
+			if err != nil {
+				klog.V(4).Infof("Unable to calculate diff, no merge is possible: %v", err)
+				return err
+			}
+			var patchMap map[string]interface{}
+			err = json.Unmarshal(patch, &patchMap)
+			if err != nil {
+				klog.V(4).Infof("Unable to calculate diff, no merge is possible: %v", err)
+				return err
+			}
+			for _, precondition := range preconditions {
+				if !precondition(patchMap) {
+					klog.V(4).Infof("Unable to calculate diff, no merge is possible: %v", err)
+					return fmt.Errorf("%s", "At least one of apiVersion, kind and name was changed")
+				}
+			}
+		case err != nil:
+			return err
+		default:
+			patchType = types.StrategicMergePatchType
+			patch, err = strategicpatch.CreateTwoWayMergePatch(originalJS, editedJS, versionedObject, preconditions...)
+			if err != nil {
+				klog.V(4).Infof("Unable to calculate diff, no merge is possible: %v", err)
+				if mergepatch.IsPreconditionFailed(err) {
+					return fmt.Errorf("%s", "At least one of apiVersion, kind and name was changed")
+				}
+				return err
+			}
+		}
+
+		if o.OutputPatch {
+			fmt.Fprintf(o.Out, "Patch: %s\n", string(patch))
+		}
+
+		patched, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.FieldManager).
+			WithFieldValidation(o.ValidationDirective).
+			WithSubresource(o.Subresource).
+			Patch(info.Namespace, info.Name, patchType, patch, nil)
+		if err != nil {
+			fmt.Fprintln(o.ErrOut, results.addError(err, info))
+			return nil
+		}
+		info.Refresh(patched, true)
+		printer, err := o.ToPrinter("edited")
+		if err != nil {
+			return err
+		}
+		return printer.PrintObj(info.Object, o.Out)
+	})
+	return err
+}
+
+func (o *EditOptions) visitToCreate(createVisitor resource.Visitor) error {
+	err := createVisitor.Visit(func(info *resource.Info, incomingErr error) error {
+		obj, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.FieldManager).
+			WithFieldValidation(o.ValidationDirective).
+			Create(info.Namespace, true, info.Object)
+		if err != nil {
+			return err
+		}
+		info.Refresh(obj, true)
+		printer, err := o.ToPrinter("created")
+		if err != nil {
+			return err
+		}
+		return printer.PrintObj(info.Object, o.Out)
+	})
+	return err
+}
+
+func (o *EditOptions) visitAnnotation(annotationVisitor resource.Visitor) error {
+	// iterate through all items to apply annotations
+	err := annotationVisitor.Visit(func(info *resource.Info, incomingErr error) error {
+		// put configuration annotation in "updates"
+		if o.ApplyAnnotation {
+			if err := util.CreateOrUpdateAnnotation(true, info.Object, scheme.DefaultJSONEncoder()); err != nil {
+				return err
+			}
+		}
+		if err := o.Recorder.Record(info.Object); err != nil {
+			klog.V(4).Infof("error recording current command: %v", err)
+		}
+
+		return nil
+
+	})
+	return err
+}
+
+// EditMode can be either NormalEditMode, EditBeforeCreateMode or ApplyEditMode
+type EditMode string
+
+const (
+	// NormalEditMode is an edit mode
+	NormalEditMode EditMode = "normal_mode"
+
+	// EditBeforeCreateMode is an edit mode
+	EditBeforeCreateMode EditMode = "edit_before_create_mode"
+
+	// ApplyEditMode is an edit mode
+	ApplyEditMode EditMode = "edit_last_applied_mode"
+)
+
+// editReason preserves a message about the reason this file must be edited again
+type editReason struct {
+	head  string
+	other []string
+}
+
+// editHeader includes a list of reasons the edit must be retried
+type editHeader struct {
+	reasons []editReason
+}
+
+// writeTo outputs the current header information into a stream
+func (h *editHeader) writeTo(w io.Writer, editMode EditMode) error {
+	if editMode == ApplyEditMode {
+		fmt.Fprint(w, `# Please edit the 'last-applied-configuration' annotations below.
+# Lines beginning with a '#' will be ignored, and an empty file will abort the edit.
+#
+`)
+	} else {
+		fmt.Fprint(w, `# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+`)
+	}
+
+	for _, r := range h.reasons {
+		if len(r.other) > 0 {
+			fmt.Fprintf(w, "# %s:\n", hashOnLineBreak(r.head))
+		} else {
+			fmt.Fprintf(w, "# %s\n", hashOnLineBreak(r.head))
+		}
+		for _, o := range r.other {
+			fmt.Fprintf(w, "# * %s\n", hashOnLineBreak(o))
+		}
+		fmt.Fprintln(w, "#")
+	}
+	return nil
+}
+
+// editResults capture the result of an update
+type editResults struct {
+	header    editHeader
+	retryable int
+	notfound  int
+	edit      []*resource.Info
+	file      string
+}
+
+func (r *editResults) addError(err error, info *resource.Info) string {
+	resourceString := info.Mapping.Resource.Resource
+	if len(info.Mapping.Resource.Group) > 0 {
+		resourceString = resourceString + "." + info.Mapping.Resource.Group
+	}
+
+	switch {
+	case apierrors.IsInvalid(err):
+		r.edit = append(r.edit, info)
+		reason := editReason{
+			head: fmt.Sprintf("%s %q was not valid", resourceString, info.Name),
+		}
+		if err, ok := err.(apierrors.APIStatus); ok {
+			if details := err.Status().Details; details != nil {
+				for _, cause := range details.Causes {
+					reason.other = append(reason.other, fmt.Sprintf("%s: %s", cause.Field, cause.Message))
+				}
+			}
+		}
+		r.header.reasons = append(r.header.reasons, reason)
+		return fmt.Sprintf("error: %s %q is invalid", resourceString, info.Name)
+	case apierrors.IsNotFound(err):
+		r.notfound++
+		return fmt.Sprintf("error: %s %q could not be found on the server", resourceString, info.Name)
+	default:
+		r.retryable++
+		return fmt.Sprintf("error: %s %q could not be patched: %v", resourceString, info.Name, err)
+	}
+}
+
+// preservedFile writes out a message about the provided file if it exists to the
+// provided output stream when an error happens. Used to notify the user where
+// their updates were preserved.
+func preservedFile(err error, path string, out io.Writer) error {
+	if len(path) > 0 {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			fmt.Fprintf(out, "A copy of your changes has been stored to %q\n", path)
+		}
+	}
+	return err
+}
+
+// hasLines returns true if any line in the provided stream is non empty - has non-whitespace
+// characters, or the first non-whitespace character is a '#' indicating a comment. Returns
+// any errors encountered reading the stream.
+func hasLines(r io.Reader) (bool, error) {
+	// TODO: if any files we read have > 64KB lines, we'll need to switch to bytes.ReadLine
+	// TODO: probably going to be secrets
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		if line := strings.TrimSpace(s.Text()); len(line) > 0 && line[0] != '#' {
+			return true, nil
+		}
+	}
+	if err := s.Err(); err != nil && err != io.EOF {
+		return false, err
+	}
+	return false, nil
+}
+
+// hashOnLineBreak returns a string built from the provided string by inserting any necessary '#'
+// characters after '\n' characters, indicating a comment.
+func hashOnLineBreak(s string) string {
+	r := ""
+	for i, ch := range s {
+		j := i + 1
+		if j < len(s) && ch == '\n' && s[j] != '#' {
+			r += "\n# "
+		} else {
+			r += string(ch)
+		}
+	}
+	return r
+}
+
+// editorEnvs returns an ordered list of env vars to check for editor preferences.
+func editorEnvs() []string {
+	return []string{
+		"KUBE_EDITOR",
+		"EDITOR",
+	}
+}

--- a/vendor/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
+++ b/vendor/k8s.io/kubectl/pkg/cmd/util/editor/editor.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package editor
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"k8s.io/kubectl/pkg/util/term"
+)
+
+const (
+	// sorry, blame Git
+	// TODO: on Windows rely on 'start' to launch the editor associated
+	// with the given file type. If we can't because of the need of
+	// blocking, use a script with 'ftype' and 'assoc' to detect it.
+	defaultEditor = "vi"
+	defaultShell  = "/bin/bash"
+	windowsEditor = "notepad"
+	windowsShell  = "cmd"
+)
+
+// Editor holds the command-line args to fire up the editor
+type Editor struct {
+	Args  []string
+	Shell bool
+}
+
+// NewDefaultEditor creates a struct Editor that uses the OS environment to
+// locate the editor program, looking at EDITOR environment variable to find
+// the proper command line. If the provided editor has no spaces, or no quotes,
+// it is treated as a bare command to be loaded. Otherwise, the string will
+// be passed to the user's shell for execution.
+func NewDefaultEditor(envs []string) Editor {
+	args, shell := defaultEnvEditor(envs)
+	return Editor{
+		Args:  args,
+		Shell: shell,
+	}
+}
+
+func defaultEnvShell() []string {
+	shell := os.Getenv("SHELL")
+	if len(shell) == 0 {
+		shell = platformize(defaultShell, windowsShell)
+	}
+	flag := "-c"
+	if shell == windowsShell {
+		flag = "/C"
+	}
+	return []string{shell, flag}
+}
+
+func defaultEnvEditor(envs []string) ([]string, bool) {
+	var editor string
+	for _, env := range envs {
+		if len(env) > 0 {
+			editor = os.Getenv(env)
+		}
+		if len(editor) > 0 {
+			break
+		}
+	}
+	if len(editor) == 0 {
+		editor = platformize(defaultEditor, windowsEditor)
+	}
+	if !strings.Contains(editor, " ") {
+		return []string{editor}, false
+	}
+	if !strings.ContainsAny(editor, "\"'\\") {
+		return strings.Split(editor, " "), false
+	}
+	// rather than parse the shell arguments ourselves, punt to the shell
+	shell := defaultEnvShell()
+	return append(shell, editor), true
+}
+
+func (e Editor) args(path string) []string {
+	args := make([]string, len(e.Args))
+	copy(args, e.Args)
+	if e.Shell {
+		last := args[len(args)-1]
+		args[len(args)-1] = fmt.Sprintf("%s %q", last, path)
+	} else {
+		args = append(args, path)
+	}
+	return args
+}
+
+// Launch opens the described or returns an error. The TTY will be protected, and
+// SIGQUIT, SIGTERM, and SIGINT will all be trapped.
+func (e Editor) Launch(path string) error {
+	if len(e.Args) == 0 {
+		return fmt.Errorf("no editor defined, can't open %s", path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	args := e.args(abs)
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	klog.V(5).Infof("Opening file with editor %v", args)
+	if err := (term.TTY{In: os.Stdin, TryDev: true}).Safe(cmd.Run); err != nil {
+		if err, ok := err.(*exec.Error); ok {
+			if err.Err == exec.ErrNotFound {
+				return fmt.Errorf("unable to launch the editor %q", strings.Join(e.Args, " "))
+			}
+		}
+		return fmt.Errorf("there was a problem with the editor %q", strings.Join(e.Args, " "))
+	}
+	return nil
+}
+
+// LaunchTempFile reads the provided stream into a temporary file in the given directory
+// and file prefix, and then invokes Launch with the path of that file. It will return
+// the contents of the file after launch, any errors that occur, and the path of the
+// temporary file so the caller can clean it up as needed.
+func (e Editor) LaunchTempFile(prefix, suffix string, r io.Reader) ([]byte, string, error) {
+	f, err := os.CreateTemp("", prefix+"*"+suffix)
+	if err != nil {
+		return nil, "", err
+	}
+	defer f.Close()
+	path := f.Name()
+	if _, err := io.Copy(f, r); err != nil {
+		os.Remove(path)
+		return nil, path, err
+	}
+	// This file descriptor needs to close so the next process (Launch) can claim it.
+	f.Close()
+	if err := e.Launch(path); err != nil {
+		return nil, path, err
+	}
+	bytes, err := os.ReadFile(path)
+	return bytes, path, err
+}
+
+func platformize(linux, windows string) string {
+	if runtime.GOOS == "windows" {
+		return windows
+	}
+	return linux
+}

--- a/vendor/k8s.io/kubectl/pkg/describe/describe.go
+++ b/vendor/k8s.io/kubectl/pkg/describe/describe.go
@@ -1,0 +1,5558 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+	"unicode"
+
+	"github.com/fatih/camelcase"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1alpha1 "k8s.io/api/networking/v1alpha1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	runtimeresource "k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
+	clientset "k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/reference"
+	utilcsr "k8s.io/client-go/util/certificate/csr"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util/certificate"
+	deploymentutil "k8s.io/kubectl/pkg/util/deployment"
+	"k8s.io/kubectl/pkg/util/event"
+	"k8s.io/kubectl/pkg/util/fieldpath"
+	"k8s.io/kubectl/pkg/util/qos"
+	"k8s.io/kubectl/pkg/util/rbac"
+	resourcehelper "k8s.io/kubectl/pkg/util/resource"
+	"k8s.io/kubectl/pkg/util/slice"
+	storageutil "k8s.io/kubectl/pkg/util/storage"
+)
+
+// Each level has 2 spaces for PrefixWriter
+const (
+	LEVEL_0 = iota
+	LEVEL_1
+	LEVEL_2
+	LEVEL_3
+	LEVEL_4
+)
+
+var (
+	// globally skipped annotations
+	skipAnnotations = sets.NewString(corev1.LastAppliedConfigAnnotation)
+
+	// DescriberFn gives a way to easily override the function for unit testing if needed
+	DescriberFn DescriberFunc = Describer
+)
+
+// Describer returns a Describer for displaying the specified RESTMapping type or an error.
+func Describer(restClientGetter genericclioptions.RESTClientGetter, mapping *meta.RESTMapping) (ResourceDescriber, error) {
+	clientConfig, err := restClientGetter.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	// try to get a describer
+	if describer, ok := DescriberFor(mapping.GroupVersionKind.GroupKind(), clientConfig); ok {
+		return describer, nil
+	}
+	// if this is a kind we don't have a describer for yet, go generic if possible
+	if genericDescriber, ok := GenericDescriberFor(mapping, clientConfig); ok {
+		return genericDescriber, nil
+	}
+	// otherwise return an unregistered error
+	return nil, fmt.Errorf("no description has been implemented for %s", mapping.GroupVersionKind.String())
+}
+
+// PrefixWriter can write text at various indentation levels.
+type PrefixWriter interface {
+	// Write writes text with the specified indentation level.
+	Write(level int, format string, a ...interface{})
+	// WriteLine writes an entire line with no indentation level.
+	WriteLine(a ...interface{})
+	// Flush forces indentation to be reset.
+	Flush()
+}
+
+// prefixWriter implements PrefixWriter
+type prefixWriter struct {
+	out io.Writer
+}
+
+var _ PrefixWriter = &prefixWriter{}
+
+// NewPrefixWriter creates a new PrefixWriter.
+func NewPrefixWriter(out io.Writer) PrefixWriter {
+	return &prefixWriter{out: out}
+}
+
+func (pw *prefixWriter) Write(level int, format string, a ...interface{}) {
+	levelSpace := "  "
+	prefix := ""
+	for i := 0; i < level; i++ {
+		prefix += levelSpace
+	}
+	output := fmt.Sprintf(prefix+format, a...)
+	printers.WriteEscaped(pw.out, output)
+}
+
+func (pw *prefixWriter) WriteLine(a ...interface{}) {
+	output := fmt.Sprintln(a...)
+	printers.WriteEscaped(pw.out, output)
+}
+
+func (pw *prefixWriter) Flush() {
+	if f, ok := pw.out.(flusher); ok {
+		f.Flush()
+	}
+}
+
+// nestedPrefixWriter implements PrefixWriter by increasing the level
+// before passing text on to some other writer.
+type nestedPrefixWriter struct {
+	PrefixWriter
+	indent int
+}
+
+var _ PrefixWriter = &prefixWriter{}
+
+// NewPrefixWriter creates a new PrefixWriter.
+func NewNestedPrefixWriter(out PrefixWriter, indent int) PrefixWriter {
+	return &nestedPrefixWriter{PrefixWriter: out, indent: indent}
+}
+
+func (npw *nestedPrefixWriter) Write(level int, format string, a ...interface{}) {
+	npw.PrefixWriter.Write(level+npw.indent, format, a...)
+}
+
+func (npw *nestedPrefixWriter) WriteLine(a ...interface{}) {
+	npw.PrefixWriter.Write(npw.indent, "%s", fmt.Sprintln(a...))
+}
+
+func describerMap(clientConfig *rest.Config) (map[schema.GroupKind]ResourceDescriber, error) {
+	c, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[schema.GroupKind]ResourceDescriber{
+		{Group: corev1.GroupName, Kind: "Pod"}:                                    &PodDescriber{c},
+		{Group: corev1.GroupName, Kind: "ReplicationController"}:                  &ReplicationControllerDescriber{c},
+		{Group: corev1.GroupName, Kind: "Secret"}:                                 &SecretDescriber{c},
+		{Group: corev1.GroupName, Kind: "Service"}:                                &ServiceDescriber{c},
+		{Group: corev1.GroupName, Kind: "ServiceAccount"}:                         &ServiceAccountDescriber{c},
+		{Group: corev1.GroupName, Kind: "Node"}:                                   &NodeDescriber{c},
+		{Group: corev1.GroupName, Kind: "LimitRange"}:                             &LimitRangeDescriber{c},
+		{Group: corev1.GroupName, Kind: "ResourceQuota"}:                          &ResourceQuotaDescriber{c},
+		{Group: corev1.GroupName, Kind: "PersistentVolume"}:                       &PersistentVolumeDescriber{c},
+		{Group: corev1.GroupName, Kind: "PersistentVolumeClaim"}:                  &PersistentVolumeClaimDescriber{c},
+		{Group: corev1.GroupName, Kind: "Namespace"}:                              &NamespaceDescriber{c},
+		{Group: corev1.GroupName, Kind: "Endpoints"}:                              &EndpointsDescriber{c},
+		{Group: corev1.GroupName, Kind: "ConfigMap"}:                              &ConfigMapDescriber{c},
+		{Group: corev1.GroupName, Kind: "PriorityClass"}:                          &PriorityClassDescriber{c},
+		{Group: discoveryv1beta1.GroupName, Kind: "EndpointSlice"}:                &EndpointSliceDescriber{c},
+		{Group: discoveryv1.GroupName, Kind: "EndpointSlice"}:                     &EndpointSliceDescriber{c},
+		{Group: autoscalingv2.GroupName, Kind: "HorizontalPodAutoscaler"}:         &HorizontalPodAutoscalerDescriber{c},
+		{Group: extensionsv1beta1.GroupName, Kind: "Ingress"}:                     &IngressDescriber{c},
+		{Group: networkingv1beta1.GroupName, Kind: "Ingress"}:                     &IngressDescriber{c},
+		{Group: networkingv1beta1.GroupName, Kind: "IngressClass"}:                &IngressClassDescriber{c},
+		{Group: networkingv1.GroupName, Kind: "Ingress"}:                          &IngressDescriber{c},
+		{Group: networkingv1.GroupName, Kind: "IngressClass"}:                     &IngressClassDescriber{c},
+		{Group: networkingv1alpha1.GroupName, Kind: "ServiceCIDR"}:                &ServiceCIDRDescriber{c},
+		{Group: networkingv1alpha1.GroupName, Kind: "IPAddress"}:                  &IPAddressDescriber{c},
+		{Group: batchv1.GroupName, Kind: "Job"}:                                   &JobDescriber{c},
+		{Group: batchv1.GroupName, Kind: "CronJob"}:                               &CronJobDescriber{c},
+		{Group: batchv1beta1.GroupName, Kind: "CronJob"}:                          &CronJobDescriber{c},
+		{Group: appsv1.GroupName, Kind: "StatefulSet"}:                            &StatefulSetDescriber{c},
+		{Group: appsv1.GroupName, Kind: "Deployment"}:                             &DeploymentDescriber{c},
+		{Group: appsv1.GroupName, Kind: "DaemonSet"}:                              &DaemonSetDescriber{c},
+		{Group: appsv1.GroupName, Kind: "ReplicaSet"}:                             &ReplicaSetDescriber{c},
+		{Group: certificatesv1beta1.GroupName, Kind: "CertificateSigningRequest"}: &CertificateSigningRequestDescriber{c},
+		{Group: storagev1.GroupName, Kind: "StorageClass"}:                        &StorageClassDescriber{c},
+		{Group: storagev1.GroupName, Kind: "CSINode"}:                             &CSINodeDescriber{c},
+		{Group: policyv1beta1.GroupName, Kind: "PodDisruptionBudget"}:             &PodDisruptionBudgetDescriber{c},
+		{Group: policyv1.GroupName, Kind: "PodDisruptionBudget"}:                  &PodDisruptionBudgetDescriber{c},
+		{Group: rbacv1.GroupName, Kind: "Role"}:                                   &RoleDescriber{c},
+		{Group: rbacv1.GroupName, Kind: "ClusterRole"}:                            &ClusterRoleDescriber{c},
+		{Group: rbacv1.GroupName, Kind: "RoleBinding"}:                            &RoleBindingDescriber{c},
+		{Group: rbacv1.GroupName, Kind: "ClusterRoleBinding"}:                     &ClusterRoleBindingDescriber{c},
+		{Group: networkingv1.GroupName, Kind: "NetworkPolicy"}:                    &NetworkPolicyDescriber{c},
+		{Group: schedulingv1.GroupName, Kind: "PriorityClass"}:                    &PriorityClassDescriber{c},
+	}
+
+	return m, nil
+}
+
+// DescriberFor returns the default describe functions for each of the standard
+// Kubernetes types.
+func DescriberFor(kind schema.GroupKind, clientConfig *rest.Config) (ResourceDescriber, bool) {
+	describers, err := describerMap(clientConfig)
+	if err != nil {
+		klog.V(1).Info(err)
+		return nil, false
+	}
+
+	f, ok := describers[kind]
+	return f, ok
+}
+
+// GenericDescriberFor returns a generic describer for the specified mapping
+// that uses only information available from runtime.Unstructured
+func GenericDescriberFor(mapping *meta.RESTMapping, clientConfig *rest.Config) (ResourceDescriber, bool) {
+	// used to fetch the resource
+	dynamicClient, err := dynamic.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, false
+	}
+
+	// used to get events for the resource
+	clientSet, err := clientset.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, false
+	}
+	eventsClient := clientSet.CoreV1()
+
+	return &genericDescriber{mapping, dynamicClient, eventsClient}, true
+}
+
+type genericDescriber struct {
+	mapping *meta.RESTMapping
+	dynamic dynamic.Interface
+	events  corev1client.EventsGetter
+}
+
+func (g *genericDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (output string, err error) {
+	obj, err := g.dynamic.Resource(g.mapping.Resource).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(g.events, obj, describerSettings.ChunkSize)
+	}
+
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", obj.GetName())
+		w.Write(LEVEL_0, "Namespace:\t%s\n", obj.GetNamespace())
+		printLabelsMultiline(w, "Labels", obj.GetLabels())
+		printAnnotationsMultiline(w, "Annotations", obj.GetAnnotations())
+		printUnstructuredContent(w, LEVEL_0, obj.UnstructuredContent(), "", ".metadata.managedFields", ".metadata.name",
+			".metadata.namespace", ".metadata.labels", ".metadata.annotations")
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func printUnstructuredContent(w PrefixWriter, level int, content map[string]interface{}, skipPrefix string, skip ...string) {
+	fields := []string{}
+	for field := range content {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+
+	for _, field := range fields {
+		value := content[field]
+		switch typedValue := value.(type) {
+		case map[string]interface{}:
+			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
+			if slice.ContainsString(skip, skipExpr, nil) {
+				continue
+			}
+			w.Write(level, "%s:\n", smartLabelFor(field))
+			printUnstructuredContent(w, level+1, typedValue, skipExpr, skip...)
+
+		case []interface{}:
+			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
+			if slice.ContainsString(skip, skipExpr, nil) {
+				continue
+			}
+			w.Write(level, "%s:\n", smartLabelFor(field))
+			for _, child := range typedValue {
+				switch typedChild := child.(type) {
+				case map[string]interface{}:
+					printUnstructuredContent(w, level+1, typedChild, skipExpr, skip...)
+				default:
+					w.Write(level+1, "%v\n", typedChild)
+				}
+			}
+
+		default:
+			skipExpr := fmt.Sprintf("%s.%s", skipPrefix, field)
+			if slice.ContainsString(skip, skipExpr, nil) {
+				continue
+			}
+			w.Write(level, "%s:\t%v\n", smartLabelFor(field), typedValue)
+		}
+	}
+}
+
+func smartLabelFor(field string) string {
+	// skip creating smart label if field name contains
+	// special characters other than '-'
+	if strings.IndexFunc(field, func(r rune) bool {
+		return !unicode.IsLetter(r) && r != '-'
+	}) != -1 {
+		return field
+	}
+
+	commonAcronyms := []string{"API", "URL", "UID", "OSB", "GUID"}
+	parts := camelcase.Split(field)
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "_" {
+			continue
+		}
+
+		if slice.ContainsString(commonAcronyms, strings.ToUpper(part), nil) {
+			part = strings.ToUpper(part)
+		} else {
+			part = strings.Title(part)
+		}
+		result = append(result, part)
+	}
+
+	return strings.Join(result, " ")
+}
+
+// DefaultObjectDescriber can describe the default Kubernetes objects.
+var DefaultObjectDescriber ObjectDescriber
+
+func init() {
+	d := &Describers{}
+	err := d.Add(
+		describeCertificateSigningRequest,
+		describeCronJob,
+		describeCSINode,
+		describeDaemonSet,
+		describeDeployment,
+		describeEndpoints,
+		describeEndpointSliceV1,
+		describeEndpointSliceV1beta1,
+		describeHorizontalPodAutoscalerV1,
+		describeHorizontalPodAutoscalerV2,
+		describeJob,
+		describeLimitRange,
+		describeNamespace,
+		describeNetworkPolicy,
+		describeNode,
+		describePersistentVolume,
+		describePersistentVolumeClaim,
+		describePod,
+		describePodDisruptionBudgetV1,
+		describePodDisruptionBudgetV1beta1,
+		describePriorityClass,
+		describeQuota,
+		describeReplicaSet,
+		describeReplicationController,
+		describeSecret,
+		describeService,
+		describeServiceAccount,
+		describeStatefulSet,
+		describeStorageClass,
+	)
+	if err != nil {
+		klog.Fatalf("Cannot register describers: %v", err)
+	}
+	DefaultObjectDescriber = d
+}
+
+// NamespaceDescriber generates information about a namespace
+type NamespaceDescriber struct {
+	clientset.Interface
+}
+
+func (d *NamespaceDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	ns, err := d.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	resourceQuotaList := &corev1.ResourceQuotaList{}
+	err = runtimeresource.FollowContinue(&metav1.ListOptions{Limit: describerSettings.ChunkSize},
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newList, err := d.CoreV1().ResourceQuotas(name).List(context.TODO(), options)
+			if err != nil {
+				return nil, runtimeresource.EnhanceListError(err, options, corev1.ResourceQuotas.String())
+			}
+			resourceQuotaList.Items = append(resourceQuotaList.Items, newList.Items...)
+			return newList, nil
+		})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Server does not support resource quotas.
+			// Not an error, will not show resource quotas information.
+			resourceQuotaList = nil
+		} else {
+			return "", err
+		}
+	}
+
+	limitRangeList := &corev1.LimitRangeList{}
+	err = runtimeresource.FollowContinue(&metav1.ListOptions{Limit: describerSettings.ChunkSize},
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newList, err := d.CoreV1().LimitRanges(name).List(context.TODO(), options)
+			if err != nil {
+				return nil, runtimeresource.EnhanceListError(err, options, "limitranges")
+			}
+			limitRangeList.Items = append(limitRangeList.Items, newList.Items...)
+			return newList, nil
+		})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Server does not support limit ranges.
+			// Not an error, will not show limit ranges information.
+			limitRangeList = nil
+		} else {
+			return "", err
+		}
+	}
+	return describeNamespace(ns, resourceQuotaList, limitRangeList)
+}
+
+func describeNamespace(namespace *corev1.Namespace, resourceQuotaList *corev1.ResourceQuotaList, limitRangeList *corev1.LimitRangeList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", namespace.Name)
+		printLabelsMultiline(w, "Labels", namespace.Labels)
+		printAnnotationsMultiline(w, "Annotations", namespace.Annotations)
+		w.Write(LEVEL_0, "Status:\t%s\n", string(namespace.Status.Phase))
+
+		if len(namespace.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n")
+			w.Write(LEVEL_1, "Type\tStatus\tLastTransitionTime\tReason\tMessage\n")
+			w.Write(LEVEL_1, "----\t------\t------------------\t------\t-------\n")
+			for _, c := range namespace.Status.Conditions {
+				w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
+					c.Type,
+					c.Status,
+					c.LastTransitionTime.Time.Format(time.RFC1123Z),
+					c.Reason,
+					c.Message)
+			}
+		}
+
+		if resourceQuotaList != nil {
+			w.Write(LEVEL_0, "\n")
+			DescribeResourceQuotas(resourceQuotaList, w)
+		}
+
+		if limitRangeList != nil {
+			w.Write(LEVEL_0, "\n")
+			DescribeLimitRanges(limitRangeList, w)
+		}
+
+		return nil
+	})
+}
+
+func describeLimitRangeSpec(spec corev1.LimitRangeSpec, prefix string, w PrefixWriter) {
+	for i := range spec.Limits {
+		item := spec.Limits[i]
+		maxResources := item.Max
+		minResources := item.Min
+		defaultLimitResources := item.Default
+		defaultRequestResources := item.DefaultRequest
+		ratio := item.MaxLimitRequestRatio
+
+		set := map[corev1.ResourceName]bool{}
+		for k := range maxResources {
+			set[k] = true
+		}
+		for k := range minResources {
+			set[k] = true
+		}
+		for k := range defaultLimitResources {
+			set[k] = true
+		}
+		for k := range defaultRequestResources {
+			set[k] = true
+		}
+		for k := range ratio {
+			set[k] = true
+		}
+
+		for k := range set {
+			// if no value is set, we output -
+			maxValue := "-"
+			minValue := "-"
+			defaultLimitValue := "-"
+			defaultRequestValue := "-"
+			ratioValue := "-"
+
+			maxQuantity, maxQuantityFound := maxResources[k]
+			if maxQuantityFound {
+				maxValue = maxQuantity.String()
+			}
+
+			minQuantity, minQuantityFound := minResources[k]
+			if minQuantityFound {
+				minValue = minQuantity.String()
+			}
+
+			defaultLimitQuantity, defaultLimitQuantityFound := defaultLimitResources[k]
+			if defaultLimitQuantityFound {
+				defaultLimitValue = defaultLimitQuantity.String()
+			}
+
+			defaultRequestQuantity, defaultRequestQuantityFound := defaultRequestResources[k]
+			if defaultRequestQuantityFound {
+				defaultRequestValue = defaultRequestQuantity.String()
+			}
+
+			ratioQuantity, ratioQuantityFound := ratio[k]
+			if ratioQuantityFound {
+				ratioValue = ratioQuantity.String()
+			}
+
+			msg := "%s%s\t%v\t%v\t%v\t%v\t%v\t%v\n"
+			w.Write(LEVEL_0, msg, prefix, item.Type, k, minValue, maxValue, defaultRequestValue, defaultLimitValue, ratioValue)
+		}
+	}
+}
+
+// DescribeLimitRanges merges a set of limit range items into a single tabular description
+func DescribeLimitRanges(limitRanges *corev1.LimitRangeList, w PrefixWriter) {
+	if len(limitRanges.Items) == 0 {
+		w.Write(LEVEL_0, "No LimitRange resource.\n")
+		return
+	}
+	w.Write(LEVEL_0, "Resource Limits\n Type\tResource\tMin\tMax\tDefault Request\tDefault Limit\tMax Limit/Request Ratio\n")
+	w.Write(LEVEL_0, " ----\t--------\t---\t---\t---------------\t-------------\t-----------------------\n")
+	for _, limitRange := range limitRanges.Items {
+		describeLimitRangeSpec(limitRange.Spec, " ", w)
+	}
+}
+
+// DescribeResourceQuotas merges a set of quota items into a single tabular description of all quotas
+func DescribeResourceQuotas(quotas *corev1.ResourceQuotaList, w PrefixWriter) {
+	if len(quotas.Items) == 0 {
+		w.Write(LEVEL_0, "No resource quota.\n")
+		return
+	}
+	sort.Sort(SortableResourceQuotas(quotas.Items))
+
+	w.Write(LEVEL_0, "Resource Quotas\n")
+	for _, q := range quotas.Items {
+		w.Write(LEVEL_1, "Name:\t%s\n", q.Name)
+		if len(q.Spec.Scopes) > 0 {
+			scopes := make([]string, 0, len(q.Spec.Scopes))
+			for _, scope := range q.Spec.Scopes {
+				scopes = append(scopes, string(scope))
+			}
+			sort.Strings(scopes)
+			w.Write(LEVEL_1, "Scopes:\t%s\n", strings.Join(scopes, ", "))
+			for _, scope := range scopes {
+				helpText := helpTextForResourceQuotaScope(corev1.ResourceQuotaScope(scope))
+				if len(helpText) > 0 {
+					w.Write(LEVEL_1, "* %s\n", helpText)
+				}
+			}
+		}
+
+		w.Write(LEVEL_1, "Resource\tUsed\tHard\n")
+		w.Write(LEVEL_1, "--------\t---\t---\n")
+
+		resources := make([]corev1.ResourceName, 0, len(q.Status.Hard))
+		for resource := range q.Status.Hard {
+			resources = append(resources, resource)
+		}
+		sort.Sort(SortableResourceNames(resources))
+
+		for _, resource := range resources {
+			hardQuantity := q.Status.Hard[resource]
+			usedQuantity := q.Status.Used[resource]
+			w.Write(LEVEL_1, "%s\t%s\t%s\n", string(resource), usedQuantity.String(), hardQuantity.String())
+		}
+	}
+}
+
+// LimitRangeDescriber generates information about a limit range
+type LimitRangeDescriber struct {
+	clientset.Interface
+}
+
+func (d *LimitRangeDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	lr := d.CoreV1().LimitRanges(namespace)
+
+	limitRange, err := lr.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return describeLimitRange(limitRange)
+}
+
+func describeLimitRange(limitRange *corev1.LimitRange) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", limitRange.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", limitRange.Namespace)
+		w.Write(LEVEL_0, "Type\tResource\tMin\tMax\tDefault Request\tDefault Limit\tMax Limit/Request Ratio\n")
+		w.Write(LEVEL_0, "----\t--------\t---\t---\t---------------\t-------------\t-----------------------\n")
+		describeLimitRangeSpec(limitRange.Spec, "", w)
+		return nil
+	})
+}
+
+// ResourceQuotaDescriber generates information about a resource quota
+type ResourceQuotaDescriber struct {
+	clientset.Interface
+}
+
+func (d *ResourceQuotaDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	rq := d.CoreV1().ResourceQuotas(namespace)
+
+	resourceQuota, err := rq.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return describeQuota(resourceQuota)
+}
+
+func helpTextForResourceQuotaScope(scope corev1.ResourceQuotaScope) string {
+	switch scope {
+	case corev1.ResourceQuotaScopeTerminating:
+		return "Matches all pods that have an active deadline. These pods have a limited lifespan on a node before being actively terminated by the system."
+	case corev1.ResourceQuotaScopeNotTerminating:
+		return "Matches all pods that do not have an active deadline. These pods usually include long running pods whose container command is not expected to terminate."
+	case corev1.ResourceQuotaScopeBestEffort:
+		return "Matches all pods that do not have resource requirements set. These pods have a best effort quality of service."
+	case corev1.ResourceQuotaScopeNotBestEffort:
+		return "Matches all pods that have at least one resource requirement set. These pods have a burstable or guaranteed quality of service."
+	default:
+		return ""
+	}
+}
+func describeQuota(resourceQuota *corev1.ResourceQuota) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", resourceQuota.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", resourceQuota.Namespace)
+		if len(resourceQuota.Spec.Scopes) > 0 {
+			scopes := make([]string, 0, len(resourceQuota.Spec.Scopes))
+			for _, scope := range resourceQuota.Spec.Scopes {
+				scopes = append(scopes, string(scope))
+			}
+			sort.Strings(scopes)
+			w.Write(LEVEL_0, "Scopes:\t%s\n", strings.Join(scopes, ", "))
+			for _, scope := range scopes {
+				helpText := helpTextForResourceQuotaScope(corev1.ResourceQuotaScope(scope))
+				if len(helpText) > 0 {
+					w.Write(LEVEL_0, " * %s\n", helpText)
+				}
+			}
+		}
+		w.Write(LEVEL_0, "Resource\tUsed\tHard\n")
+		w.Write(LEVEL_0, "--------\t----\t----\n")
+
+		resources := make([]corev1.ResourceName, 0, len(resourceQuota.Status.Hard))
+		for resource := range resourceQuota.Status.Hard {
+			resources = append(resources, resource)
+		}
+		sort.Sort(SortableResourceNames(resources))
+
+		msg := "%v\t%v\t%v\n"
+		for i := range resources {
+			resourceName := resources[i]
+			hardQuantity := resourceQuota.Status.Hard[resourceName]
+			usedQuantity := resourceQuota.Status.Used[resourceName]
+			if hardQuantity.Format != usedQuantity.Format {
+				usedQuantity = *resource.NewQuantity(usedQuantity.Value(), hardQuantity.Format)
+			}
+			w.Write(LEVEL_0, msg, resourceName, usedQuantity.String(), hardQuantity.String())
+		}
+		return nil
+	})
+}
+
+// PodDescriber generates information about a pod and the replication controllers that
+// create it.
+type PodDescriber struct {
+	clientset.Interface
+}
+
+func (d *PodDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	pod, err := d.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		if describerSettings.ShowEvents {
+			eventsInterface := d.CoreV1().Events(namespace)
+			selector := eventsInterface.GetFieldSelector(&name, &namespace, nil, nil)
+			initialOpts := metav1.ListOptions{
+				FieldSelector: selector.String(),
+				Limit:         describerSettings.ChunkSize,
+			}
+			events := &corev1.EventList{}
+			err2 := runtimeresource.FollowContinue(&initialOpts,
+				func(options metav1.ListOptions) (runtime.Object, error) {
+					newList, err := eventsInterface.List(context.TODO(), options)
+					if err != nil {
+						return nil, runtimeresource.EnhanceListError(err, options, "events")
+					}
+					events.Items = append(events.Items, newList.Items...)
+					return newList, nil
+				})
+
+			if err2 == nil && len(events.Items) > 0 {
+				return tabbedString(func(out io.Writer) error {
+					w := NewPrefixWriter(out)
+					w.Write(LEVEL_0, "Pod '%v': error '%v', but found events.\n", name, err)
+					DescribeEvents(events, w)
+					return nil
+				})
+			}
+		}
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		if ref, err := reference.GetReference(scheme.Scheme, pod); err != nil {
+			klog.Errorf("Unable to construct reference to '%#v': %v", pod, err)
+		} else {
+			ref.Kind = ""
+			if _, isMirrorPod := pod.Annotations[corev1.MirrorPodAnnotationKey]; isMirrorPod {
+				ref.UID = types.UID(pod.Annotations[corev1.MirrorPodAnnotationKey])
+			}
+			events, _ = searchEvents(d.CoreV1(), ref, describerSettings.ChunkSize)
+		}
+	}
+
+	return describePod(pod, events)
+}
+
+func describePod(pod *corev1.Pod, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", pod.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", pod.Namespace)
+		if pod.Spec.Priority != nil {
+			w.Write(LEVEL_0, "Priority:\t%d\n", *pod.Spec.Priority)
+		}
+		if len(pod.Spec.PriorityClassName) > 0 {
+			w.Write(LEVEL_0, "Priority Class Name:\t%s\n", pod.Spec.PriorityClassName)
+		}
+		if pod.Spec.RuntimeClassName != nil && len(*pod.Spec.RuntimeClassName) > 0 {
+			w.Write(LEVEL_0, "Runtime Class Name:\t%s\n", *pod.Spec.RuntimeClassName)
+		}
+		if len(pod.Spec.ServiceAccountName) > 0 {
+			w.Write(LEVEL_0, "Service Account:\t%s\n", pod.Spec.ServiceAccountName)
+		}
+		if pod.Spec.NodeName == "" {
+			w.Write(LEVEL_0, "Node:\t<none>\n")
+		} else {
+			w.Write(LEVEL_0, "Node:\t%s\n", pod.Spec.NodeName+"/"+pod.Status.HostIP)
+		}
+		if pod.Status.StartTime != nil {
+			w.Write(LEVEL_0, "Start Time:\t%s\n", pod.Status.StartTime.Time.Format(time.RFC1123Z))
+		}
+		printLabelsMultiline(w, "Labels", pod.Labels)
+		printAnnotationsMultiline(w, "Annotations", pod.Annotations)
+		if pod.DeletionTimestamp != nil {
+			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestampSince(*pod.DeletionTimestamp))
+			w.Write(LEVEL_0, "Termination Grace Period:\t%ds\n", *pod.DeletionGracePeriodSeconds)
+		} else {
+			w.Write(LEVEL_0, "Status:\t%s\n", string(pod.Status.Phase))
+		}
+		if len(pod.Status.Reason) > 0 {
+			w.Write(LEVEL_0, "Reason:\t%s\n", pod.Status.Reason)
+		}
+		if len(pod.Status.Message) > 0 {
+			w.Write(LEVEL_0, "Message:\t%s\n", pod.Status.Message)
+		}
+		if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SeccompProfile != nil {
+			w.Write(LEVEL_0, "SeccompProfile:\t%s\n", pod.Spec.SecurityContext.SeccompProfile.Type)
+			if pod.Spec.SecurityContext.SeccompProfile.Type == corev1.SeccompProfileTypeLocalhost {
+				w.Write(LEVEL_0, "LocalhostProfile:\t%s\n", *pod.Spec.SecurityContext.SeccompProfile.LocalhostProfile)
+			}
+		}
+		// remove when .IP field is depreciated
+		w.Write(LEVEL_0, "IP:\t%s\n", pod.Status.PodIP)
+		describePodIPs(pod, w, "")
+		if controlledBy := printController(pod); len(controlledBy) > 0 {
+			w.Write(LEVEL_0, "Controlled By:\t%s\n", controlledBy)
+		}
+		if len(pod.Status.NominatedNodeName) > 0 {
+			w.Write(LEVEL_0, "NominatedNodeName:\t%s\n", pod.Status.NominatedNodeName)
+		}
+
+		if len(pod.Spec.InitContainers) > 0 {
+			describeContainers("Init Containers", pod.Spec.InitContainers, pod.Status.InitContainerStatuses, EnvValueRetriever(pod), w, "")
+		}
+		describeContainers("Containers", pod.Spec.Containers, pod.Status.ContainerStatuses, EnvValueRetriever(pod), w, "")
+		if len(pod.Spec.EphemeralContainers) > 0 {
+			var ec []corev1.Container
+			for i := range pod.Spec.EphemeralContainers {
+				ec = append(ec, corev1.Container(pod.Spec.EphemeralContainers[i].EphemeralContainerCommon))
+			}
+			describeContainers("Ephemeral Containers", ec, pod.Status.EphemeralContainerStatuses, EnvValueRetriever(pod), w, "")
+		}
+		if len(pod.Spec.ReadinessGates) > 0 {
+			w.Write(LEVEL_0, "Readiness Gates:\n  Type\tStatus\n")
+			for _, g := range pod.Spec.ReadinessGates {
+				status := "<none>"
+				for _, c := range pod.Status.Conditions {
+					if c.Type == g.ConditionType {
+						status = fmt.Sprintf("%v", c.Status)
+						break
+					}
+				}
+				w.Write(LEVEL_1, "%v \t%v \n",
+					g.ConditionType,
+					status)
+			}
+		}
+		if len(pod.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n  Type\tStatus\n")
+			for _, c := range pod.Status.Conditions {
+				w.Write(LEVEL_1, "%v \t%v \n",
+					c.Type,
+					c.Status)
+			}
+		}
+		describeVolumes(pod.Spec.Volumes, w, "")
+		w.Write(LEVEL_0, "QoS Class:\t%s\n", qos.GetPodQOS(pod))
+		printLabelsMultiline(w, "Node-Selectors", pod.Spec.NodeSelector)
+		printPodTolerationsMultiline(w, "Tolerations", pod.Spec.Tolerations)
+		describeTopologySpreadConstraints(pod.Spec.TopologySpreadConstraints, w, "")
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func printController(controllee metav1.Object) string {
+	if controllerRef := metav1.GetControllerOf(controllee); controllerRef != nil {
+		return fmt.Sprintf("%s/%s", controllerRef.Kind, controllerRef.Name)
+	}
+	return ""
+}
+
+func describePodIPs(pod *corev1.Pod, w PrefixWriter, space string) {
+	if len(pod.Status.PodIPs) == 0 {
+		w.Write(LEVEL_0, "%sIPs:\t<none>\n", space)
+		return
+	}
+	w.Write(LEVEL_0, "%sIPs:\n", space)
+	for _, ipInfo := range pod.Status.PodIPs {
+		w.Write(LEVEL_1, "IP:\t%s\n", ipInfo.IP)
+	}
+}
+
+func describeTopologySpreadConstraints(tscs []corev1.TopologySpreadConstraint, w PrefixWriter, space string) {
+	if len(tscs) == 0 {
+		return
+	}
+
+	sort.Slice(tscs, func(i, j int) bool {
+		return tscs[i].TopologyKey < tscs[j].TopologyKey
+	})
+
+	w.Write(LEVEL_0, "%sTopology Spread Constraints:\t", space)
+	for i, tsc := range tscs {
+		if i != 0 {
+			w.Write(LEVEL_0, "%s", space)
+			w.Write(LEVEL_0, "%s", "\t")
+		}
+
+		w.Write(LEVEL_0, "%s:", tsc.TopologyKey)
+		w.Write(LEVEL_0, "%v", tsc.WhenUnsatisfiable)
+		w.Write(LEVEL_0, " when max skew %d is exceeded", tsc.MaxSkew)
+		if tsc.LabelSelector != nil {
+			w.Write(LEVEL_0, " for selector %s", metav1.FormatLabelSelector(tsc.LabelSelector))
+		}
+		w.Write(LEVEL_0, "\n")
+	}
+}
+
+func describeVolumes(volumes []corev1.Volume, w PrefixWriter, space string) {
+	if len(volumes) == 0 {
+		w.Write(LEVEL_0, "%sVolumes:\t<none>\n", space)
+		return
+	}
+
+	w.Write(LEVEL_0, "%sVolumes:\n", space)
+	for _, volume := range volumes {
+		nameIndent := ""
+		if len(space) > 0 {
+			nameIndent = " "
+		}
+		w.Write(LEVEL_1, "%s%v:\n", nameIndent, volume.Name)
+		switch {
+		case volume.VolumeSource.HostPath != nil:
+			printHostPathVolumeSource(volume.VolumeSource.HostPath, w)
+		case volume.VolumeSource.EmptyDir != nil:
+			printEmptyDirVolumeSource(volume.VolumeSource.EmptyDir, w)
+		case volume.VolumeSource.GCEPersistentDisk != nil:
+			printGCEPersistentDiskVolumeSource(volume.VolumeSource.GCEPersistentDisk, w)
+		case volume.VolumeSource.AWSElasticBlockStore != nil:
+			printAWSElasticBlockStoreVolumeSource(volume.VolumeSource.AWSElasticBlockStore, w)
+		case volume.VolumeSource.GitRepo != nil:
+			printGitRepoVolumeSource(volume.VolumeSource.GitRepo, w)
+		case volume.VolumeSource.Secret != nil:
+			printSecretVolumeSource(volume.VolumeSource.Secret, w)
+		case volume.VolumeSource.ConfigMap != nil:
+			printConfigMapVolumeSource(volume.VolumeSource.ConfigMap, w)
+		case volume.VolumeSource.NFS != nil:
+			printNFSVolumeSource(volume.VolumeSource.NFS, w)
+		case volume.VolumeSource.ISCSI != nil:
+			printISCSIVolumeSource(volume.VolumeSource.ISCSI, w)
+		case volume.VolumeSource.Glusterfs != nil:
+			printGlusterfsVolumeSource(volume.VolumeSource.Glusterfs, w)
+		case volume.VolumeSource.PersistentVolumeClaim != nil:
+			printPersistentVolumeClaimVolumeSource(volume.VolumeSource.PersistentVolumeClaim, w)
+		case volume.VolumeSource.Ephemeral != nil:
+			printEphemeralVolumeSource(volume.VolumeSource.Ephemeral, w)
+		case volume.VolumeSource.RBD != nil:
+			printRBDVolumeSource(volume.VolumeSource.RBD, w)
+		case volume.VolumeSource.Quobyte != nil:
+			printQuobyteVolumeSource(volume.VolumeSource.Quobyte, w)
+		case volume.VolumeSource.DownwardAPI != nil:
+			printDownwardAPIVolumeSource(volume.VolumeSource.DownwardAPI, w)
+		case volume.VolumeSource.AzureDisk != nil:
+			printAzureDiskVolumeSource(volume.VolumeSource.AzureDisk, w)
+		case volume.VolumeSource.VsphereVolume != nil:
+			printVsphereVolumeSource(volume.VolumeSource.VsphereVolume, w)
+		case volume.VolumeSource.Cinder != nil:
+			printCinderVolumeSource(volume.VolumeSource.Cinder, w)
+		case volume.VolumeSource.PhotonPersistentDisk != nil:
+			printPhotonPersistentDiskVolumeSource(volume.VolumeSource.PhotonPersistentDisk, w)
+		case volume.VolumeSource.PortworxVolume != nil:
+			printPortworxVolumeSource(volume.VolumeSource.PortworxVolume, w)
+		case volume.VolumeSource.ScaleIO != nil:
+			printScaleIOVolumeSource(volume.VolumeSource.ScaleIO, w)
+		case volume.VolumeSource.CephFS != nil:
+			printCephFSVolumeSource(volume.VolumeSource.CephFS, w)
+		case volume.VolumeSource.StorageOS != nil:
+			printStorageOSVolumeSource(volume.VolumeSource.StorageOS, w)
+		case volume.VolumeSource.FC != nil:
+			printFCVolumeSource(volume.VolumeSource.FC, w)
+		case volume.VolumeSource.AzureFile != nil:
+			printAzureFileVolumeSource(volume.VolumeSource.AzureFile, w)
+		case volume.VolumeSource.FlexVolume != nil:
+			printFlexVolumeSource(volume.VolumeSource.FlexVolume, w)
+		case volume.VolumeSource.Flocker != nil:
+			printFlockerVolumeSource(volume.VolumeSource.Flocker, w)
+		case volume.VolumeSource.Projected != nil:
+			printProjectedVolumeSource(volume.VolumeSource.Projected, w)
+		case volume.VolumeSource.CSI != nil:
+			printCSIVolumeSource(volume.VolumeSource.CSI, w)
+		default:
+			w.Write(LEVEL_1, "<unknown>\n")
+		}
+	}
+}
+
+func printHostPathVolumeSource(hostPath *corev1.HostPathVolumeSource, w PrefixWriter) {
+	hostPathType := "<none>"
+	if hostPath.Type != nil {
+		hostPathType = string(*hostPath.Type)
+	}
+	w.Write(LEVEL_2, "Type:\tHostPath (bare host directory volume)\n"+
+		"    Path:\t%v\n"+
+		"    HostPathType:\t%v\n",
+		hostPath.Path, hostPathType)
+}
+
+func printEmptyDirVolumeSource(emptyDir *corev1.EmptyDirVolumeSource, w PrefixWriter) {
+	var sizeLimit string
+	if emptyDir.SizeLimit != nil && emptyDir.SizeLimit.Cmp(resource.Quantity{}) > 0 {
+		sizeLimit = fmt.Sprintf("%v", emptyDir.SizeLimit)
+	} else {
+		sizeLimit = "<unset>"
+	}
+	w.Write(LEVEL_2, "Type:\tEmptyDir (a temporary directory that shares a pod's lifetime)\n"+
+		"    Medium:\t%v\n"+
+		"    SizeLimit:\t%v\n",
+		emptyDir.Medium, sizeLimit)
+}
+
+func printGCEPersistentDiskVolumeSource(gce *corev1.GCEPersistentDiskVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tGCEPersistentDisk (a Persistent Disk resource in Google Compute Engine)\n"+
+		"    PDName:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    Partition:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		gce.PDName, gce.FSType, gce.Partition, gce.ReadOnly)
+}
+
+func printAWSElasticBlockStoreVolumeSource(aws *corev1.AWSElasticBlockStoreVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tAWSElasticBlockStore (a Persistent Disk resource in AWS)\n"+
+		"    VolumeID:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    Partition:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		aws.VolumeID, aws.FSType, aws.Partition, aws.ReadOnly)
+}
+
+func printGitRepoVolumeSource(git *corev1.GitRepoVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tGitRepo (a volume that is pulled from git when the pod is created)\n"+
+		"    Repository:\t%v\n"+
+		"    Revision:\t%v\n",
+		git.Repository, git.Revision)
+}
+
+func printSecretVolumeSource(secret *corev1.SecretVolumeSource, w PrefixWriter) {
+	optional := secret.Optional != nil && *secret.Optional
+	w.Write(LEVEL_2, "Type:\tSecret (a volume populated by a Secret)\n"+
+		"    SecretName:\t%v\n"+
+		"    Optional:\t%v\n",
+		secret.SecretName, optional)
+}
+
+func printConfigMapVolumeSource(configMap *corev1.ConfigMapVolumeSource, w PrefixWriter) {
+	optional := configMap.Optional != nil && *configMap.Optional
+	w.Write(LEVEL_2, "Type:\tConfigMap (a volume populated by a ConfigMap)\n"+
+		"    Name:\t%v\n"+
+		"    Optional:\t%v\n",
+		configMap.Name, optional)
+}
+
+func printProjectedVolumeSource(projected *corev1.ProjectedVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tProjected (a volume that contains injected data from multiple sources)\n")
+	for _, source := range projected.Sources {
+		if source.Secret != nil {
+			w.Write(LEVEL_2, "SecretName:\t%v\n"+
+				"    SecretOptionalName:\t%v\n",
+				source.Secret.Name, source.Secret.Optional)
+		} else if source.DownwardAPI != nil {
+			w.Write(LEVEL_2, "DownwardAPI:\ttrue\n")
+		} else if source.ConfigMap != nil {
+			w.Write(LEVEL_2, "ConfigMapName:\t%v\n"+
+				"    ConfigMapOptional:\t%v\n",
+				source.ConfigMap.Name, source.ConfigMap.Optional)
+		} else if source.ServiceAccountToken != nil {
+			w.Write(LEVEL_2, "TokenExpirationSeconds:\t%d\n",
+				*source.ServiceAccountToken.ExpirationSeconds)
+		}
+	}
+}
+
+func printNFSVolumeSource(nfs *corev1.NFSVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tNFS (an NFS mount that lasts the lifetime of a pod)\n"+
+		"    Server:\t%v\n"+
+		"    Path:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		nfs.Server, nfs.Path, nfs.ReadOnly)
+}
+
+func printQuobyteVolumeSource(quobyte *corev1.QuobyteVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tQuobyte (a Quobyte mount on the host that shares a pod's lifetime)\n"+
+		"    Registry:\t%v\n"+
+		"    Volume:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		quobyte.Registry, quobyte.Volume, quobyte.ReadOnly)
+}
+
+func printPortworxVolumeSource(pwxVolume *corev1.PortworxVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tPortworxVolume (a Portworx Volume resource)\n"+
+		"    VolumeID:\t%v\n",
+		pwxVolume.VolumeID)
+}
+
+func printISCSIVolumeSource(iscsi *corev1.ISCSIVolumeSource, w PrefixWriter) {
+	initiator := "<none>"
+	if iscsi.InitiatorName != nil {
+		initiator = *iscsi.InitiatorName
+	}
+	w.Write(LEVEL_2, "Type:\tISCSI (an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod)\n"+
+		"    TargetPortal:\t%v\n"+
+		"    IQN:\t%v\n"+
+		"    Lun:\t%v\n"+
+		"    ISCSIInterface\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n"+
+		"    Portals:\t%v\n"+
+		"    DiscoveryCHAPAuth:\t%v\n"+
+		"    SessionCHAPAuth:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    InitiatorName:\t%v\n",
+		iscsi.TargetPortal, iscsi.IQN, iscsi.Lun, iscsi.ISCSIInterface, iscsi.FSType, iscsi.ReadOnly, iscsi.Portals, iscsi.DiscoveryCHAPAuth, iscsi.SessionCHAPAuth, iscsi.SecretRef, initiator)
+}
+
+func printISCSIPersistentVolumeSource(iscsi *corev1.ISCSIPersistentVolumeSource, w PrefixWriter) {
+	initiatorName := "<none>"
+	if iscsi.InitiatorName != nil {
+		initiatorName = *iscsi.InitiatorName
+	}
+	w.Write(LEVEL_2, "Type:\tISCSI (an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod)\n"+
+		"    TargetPortal:\t%v\n"+
+		"    IQN:\t%v\n"+
+		"    Lun:\t%v\n"+
+		"    ISCSIInterface\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n"+
+		"    Portals:\t%v\n"+
+		"    DiscoveryCHAPAuth:\t%v\n"+
+		"    SessionCHAPAuth:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    InitiatorName:\t%v\n",
+		iscsi.TargetPortal, iscsi.IQN, iscsi.Lun, iscsi.ISCSIInterface, iscsi.FSType, iscsi.ReadOnly, iscsi.Portals, iscsi.DiscoveryCHAPAuth, iscsi.SessionCHAPAuth, iscsi.SecretRef, initiatorName)
+}
+
+func printGlusterfsVolumeSource(glusterfs *corev1.GlusterfsVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tGlusterfs (a Glusterfs mount on the host that shares a pod's lifetime)\n"+
+		"    EndpointsName:\t%v\n"+
+		"    Path:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		glusterfs.EndpointsName, glusterfs.Path, glusterfs.ReadOnly)
+}
+
+func printGlusterfsPersistentVolumeSource(glusterfs *corev1.GlusterfsPersistentVolumeSource, w PrefixWriter) {
+	endpointsNamespace := "<unset>"
+	if glusterfs.EndpointsNamespace != nil {
+		endpointsNamespace = *glusterfs.EndpointsNamespace
+	}
+	w.Write(LEVEL_2, "Type:\tGlusterfs (a Glusterfs mount on the host that shares a pod's lifetime)\n"+
+		"    EndpointsName:\t%v\n"+
+		"    EndpointsNamespace:\t%v\n"+
+		"    Path:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		glusterfs.EndpointsName, endpointsNamespace, glusterfs.Path, glusterfs.ReadOnly)
+}
+
+func printPersistentVolumeClaimVolumeSource(claim *corev1.PersistentVolumeClaimVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tPersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)\n"+
+		"    ClaimName:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		claim.ClaimName, claim.ReadOnly)
+}
+
+func printEphemeralVolumeSource(ephemeral *corev1.EphemeralVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tEphemeralVolume (an inline specification for a volume that gets created and deleted with the pod)\n")
+	if ephemeral.VolumeClaimTemplate != nil {
+		printPersistentVolumeClaim(NewNestedPrefixWriter(w, LEVEL_2),
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: ephemeral.VolumeClaimTemplate.ObjectMeta,
+				Spec:       ephemeral.VolumeClaimTemplate.Spec,
+			}, false /* not a full PVC */)
+	}
+}
+
+func printRBDVolumeSource(rbd *corev1.RBDVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tRBD (a Rados Block Device mount on the host that shares a pod's lifetime)\n"+
+		"    CephMonitors:\t%v\n"+
+		"    RBDImage:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    RBDPool:\t%v\n"+
+		"    RadosUser:\t%v\n"+
+		"    Keyring:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		rbd.CephMonitors, rbd.RBDImage, rbd.FSType, rbd.RBDPool, rbd.RadosUser, rbd.Keyring, rbd.SecretRef, rbd.ReadOnly)
+}
+
+func printRBDPersistentVolumeSource(rbd *corev1.RBDPersistentVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tRBD (a Rados Block Device mount on the host that shares a pod's lifetime)\n"+
+		"    CephMonitors:\t%v\n"+
+		"    RBDImage:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    RBDPool:\t%v\n"+
+		"    RadosUser:\t%v\n"+
+		"    Keyring:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		rbd.CephMonitors, rbd.RBDImage, rbd.FSType, rbd.RBDPool, rbd.RadosUser, rbd.Keyring, rbd.SecretRef, rbd.ReadOnly)
+}
+
+func printDownwardAPIVolumeSource(d *corev1.DownwardAPIVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tDownwardAPI (a volume populated by information about the pod)\n    Items:\n")
+	for _, mapping := range d.Items {
+		if mapping.FieldRef != nil {
+			w.Write(LEVEL_3, "%v -> %v\n", mapping.FieldRef.FieldPath, mapping.Path)
+		}
+		if mapping.ResourceFieldRef != nil {
+			w.Write(LEVEL_3, "%v -> %v\n", mapping.ResourceFieldRef.Resource, mapping.Path)
+		}
+	}
+}
+
+func printAzureDiskVolumeSource(d *corev1.AzureDiskVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tAzureDisk (an Azure Data Disk mount on the host and bind mount to the pod)\n"+
+		"    DiskName:\t%v\n"+
+		"    DiskURI:\t%v\n"+
+		"    Kind: \t%v\n"+
+		"    FSType:\t%v\n"+
+		"    CachingMode:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		d.DiskName, d.DataDiskURI, *d.Kind, *d.FSType, *d.CachingMode, *d.ReadOnly)
+}
+
+func printVsphereVolumeSource(vsphere *corev1.VsphereVirtualDiskVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tvSphereVolume (a Persistent Disk resource in vSphere)\n"+
+		"    VolumePath:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    StoragePolicyName:\t%v\n",
+		vsphere.VolumePath, vsphere.FSType, vsphere.StoragePolicyName)
+}
+
+func printPhotonPersistentDiskVolumeSource(photon *corev1.PhotonPersistentDiskVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tPhotonPersistentDisk (a Persistent Disk resource in photon platform)\n"+
+		"    PdID:\t%v\n"+
+		"    FSType:\t%v\n",
+		photon.PdID, photon.FSType)
+}
+
+func printCinderVolumeSource(cinder *corev1.CinderVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tCinder (a Persistent Disk resource in OpenStack)\n"+
+		"    VolumeID:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n"+
+		"    SecretRef:\t%v\n",
+		cinder.VolumeID, cinder.FSType, cinder.ReadOnly, cinder.SecretRef)
+}
+
+func printCinderPersistentVolumeSource(cinder *corev1.CinderPersistentVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tCinder (a Persistent Disk resource in OpenStack)\n"+
+		"    VolumeID:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n"+
+		"    SecretRef:\t%v\n",
+		cinder.VolumeID, cinder.FSType, cinder.ReadOnly, cinder.SecretRef)
+}
+
+func printScaleIOVolumeSource(sio *corev1.ScaleIOVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tScaleIO (a persistent volume backed by a block device in ScaleIO)\n"+
+		"    Gateway:\t%v\n"+
+		"    System:\t%v\n"+
+		"    Protection Domain:\t%v\n"+
+		"    Storage Pool:\t%v\n"+
+		"    Storage Mode:\t%v\n"+
+		"    VolumeName:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		sio.Gateway, sio.System, sio.ProtectionDomain, sio.StoragePool, sio.StorageMode, sio.VolumeName, sio.FSType, sio.ReadOnly)
+}
+
+func printScaleIOPersistentVolumeSource(sio *corev1.ScaleIOPersistentVolumeSource, w PrefixWriter) {
+	var secretNS, secretName string
+	if sio.SecretRef != nil {
+		secretName = sio.SecretRef.Name
+		secretNS = sio.SecretRef.Namespace
+	}
+	w.Write(LEVEL_2, "Type:\tScaleIO (a persistent volume backed by a block device in ScaleIO)\n"+
+		"    Gateway:\t%v\n"+
+		"    System:\t%v\n"+
+		"    Protection Domain:\t%v\n"+
+		"    Storage Pool:\t%v\n"+
+		"    Storage Mode:\t%v\n"+
+		"    VolumeName:\t%v\n"+
+		"    SecretName:\t%v\n"+
+		"    SecretNamespace:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		sio.Gateway, sio.System, sio.ProtectionDomain, sio.StoragePool, sio.StorageMode, sio.VolumeName, secretName, secretNS, sio.FSType, sio.ReadOnly)
+}
+
+func printLocalVolumeSource(ls *corev1.LocalVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tLocalVolume (a persistent volume backed by local storage on a node)\n"+
+		"    Path:\t%v\n",
+		ls.Path)
+}
+
+func printCephFSVolumeSource(cephfs *corev1.CephFSVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tCephFS (a CephFS mount on the host that shares a pod's lifetime)\n"+
+		"    Monitors:\t%v\n"+
+		"    Path:\t%v\n"+
+		"    User:\t%v\n"+
+		"    SecretFile:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		cephfs.Monitors, cephfs.Path, cephfs.User, cephfs.SecretFile, cephfs.SecretRef, cephfs.ReadOnly)
+}
+
+func printCephFSPersistentVolumeSource(cephfs *corev1.CephFSPersistentVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tCephFS (a CephFS mount on the host that shares a pod's lifetime)\n"+
+		"    Monitors:\t%v\n"+
+		"    Path:\t%v\n"+
+		"    User:\t%v\n"+
+		"    SecretFile:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		cephfs.Monitors, cephfs.Path, cephfs.User, cephfs.SecretFile, cephfs.SecretRef, cephfs.ReadOnly)
+}
+
+func printStorageOSVolumeSource(storageos *corev1.StorageOSVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tStorageOS (a StorageOS Persistent Disk resource)\n"+
+		"    VolumeName:\t%v\n"+
+		"    VolumeNamespace:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		storageos.VolumeName, storageos.VolumeNamespace, storageos.FSType, storageos.ReadOnly)
+}
+
+func printStorageOSPersistentVolumeSource(storageos *corev1.StorageOSPersistentVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tStorageOS (a StorageOS Persistent Disk resource)\n"+
+		"    VolumeName:\t%v\n"+
+		"    VolumeNamespace:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		storageos.VolumeName, storageos.VolumeNamespace, storageos.FSType, storageos.ReadOnly)
+}
+
+func printFCVolumeSource(fc *corev1.FCVolumeSource, w PrefixWriter) {
+	lun := "<none>"
+	if fc.Lun != nil {
+		lun = strconv.Itoa(int(*fc.Lun))
+	}
+	w.Write(LEVEL_2, "Type:\tFC (a Fibre Channel disk)\n"+
+		"    TargetWWNs:\t%v\n"+
+		"    LUN:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		strings.Join(fc.TargetWWNs, ", "), lun, fc.FSType, fc.ReadOnly)
+}
+
+func printAzureFileVolumeSource(azureFile *corev1.AzureFileVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tAzureFile (an Azure File Service mount on the host and bind mount to the pod)\n"+
+		"    SecretName:\t%v\n"+
+		"    ShareName:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		azureFile.SecretName, azureFile.ShareName, azureFile.ReadOnly)
+}
+
+func printAzureFilePersistentVolumeSource(azureFile *corev1.AzureFilePersistentVolumeSource, w PrefixWriter) {
+	ns := ""
+	if azureFile.SecretNamespace != nil {
+		ns = *azureFile.SecretNamespace
+	}
+	w.Write(LEVEL_2, "Type:\tAzureFile (an Azure File Service mount on the host and bind mount to the pod)\n"+
+		"    SecretName:\t%v\n"+
+		"    SecretNamespace:\t%v\n"+
+		"    ShareName:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		azureFile.SecretName, ns, azureFile.ShareName, azureFile.ReadOnly)
+}
+
+func printFlexPersistentVolumeSource(flex *corev1.FlexPersistentVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tFlexVolume (a generic volume resource that is provisioned/attached using an exec based plugin)\n"+
+		"    Driver:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    ReadOnly:\t%v\n"+
+		"    Options:\t%v\n",
+		flex.Driver, flex.FSType, flex.SecretRef, flex.ReadOnly, flex.Options)
+}
+
+func printFlexVolumeSource(flex *corev1.FlexVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tFlexVolume (a generic volume resource that is provisioned/attached using an exec based plugin)\n"+
+		"    Driver:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    SecretRef:\t%v\n"+
+		"    ReadOnly:\t%v\n"+
+		"    Options:\t%v\n",
+		flex.Driver, flex.FSType, flex.SecretRef, flex.ReadOnly, flex.Options)
+}
+
+func printFlockerVolumeSource(flocker *corev1.FlockerVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tFlocker (a Flocker volume mounted by the Flocker agent)\n"+
+		"    DatasetName:\t%v\n"+
+		"    DatasetUUID:\t%v\n",
+		flocker.DatasetName, flocker.DatasetUUID)
+}
+
+func printCSIVolumeSource(csi *corev1.CSIVolumeSource, w PrefixWriter) {
+	var readOnly bool
+	var fsType string
+	if csi.ReadOnly != nil && *csi.ReadOnly {
+		readOnly = true
+	}
+	if csi.FSType != nil {
+		fsType = *csi.FSType
+	}
+	w.Write(LEVEL_2, "Type:\tCSI (a Container Storage Interface (CSI) volume source)\n"+
+		"    Driver:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		csi.Driver, fsType, readOnly)
+	printCSIPersistentVolumeAttributesMultiline(w, "VolumeAttributes", csi.VolumeAttributes)
+}
+
+func printCSIPersistentVolumeSource(csi *corev1.CSIPersistentVolumeSource, w PrefixWriter) {
+	w.Write(LEVEL_2, "Type:\tCSI (a Container Storage Interface (CSI) volume source)\n"+
+		"    Driver:\t%v\n"+
+		"    FSType:\t%v\n"+
+		"    VolumeHandle:\t%v\n"+
+		"    ReadOnly:\t%v\n",
+		csi.Driver, csi.FSType, csi.VolumeHandle, csi.ReadOnly)
+	printCSIPersistentVolumeAttributesMultiline(w, "VolumeAttributes", csi.VolumeAttributes)
+}
+
+func printCSIPersistentVolumeAttributesMultiline(w PrefixWriter, title string, annotations map[string]string) {
+	printCSIPersistentVolumeAttributesMultilineIndent(w, "", title, "\t", annotations, sets.NewString())
+}
+
+func printCSIPersistentVolumeAttributesMultilineIndent(w PrefixWriter, initialIndent, title, innerIndent string, attributes map[string]string, skip sets.String) {
+	w.Write(LEVEL_2, "%s%s:%s", initialIndent, title, innerIndent)
+
+	if len(attributes) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	// to print labels in the sorted order
+	keys := make([]string, 0, len(attributes))
+	for key := range attributes {
+		if skip.Has(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if len(attributes) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+	sort.Strings(keys)
+
+	for i, key := range keys {
+		if i != 0 {
+			w.Write(LEVEL_2, initialIndent)
+			w.Write(LEVEL_2, innerIndent)
+		}
+		line := fmt.Sprintf("%s=%s", key, attributes[key])
+		if len(line) > maxAnnotationLen {
+			w.Write(LEVEL_2, "%s...\n", line[:maxAnnotationLen])
+		} else {
+			w.Write(LEVEL_2, "%s\n", line)
+		}
+	}
+}
+
+type PersistentVolumeDescriber struct {
+	clientset.Interface
+}
+
+func (d *PersistentVolumeDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.CoreV1().PersistentVolumes()
+
+	pv, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), pv, describerSettings.ChunkSize)
+	}
+
+	return describePersistentVolume(pv, events)
+}
+
+func printVolumeNodeAffinity(w PrefixWriter, affinity *corev1.VolumeNodeAffinity) {
+	w.Write(LEVEL_0, "Node Affinity:\t")
+	if affinity == nil || affinity.Required == nil {
+		w.WriteLine("<none>")
+		return
+	}
+	w.WriteLine("")
+
+	if affinity.Required != nil {
+		w.Write(LEVEL_1, "Required Terms:\t")
+		if len(affinity.Required.NodeSelectorTerms) == 0 {
+			w.WriteLine("<none>")
+		} else {
+			w.WriteLine("")
+			for i, term := range affinity.Required.NodeSelectorTerms {
+				printNodeSelectorTermsMultilineWithIndent(w, LEVEL_2, fmt.Sprintf("Term %v", i), "\t", term.MatchExpressions)
+			}
+		}
+	}
+}
+
+// printLabelsMultiline prints multiple labels with a user-defined alignment.
+func printNodeSelectorTermsMultilineWithIndent(w PrefixWriter, indentLevel int, title, innerIndent string, reqs []corev1.NodeSelectorRequirement) {
+	w.Write(indentLevel, "%s:%s", title, innerIndent)
+
+	if len(reqs) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	for i, req := range reqs {
+		if i != 0 {
+			w.Write(indentLevel, "%s", innerIndent)
+		}
+		exprStr := fmt.Sprintf("%s %s", req.Key, strings.ToLower(string(req.Operator)))
+		if len(req.Values) > 0 {
+			exprStr = fmt.Sprintf("%s [%s]", exprStr, strings.Join(req.Values, ", "))
+		}
+		w.Write(LEVEL_0, "%s\n", exprStr)
+	}
+}
+
+func describePersistentVolume(pv *corev1.PersistentVolume, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", pv.Name)
+		printLabelsMultiline(w, "Labels", pv.ObjectMeta.Labels)
+		printAnnotationsMultiline(w, "Annotations", pv.ObjectMeta.Annotations)
+		w.Write(LEVEL_0, "Finalizers:\t%v\n", pv.ObjectMeta.Finalizers)
+		w.Write(LEVEL_0, "StorageClass:\t%s\n", storageutil.GetPersistentVolumeClass(pv))
+		if pv.ObjectMeta.DeletionTimestamp != nil {
+			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestampSince(*pv.ObjectMeta.DeletionTimestamp))
+		} else {
+			w.Write(LEVEL_0, "Status:\t%v\n", pv.Status.Phase)
+		}
+		if pv.Spec.ClaimRef != nil {
+			w.Write(LEVEL_0, "Claim:\t%s\n", pv.Spec.ClaimRef.Namespace+"/"+pv.Spec.ClaimRef.Name)
+		} else {
+			w.Write(LEVEL_0, "Claim:\t%s\n", "")
+		}
+		w.Write(LEVEL_0, "Reclaim Policy:\t%v\n", pv.Spec.PersistentVolumeReclaimPolicy)
+		w.Write(LEVEL_0, "Access Modes:\t%s\n", storageutil.GetAccessModesAsString(pv.Spec.AccessModes))
+		if pv.Spec.VolumeMode != nil {
+			w.Write(LEVEL_0, "VolumeMode:\t%v\n", *pv.Spec.VolumeMode)
+		}
+		storage := pv.Spec.Capacity[corev1.ResourceStorage]
+		w.Write(LEVEL_0, "Capacity:\t%s\n", storage.String())
+		printVolumeNodeAffinity(w, pv.Spec.NodeAffinity)
+		w.Write(LEVEL_0, "Message:\t%s\n", pv.Status.Message)
+		w.Write(LEVEL_0, "Source:\n")
+
+		switch {
+		case pv.Spec.HostPath != nil:
+			printHostPathVolumeSource(pv.Spec.HostPath, w)
+		case pv.Spec.GCEPersistentDisk != nil:
+			printGCEPersistentDiskVolumeSource(pv.Spec.GCEPersistentDisk, w)
+		case pv.Spec.AWSElasticBlockStore != nil:
+			printAWSElasticBlockStoreVolumeSource(pv.Spec.AWSElasticBlockStore, w)
+		case pv.Spec.NFS != nil:
+			printNFSVolumeSource(pv.Spec.NFS, w)
+		case pv.Spec.ISCSI != nil:
+			printISCSIPersistentVolumeSource(pv.Spec.ISCSI, w)
+		case pv.Spec.Glusterfs != nil:
+			printGlusterfsPersistentVolumeSource(pv.Spec.Glusterfs, w)
+		case pv.Spec.RBD != nil:
+			printRBDPersistentVolumeSource(pv.Spec.RBD, w)
+		case pv.Spec.Quobyte != nil:
+			printQuobyteVolumeSource(pv.Spec.Quobyte, w)
+		case pv.Spec.VsphereVolume != nil:
+			printVsphereVolumeSource(pv.Spec.VsphereVolume, w)
+		case pv.Spec.Cinder != nil:
+			printCinderPersistentVolumeSource(pv.Spec.Cinder, w)
+		case pv.Spec.AzureDisk != nil:
+			printAzureDiskVolumeSource(pv.Spec.AzureDisk, w)
+		case pv.Spec.PhotonPersistentDisk != nil:
+			printPhotonPersistentDiskVolumeSource(pv.Spec.PhotonPersistentDisk, w)
+		case pv.Spec.PortworxVolume != nil:
+			printPortworxVolumeSource(pv.Spec.PortworxVolume, w)
+		case pv.Spec.ScaleIO != nil:
+			printScaleIOPersistentVolumeSource(pv.Spec.ScaleIO, w)
+		case pv.Spec.Local != nil:
+			printLocalVolumeSource(pv.Spec.Local, w)
+		case pv.Spec.CephFS != nil:
+			printCephFSPersistentVolumeSource(pv.Spec.CephFS, w)
+		case pv.Spec.StorageOS != nil:
+			printStorageOSPersistentVolumeSource(pv.Spec.StorageOS, w)
+		case pv.Spec.FC != nil:
+			printFCVolumeSource(pv.Spec.FC, w)
+		case pv.Spec.AzureFile != nil:
+			printAzureFilePersistentVolumeSource(pv.Spec.AzureFile, w)
+		case pv.Spec.FlexVolume != nil:
+			printFlexPersistentVolumeSource(pv.Spec.FlexVolume, w)
+		case pv.Spec.Flocker != nil:
+			printFlockerVolumeSource(pv.Spec.Flocker, w)
+		case pv.Spec.CSI != nil:
+			printCSIPersistentVolumeSource(pv.Spec.CSI, w)
+		default:
+			w.Write(LEVEL_1, "<unknown>\n")
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+type PersistentVolumeClaimDescriber struct {
+	clientset.Interface
+}
+
+func (d *PersistentVolumeClaimDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.CoreV1().PersistentVolumeClaims(namespace)
+
+	pvc, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	pc := d.CoreV1().Pods(namespace)
+
+	pods, err := getPodsForPVC(pc, pvc, describerSettings)
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), pvc, describerSettings.ChunkSize)
+	}
+
+	return describePersistentVolumeClaim(pvc, events, pods)
+}
+
+func getPodsForPVC(c corev1client.PodInterface, pvc *corev1.PersistentVolumeClaim, settings DescriberSettings) ([]corev1.Pod, error) {
+	nsPods, err := getPodsInChunks(c, metav1.ListOptions{Limit: settings.ChunkSize})
+	if err != nil {
+		return []corev1.Pod{}, err
+	}
+
+	var pods []corev1.Pod
+
+	for _, pod := range nsPods.Items {
+		for _, volume := range pod.Spec.Volumes {
+			if volume.VolumeSource.PersistentVolumeClaim != nil && volume.VolumeSource.PersistentVolumeClaim.ClaimName == pvc.Name {
+				pods = append(pods, pod)
+			}
+		}
+	}
+
+ownersLoop:
+	for _, ownerRef := range pvc.ObjectMeta.OwnerReferences {
+		if ownerRef.Kind != "Pod" {
+			continue
+		}
+
+		podIndex := -1
+		for i, pod := range nsPods.Items {
+			if pod.UID == ownerRef.UID {
+				podIndex = i
+				break
+			}
+		}
+		if podIndex == -1 {
+			// Maybe the pod has been deleted
+			continue
+		}
+
+		for _, pod := range pods {
+			if pod.UID == nsPods.Items[podIndex].UID {
+				// This owner pod is already recorded, look for pods between other owners
+				continue ownersLoop
+			}
+		}
+
+		pods = append(pods, nsPods.Items[podIndex])
+	}
+
+	return pods, nil
+}
+
+func describePersistentVolumeClaim(pvc *corev1.PersistentVolumeClaim, events *corev1.EventList, pods []corev1.Pod) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		printPersistentVolumeClaim(w, pvc, true)
+		printPodsMultiline(w, "Used By", pods)
+
+		if len(pvc.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n")
+			w.Write(LEVEL_1, "Type\tStatus\tLastProbeTime\tLastTransitionTime\tReason\tMessage\n")
+			w.Write(LEVEL_1, "----\t------\t-----------------\t------------------\t------\t-------\n")
+			for _, c := range pvc.Status.Conditions {
+				w.Write(LEVEL_1, "%v \t%v \t%s \t%s \t%v \t%v\n",
+					c.Type,
+					c.Status,
+					c.LastProbeTime.Time.Format(time.RFC1123Z),
+					c.LastTransitionTime.Time.Format(time.RFC1123Z),
+					c.Reason,
+					c.Message)
+			}
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+// printPersistentVolumeClaim is used for both PVCs and PersistentVolumeClaimTemplate. For the latter,
+// we need to skip some fields which have no meaning.
+func printPersistentVolumeClaim(w PrefixWriter, pvc *corev1.PersistentVolumeClaim, isFullPVC bool) {
+	if isFullPVC {
+		w.Write(LEVEL_0, "Name:\t%s\n", pvc.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", pvc.Namespace)
+	}
+	w.Write(LEVEL_0, "StorageClass:\t%s\n", storageutil.GetPersistentVolumeClaimClass(pvc))
+	if isFullPVC {
+		if pvc.ObjectMeta.DeletionTimestamp != nil {
+			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestampSince(*pvc.ObjectMeta.DeletionTimestamp))
+		} else {
+			w.Write(LEVEL_0, "Status:\t%v\n", pvc.Status.Phase)
+		}
+	}
+	w.Write(LEVEL_0, "Volume:\t%s\n", pvc.Spec.VolumeName)
+	printLabelsMultiline(w, "Labels", pvc.Labels)
+	printAnnotationsMultiline(w, "Annotations", pvc.Annotations)
+	if isFullPVC {
+		w.Write(LEVEL_0, "Finalizers:\t%v\n", pvc.ObjectMeta.Finalizers)
+	}
+	storage := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	capacity := ""
+	accessModes := ""
+	if pvc.Spec.VolumeName != "" {
+		accessModes = storageutil.GetAccessModesAsString(pvc.Status.AccessModes)
+		storage = pvc.Status.Capacity[corev1.ResourceStorage]
+		capacity = storage.String()
+	}
+	w.Write(LEVEL_0, "Capacity:\t%s\n", capacity)
+	w.Write(LEVEL_0, "Access Modes:\t%s\n", accessModes)
+	if pvc.Spec.VolumeMode != nil {
+		w.Write(LEVEL_0, "VolumeMode:\t%v\n", *pvc.Spec.VolumeMode)
+	}
+	if pvc.Spec.DataSource != nil {
+		w.Write(LEVEL_0, "DataSource:\n")
+		if pvc.Spec.DataSource.APIGroup != nil {
+			w.Write(LEVEL_1, "APIGroup:\t%v\n", *pvc.Spec.DataSource.APIGroup)
+		}
+		w.Write(LEVEL_1, "Kind:\t%v\n", pvc.Spec.DataSource.Kind)
+		w.Write(LEVEL_1, "Name:\t%v\n", pvc.Spec.DataSource.Name)
+	}
+}
+
+func describeContainers(label string, containers []corev1.Container, containerStatuses []corev1.ContainerStatus,
+	resolverFn EnvVarResolverFunc, w PrefixWriter, space string) {
+	statuses := map[string]corev1.ContainerStatus{}
+	for _, status := range containerStatuses {
+		statuses[status.Name] = status
+	}
+
+	describeContainersLabel(containers, label, space, w)
+
+	for _, container := range containers {
+		status, ok := statuses[container.Name]
+		describeContainerBasicInfo(container, status, ok, space, w)
+		describeContainerCommand(container, w)
+		if ok {
+			describeContainerState(status, w)
+		}
+		describeContainerResource(container, w)
+		describeContainerProbe(container, w)
+		if len(container.EnvFrom) > 0 {
+			describeContainerEnvFrom(container, resolverFn, w)
+		}
+		describeContainerEnvVars(container, resolverFn, w)
+		describeContainerVolumes(container, w)
+	}
+}
+
+func describeContainersLabel(containers []corev1.Container, label, space string, w PrefixWriter) {
+	none := ""
+	if len(containers) == 0 {
+		none = " <none>"
+	}
+	w.Write(LEVEL_0, "%s%s:%s\n", space, label, none)
+}
+
+func describeContainerBasicInfo(container corev1.Container, status corev1.ContainerStatus, ok bool, space string, w PrefixWriter) {
+	nameIndent := ""
+	if len(space) > 0 {
+		nameIndent = " "
+	}
+	w.Write(LEVEL_1, "%s%v:\n", nameIndent, container.Name)
+	if ok {
+		w.Write(LEVEL_2, "Container ID:\t%s\n", status.ContainerID)
+	}
+	w.Write(LEVEL_2, "Image:\t%s\n", container.Image)
+	if ok {
+		w.Write(LEVEL_2, "Image ID:\t%s\n", status.ImageID)
+	}
+	portString := describeContainerPorts(container.Ports)
+	if strings.Contains(portString, ",") {
+		w.Write(LEVEL_2, "Ports:\t%s\n", portString)
+	} else {
+		w.Write(LEVEL_2, "Port:\t%s\n", stringOrNone(portString))
+	}
+	hostPortString := describeContainerHostPorts(container.Ports)
+	if strings.Contains(hostPortString, ",") {
+		w.Write(LEVEL_2, "Host Ports:\t%s\n", hostPortString)
+	} else {
+		w.Write(LEVEL_2, "Host Port:\t%s\n", stringOrNone(hostPortString))
+	}
+	if container.SecurityContext != nil && container.SecurityContext.SeccompProfile != nil {
+		w.Write(LEVEL_2, "SeccompProfile:\t%s\n", container.SecurityContext.SeccompProfile.Type)
+		if container.SecurityContext.SeccompProfile.Type == corev1.SeccompProfileTypeLocalhost {
+			w.Write(LEVEL_3, "LocalhostProfile:\t%s\n", *container.SecurityContext.SeccompProfile.LocalhostProfile)
+		}
+	}
+}
+
+func describeContainerPorts(cPorts []corev1.ContainerPort) string {
+	ports := make([]string, 0, len(cPorts))
+	for _, cPort := range cPorts {
+		ports = append(ports, fmt.Sprintf("%d/%s", cPort.ContainerPort, cPort.Protocol))
+	}
+	return strings.Join(ports, ", ")
+}
+
+func describeContainerHostPorts(cPorts []corev1.ContainerPort) string {
+	ports := make([]string, 0, len(cPorts))
+	for _, cPort := range cPorts {
+		ports = append(ports, fmt.Sprintf("%d/%s", cPort.HostPort, cPort.Protocol))
+	}
+	return strings.Join(ports, ", ")
+}
+
+func describeContainerCommand(container corev1.Container, w PrefixWriter) {
+	if len(container.Command) > 0 {
+		w.Write(LEVEL_2, "Command:\n")
+		for _, c := range container.Command {
+			for _, s := range strings.Split(c, "\n") {
+				w.Write(LEVEL_3, "%s\n", s)
+			}
+		}
+	}
+	if len(container.Args) > 0 {
+		w.Write(LEVEL_2, "Args:\n")
+		for _, arg := range container.Args {
+			for _, s := range strings.Split(arg, "\n") {
+				w.Write(LEVEL_3, "%s\n", s)
+			}
+		}
+	}
+}
+
+func describeContainerResource(container corev1.Container, w PrefixWriter) {
+	resources := container.Resources
+	if len(resources.Limits) > 0 {
+		w.Write(LEVEL_2, "Limits:\n")
+	}
+	for _, name := range SortedResourceNames(resources.Limits) {
+		quantity := resources.Limits[name]
+		w.Write(LEVEL_3, "%s:\t%s\n", name, quantity.String())
+	}
+
+	if len(resources.Requests) > 0 {
+		w.Write(LEVEL_2, "Requests:\n")
+	}
+	for _, name := range SortedResourceNames(resources.Requests) {
+		quantity := resources.Requests[name]
+		w.Write(LEVEL_3, "%s:\t%s\n", name, quantity.String())
+	}
+}
+
+func describeContainerState(status corev1.ContainerStatus, w PrefixWriter) {
+	describeStatus("State", status.State, w)
+	if status.LastTerminationState.Terminated != nil {
+		describeStatus("Last State", status.LastTerminationState, w)
+	}
+	w.Write(LEVEL_2, "Ready:\t%v\n", printBool(status.Ready))
+	w.Write(LEVEL_2, "Restart Count:\t%d\n", status.RestartCount)
+}
+
+func describeContainerProbe(container corev1.Container, w PrefixWriter) {
+	if container.LivenessProbe != nil {
+		probe := DescribeProbe(container.LivenessProbe)
+		w.Write(LEVEL_2, "Liveness:\t%s\n", probe)
+	}
+	if container.ReadinessProbe != nil {
+		probe := DescribeProbe(container.ReadinessProbe)
+		w.Write(LEVEL_2, "Readiness:\t%s\n", probe)
+	}
+	if container.StartupProbe != nil {
+		probe := DescribeProbe(container.StartupProbe)
+		w.Write(LEVEL_2, "Startup:\t%s\n", probe)
+	}
+}
+
+func describeContainerVolumes(container corev1.Container, w PrefixWriter) {
+	// Show volumeMounts
+	none := ""
+	if len(container.VolumeMounts) == 0 {
+		none = "\t<none>"
+	}
+	w.Write(LEVEL_2, "Mounts:%s\n", none)
+	sort.Sort(SortableVolumeMounts(container.VolumeMounts))
+	for _, mount := range container.VolumeMounts {
+		flags := []string{}
+		if mount.ReadOnly {
+			flags = append(flags, "ro")
+		} else {
+			flags = append(flags, "rw")
+		}
+		if len(mount.SubPath) > 0 {
+			flags = append(flags, fmt.Sprintf("path=%q", mount.SubPath))
+		}
+		w.Write(LEVEL_3, "%s from %s (%s)\n", mount.MountPath, mount.Name, strings.Join(flags, ","))
+	}
+	// Show volumeDevices if exists
+	if len(container.VolumeDevices) > 0 {
+		w.Write(LEVEL_2, "Devices:%s\n", none)
+		sort.Sort(SortableVolumeDevices(container.VolumeDevices))
+		for _, device := range container.VolumeDevices {
+			w.Write(LEVEL_3, "%s from %s\n", device.DevicePath, device.Name)
+		}
+	}
+}
+
+func describeContainerEnvVars(container corev1.Container, resolverFn EnvVarResolverFunc, w PrefixWriter) {
+	none := ""
+	if len(container.Env) == 0 {
+		none = "\t<none>"
+	}
+	w.Write(LEVEL_2, "Environment:%s\n", none)
+
+	for _, e := range container.Env {
+		if e.ValueFrom == nil {
+			for i, s := range strings.Split(e.Value, "\n") {
+				if i == 0 {
+					w.Write(LEVEL_3, "%s:\t%s\n", e.Name, s)
+				} else {
+					w.Write(LEVEL_3, "\t%s\n", s)
+				}
+			}
+			continue
+		}
+
+		switch {
+		case e.ValueFrom.FieldRef != nil:
+			var valueFrom string
+			if resolverFn != nil {
+				valueFrom = resolverFn(e)
+			}
+			w.Write(LEVEL_3, "%s:\t%s (%s:%s)\n", e.Name, valueFrom, e.ValueFrom.FieldRef.APIVersion, e.ValueFrom.FieldRef.FieldPath)
+		case e.ValueFrom.ResourceFieldRef != nil:
+			valueFrom, err := resourcehelper.ExtractContainerResourceValue(e.ValueFrom.ResourceFieldRef, &container)
+			if err != nil {
+				valueFrom = ""
+			}
+			resource := e.ValueFrom.ResourceFieldRef.Resource
+			if valueFrom == "0" && (resource == "limits.cpu" || resource == "limits.memory") {
+				valueFrom = "node allocatable"
+			}
+			w.Write(LEVEL_3, "%s:\t%s (%s)\n", e.Name, valueFrom, resource)
+		case e.ValueFrom.SecretKeyRef != nil:
+			optional := e.ValueFrom.SecretKeyRef.Optional != nil && *e.ValueFrom.SecretKeyRef.Optional
+			w.Write(LEVEL_3, "%s:\t<set to the key '%s' in secret '%s'>\tOptional: %t\n", e.Name, e.ValueFrom.SecretKeyRef.Key, e.ValueFrom.SecretKeyRef.Name, optional)
+		case e.ValueFrom.ConfigMapKeyRef != nil:
+			optional := e.ValueFrom.ConfigMapKeyRef.Optional != nil && *e.ValueFrom.ConfigMapKeyRef.Optional
+			w.Write(LEVEL_3, "%s:\t<set to the key '%s' of config map '%s'>\tOptional: %t\n", e.Name, e.ValueFrom.ConfigMapKeyRef.Key, e.ValueFrom.ConfigMapKeyRef.Name, optional)
+		}
+	}
+}
+
+func describeContainerEnvFrom(container corev1.Container, resolverFn EnvVarResolverFunc, w PrefixWriter) {
+	none := ""
+	if len(container.EnvFrom) == 0 {
+		none = "\t<none>"
+	}
+	w.Write(LEVEL_2, "Environment Variables from:%s\n", none)
+
+	for _, e := range container.EnvFrom {
+		from := ""
+		name := ""
+		optional := false
+		if e.ConfigMapRef != nil {
+			from = "ConfigMap"
+			name = e.ConfigMapRef.Name
+			optional = e.ConfigMapRef.Optional != nil && *e.ConfigMapRef.Optional
+		} else if e.SecretRef != nil {
+			from = "Secret"
+			name = e.SecretRef.Name
+			optional = e.SecretRef.Optional != nil && *e.SecretRef.Optional
+		}
+		if len(e.Prefix) == 0 {
+			w.Write(LEVEL_3, "%s\t%s\tOptional: %t\n", name, from, optional)
+		} else {
+			w.Write(LEVEL_3, "%s\t%s with prefix '%s'\tOptional: %t\n", name, from, e.Prefix, optional)
+		}
+	}
+}
+
+// DescribeProbe is exported for consumers in other API groups that have probes
+func DescribeProbe(probe *corev1.Probe) string {
+	attrs := fmt.Sprintf("delay=%ds timeout=%ds period=%ds #success=%d #failure=%d", probe.InitialDelaySeconds, probe.TimeoutSeconds, probe.PeriodSeconds, probe.SuccessThreshold, probe.FailureThreshold)
+	switch {
+	case probe.Exec != nil:
+		return fmt.Sprintf("exec %v %s", probe.Exec.Command, attrs)
+	case probe.HTTPGet != nil:
+		url := &url.URL{}
+		url.Scheme = strings.ToLower(string(probe.HTTPGet.Scheme))
+		if len(probe.HTTPGet.Port.String()) > 0 {
+			url.Host = net.JoinHostPort(probe.HTTPGet.Host, probe.HTTPGet.Port.String())
+		} else {
+			url.Host = probe.HTTPGet.Host
+		}
+		url.Path = probe.HTTPGet.Path
+		return fmt.Sprintf("http-get %s %s", url.String(), attrs)
+	case probe.TCPSocket != nil:
+		return fmt.Sprintf("tcp-socket %s:%s %s", probe.TCPSocket.Host, probe.TCPSocket.Port.String(), attrs)
+
+	case probe.GRPC != nil:
+		return fmt.Sprintf("grpc <pod>:%d %s %s", probe.GRPC.Port, *(probe.GRPC.Service), attrs)
+	}
+	return fmt.Sprintf("unknown %s", attrs)
+}
+
+type EnvVarResolverFunc func(e corev1.EnvVar) string
+
+// EnvValueFrom is exported for use by describers in other packages
+func EnvValueRetriever(pod *corev1.Pod) EnvVarResolverFunc {
+	return func(e corev1.EnvVar) string {
+		gv, err := schema.ParseGroupVersion(e.ValueFrom.FieldRef.APIVersion)
+		if err != nil {
+			return ""
+		}
+		gvk := gv.WithKind("Pod")
+		internalFieldPath, _, err := scheme.Scheme.ConvertFieldLabel(gvk, e.ValueFrom.FieldRef.FieldPath, "")
+		if err != nil {
+			return "" // pod validation should catch this on create
+		}
+
+		valueFrom, err := fieldpath.ExtractFieldPathAsString(pod, internalFieldPath)
+		if err != nil {
+			return "" // pod validation should catch this on create
+		}
+
+		return valueFrom
+	}
+}
+
+func describeStatus(stateName string, state corev1.ContainerState, w PrefixWriter) {
+	switch {
+	case state.Running != nil:
+		w.Write(LEVEL_2, "%s:\tRunning\n", stateName)
+		w.Write(LEVEL_3, "Started:\t%v\n", state.Running.StartedAt.Time.Format(time.RFC1123Z))
+	case state.Waiting != nil:
+		w.Write(LEVEL_2, "%s:\tWaiting\n", stateName)
+		if state.Waiting.Reason != "" {
+			w.Write(LEVEL_3, "Reason:\t%s\n", state.Waiting.Reason)
+		}
+	case state.Terminated != nil:
+		w.Write(LEVEL_2, "%s:\tTerminated\n", stateName)
+		if state.Terminated.Reason != "" {
+			w.Write(LEVEL_3, "Reason:\t%s\n", state.Terminated.Reason)
+		}
+		if state.Terminated.Message != "" {
+			w.Write(LEVEL_3, "Message:\t%s\n", state.Terminated.Message)
+		}
+		w.Write(LEVEL_3, "Exit Code:\t%d\n", state.Terminated.ExitCode)
+		if state.Terminated.Signal > 0 {
+			w.Write(LEVEL_3, "Signal:\t%d\n", state.Terminated.Signal)
+		}
+		w.Write(LEVEL_3, "Started:\t%s\n", state.Terminated.StartedAt.Time.Format(time.RFC1123Z))
+		w.Write(LEVEL_3, "Finished:\t%s\n", state.Terminated.FinishedAt.Time.Format(time.RFC1123Z))
+	default:
+		w.Write(LEVEL_2, "%s:\tWaiting\n", stateName)
+	}
+}
+
+func describeVolumeClaimTemplates(templates []corev1.PersistentVolumeClaim, w PrefixWriter) {
+	if len(templates) == 0 {
+		w.Write(LEVEL_0, "Volume Claims:\t<none>\n")
+		return
+	}
+	w.Write(LEVEL_0, "Volume Claims:\n")
+	for _, pvc := range templates {
+		w.Write(LEVEL_1, "Name:\t%s\n", pvc.Name)
+		w.Write(LEVEL_1, "StorageClass:\t%s\n", storageutil.GetPersistentVolumeClaimClass(&pvc))
+		printLabelsMultilineWithIndent(w, "  ", "Labels", "\t", pvc.Labels, sets.NewString())
+		printLabelsMultilineWithIndent(w, "  ", "Annotations", "\t", pvc.Annotations, sets.NewString())
+		if capacity, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+			w.Write(LEVEL_1, "Capacity:\t%s\n", capacity.String())
+		} else {
+			w.Write(LEVEL_1, "Capacity:\t%s\n", "<default>")
+		}
+		w.Write(LEVEL_1, "Access Modes:\t%s\n", pvc.Spec.AccessModes)
+	}
+}
+
+func printBoolPtr(value *bool) string {
+	if value != nil {
+		return printBool(*value)
+	}
+
+	return "<unset>"
+}
+
+func printBool(value bool) string {
+	if value {
+		return "True"
+	}
+
+	return "False"
+}
+
+// ReplicationControllerDescriber generates information about a replication controller
+// and the pods it has created.
+type ReplicationControllerDescriber struct {
+	clientset.Interface
+}
+
+func (d *ReplicationControllerDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	rc := d.CoreV1().ReplicationControllers(namespace)
+	pc := d.CoreV1().Pods(namespace)
+
+	controller, err := rc.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	selector := labels.SelectorFromSet(controller.Spec.Selector)
+	running, waiting, succeeded, failed, err := getPodStatusForController(pc, selector, controller.UID, describerSettings)
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), controller, describerSettings.ChunkSize)
+	}
+
+	return describeReplicationController(controller, events, running, waiting, succeeded, failed)
+}
+
+func describeReplicationController(controller *corev1.ReplicationController, events *corev1.EventList, running, waiting, succeeded, failed int) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", controller.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", controller.Namespace)
+		w.Write(LEVEL_0, "Selector:\t%s\n", labels.FormatLabels(controller.Spec.Selector))
+		printLabelsMultiline(w, "Labels", controller.Labels)
+		printAnnotationsMultiline(w, "Annotations", controller.Annotations)
+		w.Write(LEVEL_0, "Replicas:\t%d current / %d desired\n", controller.Status.Replicas, *controller.Spec.Replicas)
+		w.Write(LEVEL_0, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
+		DescribePodTemplate(controller.Spec.Template, w)
+		if len(controller.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n  Type\tStatus\tReason\n")
+			w.Write(LEVEL_1, "----\t------\t------\n")
+			for _, c := range controller.Status.Conditions {
+				w.Write(LEVEL_1, "%v \t%v\t%v\n", c.Type, c.Status, c.Reason)
+			}
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func DescribePodTemplate(template *corev1.PodTemplateSpec, w PrefixWriter) {
+	w.Write(LEVEL_0, "Pod Template:\n")
+	if template == nil {
+		w.Write(LEVEL_1, "<unset>")
+		return
+	}
+	printLabelsMultiline(w, "  Labels", template.Labels)
+	if len(template.Annotations) > 0 {
+		printAnnotationsMultiline(w, "  Annotations", template.Annotations)
+	}
+	if len(template.Spec.ServiceAccountName) > 0 {
+		w.Write(LEVEL_1, "Service Account:\t%s\n", template.Spec.ServiceAccountName)
+	}
+	if len(template.Spec.InitContainers) > 0 {
+		describeContainers("Init Containers", template.Spec.InitContainers, nil, nil, w, "  ")
+	}
+	describeContainers("Containers", template.Spec.Containers, nil, nil, w, "  ")
+	describeVolumes(template.Spec.Volumes, w, "  ")
+	describeTopologySpreadConstraints(template.Spec.TopologySpreadConstraints, w, "  ")
+	if len(template.Spec.PriorityClassName) > 0 {
+		w.Write(LEVEL_1, "Priority Class Name:\t%s\n", template.Spec.PriorityClassName)
+	}
+}
+
+// ReplicaSetDescriber generates information about a ReplicaSet and the pods it has created.
+type ReplicaSetDescriber struct {
+	clientset.Interface
+}
+
+func (d *ReplicaSetDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	rsc := d.AppsV1().ReplicaSets(namespace)
+	pc := d.CoreV1().Pods(namespace)
+
+	rs, err := rsc.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector)
+	if err != nil {
+		return "", err
+	}
+
+	running, waiting, succeeded, failed, getPodErr := getPodStatusForController(pc, selector, rs.UID, describerSettings)
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), rs, describerSettings.ChunkSize)
+	}
+
+	return describeReplicaSet(rs, events, running, waiting, succeeded, failed, getPodErr)
+}
+
+func describeReplicaSet(rs *appsv1.ReplicaSet, events *corev1.EventList, running, waiting, succeeded, failed int, getPodErr error) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", rs.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", rs.Namespace)
+		w.Write(LEVEL_0, "Selector:\t%s\n", metav1.FormatLabelSelector(rs.Spec.Selector))
+		printLabelsMultiline(w, "Labels", rs.Labels)
+		printAnnotationsMultiline(w, "Annotations", rs.Annotations)
+		if controlledBy := printController(rs); len(controlledBy) > 0 {
+			w.Write(LEVEL_0, "Controlled By:\t%s\n", controlledBy)
+		}
+		w.Write(LEVEL_0, "Replicas:\t%d current / %d desired\n", rs.Status.Replicas, *rs.Spec.Replicas)
+		w.Write(LEVEL_0, "Pods Status:\t")
+		if getPodErr != nil {
+			w.Write(LEVEL_0, "error in fetching pods: %s\n", getPodErr)
+		} else {
+			w.Write(LEVEL_0, "%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
+		}
+		DescribePodTemplate(&rs.Spec.Template, w)
+		if len(rs.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n  Type\tStatus\tReason\n")
+			w.Write(LEVEL_1, "----\t------\t------\n")
+			for _, c := range rs.Status.Conditions {
+				w.Write(LEVEL_1, "%v \t%v\t%v\n", c.Type, c.Status, c.Reason)
+			}
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// JobDescriber generates information about a job and the pods it has created.
+type JobDescriber struct {
+	clientset.Interface
+}
+
+func (d *JobDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	job, err := d.BatchV1().Jobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), job, describerSettings.ChunkSize)
+	}
+
+	return describeJob(job, events)
+}
+
+func describeJob(job *batchv1.Job, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", job.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", job.Namespace)
+		if selector, err := metav1.LabelSelectorAsSelector(job.Spec.Selector); err == nil {
+			w.Write(LEVEL_0, "Selector:\t%s\n", selector)
+		} else {
+			w.Write(LEVEL_0, "Selector:\tFailed to get selector: %s\n", err)
+		}
+		printLabelsMultiline(w, "Labels", job.Labels)
+		printAnnotationsMultiline(w, "Annotations", job.Annotations)
+		if controlledBy := printController(job); len(controlledBy) > 0 {
+			w.Write(LEVEL_0, "Controlled By:\t%s\n", controlledBy)
+		}
+		if job.Spec.Parallelism != nil {
+			w.Write(LEVEL_0, "Parallelism:\t%d\n", *job.Spec.Parallelism)
+		}
+		if job.Spec.Completions != nil {
+			w.Write(LEVEL_0, "Completions:\t%d\n", *job.Spec.Completions)
+		} else {
+			w.Write(LEVEL_0, "Completions:\t<unset>\n")
+		}
+		if job.Spec.CompletionMode != nil {
+			w.Write(LEVEL_0, "Completion Mode:\t%s\n", *job.Spec.CompletionMode)
+		}
+		if job.Status.StartTime != nil {
+			w.Write(LEVEL_0, "Start Time:\t%s\n", job.Status.StartTime.Time.Format(time.RFC1123Z))
+		}
+		if job.Status.CompletionTime != nil {
+			w.Write(LEVEL_0, "Completed At:\t%s\n", job.Status.CompletionTime.Time.Format(time.RFC1123Z))
+		}
+		if job.Status.StartTime != nil && job.Status.CompletionTime != nil {
+			w.Write(LEVEL_0, "Duration:\t%s\n", duration.HumanDuration(job.Status.CompletionTime.Sub(job.Status.StartTime.Time)))
+		}
+		if job.Spec.ActiveDeadlineSeconds != nil {
+			w.Write(LEVEL_0, "Active Deadline Seconds:\t%ds\n", *job.Spec.ActiveDeadlineSeconds)
+		}
+		if job.Status.Ready == nil {
+			w.Write(LEVEL_0, "Pods Statuses:\t%d Active / %d Succeeded / %d Failed\n", job.Status.Active, job.Status.Succeeded, job.Status.Failed)
+		} else {
+			w.Write(LEVEL_0, "Pods Statuses:\t%d Active (%d Ready) / %d Succeeded / %d Failed\n", job.Status.Active, *job.Status.Ready, job.Status.Succeeded, job.Status.Failed)
+		}
+		if job.Spec.CompletionMode != nil && *job.Spec.CompletionMode == batchv1.IndexedCompletion {
+			w.Write(LEVEL_0, "Completed Indexes:\t%s\n", capIndexesListOrNone(job.Status.CompletedIndexes, 50))
+		}
+		DescribePodTemplate(&job.Spec.Template, w)
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func capIndexesListOrNone(indexes string, softLimit int) string {
+	if len(indexes) == 0 {
+		return "<none>"
+	}
+	ix := softLimit
+	for ; ix < len(indexes); ix++ {
+		if indexes[ix] == ',' {
+			break
+		}
+	}
+	if ix >= len(indexes) {
+		return indexes
+	}
+	return indexes[:ix+1] + "..."
+}
+
+// CronJobDescriber generates information about a cron job and the jobs it has created.
+type CronJobDescriber struct {
+	client clientset.Interface
+}
+
+func (d *CronJobDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var events *corev1.EventList
+
+	cronJob, err := d.client.BatchV1().CronJobs(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.client.CoreV1(), cronJob, describerSettings.ChunkSize)
+	}
+	return describeCronJob(cronJob, events)
+}
+
+func describeCronJob(cronJob *batchv1.CronJob, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", cronJob.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", cronJob.Namespace)
+		printLabelsMultiline(w, "Labels", cronJob.Labels)
+		printAnnotationsMultiline(w, "Annotations", cronJob.Annotations)
+		w.Write(LEVEL_0, "Schedule:\t%s\n", cronJob.Spec.Schedule)
+		w.Write(LEVEL_0, "Concurrency Policy:\t%s\n", cronJob.Spec.ConcurrencyPolicy)
+		w.Write(LEVEL_0, "Suspend:\t%s\n", printBoolPtr(cronJob.Spec.Suspend))
+		if cronJob.Spec.SuccessfulJobsHistoryLimit != nil {
+			w.Write(LEVEL_0, "Successful Job History Limit:\t%d\n", *cronJob.Spec.SuccessfulJobsHistoryLimit)
+		} else {
+			w.Write(LEVEL_0, "Successful Job History Limit:\t<unset>\n")
+		}
+		if cronJob.Spec.FailedJobsHistoryLimit != nil {
+			w.Write(LEVEL_0, "Failed Job History Limit:\t%d\n", *cronJob.Spec.FailedJobsHistoryLimit)
+		} else {
+			w.Write(LEVEL_0, "Failed Job History Limit:\t<unset>\n")
+		}
+		if cronJob.Spec.StartingDeadlineSeconds != nil {
+			w.Write(LEVEL_0, "Starting Deadline Seconds:\t%ds\n", *cronJob.Spec.StartingDeadlineSeconds)
+		} else {
+			w.Write(LEVEL_0, "Starting Deadline Seconds:\t<unset>\n")
+		}
+		describeJobTemplate(cronJob.Spec.JobTemplate, w)
+		if cronJob.Status.LastScheduleTime != nil {
+			w.Write(LEVEL_0, "Last Schedule Time:\t%s\n", cronJob.Status.LastScheduleTime.Time.Format(time.RFC1123Z))
+		} else {
+			w.Write(LEVEL_0, "Last Schedule Time:\t<unset>\n")
+		}
+		printActiveJobs(w, "Active Jobs", cronJob.Status.Active)
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func describeJobTemplate(jobTemplate batchv1.JobTemplateSpec, w PrefixWriter) {
+	if jobTemplate.Spec.Selector != nil {
+		if selector, err := metav1.LabelSelectorAsSelector(jobTemplate.Spec.Selector); err == nil {
+			w.Write(LEVEL_0, "Selector:\t%s\n", selector)
+		} else {
+			w.Write(LEVEL_0, "Selector:\tFailed to get selector: %s\n", err)
+		}
+	} else {
+		w.Write(LEVEL_0, "Selector:\t<unset>\n")
+	}
+	if jobTemplate.Spec.Parallelism != nil {
+		w.Write(LEVEL_0, "Parallelism:\t%d\n", *jobTemplate.Spec.Parallelism)
+	} else {
+		w.Write(LEVEL_0, "Parallelism:\t<unset>\n")
+	}
+	if jobTemplate.Spec.Completions != nil {
+		w.Write(LEVEL_0, "Completions:\t%d\n", *jobTemplate.Spec.Completions)
+	} else {
+		w.Write(LEVEL_0, "Completions:\t<unset>\n")
+	}
+	if jobTemplate.Spec.ActiveDeadlineSeconds != nil {
+		w.Write(LEVEL_0, "Active Deadline Seconds:\t%ds\n", *jobTemplate.Spec.ActiveDeadlineSeconds)
+	}
+	DescribePodTemplate(&jobTemplate.Spec.Template, w)
+}
+
+func printActiveJobs(w PrefixWriter, title string, jobs []corev1.ObjectReference) {
+	w.Write(LEVEL_0, "%s:\t", title)
+	if len(jobs) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	for i, job := range jobs {
+		if i != 0 {
+			w.Write(LEVEL_0, ", ")
+		}
+		w.Write(LEVEL_0, "%s", job.Name)
+	}
+	w.WriteLine("")
+}
+
+// DaemonSetDescriber generates information about a daemon set and the pods it has created.
+type DaemonSetDescriber struct {
+	clientset.Interface
+}
+
+func (d *DaemonSetDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	dc := d.AppsV1().DaemonSets(namespace)
+	pc := d.CoreV1().Pods(namespace)
+
+	daemon, err := dc.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(daemon.Spec.Selector)
+	if err != nil {
+		return "", err
+	}
+	running, waiting, succeeded, failed, err := getPodStatusForController(pc, selector, daemon.UID, describerSettings)
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), daemon, describerSettings.ChunkSize)
+	}
+
+	return describeDaemonSet(daemon, events, running, waiting, succeeded, failed)
+}
+
+func describeDaemonSet(daemon *appsv1.DaemonSet, events *corev1.EventList, running, waiting, succeeded, failed int) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", daemon.Name)
+		selector, err := metav1.LabelSelectorAsSelector(daemon.Spec.Selector)
+		if err != nil {
+			// this shouldn't happen if LabelSelector passed validation
+			return err
+		}
+		w.Write(LEVEL_0, "Selector:\t%s\n", selector)
+		w.Write(LEVEL_0, "Node-Selector:\t%s\n", labels.FormatLabels(daemon.Spec.Template.Spec.NodeSelector))
+		printLabelsMultiline(w, "Labels", daemon.Labels)
+		printAnnotationsMultiline(w, "Annotations", daemon.Annotations)
+		w.Write(LEVEL_0, "Desired Number of Nodes Scheduled: %d\n", daemon.Status.DesiredNumberScheduled)
+		w.Write(LEVEL_0, "Current Number of Nodes Scheduled: %d\n", daemon.Status.CurrentNumberScheduled)
+		w.Write(LEVEL_0, "Number of Nodes Scheduled with Up-to-date Pods: %d\n", daemon.Status.UpdatedNumberScheduled)
+		w.Write(LEVEL_0, "Number of Nodes Scheduled with Available Pods: %d\n", daemon.Status.NumberAvailable)
+		w.Write(LEVEL_0, "Number of Nodes Misscheduled: %d\n", daemon.Status.NumberMisscheduled)
+		w.Write(LEVEL_0, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
+		DescribePodTemplate(&daemon.Spec.Template, w)
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// SecretDescriber generates information about a secret
+type SecretDescriber struct {
+	clientset.Interface
+}
+
+func (d *SecretDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.CoreV1().Secrets(namespace)
+
+	secret, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return describeSecret(secret)
+}
+
+func describeSecret(secret *corev1.Secret) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", secret.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", secret.Namespace)
+		printLabelsMultiline(w, "Labels", secret.Labels)
+		printAnnotationsMultiline(w, "Annotations", secret.Annotations)
+
+		w.Write(LEVEL_0, "\nType:\t%s\n", secret.Type)
+
+		w.Write(LEVEL_0, "\nData\n====\n")
+		for k, v := range secret.Data {
+			switch {
+			case k == corev1.ServiceAccountTokenKey && secret.Type == corev1.SecretTypeServiceAccountToken:
+				w.Write(LEVEL_0, "%s:\t%s\n", k, string(v))
+			default:
+				w.Write(LEVEL_0, "%s:\t%d bytes\n", k, len(v))
+			}
+		}
+
+		return nil
+	})
+}
+
+type IngressDescriber struct {
+	client clientset.Interface
+}
+
+func (i *IngressDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var events *corev1.EventList
+
+	// try ingress/v1 first (v1.19) and fallback to ingress/v1beta if an err occurs
+	netV1, err := i.client.NetworkingV1().Ingresses(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(i.client.CoreV1(), netV1, describerSettings.ChunkSize)
+		}
+		return i.describeIngressV1(netV1, events)
+	}
+	netV1beta1, err := i.client.NetworkingV1beta1().Ingresses(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(i.client.CoreV1(), netV1beta1, describerSettings.ChunkSize)
+		}
+		return i.describeIngressV1beta1(netV1beta1, events)
+	}
+	return "", err
+}
+
+func (i *IngressDescriber) describeBackendV1beta1(ns string, backend *networkingv1beta1.IngressBackend) string {
+	endpoints, err := i.client.CoreV1().Endpoints(ns).Get(context.TODO(), backend.ServiceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("<error: %v>", err)
+	}
+	service, err := i.client.CoreV1().Services(ns).Get(context.TODO(), backend.ServiceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("<error: %v>", err)
+	}
+	spName := ""
+	for i := range service.Spec.Ports {
+		sp := &service.Spec.Ports[i]
+		switch backend.ServicePort.Type {
+		case intstr.String:
+			if backend.ServicePort.StrVal == sp.Name {
+				spName = sp.Name
+			}
+		case intstr.Int:
+			if int32(backend.ServicePort.IntVal) == sp.Port {
+				spName = sp.Name
+			}
+		}
+	}
+	return formatEndpoints(endpoints, sets.NewString(spName))
+}
+
+func (i *IngressDescriber) describeBackendV1(ns string, backend *networkingv1.IngressBackend) string {
+
+	if backend.Service != nil {
+		sb := serviceBackendStringer(backend.Service)
+		endpoints, err := i.client.CoreV1().Endpoints(ns).Get(context.TODO(), backend.Service.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Sprintf("%v (<error: %v>)", sb, err)
+		}
+		service, err := i.client.CoreV1().Services(ns).Get(context.TODO(), backend.Service.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Sprintf("%v(<error: %v>)", sb, err)
+		}
+		spName := ""
+		for i := range service.Spec.Ports {
+			sp := &service.Spec.Ports[i]
+			if backend.Service.Port.Number != 0 && backend.Service.Port.Number == sp.Port {
+				spName = sp.Name
+			} else if len(backend.Service.Port.Name) > 0 && backend.Service.Port.Name == sp.Name {
+				spName = sp.Name
+			}
+		}
+		ep := formatEndpoints(endpoints, sets.NewString(spName))
+		return fmt.Sprintf("%s (%s)", sb, ep)
+	}
+	if backend.Resource != nil {
+		ic := backend.Resource
+		apiGroup := "<none>"
+		if ic.APIGroup != nil {
+			apiGroup = fmt.Sprintf("%v", *ic.APIGroup)
+		}
+		return fmt.Sprintf("APIGroup: %v, Kind: %v, Name: %v", apiGroup, ic.Kind, ic.Name)
+	}
+	return ""
+}
+
+func (i *IngressDescriber) describeIngressV1(ing *networkingv1.Ingress, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%v\n", ing.Name)
+		printLabelsMultiline(w, "Labels", ing.Labels)
+		w.Write(LEVEL_0, "Namespace:\t%v\n", ing.Namespace)
+		w.Write(LEVEL_0, "Address:\t%v\n", ingressLoadBalancerStatusStringerV1(ing.Status.LoadBalancer, true))
+		ingressClassName := "<none>"
+		if ing.Spec.IngressClassName != nil {
+			ingressClassName = *ing.Spec.IngressClassName
+		}
+		w.Write(LEVEL_0, "Ingress Class:\t%v\n", ingressClassName)
+		def := ing.Spec.DefaultBackend
+		ns := ing.Namespace
+		defaultBackendDescribe := "<default>"
+		if def != nil {
+			defaultBackendDescribe = i.describeBackendV1(ns, def)
+		}
+		w.Write(LEVEL_0, "Default backend:\t%s\n", defaultBackendDescribe)
+		if len(ing.Spec.TLS) != 0 {
+			describeIngressTLSV1(w, ing.Spec.TLS)
+		}
+		w.Write(LEVEL_0, "Rules:\n  Host\tPath\tBackends\n")
+		w.Write(LEVEL_1, "----\t----\t--------\n")
+		count := 0
+		for _, rules := range ing.Spec.Rules {
+
+			if rules.HTTP == nil {
+				continue
+			}
+			count++
+			host := rules.Host
+			if len(host) == 0 {
+				host = "*"
+			}
+			w.Write(LEVEL_1, "%s\t\n", host)
+			for _, path := range rules.HTTP.Paths {
+				w.Write(LEVEL_2, "\t%s \t%s\n", path.Path, i.describeBackendV1(ing.Namespace, &path.Backend))
+			}
+		}
+		if count == 0 {
+			w.Write(LEVEL_1, "%s\t%s\t%s\n", "*", "*", defaultBackendDescribe)
+		}
+		printAnnotationsMultiline(w, "Annotations", ing.Annotations)
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func (i *IngressDescriber) describeIngressV1beta1(ing *networkingv1beta1.Ingress, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%v\n", ing.Name)
+		printLabelsMultiline(w, "Labels", ing.Labels)
+		w.Write(LEVEL_0, "Namespace:\t%v\n", ing.Namespace)
+		w.Write(LEVEL_0, "Address:\t%v\n", ingressLoadBalancerStatusStringerV1beta1(ing.Status.LoadBalancer, true))
+		ingressClassName := "<none>"
+		if ing.Spec.IngressClassName != nil {
+			ingressClassName = *ing.Spec.IngressClassName
+		}
+		w.Write(LEVEL_0, "Ingress Class:\t%v\n", ingressClassName)
+		def := ing.Spec.Backend
+		ns := ing.Namespace
+		if def == nil {
+			w.Write(LEVEL_0, "Default backend:\t<default>\n")
+		} else {
+			w.Write(LEVEL_0, "Default backend:\t%s\n", i.describeBackendV1beta1(ns, def))
+		}
+		if len(ing.Spec.TLS) != 0 {
+			describeIngressTLSV1beta1(w, ing.Spec.TLS)
+		}
+		w.Write(LEVEL_0, "Rules:\n  Host\tPath\tBackends\n")
+		w.Write(LEVEL_1, "----\t----\t--------\n")
+		count := 0
+		for _, rules := range ing.Spec.Rules {
+
+			if rules.HTTP == nil {
+				continue
+			}
+			count++
+			host := rules.Host
+			if len(host) == 0 {
+				host = "*"
+			}
+			w.Write(LEVEL_1, "%s\t\n", host)
+			for _, path := range rules.HTTP.Paths {
+				w.Write(LEVEL_2, "\t%s \t%s (%s)\n", path.Path, backendStringer(&path.Backend), i.describeBackendV1beta1(ing.Namespace, &path.Backend))
+			}
+		}
+		if count == 0 {
+			w.Write(LEVEL_1, "%s\t%s \t<default>\n", "*", "*")
+		}
+		printAnnotationsMultiline(w, "Annotations", ing.Annotations)
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func describeIngressTLSV1beta1(w PrefixWriter, ingTLS []networkingv1beta1.IngressTLS) {
+	w.Write(LEVEL_0, "TLS:\n")
+	for _, t := range ingTLS {
+		if t.SecretName == "" {
+			w.Write(LEVEL_1, "SNI routes %v\n", strings.Join(t.Hosts, ","))
+		} else {
+			w.Write(LEVEL_1, "%v terminates %v\n", t.SecretName, strings.Join(t.Hosts, ","))
+		}
+	}
+}
+
+func describeIngressTLSV1(w PrefixWriter, ingTLS []networkingv1.IngressTLS) {
+	w.Write(LEVEL_0, "TLS:\n")
+	for _, t := range ingTLS {
+		if t.SecretName == "" {
+			w.Write(LEVEL_1, "SNI routes %v\n", strings.Join(t.Hosts, ","))
+		} else {
+			w.Write(LEVEL_1, "%v terminates %v\n", t.SecretName, strings.Join(t.Hosts, ","))
+		}
+	}
+}
+
+type IngressClassDescriber struct {
+	client clientset.Interface
+}
+
+func (i *IngressClassDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var events *corev1.EventList
+	// try IngressClass/v1 first (v1.19) and fallback to IngressClass/v1beta if an err occurs
+	netV1, err := i.client.NetworkingV1().IngressClasses().Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(i.client.CoreV1(), netV1, describerSettings.ChunkSize)
+		}
+		return i.describeIngressClassV1(netV1, events)
+	}
+	netV1beta1, err := i.client.NetworkingV1beta1().IngressClasses().Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(i.client.CoreV1(), netV1beta1, describerSettings.ChunkSize)
+		}
+		return i.describeIngressClassV1beta1(netV1beta1, events)
+	}
+	return "", err
+}
+
+func (i *IngressClassDescriber) describeIngressClassV1beta1(ic *networkingv1beta1.IngressClass, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", ic.Name)
+		printLabelsMultiline(w, "Labels", ic.Labels)
+		printAnnotationsMultiline(w, "Annotations", ic.Annotations)
+		w.Write(LEVEL_0, "Controller:\t%v\n", ic.Spec.Controller)
+
+		if ic.Spec.Parameters != nil {
+			w.Write(LEVEL_0, "Parameters:\n")
+			if ic.Spec.Parameters.APIGroup != nil {
+				w.Write(LEVEL_1, "APIGroup:\t%v\n", *ic.Spec.Parameters.APIGroup)
+			}
+			w.Write(LEVEL_1, "Kind:\t%v\n", ic.Spec.Parameters.Kind)
+			w.Write(LEVEL_1, "Name:\t%v\n", ic.Spec.Parameters.Name)
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func (i *IngressClassDescriber) describeIngressClassV1(ic *networkingv1.IngressClass, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", ic.Name)
+		printLabelsMultiline(w, "Labels", ic.Labels)
+		printAnnotationsMultiline(w, "Annotations", ic.Annotations)
+		w.Write(LEVEL_0, "Controller:\t%v\n", ic.Spec.Controller)
+
+		if ic.Spec.Parameters != nil {
+			w.Write(LEVEL_0, "Parameters:\n")
+			if ic.Spec.Parameters.APIGroup != nil {
+				w.Write(LEVEL_1, "APIGroup:\t%v\n", *ic.Spec.Parameters.APIGroup)
+			}
+			w.Write(LEVEL_1, "Kind:\t%v\n", ic.Spec.Parameters.Kind)
+			w.Write(LEVEL_1, "Name:\t%v\n", ic.Spec.Parameters.Name)
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// ServiceCIDRDescriber generates information about a ServiceCIDR.
+type ServiceCIDRDescriber struct {
+	client clientset.Interface
+}
+
+func (c *ServiceCIDRDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var events *corev1.EventList
+
+	svcV1alpha1, err := c.client.NetworkingV1alpha1().ServiceCIDRs().Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(c.client.CoreV1(), svcV1alpha1, describerSettings.ChunkSize)
+		}
+		return c.describeServiceCIDRV1alpha1(svcV1alpha1, events)
+	}
+	return "", err
+}
+
+func (c *ServiceCIDRDescriber) describeServiceCIDRV1alpha1(svc *networkingv1alpha1.ServiceCIDR, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%v\n", svc.Name)
+		printLabelsMultiline(w, "Labels", svc.Labels)
+		printAnnotationsMultiline(w, "Annotations", svc.Annotations)
+
+		w.Write(LEVEL_0, "CIDRs:\t%v\n", strings.Join(svc.Spec.CIDRs, ", "))
+
+		if len(svc.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Status:\n")
+			w.Write(LEVEL_0, "Conditions:\n")
+			w.Write(LEVEL_1, "Type\tStatus\tLastTransitionTime\tReason\tMessage\n")
+			w.Write(LEVEL_1, "----\t------\t------------------\t------\t-------\n")
+			for _, c := range svc.Status.Conditions {
+				w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
+					c.Type,
+					c.Status,
+					c.LastTransitionTime.Time.Format(time.RFC1123Z),
+					c.Reason,
+					c.Message)
+			}
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// IPAddressDescriber generates information about an IPAddress.
+type IPAddressDescriber struct {
+	client clientset.Interface
+}
+
+func (c *IPAddressDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var events *corev1.EventList
+
+	ipV1alpha1, err := c.client.NetworkingV1alpha1().IPAddresses().Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(c.client.CoreV1(), ipV1alpha1, describerSettings.ChunkSize)
+		}
+		return c.describeIPAddressV1alpha1(ipV1alpha1, events)
+	}
+	return "", err
+}
+
+func (c *IPAddressDescriber) describeIPAddressV1alpha1(ip *networkingv1alpha1.IPAddress, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%v\n", ip.Name)
+		printLabelsMultiline(w, "Labels", ip.Labels)
+		printAnnotationsMultiline(w, "Annotations", ip.Annotations)
+
+		if ip.Spec.ParentRef != nil {
+			w.Write(LEVEL_0, "Parent Reference:\n")
+			w.Write(LEVEL_1, "Group:\t%v\n", ip.Spec.ParentRef.Group)
+			w.Write(LEVEL_1, "Resource:\t%v\n", ip.Spec.ParentRef.Resource)
+			w.Write(LEVEL_1, "Namespace:\t%v\n", ip.Spec.ParentRef.Namespace)
+			w.Write(LEVEL_1, "Name:\t%v\n", ip.Spec.ParentRef.Name)
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// ServiceDescriber generates information about a service.
+type ServiceDescriber struct {
+	clientset.Interface
+}
+
+func (d *ServiceDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.CoreV1().Services(namespace)
+
+	service, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	endpoints, _ := d.CoreV1().Endpoints(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), service, describerSettings.ChunkSize)
+	}
+	return describeService(service, endpoints, events)
+}
+
+func buildIngressString(ingress []corev1.LoadBalancerIngress) string {
+	var buffer bytes.Buffer
+
+	for i := range ingress {
+		if i != 0 {
+			buffer.WriteString(", ")
+		}
+		if ingress[i].IP != "" {
+			buffer.WriteString(ingress[i].IP)
+		} else {
+			buffer.WriteString(ingress[i].Hostname)
+		}
+	}
+	return buffer.String()
+}
+
+func describeService(service *corev1.Service, endpoints *corev1.Endpoints, events *corev1.EventList) (string, error) {
+	if endpoints == nil {
+		endpoints = &corev1.Endpoints{}
+	}
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", service.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", service.Namespace)
+		printLabelsMultiline(w, "Labels", service.Labels)
+		printAnnotationsMultiline(w, "Annotations", service.Annotations)
+		w.Write(LEVEL_0, "Selector:\t%s\n", labels.FormatLabels(service.Spec.Selector))
+		w.Write(LEVEL_0, "Type:\t%s\n", service.Spec.Type)
+
+		if service.Spec.IPFamilyPolicy != nil {
+			w.Write(LEVEL_0, "IP Family Policy:\t%s\n", *(service.Spec.IPFamilyPolicy))
+		}
+
+		if len(service.Spec.IPFamilies) > 0 {
+			ipfamiliesStrings := make([]string, 0, len(service.Spec.IPFamilies))
+			for _, family := range service.Spec.IPFamilies {
+				ipfamiliesStrings = append(ipfamiliesStrings, string(family))
+			}
+
+			w.Write(LEVEL_0, "IP Families:\t%s\n", strings.Join(ipfamiliesStrings, ","))
+		} else {
+			w.Write(LEVEL_0, "IP Families:\t%s\n", "<none>")
+		}
+
+		w.Write(LEVEL_0, "IP:\t%s\n", service.Spec.ClusterIP)
+		if len(service.Spec.ClusterIPs) > 0 {
+			w.Write(LEVEL_0, "IPs:\t%s\n", strings.Join(service.Spec.ClusterIPs, ","))
+		} else {
+			w.Write(LEVEL_0, "IPs:\t%s\n", "<none>")
+		}
+
+		if len(service.Spec.ExternalIPs) > 0 {
+			w.Write(LEVEL_0, "External IPs:\t%v\n", strings.Join(service.Spec.ExternalIPs, ","))
+		}
+		if service.Spec.LoadBalancerIP != "" {
+			w.Write(LEVEL_0, "IP:\t%s\n", service.Spec.LoadBalancerIP)
+		}
+		if service.Spec.ExternalName != "" {
+			w.Write(LEVEL_0, "External Name:\t%s\n", service.Spec.ExternalName)
+		}
+		if len(service.Status.LoadBalancer.Ingress) > 0 {
+			list := buildIngressString(service.Status.LoadBalancer.Ingress)
+			w.Write(LEVEL_0, "LoadBalancer Ingress:\t%s\n", list)
+		}
+		for i := range service.Spec.Ports {
+			sp := &service.Spec.Ports[i]
+
+			name := sp.Name
+			if name == "" {
+				name = "<unset>"
+			}
+			w.Write(LEVEL_0, "Port:\t%s\t%d/%s\n", name, sp.Port, sp.Protocol)
+			if sp.TargetPort.Type == intstr.Type(intstr.Int) {
+				w.Write(LEVEL_0, "TargetPort:\t%d/%s\n", sp.TargetPort.IntVal, sp.Protocol)
+			} else {
+				w.Write(LEVEL_0, "TargetPort:\t%s/%s\n", sp.TargetPort.StrVal, sp.Protocol)
+			}
+			if sp.NodePort != 0 {
+				w.Write(LEVEL_0, "NodePort:\t%s\t%d/%s\n", name, sp.NodePort, sp.Protocol)
+			}
+			w.Write(LEVEL_0, "Endpoints:\t%s\n", formatEndpoints(endpoints, sets.NewString(sp.Name)))
+		}
+		w.Write(LEVEL_0, "Session Affinity:\t%s\n", service.Spec.SessionAffinity)
+		if service.Spec.ExternalTrafficPolicy != "" {
+			w.Write(LEVEL_0, "External Traffic Policy:\t%s\n", service.Spec.ExternalTrafficPolicy)
+		}
+		if service.Spec.HealthCheckNodePort != 0 {
+			w.Write(LEVEL_0, "HealthCheck NodePort:\t%d\n", service.Spec.HealthCheckNodePort)
+		}
+		if len(service.Spec.LoadBalancerSourceRanges) > 0 {
+			w.Write(LEVEL_0, "LoadBalancer Source Ranges:\t%v\n", strings.Join(service.Spec.LoadBalancerSourceRanges, ","))
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// EndpointsDescriber generates information about an Endpoint.
+type EndpointsDescriber struct {
+	clientset.Interface
+}
+
+func (d *EndpointsDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.CoreV1().Endpoints(namespace)
+
+	ep, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), ep, describerSettings.ChunkSize)
+	}
+
+	return describeEndpoints(ep, events)
+}
+
+func describeEndpoints(ep *corev1.Endpoints, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", ep.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", ep.Namespace)
+		printLabelsMultiline(w, "Labels", ep.Labels)
+		printAnnotationsMultiline(w, "Annotations", ep.Annotations)
+
+		w.Write(LEVEL_0, "Subsets:\n")
+		for i := range ep.Subsets {
+			subset := &ep.Subsets[i]
+
+			addresses := make([]string, 0, len(subset.Addresses))
+			for _, addr := range subset.Addresses {
+				addresses = append(addresses, addr.IP)
+			}
+			addressesString := strings.Join(addresses, ",")
+			if len(addressesString) == 0 {
+				addressesString = "<none>"
+			}
+			w.Write(LEVEL_1, "Addresses:\t%s\n", addressesString)
+
+			notReadyAddresses := make([]string, 0, len(subset.NotReadyAddresses))
+			for _, addr := range subset.NotReadyAddresses {
+				notReadyAddresses = append(notReadyAddresses, addr.IP)
+			}
+			notReadyAddressesString := strings.Join(notReadyAddresses, ",")
+			if len(notReadyAddressesString) == 0 {
+				notReadyAddressesString = "<none>"
+			}
+			w.Write(LEVEL_1, "NotReadyAddresses:\t%s\n", notReadyAddressesString)
+
+			if len(subset.Ports) > 0 {
+				w.Write(LEVEL_1, "Ports:\n")
+				w.Write(LEVEL_2, "Name\tPort\tProtocol\n")
+				w.Write(LEVEL_2, "----\t----\t--------\n")
+				for _, port := range subset.Ports {
+					name := port.Name
+					if len(name) == 0 {
+						name = "<unset>"
+					}
+					w.Write(LEVEL_2, "%s\t%d\t%s\n", name, port.Port, port.Protocol)
+				}
+			}
+			w.Write(LEVEL_0, "\n")
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// EndpointSliceDescriber generates information about an EndpointSlice.
+type EndpointSliceDescriber struct {
+	clientset.Interface
+}
+
+func (d *EndpointSliceDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var events *corev1.EventList
+	// try endpointslice/v1 first (v1.21) and fallback to v1beta1 if error occurs
+
+	epsV1, err := d.DiscoveryV1().EndpointSlices(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(d.CoreV1(), epsV1, describerSettings.ChunkSize)
+		}
+		return describeEndpointSliceV1(epsV1, events)
+	}
+
+	epsV1beta1, err := d.DiscoveryV1beta1().EndpointSlices(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), epsV1beta1, describerSettings.ChunkSize)
+	}
+
+	return describeEndpointSliceV1beta1(epsV1beta1, events)
+}
+
+func describeEndpointSliceV1(eps *discoveryv1.EndpointSlice, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", eps.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", eps.Namespace)
+		printLabelsMultiline(w, "Labels", eps.Labels)
+		printAnnotationsMultiline(w, "Annotations", eps.Annotations)
+
+		w.Write(LEVEL_0, "AddressType:\t%s\n", string(eps.AddressType))
+
+		if len(eps.Ports) == 0 {
+			w.Write(LEVEL_0, "Ports: <unset>\n")
+		} else {
+			w.Write(LEVEL_0, "Ports:\n")
+			w.Write(LEVEL_1, "Name\tPort\tProtocol\n")
+			w.Write(LEVEL_1, "----\t----\t--------\n")
+			for _, port := range eps.Ports {
+				portName := "<unset>"
+				if port.Name != nil && len(*port.Name) > 0 {
+					portName = *port.Name
+				}
+
+				portNum := "<unset>"
+				if port.Port != nil {
+					portNum = strconv.Itoa(int(*port.Port))
+				}
+
+				w.Write(LEVEL_1, "%s\t%s\t%s\n", portName, portNum, *port.Protocol)
+			}
+		}
+
+		if len(eps.Endpoints) == 0 {
+			w.Write(LEVEL_0, "Endpoints: <none>\n")
+		} else {
+			w.Write(LEVEL_0, "Endpoints:\n")
+			for i := range eps.Endpoints {
+				endpoint := &eps.Endpoints[i]
+
+				addressesString := strings.Join(endpoint.Addresses, ", ")
+				if len(addressesString) == 0 {
+					addressesString = "<none>"
+				}
+				w.Write(LEVEL_1, "- Addresses:\t%s\n", addressesString)
+
+				w.Write(LEVEL_2, "Conditions:\n")
+				readyText := "<unset>"
+				if endpoint.Conditions.Ready != nil {
+					readyText = strconv.FormatBool(*endpoint.Conditions.Ready)
+				}
+				w.Write(LEVEL_3, "Ready:\t%s\n", readyText)
+
+				hostnameText := "<unset>"
+				if endpoint.Hostname != nil {
+					hostnameText = *endpoint.Hostname
+				}
+				w.Write(LEVEL_2, "Hostname:\t%s\n", hostnameText)
+
+				if endpoint.TargetRef != nil {
+					w.Write(LEVEL_2, "TargetRef:\t%s/%s\n", endpoint.TargetRef.Kind, endpoint.TargetRef.Name)
+				}
+
+				nodeNameText := "<unset>"
+				if endpoint.NodeName != nil {
+					nodeNameText = *endpoint.NodeName
+				}
+				w.Write(LEVEL_2, "NodeName:\t%s\n", nodeNameText)
+
+				zoneText := "<unset>"
+				if endpoint.Zone != nil {
+					zoneText = *endpoint.Zone
+				}
+				w.Write(LEVEL_2, "Zone:\t%s\n", zoneText)
+			}
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func describeEndpointSliceV1beta1(eps *discoveryv1beta1.EndpointSlice, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", eps.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", eps.Namespace)
+		printLabelsMultiline(w, "Labels", eps.Labels)
+		printAnnotationsMultiline(w, "Annotations", eps.Annotations)
+
+		w.Write(LEVEL_0, "AddressType:\t%s\n", string(eps.AddressType))
+
+		if len(eps.Ports) == 0 {
+			w.Write(LEVEL_0, "Ports: <unset>\n")
+		} else {
+			w.Write(LEVEL_0, "Ports:\n")
+			w.Write(LEVEL_1, "Name\tPort\tProtocol\n")
+			w.Write(LEVEL_1, "----\t----\t--------\n")
+			for _, port := range eps.Ports {
+				portName := "<unset>"
+				if port.Name != nil && len(*port.Name) > 0 {
+					portName = *port.Name
+				}
+
+				portNum := "<unset>"
+				if port.Port != nil {
+					portNum = strconv.Itoa(int(*port.Port))
+				}
+
+				w.Write(LEVEL_1, "%s\t%s\t%s\n", portName, portNum, *port.Protocol)
+			}
+		}
+
+		if len(eps.Endpoints) == 0 {
+			w.Write(LEVEL_0, "Endpoints: <none>\n")
+		} else {
+			w.Write(LEVEL_0, "Endpoints:\n")
+			for i := range eps.Endpoints {
+				endpoint := &eps.Endpoints[i]
+
+				addressesString := strings.Join(endpoint.Addresses, ",")
+				if len(addressesString) == 0 {
+					addressesString = "<none>"
+				}
+				w.Write(LEVEL_1, "- Addresses:\t%s\n", addressesString)
+
+				w.Write(LEVEL_2, "Conditions:\n")
+				readyText := "<unset>"
+				if endpoint.Conditions.Ready != nil {
+					readyText = strconv.FormatBool(*endpoint.Conditions.Ready)
+				}
+				w.Write(LEVEL_3, "Ready:\t%s\n", readyText)
+
+				hostnameText := "<unset>"
+				if endpoint.Hostname != nil {
+					hostnameText = *endpoint.Hostname
+				}
+				w.Write(LEVEL_2, "Hostname:\t%s\n", hostnameText)
+
+				if endpoint.TargetRef != nil {
+					w.Write(LEVEL_2, "TargetRef:\t%s/%s\n", endpoint.TargetRef.Kind, endpoint.TargetRef.Name)
+				}
+
+				printLabelsMultilineWithIndent(w, "    ", "Topology", "\t", endpoint.Topology, sets.NewString())
+			}
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+// ServiceAccountDescriber generates information about a service.
+type ServiceAccountDescriber struct {
+	clientset.Interface
+}
+
+func (d *ServiceAccountDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.CoreV1().ServiceAccounts(namespace)
+
+	serviceAccount, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	tokens := []corev1.Secret{}
+
+	// missingSecrets is the set of all secrets present in the
+	// serviceAccount but not present in the set of existing secrets.
+	missingSecrets := sets.NewString()
+	secrets := corev1.SecretList{}
+	err = runtimeresource.FollowContinue(&metav1.ListOptions{Limit: describerSettings.ChunkSize},
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newList, err := d.CoreV1().Secrets(namespace).List(context.TODO(), options)
+			if err != nil {
+				return nil, runtimeresource.EnhanceListError(err, options, corev1.ResourceSecrets.String())
+			}
+			secrets.Items = append(secrets.Items, newList.Items...)
+			return newList, nil
+		})
+
+	// errors are tolerated here in order to describe the serviceAccount with all
+	// of the secrets that it references, even if those secrets cannot be fetched.
+	if err == nil {
+		// existingSecrets is the set of all secrets remaining on a
+		// service account that are not present in the "tokens" slice.
+		existingSecrets := sets.NewString()
+
+		for _, s := range secrets.Items {
+			if s.Type == corev1.SecretTypeServiceAccountToken {
+				name := s.Annotations[corev1.ServiceAccountNameKey]
+				uid := s.Annotations[corev1.ServiceAccountUIDKey]
+				if name == serviceAccount.Name && uid == string(serviceAccount.UID) {
+					tokens = append(tokens, s)
+				}
+			}
+			existingSecrets.Insert(s.Name)
+		}
+
+		for _, s := range serviceAccount.Secrets {
+			if !existingSecrets.Has(s.Name) {
+				missingSecrets.Insert(s.Name)
+			}
+		}
+		for _, s := range serviceAccount.ImagePullSecrets {
+			if !existingSecrets.Has(s.Name) {
+				missingSecrets.Insert(s.Name)
+			}
+		}
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(d.CoreV1(), serviceAccount, describerSettings.ChunkSize)
+	}
+
+	return describeServiceAccount(serviceAccount, tokens, missingSecrets, events)
+}
+
+func describeServiceAccount(serviceAccount *corev1.ServiceAccount, tokens []corev1.Secret, missingSecrets sets.String, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", serviceAccount.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", serviceAccount.Namespace)
+		printLabelsMultiline(w, "Labels", serviceAccount.Labels)
+		printAnnotationsMultiline(w, "Annotations", serviceAccount.Annotations)
+
+		var (
+			emptyHeader = "                   "
+			pullHeader  = "Image pull secrets:"
+			mountHeader = "Mountable secrets: "
+			tokenHeader = "Tokens:            "
+
+			pullSecretNames  = []string{}
+			mountSecretNames = []string{}
+			tokenSecretNames = []string{}
+		)
+
+		for _, s := range serviceAccount.ImagePullSecrets {
+			pullSecretNames = append(pullSecretNames, s.Name)
+		}
+		for _, s := range serviceAccount.Secrets {
+			mountSecretNames = append(mountSecretNames, s.Name)
+		}
+		for _, s := range tokens {
+			tokenSecretNames = append(tokenSecretNames, s.Name)
+		}
+
+		types := map[string][]string{
+			pullHeader:  pullSecretNames,
+			mountHeader: mountSecretNames,
+			tokenHeader: tokenSecretNames,
+		}
+		for _, header := range sets.StringKeySet(types).List() {
+			names := types[header]
+			if len(names) == 0 {
+				w.Write(LEVEL_0, "%s\t<none>\n", header)
+			} else {
+				prefix := header
+				for _, name := range names {
+					if missingSecrets.Has(name) {
+						w.Write(LEVEL_0, "%s\t%s (not found)\n", prefix, name)
+					} else {
+						w.Write(LEVEL_0, "%s\t%s\n", prefix, name)
+					}
+					prefix = emptyHeader
+				}
+			}
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+// RoleDescriber generates information about a node.
+type RoleDescriber struct {
+	clientset.Interface
+}
+
+func (d *RoleDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	role, err := d.RbacV1().Roles(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	breakdownRules := []rbacv1.PolicyRule{}
+	for _, rule := range role.Rules {
+		breakdownRules = append(breakdownRules, rbac.BreakdownRule(rule)...)
+	}
+
+	compactRules, err := rbac.CompactRules(breakdownRules)
+	if err != nil {
+		return "", err
+	}
+	sort.Stable(rbac.SortableRuleSlice(compactRules))
+
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", role.Name)
+		printLabelsMultiline(w, "Labels", role.Labels)
+		printAnnotationsMultiline(w, "Annotations", role.Annotations)
+
+		w.Write(LEVEL_0, "PolicyRule:\n")
+		w.Write(LEVEL_1, "Resources\tNon-Resource URLs\tResource Names\tVerbs\n")
+		w.Write(LEVEL_1, "---------\t-----------------\t--------------\t-----\n")
+		for _, r := range compactRules {
+			w.Write(LEVEL_1, "%s\t%v\t%v\t%v\n", CombineResourceGroup(r.Resources, r.APIGroups), r.NonResourceURLs, r.ResourceNames, r.Verbs)
+		}
+
+		return nil
+	})
+}
+
+// ClusterRoleDescriber generates information about a node.
+type ClusterRoleDescriber struct {
+	clientset.Interface
+}
+
+func (d *ClusterRoleDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	role, err := d.RbacV1().ClusterRoles().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	breakdownRules := []rbacv1.PolicyRule{}
+	for _, rule := range role.Rules {
+		breakdownRules = append(breakdownRules, rbac.BreakdownRule(rule)...)
+	}
+
+	compactRules, err := rbac.CompactRules(breakdownRules)
+	if err != nil {
+		return "", err
+	}
+	sort.Stable(rbac.SortableRuleSlice(compactRules))
+
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", role.Name)
+		printLabelsMultiline(w, "Labels", role.Labels)
+		printAnnotationsMultiline(w, "Annotations", role.Annotations)
+
+		w.Write(LEVEL_0, "PolicyRule:\n")
+		w.Write(LEVEL_1, "Resources\tNon-Resource URLs\tResource Names\tVerbs\n")
+		w.Write(LEVEL_1, "---------\t-----------------\t--------------\t-----\n")
+		for _, r := range compactRules {
+			w.Write(LEVEL_1, "%s\t%v\t%v\t%v\n", CombineResourceGroup(r.Resources, r.APIGroups), r.NonResourceURLs, r.ResourceNames, r.Verbs)
+		}
+
+		return nil
+	})
+}
+
+func CombineResourceGroup(resource, group []string) string {
+	if len(resource) == 0 {
+		return ""
+	}
+	parts := strings.SplitN(resource[0], "/", 2)
+	combine := parts[0]
+
+	if len(group) > 0 && group[0] != "" {
+		combine = combine + "." + group[0]
+	}
+
+	if len(parts) == 2 {
+		combine = combine + "/" + parts[1]
+	}
+	return combine
+}
+
+// RoleBindingDescriber generates information about a node.
+type RoleBindingDescriber struct {
+	clientset.Interface
+}
+
+func (d *RoleBindingDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	binding, err := d.RbacV1().RoleBindings(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", binding.Name)
+		printLabelsMultiline(w, "Labels", binding.Labels)
+		printAnnotationsMultiline(w, "Annotations", binding.Annotations)
+
+		w.Write(LEVEL_0, "Role:\n")
+		w.Write(LEVEL_1, "Kind:\t%s\n", binding.RoleRef.Kind)
+		w.Write(LEVEL_1, "Name:\t%s\n", binding.RoleRef.Name)
+
+		w.Write(LEVEL_0, "Subjects:\n")
+		w.Write(LEVEL_1, "Kind\tName\tNamespace\n")
+		w.Write(LEVEL_1, "----\t----\t---------\n")
+		for _, s := range binding.Subjects {
+			w.Write(LEVEL_1, "%s\t%s\t%s\n", s.Kind, s.Name, s.Namespace)
+		}
+
+		return nil
+	})
+}
+
+// ClusterRoleBindingDescriber generates information about a node.
+type ClusterRoleBindingDescriber struct {
+	clientset.Interface
+}
+
+func (d *ClusterRoleBindingDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	binding, err := d.RbacV1().ClusterRoleBindings().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", binding.Name)
+		printLabelsMultiline(w, "Labels", binding.Labels)
+		printAnnotationsMultiline(w, "Annotations", binding.Annotations)
+
+		w.Write(LEVEL_0, "Role:\n")
+		w.Write(LEVEL_1, "Kind:\t%s\n", binding.RoleRef.Kind)
+		w.Write(LEVEL_1, "Name:\t%s\n", binding.RoleRef.Name)
+
+		w.Write(LEVEL_0, "Subjects:\n")
+		w.Write(LEVEL_1, "Kind\tName\tNamespace\n")
+		w.Write(LEVEL_1, "----\t----\t---------\n")
+		for _, s := range binding.Subjects {
+			w.Write(LEVEL_1, "%s\t%s\t%s\n", s.Kind, s.Name, s.Namespace)
+		}
+
+		return nil
+	})
+}
+
+// NodeDescriber generates information about a node.
+type NodeDescriber struct {
+	clientset.Interface
+}
+
+func (d *NodeDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	mc := d.CoreV1().Nodes()
+	node, err := mc.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	fieldSelector, err := fields.ParseSelector("spec.nodeName=" + name + ",status.phase!=" + string(corev1.PodSucceeded) + ",status.phase!=" + string(corev1.PodFailed))
+	if err != nil {
+		return "", err
+	}
+	// in a policy aware setting, users may have access to a node, but not all pods
+	// in that case, we note that the user does not have access to the pods
+	canViewPods := true
+	initialOpts := metav1.ListOptions{
+		FieldSelector: fieldSelector.String(),
+		Limit:         describerSettings.ChunkSize,
+	}
+	nodeNonTerminatedPodsList, err := getPodsInChunks(d.CoreV1().Pods(namespace), initialOpts)
+	if err != nil {
+		if !apierrors.IsForbidden(err) {
+			return "", err
+		}
+		canViewPods = false
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		if ref, err := reference.GetReference(scheme.Scheme, node); err != nil {
+			klog.Errorf("Unable to construct reference to '%#v': %v", node, err)
+		} else {
+			// TODO: We haven't decided the namespace for Node object yet.
+			// there are two UIDs for host events:
+			// controller use node.uid
+			// kubelet use node.name
+			// TODO: Uniform use of UID
+			events, _ = searchEvents(d.CoreV1(), ref, describerSettings.ChunkSize)
+
+			ref.UID = types.UID(ref.Name)
+			eventsInvName, _ := searchEvents(d.CoreV1(), ref, describerSettings.ChunkSize)
+
+			// Merge the results of two queries
+			events.Items = append(events.Items, eventsInvName.Items...)
+		}
+	}
+
+	return describeNode(node, nodeNonTerminatedPodsList, events, canViewPods, &LeaseDescriber{d})
+}
+
+type LeaseDescriber struct {
+	client clientset.Interface
+}
+
+func describeNode(node *corev1.Node, nodeNonTerminatedPodsList *corev1.PodList, events *corev1.EventList,
+	canViewPods bool, ld *LeaseDescriber) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", node.Name)
+		if roles := findNodeRoles(node); len(roles) > 0 {
+			w.Write(LEVEL_0, "Roles:\t%s\n", strings.Join(roles, ","))
+		} else {
+			w.Write(LEVEL_0, "Roles:\t%s\n", "<none>")
+		}
+		printLabelsMultiline(w, "Labels", node.Labels)
+		printAnnotationsMultiline(w, "Annotations", node.Annotations)
+		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", node.CreationTimestamp.Time.Format(time.RFC1123Z))
+		printNodeTaintsMultiline(w, "Taints", node.Spec.Taints)
+		w.Write(LEVEL_0, "Unschedulable:\t%v\n", node.Spec.Unschedulable)
+
+		if ld != nil {
+			if lease, err := ld.client.CoordinationV1().Leases(corev1.NamespaceNodeLease).Get(context.TODO(), node.Name, metav1.GetOptions{}); err == nil {
+				describeNodeLease(lease, w)
+			} else {
+				w.Write(LEVEL_0, "Lease:\tFailed to get lease: %s\n", err)
+			}
+		}
+
+		if len(node.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n  Type\tStatus\tLastHeartbeatTime\tLastTransitionTime\tReason\tMessage\n")
+			w.Write(LEVEL_1, "----\t------\t-----------------\t------------------\t------\t-------\n")
+			for _, c := range node.Status.Conditions {
+				w.Write(LEVEL_1, "%v \t%v \t%s \t%s \t%v \t%v\n",
+					c.Type,
+					c.Status,
+					c.LastHeartbeatTime.Time.Format(time.RFC1123Z),
+					c.LastTransitionTime.Time.Format(time.RFC1123Z),
+					c.Reason,
+					c.Message)
+			}
+		}
+
+		w.Write(LEVEL_0, "Addresses:\n")
+		for _, address := range node.Status.Addresses {
+			w.Write(LEVEL_1, "%s:\t%s\n", address.Type, address.Address)
+		}
+
+		printResourceList := func(resourceList corev1.ResourceList) {
+			resources := make([]corev1.ResourceName, 0, len(resourceList))
+			for resource := range resourceList {
+				resources = append(resources, resource)
+			}
+			sort.Sort(SortableResourceNames(resources))
+			for _, resource := range resources {
+				value := resourceList[resource]
+				w.Write(LEVEL_0, "  %s:\t%s\n", resource, value.String())
+			}
+		}
+
+		if len(node.Status.Capacity) > 0 {
+			w.Write(LEVEL_0, "Capacity:\n")
+			printResourceList(node.Status.Capacity)
+		}
+		if len(node.Status.Allocatable) > 0 {
+			w.Write(LEVEL_0, "Allocatable:\n")
+			printResourceList(node.Status.Allocatable)
+		}
+
+		w.Write(LEVEL_0, "System Info:\n")
+		w.Write(LEVEL_0, "  Machine ID:\t%s\n", node.Status.NodeInfo.MachineID)
+		w.Write(LEVEL_0, "  System UUID:\t%s\n", node.Status.NodeInfo.SystemUUID)
+		w.Write(LEVEL_0, "  Boot ID:\t%s\n", node.Status.NodeInfo.BootID)
+		w.Write(LEVEL_0, "  Kernel Version:\t%s\n", node.Status.NodeInfo.KernelVersion)
+		w.Write(LEVEL_0, "  OS Image:\t%s\n", node.Status.NodeInfo.OSImage)
+		w.Write(LEVEL_0, "  Operating System:\t%s\n", node.Status.NodeInfo.OperatingSystem)
+		w.Write(LEVEL_0, "  Architecture:\t%s\n", node.Status.NodeInfo.Architecture)
+		w.Write(LEVEL_0, "  Container Runtime Version:\t%s\n", node.Status.NodeInfo.ContainerRuntimeVersion)
+		w.Write(LEVEL_0, "  Kubelet Version:\t%s\n", node.Status.NodeInfo.KubeletVersion)
+		w.Write(LEVEL_0, "  Kube-Proxy Version:\t%s\n", node.Status.NodeInfo.KubeProxyVersion)
+
+		// remove when .PodCIDR is depreciated
+		if len(node.Spec.PodCIDR) > 0 {
+			w.Write(LEVEL_0, "PodCIDR:\t%s\n", node.Spec.PodCIDR)
+		}
+
+		if len(node.Spec.PodCIDRs) > 0 {
+			w.Write(LEVEL_0, "PodCIDRs:\t%s\n", strings.Join(node.Spec.PodCIDRs, ","))
+		}
+		if len(node.Spec.ProviderID) > 0 {
+			w.Write(LEVEL_0, "ProviderID:\t%s\n", node.Spec.ProviderID)
+		}
+		if canViewPods && nodeNonTerminatedPodsList != nil {
+			describeNodeResource(nodeNonTerminatedPodsList, node, w)
+		} else {
+			w.Write(LEVEL_0, "Pods:\tnot authorized\n")
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func describeNodeLease(lease *coordinationv1.Lease, w PrefixWriter) {
+	w.Write(LEVEL_0, "Lease:\n")
+	holderIdentity := "<unset>"
+	if lease != nil && lease.Spec.HolderIdentity != nil {
+		holderIdentity = *lease.Spec.HolderIdentity
+	}
+	w.Write(LEVEL_1, "HolderIdentity:\t%s\n", holderIdentity)
+	acquireTime := "<unset>"
+	if lease != nil && lease.Spec.AcquireTime != nil {
+		acquireTime = lease.Spec.AcquireTime.Time.Format(time.RFC1123Z)
+	}
+	w.Write(LEVEL_1, "AcquireTime:\t%s\n", acquireTime)
+	renewTime := "<unset>"
+	if lease != nil && lease.Spec.RenewTime != nil {
+		renewTime = lease.Spec.RenewTime.Time.Format(time.RFC1123Z)
+	}
+	w.Write(LEVEL_1, "RenewTime:\t%s\n", renewTime)
+}
+
+type StatefulSetDescriber struct {
+	client clientset.Interface
+}
+
+func (p *StatefulSetDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	ps, err := p.client.AppsV1().StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	pc := p.client.CoreV1().Pods(namespace)
+
+	selector, err := metav1.LabelSelectorAsSelector(ps.Spec.Selector)
+	if err != nil {
+		return "", err
+	}
+
+	running, waiting, succeeded, failed, err := getPodStatusForController(pc, selector, ps.UID, describerSettings)
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(p.client.CoreV1(), ps, describerSettings.ChunkSize)
+	}
+
+	return describeStatefulSet(ps, selector, events, running, waiting, succeeded, failed)
+}
+
+func describeStatefulSet(ps *appsv1.StatefulSet, selector labels.Selector, events *corev1.EventList, running, waiting, succeeded, failed int) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", ps.ObjectMeta.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", ps.ObjectMeta.Namespace)
+		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", ps.CreationTimestamp.Time.Format(time.RFC1123Z))
+		w.Write(LEVEL_0, "Selector:\t%s\n", selector)
+		printLabelsMultiline(w, "Labels", ps.Labels)
+		printAnnotationsMultiline(w, "Annotations", ps.Annotations)
+		w.Write(LEVEL_0, "Replicas:\t%d desired | %d total\n", *ps.Spec.Replicas, ps.Status.Replicas)
+		w.Write(LEVEL_0, "Update Strategy:\t%s\n", ps.Spec.UpdateStrategy.Type)
+		if ps.Spec.UpdateStrategy.RollingUpdate != nil {
+			ru := ps.Spec.UpdateStrategy.RollingUpdate
+			if ru.Partition != nil {
+				w.Write(LEVEL_1, "Partition:\t%d\n", *ru.Partition)
+				if ru.MaxUnavailable != nil {
+					w.Write(LEVEL_1, "MaxUnavailable:\t%s\n", ru.MaxUnavailable.String())
+				}
+			}
+		}
+
+		w.Write(LEVEL_0, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
+		DescribePodTemplate(&ps.Spec.Template, w)
+		describeVolumeClaimTemplates(ps.Spec.VolumeClaimTemplates, w)
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+type CertificateSigningRequestDescriber struct {
+	client clientset.Interface
+}
+
+func (p *CertificateSigningRequestDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+
+	var (
+		crBytes           []byte
+		metadata          metav1.ObjectMeta
+		status            string
+		signerName        string
+		expirationSeconds *int32
+		username          string
+		events            *corev1.EventList
+	)
+
+	if csr, err := p.client.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), name, metav1.GetOptions{}); err == nil {
+		crBytes = csr.Spec.Request
+		metadata = csr.ObjectMeta
+		conditionTypes := []string{}
+		for _, c := range csr.Status.Conditions {
+			conditionTypes = append(conditionTypes, string(c.Type))
+		}
+		status = extractCSRStatus(conditionTypes, csr.Status.Certificate)
+		signerName = csr.Spec.SignerName
+		expirationSeconds = csr.Spec.ExpirationSeconds
+		username = csr.Spec.Username
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(p.client.CoreV1(), csr, describerSettings.ChunkSize)
+		}
+	} else if csr, err := p.client.CertificatesV1beta1().CertificateSigningRequests().Get(context.TODO(), name, metav1.GetOptions{}); err == nil {
+		crBytes = csr.Spec.Request
+		metadata = csr.ObjectMeta
+		conditionTypes := []string{}
+		for _, c := range csr.Status.Conditions {
+			conditionTypes = append(conditionTypes, string(c.Type))
+		}
+		status = extractCSRStatus(conditionTypes, csr.Status.Certificate)
+		if csr.Spec.SignerName != nil {
+			signerName = *csr.Spec.SignerName
+		}
+		expirationSeconds = csr.Spec.ExpirationSeconds
+		username = csr.Spec.Username
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(p.client.CoreV1(), csr, describerSettings.ChunkSize)
+		}
+	} else {
+		return "", err
+	}
+
+	cr, err := certificate.ParseCSR(crBytes)
+	if err != nil {
+		return "", fmt.Errorf("Error parsing CSR: %v", err)
+	}
+
+	return describeCertificateSigningRequest(metadata, signerName, expirationSeconds, username, cr, status, events)
+}
+
+func describeCertificateSigningRequest(csr metav1.ObjectMeta, signerName string, expirationSeconds *int32, username string, cr *x509.CertificateRequest, status string, events *corev1.EventList) (string, error) {
+	printListHelper := func(w PrefixWriter, prefix, name string, values []string) {
+		if len(values) == 0 {
+			return
+		}
+		w.Write(LEVEL_0, prefix+name+":\t")
+		w.Write(LEVEL_0, strings.Join(values, "\n"+prefix+"\t"))
+		w.Write(LEVEL_0, "\n")
+	}
+
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", csr.Name)
+		w.Write(LEVEL_0, "Labels:\t%s\n", labels.FormatLabels(csr.Labels))
+		w.Write(LEVEL_0, "Annotations:\t%s\n", labels.FormatLabels(csr.Annotations))
+		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", csr.CreationTimestamp.Time.Format(time.RFC1123Z))
+		w.Write(LEVEL_0, "Requesting User:\t%s\n", username)
+		if len(signerName) > 0 {
+			w.Write(LEVEL_0, "Signer:\t%s\n", signerName)
+		}
+		if expirationSeconds != nil {
+			w.Write(LEVEL_0, "Requested Duration:\t%s\n", duration.HumanDuration(utilcsr.ExpirationSecondsToDuration(*expirationSeconds)))
+		}
+		w.Write(LEVEL_0, "Status:\t%s\n", status)
+
+		w.Write(LEVEL_0, "Subject:\n")
+		w.Write(LEVEL_0, "\tCommon Name:\t%s\n", cr.Subject.CommonName)
+		w.Write(LEVEL_0, "\tSerial Number:\t%s\n", cr.Subject.SerialNumber)
+		printListHelper(w, "\t", "Organization", cr.Subject.Organization)
+		printListHelper(w, "\t", "Organizational Unit", cr.Subject.OrganizationalUnit)
+		printListHelper(w, "\t", "Country", cr.Subject.Country)
+		printListHelper(w, "\t", "Locality", cr.Subject.Locality)
+		printListHelper(w, "\t", "Province", cr.Subject.Province)
+		printListHelper(w, "\t", "StreetAddress", cr.Subject.StreetAddress)
+		printListHelper(w, "\t", "PostalCode", cr.Subject.PostalCode)
+
+		if len(cr.DNSNames)+len(cr.EmailAddresses)+len(cr.IPAddresses)+len(cr.URIs) > 0 {
+			w.Write(LEVEL_0, "Subject Alternative Names:\n")
+			printListHelper(w, "\t", "DNS Names", cr.DNSNames)
+			printListHelper(w, "\t", "Email Addresses", cr.EmailAddresses)
+			var uris []string
+			for _, uri := range cr.URIs {
+				uris = append(uris, uri.String())
+			}
+			printListHelper(w, "\t", "URIs", uris)
+			var ipaddrs []string
+			for _, ipaddr := range cr.IPAddresses {
+				ipaddrs = append(ipaddrs, ipaddr.String())
+			}
+			printListHelper(w, "\t", "IP Addresses", ipaddrs)
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+// HorizontalPodAutoscalerDescriber generates information about a horizontal pod autoscaler.
+type HorizontalPodAutoscalerDescriber struct {
+	client clientset.Interface
+}
+
+func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var events *corev1.EventList
+
+	// autoscaling/v2 is introduced since v1.23 and autoscaling/v1 does not have full backward compatibility
+	// with autoscaling/v2, so describer will try to get and describe hpa v2 object firstly, if it fails,
+	// describer will fall back to do with hpa v1 object
+	hpaV2, err := d.client.AutoscalingV2().HorizontalPodAutoscalers(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(d.client.CoreV1(), hpaV2, describerSettings.ChunkSize)
+		}
+		return describeHorizontalPodAutoscalerV2(hpaV2, events, d)
+	}
+
+	hpaV1, err := d.client.AutoscalingV1().HorizontalPodAutoscalers(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(d.client.CoreV1(), hpaV1, describerSettings.ChunkSize)
+		}
+		return describeHorizontalPodAutoscalerV1(hpaV1, events, d)
+	}
+
+	return "", err
+}
+
+func describeHorizontalPodAutoscalerV2(hpa *autoscalingv2.HorizontalPodAutoscaler, events *corev1.EventList, d *HorizontalPodAutoscalerDescriber) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", hpa.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", hpa.Namespace)
+		printLabelsMultiline(w, "Labels", hpa.Labels)
+		printAnnotationsMultiline(w, "Annotations", hpa.Annotations)
+		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", hpa.CreationTimestamp.Time.Format(time.RFC1123Z))
+		w.Write(LEVEL_0, "Reference:\t%s/%s\n",
+			hpa.Spec.ScaleTargetRef.Kind,
+			hpa.Spec.ScaleTargetRef.Name)
+		w.Write(LEVEL_0, "Metrics:\t( current / target )\n")
+		for i, metric := range hpa.Spec.Metrics {
+			switch metric.Type {
+			case autoscalingv2.ExternalMetricSourceType:
+				if metric.External.Target.AverageValue != nil {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].External != nil &&
+						hpa.Status.CurrentMetrics[i].External.Current.AverageValue != nil {
+						current = hpa.Status.CurrentMetrics[i].External.Current.AverageValue.String()
+					}
+					w.Write(LEVEL_1, "%q (target average value):\t%s / %s\n", metric.External.Metric.Name, current, metric.External.Target.AverageValue.String())
+				} else {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].External != nil {
+						current = hpa.Status.CurrentMetrics[i].External.Current.Value.String()
+					}
+					w.Write(LEVEL_1, "%q (target value):\t%s / %s\n", metric.External.Metric.Name, current, metric.External.Target.Value.String())
+
+				}
+			case autoscalingv2.PodsMetricSourceType:
+				current := "<unknown>"
+				if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].Pods != nil {
+					current = hpa.Status.CurrentMetrics[i].Pods.Current.AverageValue.String()
+				}
+				w.Write(LEVEL_1, "%q on pods:\t%s / %s\n", metric.Pods.Metric.Name, current, metric.Pods.Target.AverageValue.String())
+			case autoscalingv2.ObjectMetricSourceType:
+				w.Write(LEVEL_1, "\"%s\" on %s/%s ", metric.Object.Metric.Name, metric.Object.DescribedObject.Kind, metric.Object.DescribedObject.Name)
+				if metric.Object.Target.Type == autoscalingv2.AverageValueMetricType {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].Object != nil {
+						current = hpa.Status.CurrentMetrics[i].Object.Current.AverageValue.String()
+					}
+					w.Write(LEVEL_0, "(target average value):\t%s / %s\n", current, metric.Object.Target.AverageValue.String())
+				} else {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].Object != nil {
+						current = hpa.Status.CurrentMetrics[i].Object.Current.Value.String()
+					}
+					w.Write(LEVEL_0, "(target value):\t%s / %s\n", current, metric.Object.Target.Value.String())
+				}
+			case autoscalingv2.ResourceMetricSourceType:
+				w.Write(LEVEL_1, "resource %s on pods", string(metric.Resource.Name))
+				if metric.Resource.Target.AverageValue != nil {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].Resource != nil {
+						current = hpa.Status.CurrentMetrics[i].Resource.Current.AverageValue.String()
+					}
+					w.Write(LEVEL_0, ":\t%s / %s\n", current, metric.Resource.Target.AverageValue.String())
+				} else {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].Resource != nil && hpa.Status.CurrentMetrics[i].Resource.Current.AverageUtilization != nil {
+						current = fmt.Sprintf("%d%% (%s)", *hpa.Status.CurrentMetrics[i].Resource.Current.AverageUtilization, hpa.Status.CurrentMetrics[i].Resource.Current.AverageValue.String())
+					}
+
+					target := "<auto>"
+					if metric.Resource.Target.AverageUtilization != nil {
+						target = fmt.Sprintf("%d%%", *metric.Resource.Target.AverageUtilization)
+					}
+					w.Write(LEVEL_1, "(as a percentage of request):\t%s / %s\n", current, target)
+				}
+			case autoscalingv2.ContainerResourceMetricSourceType:
+				w.Write(LEVEL_1, "resource %s of container \"%s\" on pods", string(metric.ContainerResource.Name), metric.ContainerResource.Container)
+				if metric.ContainerResource.Target.AverageValue != nil {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].ContainerResource != nil {
+						current = hpa.Status.CurrentMetrics[i].ContainerResource.Current.AverageValue.String()
+					}
+					w.Write(LEVEL_0, ":\t%s / %s\n", current, metric.ContainerResource.Target.AverageValue.String())
+				} else {
+					current := "<unknown>"
+					if len(hpa.Status.CurrentMetrics) > i && hpa.Status.CurrentMetrics[i].ContainerResource != nil && hpa.Status.CurrentMetrics[i].ContainerResource.Current.AverageUtilization != nil {
+						current = fmt.Sprintf("%d%% (%s)", *hpa.Status.CurrentMetrics[i].ContainerResource.Current.AverageUtilization, hpa.Status.CurrentMetrics[i].ContainerResource.Current.AverageValue.String())
+					}
+
+					target := "<auto>"
+					if metric.ContainerResource.Target.AverageUtilization != nil {
+						target = fmt.Sprintf("%d%%", *metric.ContainerResource.Target.AverageUtilization)
+					}
+					w.Write(LEVEL_1, "(as a percentage of request):\t%s / %s\n", current, target)
+				}
+			default:
+				w.Write(LEVEL_1, "<unknown metric type %q>\n", string(metric.Type))
+			}
+		}
+		minReplicas := "<unset>"
+		if hpa.Spec.MinReplicas != nil {
+			minReplicas = fmt.Sprintf("%d", *hpa.Spec.MinReplicas)
+		}
+		w.Write(LEVEL_0, "Min replicas:\t%s\n", minReplicas)
+		w.Write(LEVEL_0, "Max replicas:\t%d\n", hpa.Spec.MaxReplicas)
+		// only print the hpa behavior if present
+		if hpa.Spec.Behavior != nil {
+			w.Write(LEVEL_0, "Behavior:\n")
+			printDirectionBehavior(w, "Scale Up", hpa.Spec.Behavior.ScaleUp)
+			printDirectionBehavior(w, "Scale Down", hpa.Spec.Behavior.ScaleDown)
+		}
+		w.Write(LEVEL_0, "%s pods:\t", hpa.Spec.ScaleTargetRef.Kind)
+		w.Write(LEVEL_0, "%d current / %d desired\n", hpa.Status.CurrentReplicas, hpa.Status.DesiredReplicas)
+
+		if len(hpa.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n")
+			w.Write(LEVEL_1, "Type\tStatus\tReason\tMessage\n")
+			w.Write(LEVEL_1, "----\t------\t------\t-------\n")
+			for _, c := range hpa.Status.Conditions {
+				w.Write(LEVEL_1, "%v\t%v\t%v\t%v\n", c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+func printDirectionBehavior(w PrefixWriter, direction string, rules *autoscalingv2.HPAScalingRules) {
+	if rules != nil {
+		w.Write(LEVEL_1, "%s:\n", direction)
+		if rules.StabilizationWindowSeconds != nil {
+			w.Write(LEVEL_2, "Stabilization Window: %d seconds\n", *rules.StabilizationWindowSeconds)
+		}
+		if len(rules.Policies) > 0 {
+			if rules.SelectPolicy != nil {
+				w.Write(LEVEL_2, "Select Policy: %s\n", *rules.SelectPolicy)
+			} else {
+				w.Write(LEVEL_2, "Select Policy: %s\n", autoscalingv2.MaxChangePolicySelect)
+			}
+			w.Write(LEVEL_2, "Policies:\n")
+			for _, p := range rules.Policies {
+				w.Write(LEVEL_3, "- Type: %s\tValue: %d\tPeriod: %d seconds\n", p.Type, p.Value, p.PeriodSeconds)
+			}
+		}
+	}
+}
+
+func describeHorizontalPodAutoscalerV1(hpa *autoscalingv1.HorizontalPodAutoscaler, events *corev1.EventList, d *HorizontalPodAutoscalerDescriber) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", hpa.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", hpa.Namespace)
+		printLabelsMultiline(w, "Labels", hpa.Labels)
+		printAnnotationsMultiline(w, "Annotations", hpa.Annotations)
+		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", hpa.CreationTimestamp.Time.Format(time.RFC1123Z))
+		w.Write(LEVEL_0, "Reference:\t%s/%s\n",
+			hpa.Spec.ScaleTargetRef.Kind,
+			hpa.Spec.ScaleTargetRef.Name)
+
+		if hpa.Spec.TargetCPUUtilizationPercentage != nil {
+			w.Write(LEVEL_0, "Target CPU utilization:\t%d%%\n", *hpa.Spec.TargetCPUUtilizationPercentage)
+			current := "<unknown>"
+			if hpa.Status.CurrentCPUUtilizationPercentage != nil {
+				current = fmt.Sprintf("%d", *hpa.Status.CurrentCPUUtilizationPercentage)
+			}
+			w.Write(LEVEL_0, "Current CPU utilization:\t%s%%\n", current)
+		}
+
+		minReplicas := "<unset>"
+		if hpa.Spec.MinReplicas != nil {
+			minReplicas = fmt.Sprintf("%d", *hpa.Spec.MinReplicas)
+		}
+		w.Write(LEVEL_0, "Min replicas:\t%s\n", minReplicas)
+		w.Write(LEVEL_0, "Max replicas:\t%d\n", hpa.Spec.MaxReplicas)
+		w.Write(LEVEL_0, "%s pods:\t", hpa.Spec.ScaleTargetRef.Kind)
+		w.Write(LEVEL_0, "%d current / %d desired\n", hpa.Status.CurrentReplicas, hpa.Status.DesiredReplicas)
+
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev1.Node, w PrefixWriter) {
+	w.Write(LEVEL_0, "Non-terminated Pods:\t(%d in total)\n", len(nodeNonTerminatedPodsList.Items))
+	w.Write(LEVEL_1, "Namespace\tName\t\tCPU Requests\tCPU Limits\tMemory Requests\tMemory Limits\tAge\n")
+	w.Write(LEVEL_1, "---------\t----\t\t------------\t----------\t---------------\t-------------\t---\n")
+	allocatable := node.Status.Capacity
+	if len(node.Status.Allocatable) > 0 {
+		allocatable = node.Status.Allocatable
+	}
+
+	for _, pod := range nodeNonTerminatedPodsList.Items {
+		req, limit := resourcehelper.PodRequestsAndLimits(&pod)
+		cpuReq, cpuLimit, memoryReq, memoryLimit := req[corev1.ResourceCPU], limit[corev1.ResourceCPU], req[corev1.ResourceMemory], limit[corev1.ResourceMemory]
+		fractionCpuReq := float64(cpuReq.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+		fractionCpuLimit := float64(cpuLimit.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+		fractionMemoryReq := float64(memoryReq.Value()) / float64(allocatable.Memory().Value()) * 100
+		fractionMemoryLimit := float64(memoryLimit.Value()) / float64(allocatable.Memory().Value()) * 100
+		w.Write(LEVEL_1, "%s\t%s\t\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\t%s\n", pod.Namespace, pod.Name,
+			cpuReq.String(), int64(fractionCpuReq), cpuLimit.String(), int64(fractionCpuLimit),
+			memoryReq.String(), int64(fractionMemoryReq), memoryLimit.String(), int64(fractionMemoryLimit), translateTimestampSince(pod.CreationTimestamp))
+	}
+
+	w.Write(LEVEL_0, "Allocated resources:\n  (Total limits may be over 100 percent, i.e., overcommitted.)\n")
+	w.Write(LEVEL_1, "Resource\tRequests\tLimits\n")
+	w.Write(LEVEL_1, "--------\t--------\t------\n")
+	reqs, limits := getPodsTotalRequestsAndLimits(nodeNonTerminatedPodsList)
+	cpuReqs, cpuLimits, memoryReqs, memoryLimits, ephemeralstorageReqs, ephemeralstorageLimits :=
+		reqs[corev1.ResourceCPU], limits[corev1.ResourceCPU], reqs[corev1.ResourceMemory], limits[corev1.ResourceMemory], reqs[corev1.ResourceEphemeralStorage], limits[corev1.ResourceEphemeralStorage]
+	fractionCpuReqs := float64(0)
+	fractionCpuLimits := float64(0)
+	if allocatable.Cpu().MilliValue() != 0 {
+		fractionCpuReqs = float64(cpuReqs.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+		fractionCpuLimits = float64(cpuLimits.MilliValue()) / float64(allocatable.Cpu().MilliValue()) * 100
+	}
+	fractionMemoryReqs := float64(0)
+	fractionMemoryLimits := float64(0)
+	if allocatable.Memory().Value() != 0 {
+		fractionMemoryReqs = float64(memoryReqs.Value()) / float64(allocatable.Memory().Value()) * 100
+		fractionMemoryLimits = float64(memoryLimits.Value()) / float64(allocatable.Memory().Value()) * 100
+	}
+	fractionEphemeralStorageReqs := float64(0)
+	fractionEphemeralStorageLimits := float64(0)
+	if allocatable.StorageEphemeral().Value() != 0 {
+		fractionEphemeralStorageReqs = float64(ephemeralstorageReqs.Value()) / float64(allocatable.StorageEphemeral().Value()) * 100
+		fractionEphemeralStorageLimits = float64(ephemeralstorageLimits.Value()) / float64(allocatable.StorageEphemeral().Value()) * 100
+	}
+	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
+		corev1.ResourceCPU, cpuReqs.String(), int64(fractionCpuReqs), cpuLimits.String(), int64(fractionCpuLimits))
+	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
+		corev1.ResourceMemory, memoryReqs.String(), int64(fractionMemoryReqs), memoryLimits.String(), int64(fractionMemoryLimits))
+	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
+		corev1.ResourceEphemeralStorage, ephemeralstorageReqs.String(), int64(fractionEphemeralStorageReqs), ephemeralstorageLimits.String(), int64(fractionEphemeralStorageLimits))
+
+	extResources := make([]string, 0, len(allocatable))
+	hugePageResources := make([]string, 0, len(allocatable))
+	for resource := range allocatable {
+		if resourcehelper.IsHugePageResourceName(resource) {
+			hugePageResources = append(hugePageResources, string(resource))
+		} else if !resourcehelper.IsStandardContainerResourceName(string(resource)) && resource != corev1.ResourcePods {
+			extResources = append(extResources, string(resource))
+		}
+	}
+
+	sort.Strings(extResources)
+	sort.Strings(hugePageResources)
+
+	for _, resource := range hugePageResources {
+		hugePageSizeRequests, hugePageSizeLimits, hugePageSizeAllocable := reqs[corev1.ResourceName(resource)], limits[corev1.ResourceName(resource)], allocatable[corev1.ResourceName(resource)]
+		fractionHugePageSizeRequests := float64(0)
+		fractionHugePageSizeLimits := float64(0)
+		if hugePageSizeAllocable.Value() != 0 {
+			fractionHugePageSizeRequests = float64(hugePageSizeRequests.Value()) / float64(hugePageSizeAllocable.Value()) * 100
+			fractionHugePageSizeLimits = float64(hugePageSizeLimits.Value()) / float64(hugePageSizeAllocable.Value()) * 100
+		}
+		w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
+			resource, hugePageSizeRequests.String(), int64(fractionHugePageSizeRequests), hugePageSizeLimits.String(), int64(fractionHugePageSizeLimits))
+	}
+
+	for _, ext := range extResources {
+		extRequests, extLimits := reqs[corev1.ResourceName(ext)], limits[corev1.ResourceName(ext)]
+		w.Write(LEVEL_1, "%s\t%s\t%s\n", ext, extRequests.String(), extLimits.String())
+	}
+}
+
+func getPodsTotalRequestsAndLimits(podList *corev1.PodList) (reqs map[corev1.ResourceName]resource.Quantity, limits map[corev1.ResourceName]resource.Quantity) {
+	reqs, limits = map[corev1.ResourceName]resource.Quantity{}, map[corev1.ResourceName]resource.Quantity{}
+	for _, pod := range podList.Items {
+		podReqs, podLimits := resourcehelper.PodRequestsAndLimits(&pod)
+		for podReqName, podReqValue := range podReqs {
+			if value, ok := reqs[podReqName]; !ok {
+				reqs[podReqName] = podReqValue.DeepCopy()
+			} else {
+				value.Add(podReqValue)
+				reqs[podReqName] = value
+			}
+		}
+		for podLimitName, podLimitValue := range podLimits {
+			if value, ok := limits[podLimitName]; !ok {
+				limits[podLimitName] = podLimitValue.DeepCopy()
+			} else {
+				value.Add(podLimitValue)
+				limits[podLimitName] = value
+			}
+		}
+	}
+	return
+}
+
+func DescribeEvents(el *corev1.EventList, w PrefixWriter) {
+	if len(el.Items) == 0 {
+		w.Write(LEVEL_0, "Events:\t<none>\n")
+		return
+	}
+	w.Flush()
+	sort.Sort(event.SortableEvents(el.Items))
+	w.Write(LEVEL_0, "Events:\n  Type\tReason\tAge\tFrom\tMessage\n")
+	w.Write(LEVEL_1, "----\t------\t----\t----\t-------\n")
+	for _, e := range el.Items {
+		var interval string
+		firstTimestampSince := translateMicroTimestampSince(e.EventTime)
+		if e.EventTime.IsZero() {
+			firstTimestampSince = translateTimestampSince(e.FirstTimestamp)
+		}
+		if e.Series != nil {
+			interval = fmt.Sprintf("%s (x%d over %s)", translateMicroTimestampSince(e.Series.LastObservedTime), e.Series.Count, firstTimestampSince)
+		} else if e.Count > 1 {
+			interval = fmt.Sprintf("%s (x%d over %s)", translateTimestampSince(e.LastTimestamp), e.Count, firstTimestampSince)
+		} else {
+			interval = firstTimestampSince
+		}
+		source := e.Source.Component
+		if source == "" {
+			source = e.ReportingController
+		}
+		w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
+			e.Type,
+			e.Reason,
+			interval,
+			source,
+			strings.TrimSpace(e.Message),
+		)
+	}
+}
+
+// DeploymentDescriber generates information about a deployment.
+type DeploymentDescriber struct {
+	client clientset.Interface
+}
+
+func (dd *DeploymentDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	d, err := dd.client.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(dd.client.CoreV1(), d, describerSettings.ChunkSize)
+	}
+
+	var oldRSs, newRSs []*appsv1.ReplicaSet
+	if _, oldResult, newResult, err := deploymentutil.GetAllReplicaSetsInChunks(d, dd.client.AppsV1(), describerSettings.ChunkSize); err == nil {
+		oldRSs = oldResult
+		if newResult != nil {
+			newRSs = append(newRSs, newResult)
+		}
+	}
+
+	return describeDeployment(d, oldRSs, newRSs, events)
+}
+
+func describeDeployment(d *appsv1.Deployment, oldRSs []*appsv1.ReplicaSet, newRSs []*appsv1.ReplicaSet, events *corev1.EventList) (string, error) {
+	selector, err := metav1.LabelSelectorAsSelector(d.Spec.Selector)
+	if err != nil {
+		return "", err
+	}
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", d.ObjectMeta.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", d.ObjectMeta.Namespace)
+		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", d.CreationTimestamp.Time.Format(time.RFC1123Z))
+		printLabelsMultiline(w, "Labels", d.Labels)
+		printAnnotationsMultiline(w, "Annotations", d.Annotations)
+		w.Write(LEVEL_0, "Selector:\t%s\n", selector)
+		w.Write(LEVEL_0, "Replicas:\t%d desired | %d updated | %d total | %d available | %d unavailable\n", *(d.Spec.Replicas), d.Status.UpdatedReplicas, d.Status.Replicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
+		w.Write(LEVEL_0, "StrategyType:\t%s\n", d.Spec.Strategy.Type)
+		w.Write(LEVEL_0, "MinReadySeconds:\t%d\n", d.Spec.MinReadySeconds)
+		if d.Spec.Strategy.RollingUpdate != nil {
+			ru := d.Spec.Strategy.RollingUpdate
+			w.Write(LEVEL_0, "RollingUpdateStrategy:\t%s max unavailable, %s max surge\n", ru.MaxUnavailable.String(), ru.MaxSurge.String())
+		}
+		DescribePodTemplate(&d.Spec.Template, w)
+		if len(d.Status.Conditions) > 0 {
+			w.Write(LEVEL_0, "Conditions:\n  Type\tStatus\tReason\n")
+			w.Write(LEVEL_1, "----\t------\t------\n")
+			for _, c := range d.Status.Conditions {
+				w.Write(LEVEL_1, "%v \t%v\t%v\n", c.Type, c.Status, c.Reason)
+			}
+		}
+
+		if len(oldRSs) > 0 || len(newRSs) > 0 {
+			w.Write(LEVEL_0, "OldReplicaSets:\t%s\n", printReplicaSetsByLabels(oldRSs))
+			w.Write(LEVEL_0, "NewReplicaSet:\t%s\n", printReplicaSetsByLabels(newRSs))
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+func printReplicaSetsByLabels(matchingRSs []*appsv1.ReplicaSet) string {
+	// Format the matching ReplicaSets into strings.
+	rsStrings := make([]string, 0, len(matchingRSs))
+	for _, rs := range matchingRSs {
+		rsStrings = append(rsStrings, fmt.Sprintf("%s (%d/%d replicas created)", rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
+	}
+
+	list := strings.Join(rsStrings, ", ")
+	if list == "" {
+		return "<none>"
+	}
+	return list
+}
+
+func getPodStatusForController(c corev1client.PodInterface, selector labels.Selector, uid types.UID, settings DescriberSettings) (
+	running, waiting, succeeded, failed int, err error) {
+	initialOpts := metav1.ListOptions{LabelSelector: selector.String(), Limit: settings.ChunkSize}
+	rcPods, err := getPodsInChunks(c, initialOpts)
+	if err != nil {
+		return
+	}
+	for _, pod := range rcPods.Items {
+		controllerRef := metav1.GetControllerOf(&pod)
+		// Skip pods that are orphans or owned by other controllers.
+		if controllerRef == nil || controllerRef.UID != uid {
+			continue
+		}
+		switch pod.Status.Phase {
+		case corev1.PodRunning:
+			running++
+		case corev1.PodPending:
+			waiting++
+		case corev1.PodSucceeded:
+			succeeded++
+		case corev1.PodFailed:
+			failed++
+		}
+	}
+	return
+}
+
+func getPodsInChunks(c corev1client.PodInterface, initialOpts metav1.ListOptions) (*corev1.PodList, error) {
+	podList := &corev1.PodList{}
+	err := runtimeresource.FollowContinue(&initialOpts,
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newList, err := c.List(context.TODO(), options)
+			if err != nil {
+				return nil, runtimeresource.EnhanceListError(err, options, corev1.ResourcePods.String())
+			}
+			podList.Items = append(podList.Items, newList.Items...)
+			return newList, nil
+		})
+	return podList, err
+}
+
+// ConfigMapDescriber generates information about a ConfigMap
+type ConfigMapDescriber struct {
+	clientset.Interface
+}
+
+func (d *ConfigMapDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.CoreV1().ConfigMaps(namespace)
+
+	configMap, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", configMap.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", configMap.Namespace)
+		printLabelsMultiline(w, "Labels", configMap.Labels)
+		printAnnotationsMultiline(w, "Annotations", configMap.Annotations)
+
+		w.Write(LEVEL_0, "\nData\n====\n")
+		for k, v := range configMap.Data {
+			w.Write(LEVEL_0, "%s:\n----\n", k)
+			w.Write(LEVEL_0, "%s\n", string(v))
+		}
+		w.Write(LEVEL_0, "\nBinaryData\n====\n")
+		for k, v := range configMap.BinaryData {
+			w.Write(LEVEL_0, "%s: %s bytes\n", k, strconv.Itoa(len(v)))
+		}
+		w.Write(LEVEL_0, "\n")
+
+		if describerSettings.ShowEvents {
+			events, err := searchEvents(d.CoreV1(), configMap, describerSettings.ChunkSize)
+			if err != nil {
+				return err
+			}
+			if events != nil {
+				DescribeEvents(events, w)
+			}
+		}
+		return nil
+	})
+}
+
+// NetworkPolicyDescriber generates information about a networkingv1.NetworkPolicy
+type NetworkPolicyDescriber struct {
+	clientset.Interface
+}
+
+func (d *NetworkPolicyDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	c := d.NetworkingV1().NetworkPolicies(namespace)
+
+	networkPolicy, err := c.Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	return describeNetworkPolicy(networkPolicy)
+}
+
+func describeNetworkPolicy(networkPolicy *networkingv1.NetworkPolicy) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", networkPolicy.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", networkPolicy.Namespace)
+		w.Write(LEVEL_0, "Created on:\t%s\n", networkPolicy.CreationTimestamp)
+		printLabelsMultiline(w, "Labels", networkPolicy.Labels)
+		printAnnotationsMultiline(w, "Annotations", networkPolicy.Annotations)
+		describeNetworkPolicySpec(networkPolicy.Spec, w)
+		return nil
+	})
+}
+
+func describeNetworkPolicySpec(nps networkingv1.NetworkPolicySpec, w PrefixWriter) {
+	w.Write(LEVEL_0, "Spec:\n")
+	w.Write(LEVEL_1, "PodSelector: ")
+	if len(nps.PodSelector.MatchLabels) == 0 && len(nps.PodSelector.MatchExpressions) == 0 {
+		w.Write(LEVEL_2, "<none> (Allowing the specific traffic to all pods in this namespace)\n")
+	} else {
+		w.Write(LEVEL_2, "%s\n", metav1.FormatLabelSelector(&nps.PodSelector))
+	}
+
+	ingressEnabled, egressEnabled := getPolicyType(nps)
+	if ingressEnabled {
+		w.Write(LEVEL_1, "Allowing ingress traffic:\n")
+		printNetworkPolicySpecIngressFrom(nps.Ingress, "    ", w)
+	} else {
+		w.Write(LEVEL_1, "Not affecting ingress traffic\n")
+	}
+	if egressEnabled {
+		w.Write(LEVEL_1, "Allowing egress traffic:\n")
+		printNetworkPolicySpecEgressTo(nps.Egress, "    ", w)
+	} else {
+		w.Write(LEVEL_1, "Not affecting egress traffic\n")
+
+	}
+	w.Write(LEVEL_1, "Policy Types: %v\n", policyTypesToString(nps.PolicyTypes))
+}
+
+func getPolicyType(nps networkingv1.NetworkPolicySpec) (bool, bool) {
+	var ingress, egress bool
+	for _, pt := range nps.PolicyTypes {
+		switch pt {
+		case networkingv1.PolicyTypeIngress:
+			ingress = true
+		case networkingv1.PolicyTypeEgress:
+			egress = true
+		}
+	}
+
+	return ingress, egress
+}
+
+func printNetworkPolicySpecIngressFrom(npirs []networkingv1.NetworkPolicyIngressRule, initialIndent string, w PrefixWriter) {
+	if len(npirs) == 0 {
+		w.Write(LEVEL_0, "%s%s\n", initialIndent, "<none> (Selected pods are isolated for ingress connectivity)")
+		return
+	}
+	for i, npir := range npirs {
+		if len(npir.Ports) == 0 {
+			w.Write(LEVEL_0, "%s%s\n", initialIndent, "To Port: <any> (traffic allowed to all ports)")
+		} else {
+			for _, port := range npir.Ports {
+				var proto corev1.Protocol
+				if port.Protocol != nil {
+					proto = *port.Protocol
+				} else {
+					proto = corev1.ProtocolTCP
+				}
+				w.Write(LEVEL_0, "%s%s: %s/%s\n", initialIndent, "To Port", port.Port, proto)
+			}
+		}
+		if len(npir.From) == 0 {
+			w.Write(LEVEL_0, "%s%s\n", initialIndent, "From: <any> (traffic not restricted by source)")
+		} else {
+			for _, from := range npir.From {
+				w.Write(LEVEL_0, "%s%s\n", initialIndent, "From:")
+				if from.PodSelector != nil && from.NamespaceSelector != nil {
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "NamespaceSelector", metav1.FormatLabelSelector(from.NamespaceSelector))
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "PodSelector", metav1.FormatLabelSelector(from.PodSelector))
+				} else if from.PodSelector != nil {
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "PodSelector", metav1.FormatLabelSelector(from.PodSelector))
+				} else if from.NamespaceSelector != nil {
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "NamespaceSelector", metav1.FormatLabelSelector(from.NamespaceSelector))
+				} else if from.IPBlock != nil {
+					w.Write(LEVEL_1, "%sIPBlock:\n", initialIndent)
+					w.Write(LEVEL_2, "%sCIDR: %s\n", initialIndent, from.IPBlock.CIDR)
+					w.Write(LEVEL_2, "%sExcept: %v\n", initialIndent, strings.Join(from.IPBlock.Except, ", "))
+				}
+			}
+		}
+		if i != len(npirs)-1 {
+			w.Write(LEVEL_0, "%s%s\n", initialIndent, "----------")
+		}
+	}
+}
+
+func printNetworkPolicySpecEgressTo(npers []networkingv1.NetworkPolicyEgressRule, initialIndent string, w PrefixWriter) {
+	if len(npers) == 0 {
+		w.Write(LEVEL_0, "%s%s\n", initialIndent, "<none> (Selected pods are isolated for egress connectivity)")
+		return
+	}
+	for i, nper := range npers {
+		if len(nper.Ports) == 0 {
+			w.Write(LEVEL_0, "%s%s\n", initialIndent, "To Port: <any> (traffic allowed to all ports)")
+		} else {
+			for _, port := range nper.Ports {
+				var proto corev1.Protocol
+				if port.Protocol != nil {
+					proto = *port.Protocol
+				} else {
+					proto = corev1.ProtocolTCP
+				}
+				w.Write(LEVEL_0, "%s%s: %s/%s\n", initialIndent, "To Port", port.Port, proto)
+			}
+		}
+		if len(nper.To) == 0 {
+			w.Write(LEVEL_0, "%s%s\n", initialIndent, "To: <any> (traffic not restricted by destination)")
+		} else {
+			for _, to := range nper.To {
+				w.Write(LEVEL_0, "%s%s\n", initialIndent, "To:")
+				if to.PodSelector != nil && to.NamespaceSelector != nil {
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "NamespaceSelector", metav1.FormatLabelSelector(to.NamespaceSelector))
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "PodSelector", metav1.FormatLabelSelector(to.PodSelector))
+				} else if to.PodSelector != nil {
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "PodSelector", metav1.FormatLabelSelector(to.PodSelector))
+				} else if to.NamespaceSelector != nil {
+					w.Write(LEVEL_1, "%s%s: %s\n", initialIndent, "NamespaceSelector", metav1.FormatLabelSelector(to.NamespaceSelector))
+				} else if to.IPBlock != nil {
+					w.Write(LEVEL_1, "%sIPBlock:\n", initialIndent)
+					w.Write(LEVEL_2, "%sCIDR: %s\n", initialIndent, to.IPBlock.CIDR)
+					w.Write(LEVEL_2, "%sExcept: %v\n", initialIndent, strings.Join(to.IPBlock.Except, ", "))
+				}
+			}
+		}
+		if i != len(npers)-1 {
+			w.Write(LEVEL_0, "%s%s\n", initialIndent, "----------")
+		}
+	}
+}
+
+type StorageClassDescriber struct {
+	clientset.Interface
+}
+
+func (s *StorageClassDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	sc, err := s.StorageV1().StorageClasses().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(s.CoreV1(), sc, describerSettings.ChunkSize)
+	}
+
+	return describeStorageClass(sc, events)
+}
+
+func describeStorageClass(sc *storagev1.StorageClass, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", sc.Name)
+		w.Write(LEVEL_0, "IsDefaultClass:\t%s\n", storageutil.IsDefaultAnnotationText(sc.ObjectMeta))
+		w.Write(LEVEL_0, "Annotations:\t%s\n", labels.FormatLabels(sc.Annotations))
+		w.Write(LEVEL_0, "Provisioner:\t%s\n", sc.Provisioner)
+		w.Write(LEVEL_0, "Parameters:\t%s\n", labels.FormatLabels(sc.Parameters))
+		w.Write(LEVEL_0, "AllowVolumeExpansion:\t%s\n", printBoolPtr(sc.AllowVolumeExpansion))
+		if len(sc.MountOptions) == 0 {
+			w.Write(LEVEL_0, "MountOptions:\t<none>\n")
+		} else {
+			w.Write(LEVEL_0, "MountOptions:\n")
+			for _, option := range sc.MountOptions {
+				w.Write(LEVEL_1, "%s\n", option)
+			}
+		}
+		if sc.ReclaimPolicy != nil {
+			w.Write(LEVEL_0, "ReclaimPolicy:\t%s\n", *sc.ReclaimPolicy)
+		}
+		if sc.VolumeBindingMode != nil {
+			w.Write(LEVEL_0, "VolumeBindingMode:\t%s\n", *sc.VolumeBindingMode)
+		}
+		if sc.AllowedTopologies != nil {
+			printAllowedTopologies(w, sc.AllowedTopologies)
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+type CSINodeDescriber struct {
+	clientset.Interface
+}
+
+func (c *CSINodeDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	csi, err := c.StorageV1().CSINodes().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(c.CoreV1(), csi, describerSettings.ChunkSize)
+	}
+
+	return describeCSINode(csi, events)
+}
+
+func describeCSINode(csi *storagev1.CSINode, events *corev1.EventList) (output string, err error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", csi.GetName())
+		printLabelsMultiline(w, "Labels", csi.GetLabels())
+		printAnnotationsMultiline(w, "Annotations", csi.GetAnnotations())
+		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", csi.CreationTimestamp.Time.Format(time.RFC1123Z))
+		w.Write(LEVEL_0, "Spec:\n")
+		if csi.Spec.Drivers != nil {
+			w.Write(LEVEL_1, "Drivers:\n")
+			for _, driver := range csi.Spec.Drivers {
+				w.Write(LEVEL_2, "%s:\n", driver.Name)
+				w.Write(LEVEL_3, "Node ID:\t%s\n", driver.NodeID)
+				if driver.Allocatable != nil && driver.Allocatable.Count != nil {
+					w.Write(LEVEL_3, "Allocatables:\n")
+					w.Write(LEVEL_4, "Count:\t%d\n", *driver.Allocatable.Count)
+				}
+				if driver.TopologyKeys != nil {
+					w.Write(LEVEL_3, "Topology Keys:\t%s\n", driver.TopologyKeys)
+				}
+			}
+		}
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+		return nil
+	})
+}
+
+func printAllowedTopologies(w PrefixWriter, topologies []corev1.TopologySelectorTerm) {
+	w.Write(LEVEL_0, "AllowedTopologies:\t")
+	if len(topologies) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+	w.WriteLine("")
+	for i, term := range topologies {
+		printTopologySelectorTermsMultilineWithIndent(w, LEVEL_1, fmt.Sprintf("Term %d", i), "\t", term.MatchLabelExpressions)
+	}
+}
+
+func printTopologySelectorTermsMultilineWithIndent(w PrefixWriter, indentLevel int, title, innerIndent string, reqs []corev1.TopologySelectorLabelRequirement) {
+	w.Write(indentLevel, "%s:%s", title, innerIndent)
+
+	if len(reqs) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	for i, req := range reqs {
+		if i != 0 {
+			w.Write(indentLevel, "%s", innerIndent)
+		}
+		exprStr := fmt.Sprintf("%s %s", req.Key, "in")
+		if len(req.Values) > 0 {
+			exprStr = fmt.Sprintf("%s [%s]", exprStr, strings.Join(req.Values, ", "))
+		}
+		w.Write(LEVEL_0, "%s\n", exprStr)
+	}
+}
+
+type PodDisruptionBudgetDescriber struct {
+	clientset.Interface
+}
+
+func (p *PodDisruptionBudgetDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	var (
+		pdbv1      *policyv1.PodDisruptionBudget
+		pdbv1beta1 *policyv1beta1.PodDisruptionBudget
+		err        error
+	)
+
+	pdbv1, err = p.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		var events *corev1.EventList
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(p.CoreV1(), pdbv1, describerSettings.ChunkSize)
+		}
+		return describePodDisruptionBudgetV1(pdbv1, events)
+	}
+
+	// try falling back to v1beta1 in NotFound error cases
+	if apierrors.IsNotFound(err) {
+		pdbv1beta1, err = p.PolicyV1beta1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	}
+	if err == nil {
+		var events *corev1.EventList
+		if describerSettings.ShowEvents {
+			events, _ = searchEvents(p.CoreV1(), pdbv1beta1, describerSettings.ChunkSize)
+		}
+		return describePodDisruptionBudgetV1beta1(pdbv1beta1, events)
+	}
+
+	return "", err
+}
+
+func describePodDisruptionBudgetV1(pdb *policyv1.PodDisruptionBudget, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", pdb.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", pdb.Namespace)
+
+		if pdb.Spec.MinAvailable != nil {
+			w.Write(LEVEL_0, "Min available:\t%s\n", pdb.Spec.MinAvailable.String())
+		} else if pdb.Spec.MaxUnavailable != nil {
+			w.Write(LEVEL_0, "Max unavailable:\t%s\n", pdb.Spec.MaxUnavailable.String())
+		}
+
+		if pdb.Spec.Selector != nil {
+			w.Write(LEVEL_0, "Selector:\t%s\n", metav1.FormatLabelSelector(pdb.Spec.Selector))
+		} else {
+			w.Write(LEVEL_0, "Selector:\t<unset>\n")
+		}
+		w.Write(LEVEL_0, "Status:\n")
+		w.Write(LEVEL_2, "Allowed disruptions:\t%d\n", pdb.Status.DisruptionsAllowed)
+		w.Write(LEVEL_2, "Current:\t%d\n", pdb.Status.CurrentHealthy)
+		w.Write(LEVEL_2, "Desired:\t%d\n", pdb.Status.DesiredHealthy)
+		w.Write(LEVEL_2, "Total:\t%d\n", pdb.Status.ExpectedPods)
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+func describePodDisruptionBudgetV1beta1(pdb *policyv1beta1.PodDisruptionBudget, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", pdb.Name)
+		w.Write(LEVEL_0, "Namespace:\t%s\n", pdb.Namespace)
+
+		if pdb.Spec.MinAvailable != nil {
+			w.Write(LEVEL_0, "Min available:\t%s\n", pdb.Spec.MinAvailable.String())
+		} else if pdb.Spec.MaxUnavailable != nil {
+			w.Write(LEVEL_0, "Max unavailable:\t%s\n", pdb.Spec.MaxUnavailable.String())
+		}
+
+		if pdb.Spec.Selector != nil {
+			w.Write(LEVEL_0, "Selector:\t%s\n", metav1.FormatLabelSelector(pdb.Spec.Selector))
+		} else {
+			w.Write(LEVEL_0, "Selector:\t<unset>\n")
+		}
+		w.Write(LEVEL_0, "Status:\n")
+		w.Write(LEVEL_2, "Allowed disruptions:\t%d\n", pdb.Status.DisruptionsAllowed)
+		w.Write(LEVEL_2, "Current:\t%d\n", pdb.Status.CurrentHealthy)
+		w.Write(LEVEL_2, "Desired:\t%d\n", pdb.Status.DesiredHealthy)
+		w.Write(LEVEL_2, "Total:\t%d\n", pdb.Status.ExpectedPods)
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+// PriorityClassDescriber generates information about a PriorityClass.
+type PriorityClassDescriber struct {
+	clientset.Interface
+}
+
+func (s *PriorityClassDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (string, error) {
+	pc, err := s.SchedulingV1().PriorityClasses().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	var events *corev1.EventList
+	if describerSettings.ShowEvents {
+		events, _ = searchEvents(s.CoreV1(), pc, describerSettings.ChunkSize)
+	}
+
+	return describePriorityClass(pc, events)
+}
+
+func describePriorityClass(pc *schedulingv1.PriorityClass, events *corev1.EventList) (string, error) {
+	return tabbedString(func(out io.Writer) error {
+		w := NewPrefixWriter(out)
+		w.Write(LEVEL_0, "Name:\t%s\n", pc.Name)
+		w.Write(LEVEL_0, "Value:\t%v\n", pc.Value)
+		w.Write(LEVEL_0, "GlobalDefault:\t%v\n", pc.GlobalDefault)
+		w.Write(LEVEL_0, "PreemptionPolicy:\t%s\n", *pc.PreemptionPolicy)
+		w.Write(LEVEL_0, "Description:\t%s\n", pc.Description)
+
+		w.Write(LEVEL_0, "Annotations:\t%s\n", labels.FormatLabels(pc.Annotations))
+		if events != nil {
+			DescribeEvents(events, w)
+		}
+
+		return nil
+	})
+}
+
+func stringOrNone(s string) string {
+	return stringOrDefaultValue(s, "<none>")
+}
+
+func stringOrDefaultValue(s, defaultValue string) string {
+	if len(s) > 0 {
+		return s
+	}
+	return defaultValue
+}
+
+func policyTypesToString(pts []networkingv1.PolicyType) string {
+	formattedString := ""
+	if pts != nil {
+		strPts := []string{}
+		for _, p := range pts {
+			strPts = append(strPts, string(p))
+		}
+		formattedString = strings.Join(strPts, ", ")
+	}
+	return stringOrNone(formattedString)
+}
+
+// newErrNoDescriber creates a new ErrNoDescriber with the names of the provided types.
+func newErrNoDescriber(types ...reflect.Type) error {
+	names := make([]string, 0, len(types))
+	for _, t := range types {
+		names = append(names, t.String())
+	}
+	return ErrNoDescriber{Types: names}
+}
+
+// Describers implements ObjectDescriber against functions registered via Add. Those functions can
+// be strongly typed. Types are exactly matched (no conversion or assignable checks).
+type Describers struct {
+	searchFns map[reflect.Type][]typeFunc
+}
+
+// DescribeObject implements ObjectDescriber and will attempt to print the provided object to a string,
+// if at least one describer function has been registered with the exact types passed, or if any
+// describer can print the exact object in its first argument (the remainder will be provided empty
+// values). If no function registered with Add can satisfy the passed objects, an ErrNoDescriber will
+// be returned
+// TODO: reorder and partial match extra.
+func (d *Describers) DescribeObject(exact interface{}, extra ...interface{}) (string, error) {
+	exactType := reflect.TypeOf(exact)
+	fns, ok := d.searchFns[exactType]
+	if !ok {
+		return "", newErrNoDescriber(exactType)
+	}
+	if len(extra) == 0 {
+		for _, typeFn := range fns {
+			if len(typeFn.Extra) == 0 {
+				return typeFn.Describe(exact, extra...)
+			}
+		}
+		typeFn := fns[0]
+		for _, t := range typeFn.Extra {
+			v := reflect.New(t).Elem()
+			extra = append(extra, v.Interface())
+		}
+		return fns[0].Describe(exact, extra...)
+	}
+
+	types := make([]reflect.Type, 0, len(extra))
+	for _, obj := range extra {
+		types = append(types, reflect.TypeOf(obj))
+	}
+	for _, typeFn := range fns {
+		if typeFn.Matches(types) {
+			return typeFn.Describe(exact, extra...)
+		}
+	}
+	return "", newErrNoDescriber(append([]reflect.Type{exactType}, types...)...)
+}
+
+// Add adds one or more describer functions to the Describer. The passed function must
+// match the signature:
+//
+//	func(...) (string, error)
+//
+// Any number of arguments may be provided.
+func (d *Describers) Add(fns ...interface{}) error {
+	for _, fn := range fns {
+		fv := reflect.ValueOf(fn)
+		ft := fv.Type()
+		if ft.Kind() != reflect.Func {
+			return fmt.Errorf("expected func, got: %v", ft)
+		}
+		numIn := ft.NumIn()
+		if numIn == 0 {
+			return fmt.Errorf("expected at least one 'in' params, got: %v", ft)
+		}
+		if ft.NumOut() != 2 {
+			return fmt.Errorf("expected two 'out' params - (string, error), got: %v", ft)
+		}
+		types := make([]reflect.Type, 0, numIn)
+		for i := 0; i < numIn; i++ {
+			types = append(types, ft.In(i))
+		}
+		if ft.Out(0) != reflect.TypeOf(string("")) {
+			return fmt.Errorf("expected string return, got: %v", ft)
+		}
+		var forErrorType error
+		// This convolution is necessary, otherwise TypeOf picks up on the fact
+		// that forErrorType is nil.
+		errorType := reflect.TypeOf(&forErrorType).Elem()
+		if ft.Out(1) != errorType {
+			return fmt.Errorf("expected error return, got: %v", ft)
+		}
+
+		exact := types[0]
+		extra := types[1:]
+		if d.searchFns == nil {
+			d.searchFns = make(map[reflect.Type][]typeFunc)
+		}
+		fns := d.searchFns[exact]
+		fn := typeFunc{Extra: extra, Fn: fv}
+		fns = append(fns, fn)
+		d.searchFns[exact] = fns
+	}
+	return nil
+}
+
+// typeFunc holds information about a describer function and the types it accepts
+type typeFunc struct {
+	Extra []reflect.Type
+	Fn    reflect.Value
+}
+
+// Matches returns true when the passed types exactly match the Extra list.
+func (fn typeFunc) Matches(types []reflect.Type) bool {
+	if len(fn.Extra) != len(types) {
+		return false
+	}
+	// reorder the items in array types and fn.Extra
+	// convert the type into string and sort them, check if they are matched
+	varMap := make(map[reflect.Type]bool)
+	for i := range fn.Extra {
+		varMap[fn.Extra[i]] = true
+	}
+	for i := range types {
+		if _, found := varMap[types[i]]; !found {
+			return false
+		}
+	}
+	return true
+}
+
+// Describe invokes the nested function with the exact number of arguments.
+func (fn typeFunc) Describe(exact interface{}, extra ...interface{}) (string, error) {
+	values := []reflect.Value{reflect.ValueOf(exact)}
+	for i, obj := range extra {
+		if obj != nil {
+			values = append(values, reflect.ValueOf(obj))
+		} else {
+			values = append(values, reflect.New(fn.Extra[i]).Elem())
+		}
+	}
+	out := fn.Fn.Call(values)
+	s := out[0].Interface().(string)
+	var err error
+	if !out[1].IsNil() {
+		err = out[1].Interface().(error)
+	}
+	return s, err
+}
+
+// printLabelsMultiline prints multiple labels with a proper alignment.
+func printLabelsMultiline(w PrefixWriter, title string, labels map[string]string) {
+	printLabelsMultilineWithIndent(w, "", title, "\t", labels, sets.NewString())
+}
+
+// printLabelsMultiline prints multiple labels with a user-defined alignment.
+func printLabelsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, labels map[string]string, skip sets.String) {
+	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
+
+	if len(labels) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	// to print labels in the sorted order
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		if skip.Has(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+	sort.Strings(keys)
+
+	for i, key := range keys {
+		if i != 0 {
+			w.Write(LEVEL_0, "%s", initialIndent)
+			w.Write(LEVEL_0, "%s", innerIndent)
+		}
+		w.Write(LEVEL_0, "%s=%s\n", key, labels[key])
+	}
+}
+
+// printTaintsMultiline prints multiple taints with a proper alignment.
+func printNodeTaintsMultiline(w PrefixWriter, title string, taints []corev1.Taint) {
+	printTaintsMultilineWithIndent(w, "", title, "\t", taints)
+}
+
+// printTaintsMultilineWithIndent prints multiple taints with a user-defined alignment.
+func printTaintsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, taints []corev1.Taint) {
+	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
+
+	if len(taints) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	// to print taints in the sorted order
+	sort.Slice(taints, func(i, j int) bool {
+		cmpKey := func(taint corev1.Taint) string {
+			return string(taint.Effect) + "," + taint.Key
+		}
+		return cmpKey(taints[i]) < cmpKey(taints[j])
+	})
+
+	for i, taint := range taints {
+		if i != 0 {
+			w.Write(LEVEL_0, "%s", initialIndent)
+			w.Write(LEVEL_0, "%s", innerIndent)
+		}
+		w.Write(LEVEL_0, "%s\n", taint.ToString())
+	}
+}
+
+// printPodsMultiline prints multiple pods with a proper alignment.
+func printPodsMultiline(w PrefixWriter, title string, pods []corev1.Pod) {
+	printPodsMultilineWithIndent(w, "", title, "\t", pods)
+}
+
+// printPodsMultilineWithIndent prints multiple pods with a user-defined alignment.
+func printPodsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, pods []corev1.Pod) {
+	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
+
+	if len(pods) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	// to print pods in the sorted order
+	sort.Slice(pods, func(i, j int) bool {
+		cmpKey := func(pod corev1.Pod) string {
+			return pod.Name
+		}
+		return cmpKey(pods[i]) < cmpKey(pods[j])
+	})
+
+	for i, pod := range pods {
+		if i != 0 {
+			w.Write(LEVEL_0, "%s", initialIndent)
+			w.Write(LEVEL_0, "%s", innerIndent)
+		}
+		w.Write(LEVEL_0, "%s\n", pod.Name)
+	}
+}
+
+// printPodTolerationsMultiline prints multiple tolerations with a proper alignment.
+func printPodTolerationsMultiline(w PrefixWriter, title string, tolerations []corev1.Toleration) {
+	printTolerationsMultilineWithIndent(w, "", title, "\t", tolerations)
+}
+
+// printTolerationsMultilineWithIndent prints multiple tolerations with a user-defined alignment.
+func printTolerationsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, tolerations []corev1.Toleration) {
+	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
+
+	if len(tolerations) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+
+	// to print tolerations in the sorted order
+	sort.Slice(tolerations, func(i, j int) bool {
+		return tolerations[i].Key < tolerations[j].Key
+	})
+
+	for i, toleration := range tolerations {
+		if i != 0 {
+			w.Write(LEVEL_0, "%s", initialIndent)
+			w.Write(LEVEL_0, "%s", innerIndent)
+		}
+		w.Write(LEVEL_0, "%s", toleration.Key)
+		if len(toleration.Value) != 0 {
+			w.Write(LEVEL_0, "=%s", toleration.Value)
+		}
+		if len(toleration.Effect) != 0 {
+			w.Write(LEVEL_0, ":%s", toleration.Effect)
+		}
+		// tolerations:
+		// - operator: "Exists"
+		// is a special case which tolerates everything
+		if toleration.Operator == corev1.TolerationOpExists && len(toleration.Value) == 0 {
+			if len(toleration.Key) != 0 || len(toleration.Effect) != 0 {
+				w.Write(LEVEL_0, " op=Exists")
+			} else {
+				w.Write(LEVEL_0, "op=Exists")
+			}
+		}
+
+		if toleration.TolerationSeconds != nil {
+			w.Write(LEVEL_0, " for %ds", *toleration.TolerationSeconds)
+		}
+		w.Write(LEVEL_0, "\n")
+	}
+}
+
+type flusher interface {
+	Flush()
+}
+
+func tabbedString(f func(io.Writer) error) (string, error) {
+	out := new(tabwriter.Writer)
+	buf := &bytes.Buffer{}
+	out.Init(buf, 0, 8, 2, ' ', 0)
+
+	err := f(out)
+	if err != nil {
+		return "", err
+	}
+
+	out.Flush()
+	return buf.String(), nil
+}
+
+type SortableResourceNames []corev1.ResourceName
+
+func (list SortableResourceNames) Len() int {
+	return len(list)
+}
+
+func (list SortableResourceNames) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableResourceNames) Less(i, j int) bool {
+	return list[i] < list[j]
+}
+
+// SortedResourceNames returns the sorted resource names of a resource list.
+func SortedResourceNames(list corev1.ResourceList) []corev1.ResourceName {
+	resources := make([]corev1.ResourceName, 0, len(list))
+	for res := range list {
+		resources = append(resources, res)
+	}
+	sort.Sort(SortableResourceNames(resources))
+	return resources
+}
+
+type SortableResourceQuotas []corev1.ResourceQuota
+
+func (list SortableResourceQuotas) Len() int {
+	return len(list)
+}
+
+func (list SortableResourceQuotas) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableResourceQuotas) Less(i, j int) bool {
+	return list[i].Name < list[j].Name
+}
+
+type SortableVolumeMounts []corev1.VolumeMount
+
+func (list SortableVolumeMounts) Len() int {
+	return len(list)
+}
+
+func (list SortableVolumeMounts) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableVolumeMounts) Less(i, j int) bool {
+	return list[i].MountPath < list[j].MountPath
+}
+
+type SortableVolumeDevices []corev1.VolumeDevice
+
+func (list SortableVolumeDevices) Len() int {
+	return len(list)
+}
+
+func (list SortableVolumeDevices) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableVolumeDevices) Less(i, j int) bool {
+	return list[i].DevicePath < list[j].DevicePath
+}
+
+var maxAnnotationLen = 140
+
+// printAnnotationsMultiline prints multiple annotations with a proper alignment.
+// If annotation string is too long, we omit chars more than 200 length.
+func printAnnotationsMultiline(w PrefixWriter, title string, annotations map[string]string) {
+	w.Write(LEVEL_0, "%s:\t", title)
+
+	// to print labels in the sorted order
+	keys := make([]string, 0, len(annotations))
+	for key := range annotations {
+		if skipAnnotations.Has(key) {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		w.WriteLine("<none>")
+		return
+	}
+	sort.Strings(keys)
+	indent := "\t"
+	for i, key := range keys {
+		if i != 0 {
+			w.Write(LEVEL_0, indent)
+		}
+		value := strings.TrimSuffix(annotations[key], "\n")
+		if (len(value)+len(key)+2) > maxAnnotationLen || strings.Contains(value, "\n") {
+			w.Write(LEVEL_0, "%s:\n", key)
+			for _, s := range strings.Split(value, "\n") {
+				w.Write(LEVEL_0, "%s  %s\n", indent, shorten(s, maxAnnotationLen-2))
+			}
+		} else {
+			w.Write(LEVEL_0, "%s: %s\n", key, value)
+		}
+	}
+}
+
+func shorten(s string, maxLength int) string {
+	if len(s) > maxLength {
+		return s[:maxLength] + "..."
+	}
+	return s
+}
+
+// translateMicroTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateMicroTimestampSince(timestamp metav1.MicroTime) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// translateTimestampSince returns the elapsed time since timestamp in
+// human-readable approximation.
+func translateTimestampSince(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// Pass ports=nil for all ports.
+func formatEndpoints(endpoints *corev1.Endpoints, ports sets.String) string {
+	if len(endpoints.Subsets) == 0 {
+		return "<none>"
+	}
+	list := []string{}
+	max := 3
+	more := false
+	count := 0
+	for i := range endpoints.Subsets {
+		ss := &endpoints.Subsets[i]
+		if len(ss.Ports) == 0 {
+			// It's possible to have headless services with no ports.
+			for i := range ss.Addresses {
+				if len(list) == max {
+					more = true
+				}
+				if !more {
+					list = append(list, ss.Addresses[i].IP)
+				}
+				count++
+			}
+		} else {
+			// "Normal" services with ports defined.
+			for i := range ss.Ports {
+				port := &ss.Ports[i]
+				if ports == nil || ports.Has(port.Name) {
+					for i := range ss.Addresses {
+						if len(list) == max {
+							more = true
+						}
+						addr := &ss.Addresses[i]
+						if !more {
+							hostPort := net.JoinHostPort(addr.IP, strconv.Itoa(int(port.Port)))
+							list = append(list, hostPort)
+						}
+						count++
+					}
+				}
+			}
+		}
+	}
+	ret := strings.Join(list, ",")
+	if more {
+		return fmt.Sprintf("%s + %d more...", ret, count-max)
+	}
+	return ret
+}
+
+func extractCSRStatus(conditions []string, certificateBytes []byte) string {
+	var approved, denied, failed bool
+	for _, c := range conditions {
+		switch c {
+		case string(certificatesv1beta1.CertificateApproved):
+			approved = true
+		case string(certificatesv1beta1.CertificateDenied):
+			denied = true
+		case string(certificatesv1beta1.CertificateFailed):
+			failed = true
+		}
+	}
+	var status string
+	// must be in order of precedence
+	if denied {
+		status += "Denied"
+	} else if approved {
+		status += "Approved"
+	} else {
+		status += "Pending"
+	}
+	if failed {
+		status += ",Failed"
+	}
+	if len(certificateBytes) > 0 {
+		status += ",Issued"
+	}
+	return status
+}
+
+// backendStringer behaves just like a string interface and converts the given backend to a string.
+func serviceBackendStringer(backend *networkingv1.IngressServiceBackend) string {
+	if backend == nil {
+		return ""
+	}
+	var bPort string
+	if backend.Port.Number != 0 {
+		sNum := int64(backend.Port.Number)
+		bPort = strconv.FormatInt(sNum, 10)
+	} else {
+		bPort = backend.Port.Name
+	}
+	return fmt.Sprintf("%v:%v", backend.Name, bPort)
+}
+
+// backendStringer behaves just like a string interface and converts the given backend to a string.
+func backendStringer(backend *networkingv1beta1.IngressBackend) string {
+	if backend == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v:%v", backend.ServiceName, backend.ServicePort.String())
+}
+
+// findNodeRoles returns the roles of a given node.
+// The roles are determined by looking for:
+// * a node-role.kubernetes.io/<role>="" label
+// * a kubernetes.io/role="<role>" label
+func findNodeRoles(node *corev1.Node) []string {
+	roles := sets.NewString()
+	for k, v := range node.Labels {
+		switch {
+		case strings.HasPrefix(k, LabelNodeRolePrefix):
+			if role := strings.TrimPrefix(k, LabelNodeRolePrefix); len(role) > 0 {
+				roles.Insert(role)
+			}
+
+		case k == NodeLabelRole && v != "":
+			roles.Insert(v)
+		}
+	}
+	return roles.List()
+}
+
+// ingressLoadBalancerStatusStringerV1 behaves mostly like a string interface and converts the given status to a string.
+// `wide` indicates whether the returned value is meant for --o=wide output. If not, it's clipped to 16 bytes.
+func ingressLoadBalancerStatusStringerV1(s networkingv1.IngressLoadBalancerStatus, wide bool) string {
+	ingress := s.Ingress
+	result := sets.NewString()
+	for i := range ingress {
+		if ingress[i].IP != "" {
+			result.Insert(ingress[i].IP)
+		} else if ingress[i].Hostname != "" {
+			result.Insert(ingress[i].Hostname)
+		}
+	}
+
+	r := strings.Join(result.List(), ",")
+	if !wide && len(r) > LoadBalancerWidth {
+		r = r[0:(LoadBalancerWidth-3)] + "..."
+	}
+	return r
+}
+
+// ingressLoadBalancerStatusStringerV1beta1 behaves mostly like a string interface and converts the given status to a string.
+// `wide` indicates whether the returned value is meant for --o=wide output. If not, it's clipped to 16 bytes.
+func ingressLoadBalancerStatusStringerV1beta1(s networkingv1beta1.IngressLoadBalancerStatus, wide bool) string {
+	ingress := s.Ingress
+	result := sets.NewString()
+	for i := range ingress {
+		if ingress[i].IP != "" {
+			result.Insert(ingress[i].IP)
+		} else if ingress[i].Hostname != "" {
+			result.Insert(ingress[i].Hostname)
+		}
+	}
+
+	r := strings.Join(result.List(), ",")
+	if !wide && len(r) > LoadBalancerWidth {
+		r = r[0:(LoadBalancerWidth-3)] + "..."
+	}
+	return r
+}
+
+// searchEvents finds events about the specified object.
+// It is very similar to CoreV1.Events.Search, but supports the Limit parameter.
+func searchEvents(client corev1client.EventsGetter, objOrRef runtime.Object, limit int64) (*corev1.EventList, error) {
+	ref, err := reference.GetReference(scheme.Scheme, objOrRef)
+	if err != nil {
+		return nil, err
+	}
+	stringRefKind := string(ref.Kind)
+	var refKind *string
+	if len(stringRefKind) > 0 {
+		refKind = &stringRefKind
+	}
+	stringRefUID := string(ref.UID)
+	var refUID *string
+	if len(stringRefUID) > 0 {
+		refUID = &stringRefUID
+	}
+
+	e := client.Events(ref.Namespace)
+	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, refKind, refUID)
+	initialOpts := metav1.ListOptions{FieldSelector: fieldSelector.String(), Limit: limit}
+	eventList := &corev1.EventList{}
+	err = runtimeresource.FollowContinue(&initialOpts,
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newEvents, err := e.List(context.TODO(), options)
+			if err != nil {
+				return nil, runtimeresource.EnhanceListError(err, options, "events")
+			}
+			eventList.Items = append(eventList.Items, newEvents.Items...)
+			return newEvents, nil
+		})
+	return eventList, err
+}

--- a/vendor/k8s.io/kubectl/pkg/describe/interface.go
+++ b/vendor/k8s.io/kubectl/pkg/describe/interface.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+const (
+	// LoadBalancerWidth is the width how we describe load balancer
+	LoadBalancerWidth = 16
+
+	// LabelNodeRolePrefix is a label prefix for node roles
+	// It's copied over to here until it's merged in core: https://github.com/kubernetes/kubernetes/pull/39112
+	LabelNodeRolePrefix = "node-role.kubernetes.io/"
+
+	// NodeLabelRole specifies the role of a node
+	NodeLabelRole = "kubernetes.io/role"
+)
+
+// DescriberFunc gives a way to display the specified RESTMapping type
+type DescriberFunc func(restClientGetter genericclioptions.RESTClientGetter, mapping *meta.RESTMapping) (ResourceDescriber, error)
+
+// ResourceDescriber generates output for the named resource or an error
+// if the output could not be generated. Implementers typically
+// abstract the retrieval of the named object from a remote server.
+type ResourceDescriber interface {
+	Describe(namespace, name string, describerSettings DescriberSettings) (output string, err error)
+}
+
+// DescriberSettings holds display configuration for each object
+// describer to control what is printed.
+type DescriberSettings struct {
+	ShowEvents bool
+	ChunkSize  int64
+}
+
+// ObjectDescriber is an interface for displaying arbitrary objects with extra
+// information. Use when an object is in hand (on disk, or already retrieved).
+// Implementers may ignore the additional information passed on extra, or use it
+// by default. ObjectDescribers may return ErrNoDescriber if no suitable describer
+// is found.
+type ObjectDescriber interface {
+	DescribeObject(object interface{}, extra ...interface{}) (output string, err error)
+}
+
+// ErrNoDescriber is a structured error indicating the provided object or objects
+// cannot be described.
+type ErrNoDescriber struct {
+	Types []string
+}
+
+// Error implements the error interface.
+func (e ErrNoDescriber) Error() string {
+	return fmt.Sprintf("no describer has been defined for %v", e.Types)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/apply.go
+++ b/vendor/k8s.io/kubectl/pkg/util/apply.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var metadataAccessor = meta.NewAccessor()
+
+// GetOriginalConfiguration retrieves the original configuration of the object
+// from the annotation, or nil if no annotation was found.
+func GetOriginalConfiguration(obj runtime.Object) ([]byte, error) {
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		return nil, nil
+	}
+
+	original, ok := annots[v1.LastAppliedConfigAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	return []byte(original), nil
+}
+
+// SetOriginalConfiguration sets the original configuration of the object
+// as the annotation on the object for later use in computing a three way patch.
+func setOriginalConfiguration(obj runtime.Object, original []byte) error {
+	if len(original) < 1 {
+		return nil
+	}
+
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	annots[v1.LastAppliedConfigAnnotation] = string(original)
+	return metadataAccessor.SetAnnotations(obj, annots)
+}
+
+// GetModifiedConfiguration retrieves the modified configuration of the object.
+// If annotate is true, it embeds the result as an annotation in the modified
+// configuration. If an object was read from the command input, it will use that
+// version of the object. Otherwise, it will use the version from the server.
+func GetModifiedConfiguration(obj runtime.Object, annotate bool, codec runtime.Encoder) ([]byte, error) {
+	// First serialize the object without the annotation to prevent recursion,
+	// then add that serialization to it as the annotation and serialize it again.
+	var modified []byte
+
+	// Otherwise, use the server side version of the object.
+	// Get the current annotations from the object.
+	annots, err := metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	original := annots[v1.LastAppliedConfigAnnotation]
+	delete(annots, v1.LastAppliedConfigAnnotation)
+	if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	modified, err = runtime.Encode(codec, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annotate {
+		annots[v1.LastAppliedConfigAnnotation] = string(modified)
+		if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+			return nil, err
+		}
+
+		modified, err = runtime.Encode(codec, obj)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Restore the object to its original condition.
+	annots[v1.LastAppliedConfigAnnotation] = original
+	if err := metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	return modified, nil
+}
+
+// updateApplyAnnotation calls CreateApplyAnnotation if the last applied
+// configuration annotation is already present. Otherwise, it does nothing.
+func updateApplyAnnotation(obj runtime.Object, codec runtime.Encoder) error {
+	if original, err := GetOriginalConfiguration(obj); err != nil || len(original) <= 0 {
+		return err
+	}
+	return CreateApplyAnnotation(obj, codec)
+}
+
+// CreateApplyAnnotation gets the modified configuration of the object,
+// without embedding it again, and then sets it on the object as the annotation.
+func CreateApplyAnnotation(obj runtime.Object, codec runtime.Encoder) error {
+	modified, err := GetModifiedConfiguration(obj, false, codec)
+	if err != nil {
+		return err
+	}
+	return setOriginalConfiguration(obj, modified)
+}
+
+// CreateOrUpdateAnnotation creates the annotation used by
+// kubectl apply only when createAnnotation is true
+// Otherwise, only update the annotation when it already exists
+func CreateOrUpdateAnnotation(createAnnotation bool, obj runtime.Object, codec runtime.Encoder) error {
+	if createAnnotation {
+		return CreateApplyAnnotation(obj, codec)
+	}
+	return updateApplyAnnotation(obj, codec)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/certificate/certificate.go
+++ b/vendor/k8s.io/kubectl/pkg/util/certificate/certificate.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+// TODO(yue9944882): Remove this helper package once it's copied to k/api
+
+// ParseCSR extracts the CSR from the API object and decodes it.
+func ParseCSR(pemBytes []byte) (*x509.CertificateRequest, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return csr, nil
+}

--- a/vendor/k8s.io/kubectl/pkg/util/deployment/deployment.go
+++ b/vendor/k8s.io/kubectl/pkg/util/deployment/deployment.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+	"sort"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
+	runtimeresource "k8s.io/cli-runtime/pkg/resource"
+	appsclient "k8s.io/client-go/kubernetes/typed/apps/v1"
+)
+
+const (
+	// RevisionAnnotation is the revision annotation of a deployment's replica sets which records its rollout sequence
+	RevisionAnnotation = "deployment.kubernetes.io/revision"
+	// RevisionHistoryAnnotation maintains the history of all old revisions that a replica set has served for a deployment.
+	RevisionHistoryAnnotation = "deployment.kubernetes.io/revision-history"
+	// DesiredReplicasAnnotation is the desired replicas for a deployment recorded as an annotation
+	// in its replica sets. Helps in separating scaling events from the rollout process and for
+	// determining if the new replica set for a deployment is really saturated.
+	DesiredReplicasAnnotation = "deployment.kubernetes.io/desired-replicas"
+	// MaxReplicasAnnotation is the maximum replicas a deployment can have at a given point, which
+	// is deployment.spec.replicas + maxSurge. Used by the underlying replica sets to estimate their
+	// proportions in case the deployment has surge replicas.
+	MaxReplicasAnnotation = "deployment.kubernetes.io/max-replicas"
+	// RollbackRevisionNotFound is not found rollback event reason
+	RollbackRevisionNotFound = "DeploymentRollbackRevisionNotFound"
+	// RollbackTemplateUnchanged is the template unchanged rollback event reason
+	RollbackTemplateUnchanged = "DeploymentRollbackTemplateUnchanged"
+	// RollbackDone is the done rollback event reason
+	RollbackDone = "DeploymentRollback"
+	// TimedOutReason is added in a deployment when its newest replica set fails to show any progress
+	// within the given deadline (progressDeadlineSeconds).
+	TimedOutReason = "ProgressDeadlineExceeded"
+)
+
+// GetDeploymentCondition returns the condition with the provided type.
+func GetDeploymentCondition(status appsv1.DeploymentStatus, condType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range status.Conditions {
+		c := status.Conditions[i]
+		if c.Type == condType {
+			return &c
+		}
+	}
+	return nil
+}
+
+// Revision returns the revision number of the input object.
+func Revision(obj runtime.Object) (int64, error) {
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return 0, err
+	}
+	v, ok := acc.GetAnnotations()[RevisionAnnotation]
+	if !ok {
+		return 0, nil
+	}
+	return strconv.ParseInt(v, 10, 64)
+}
+
+// GetAllReplicaSets returns the old and new replica sets targeted by the given Deployment. It gets PodList and
+// ReplicaSetList from client interface. Note that the first set of old replica sets doesn't include the ones
+// with no pods, and the second set of old replica sets include all old replica sets. The third returned value
+// is the new replica set, and it may be nil if it doesn't exist yet.
+func GetAllReplicaSets(deployment *appsv1.Deployment, c appsclient.AppsV1Interface) ([]*appsv1.ReplicaSet, []*appsv1.ReplicaSet, *appsv1.ReplicaSet, error) {
+	rsList, err := listReplicaSets(deployment, rsListFromClient(c), nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	newRS := findNewReplicaSet(deployment, rsList)
+	oldRSes, allOldRSes := findOldReplicaSets(deployment, rsList, newRS)
+	return oldRSes, allOldRSes, newRS, nil
+}
+
+// GetAllReplicaSetsInChunks is the same as GetAllReplicaSets, but accepts a chunk size argument.
+// It returns the old and new replica sets targeted by the given Deployment. It gets PodList and
+// ReplicaSetList from client interface. Note that the first set of old replica sets doesn't include the ones
+// with no pods, and the second set of old replica sets include all old replica sets. The third returned value
+// is the new replica set, and it may be nil if it doesn't exist yet.
+func GetAllReplicaSetsInChunks(deployment *appsv1.Deployment, c appsclient.AppsV1Interface, chunkSize int64) ([]*appsv1.ReplicaSet, []*appsv1.ReplicaSet, *appsv1.ReplicaSet, error) {
+	rsList, err := listReplicaSets(deployment, rsListFromClient(c), &chunkSize)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	newRS := findNewReplicaSet(deployment, rsList)
+	oldRSes, allOldRSes := findOldReplicaSets(deployment, rsList, newRS)
+	return oldRSes, allOldRSes, newRS, nil
+}
+
+// RsListFromClient returns an rsListFunc that wraps the given client.
+func rsListFromClient(c appsclient.AppsV1Interface) rsListFunc {
+	return func(namespace string, initialOpts metav1.ListOptions) ([]*appsv1.ReplicaSet, error) {
+		rsList := &appsv1.ReplicaSetList{}
+		err := runtimeresource.FollowContinue(&initialOpts,
+			func(opts metav1.ListOptions) (runtime.Object, error) {
+				newRs, err := c.ReplicaSets(namespace).List(context.TODO(), opts)
+				if err != nil {
+					return nil, runtimeresource.EnhanceListError(err, opts, "replicasets")
+				}
+				rsList.Items = append(rsList.Items, newRs.Items...)
+				return newRs, nil
+			})
+		if err != nil {
+			return nil, err
+		}
+		var ret []*appsv1.ReplicaSet
+		for i := range rsList.Items {
+			ret = append(ret, &rsList.Items[i])
+		}
+		return ret, err
+	}
+}
+
+// TODO: switch this to full namespacers
+type rsListFunc func(string, metav1.ListOptions) ([]*appsv1.ReplicaSet, error)
+
+// listReplicaSets returns a slice of RSes the given deployment targets.
+// Note that this does NOT attempt to reconcile ControllerRef (adopt/orphan),
+// because only the controller itself should do that.
+// However, it does filter out anything whose ControllerRef doesn't match.
+func listReplicaSets(deployment *appsv1.Deployment, getRSList rsListFunc, chunkSize *int64) ([]*appsv1.ReplicaSet, error) {
+	// TODO: Right now we list replica sets by their labels. We should list them by selector, i.e. the replica set's selector
+	//       should be a superset of the deployment's selector, see https://github.com/kubernetes/kubernetes/issues/19830.
+	namespace := deployment.Namespace
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+	options := metav1.ListOptions{LabelSelector: selector.String()}
+	if chunkSize != nil {
+		options.Limit = *chunkSize
+	}
+	all, err := getRSList(namespace, options)
+	if err != nil {
+		return nil, err
+	}
+	// Only include those whose ControllerRef matches the Deployment.
+	owned := make([]*appsv1.ReplicaSet, 0, len(all))
+	for _, rs := range all {
+		if metav1.IsControlledBy(rs, deployment) {
+			owned = append(owned, rs)
+		}
+	}
+	return owned, nil
+}
+
+// EqualIgnoreHash returns true if two given podTemplateSpec are equal, ignoring the diff in value of Labels[pod-template-hash]
+// We ignore pod-template-hash because:
+//  1. The hash result would be different upon podTemplateSpec API changes
+//     (e.g. the addition of a new field will cause the hash code to change)
+//  2. The deployment template won't have hash labels
+func equalIgnoreHash(template1, template2 *corev1.PodTemplateSpec) bool {
+	t1Copy := template1.DeepCopy()
+	t2Copy := template2.DeepCopy()
+	// Remove hash labels from template.Labels before comparing
+	delete(t1Copy.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+	delete(t2Copy.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+	return apiequality.Semantic.DeepEqual(t1Copy, t2Copy)
+}
+
+// FindNewReplicaSet returns the new RS this given deployment targets (the one with the same pod template).
+func findNewReplicaSet(deployment *appsv1.Deployment, rsList []*appsv1.ReplicaSet) *appsv1.ReplicaSet {
+	sort.Sort(replicaSetsByCreationTimestamp(rsList))
+	for i := range rsList {
+		if equalIgnoreHash(&rsList[i].Spec.Template, &deployment.Spec.Template) {
+			// In rare cases, such as after cluster upgrades, Deployment may end up with
+			// having more than one new ReplicaSets that have the same template as its template,
+			// see https://github.com/kubernetes/kubernetes/issues/40415
+			// We deterministically choose the oldest new ReplicaSet.
+			return rsList[i]
+		}
+	}
+	// new ReplicaSet does not exist.
+	return nil
+}
+
+// replicaSetsByCreationTimestamp sorts a list of ReplicaSet by creation timestamp, using their names as a tie breaker.
+type replicaSetsByCreationTimestamp []*appsv1.ReplicaSet
+
+func (o replicaSetsByCreationTimestamp) Len() int      { return len(o) }
+func (o replicaSetsByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o replicaSetsByCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+// // FindOldReplicaSets returns the old replica sets targeted by the given Deployment, with the given slice of RSes.
+// // Note that the first set of old replica sets doesn't include the ones with no pods, and the second set of old replica sets include all old replica sets.
+func findOldReplicaSets(deployment *appsv1.Deployment, rsList []*appsv1.ReplicaSet, newRS *appsv1.ReplicaSet) ([]*appsv1.ReplicaSet, []*appsv1.ReplicaSet) {
+	var requiredRSs []*appsv1.ReplicaSet
+	var allRSs []*appsv1.ReplicaSet
+	for _, rs := range rsList {
+		// Filter out new replica set
+		if newRS != nil && rs.UID == newRS.UID {
+			continue
+		}
+		allRSs = append(allRSs, rs)
+		if *(rs.Spec.Replicas) != 0 {
+			requiredRSs = append(requiredRSs, rs)
+		}
+	}
+	return requiredRSs, allRSs
+}
+
+// ResolveFenceposts resolves both maxSurge and maxUnavailable. This needs to happen in one
+// step. For example:
+//
+// 2 desired, max unavailable 1%, surge 0% - should scale old(-1), then new(+1), then old(-1), then new(+1)
+// 1 desired, max unavailable 1%, surge 0% - should scale old(-1), then new(+1)
+// 2 desired, max unavailable 25%, surge 1% - should scale new(+1), then old(-1), then new(+1), then old(-1)
+// 1 desired, max unavailable 25%, surge 1% - should scale new(+1), then old(-1)
+// 2 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1), then new(+1), then old(-1)
+// 1 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1)
+func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired int32) (int32, int32, error) {
+	surge, err := intstrutil.GetScaledValueFromIntOrPercent(intstrutil.ValueOrDefault(maxSurge, intstrutil.FromInt32(0)), int(desired), true)
+	if err != nil {
+		return 0, 0, err
+	}
+	unavailable, err := intstrutil.GetScaledValueFromIntOrPercent(intstrutil.ValueOrDefault(maxUnavailable, intstrutil.FromInt32(0)), int(desired), false)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if surge == 0 && unavailable == 0 {
+		// Validation should never allow the user to explicitly use zero values for both maxSurge
+		// maxUnavailable. Due to rounding down maxUnavailable though, it may resolve to zero.
+		// If both fenceposts resolve to zero, then we should set maxUnavailable to 1 on the
+		// theory that surge might not work due to quota.
+		unavailable = 1
+	}
+
+	return int32(surge), int32(unavailable), nil
+}

--- a/vendor/k8s.io/kubectl/pkg/util/event/sorted_event_list.go
+++ b/vendor/k8s.io/kubectl/pkg/util/event/sorted_event_list.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The KubeEdge Authors.
+Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,23 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package get
+package event
 
-import "github.com/spf13/cobra"
-
-var (
-	edgeGetShortDescription = `Get resources in edge node`
+import (
+	corev1 "k8s.io/api/core/v1"
 )
 
-// NewEdgeGet returns KubeEdge edge resources get command.
-func NewEdgeGet() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get",
-		Short: edgeGetShortDescription,
-		Long:  edgeGetShortDescription,
-	}
+// SortableEvents implements sort.Interface for []api.Event based on the Timestamp field
+type SortableEvents []corev1.Event
 
-	cmd.AddCommand(NewEdgePodGet())
-	cmd.AddCommand(NewEdgeDeviceGet())
-	return cmd
+func (list SortableEvents) Len() int {
+	return len(list)
+}
+
+func (list SortableEvents) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list SortableEvents) Less(i, j int) bool {
+	return list[i].LastTimestamp.Time.Before(list[j].LastTimestamp.Time)
 }

--- a/vendor/k8s.io/kubectl/pkg/util/fieldpath/fieldpath.go
+++ b/vendor/k8s.io/kubectl/pkg/util/fieldpath/fieldpath.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fieldpath
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// TODO(yue9944882): Remove this helper package once it's copied to k/apimachinery
+
+// FormatMap formats map[string]string to a string.
+func FormatMap(m map[string]string) (fmtStr string) {
+	// output with keys in sorted order to provide stable output
+	keys := sets.NewString()
+	for key := range m {
+		keys.Insert(key)
+	}
+	for _, key := range keys.List() {
+		fmtStr += fmt.Sprintf("%v=%q\n", key, m[key])
+	}
+	fmtStr = strings.TrimSuffix(fmtStr, "\n")
+
+	return
+}
+
+// ExtractFieldPathAsString extracts the field from the given object
+// and returns it as a string.  The object must be a pointer to an
+// API type.
+func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", nil
+	}
+
+	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.annotations":
+		return FormatMap(accessor.GetAnnotations()), nil
+	case "metadata.labels":
+		return FormatMap(accessor.GetLabels()), nil
+	case "metadata.name":
+		return accessor.GetName(), nil
+	case "metadata.namespace":
+		return accessor.GetNamespace(), nil
+	case "metadata.uid":
+		return string(accessor.GetUID()), nil
+	}
+
+	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+// SplitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//   - if yes, this function splits the fieldPath into path and subscript, and
+//     returns (path, subscript, true).
+//   - if no, this function returns (fieldPath, "", false).
+//
+// Example inputs and outputs:
+//
+//	"metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//	"metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//	"metadata.labels['']"           --> ("metadata.labels", "", true)
+//	"metadata.labels"               --> ("metadata.labels", "", false)
+func SplitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/vendor/k8s.io/kubectl/pkg/util/pod_port.go
+++ b/vendor/k8s.io/kubectl/pkg/util/pod_port.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The KubeEdge Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,23 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package get
+package util
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
 
-var (
-	edgeGetShortDescription = `Get resources in edge node`
+	"k8s.io/api/core/v1"
 )
 
-// NewEdgeGet returns KubeEdge edge resources get command.
-func NewEdgeGet() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get",
-		Short: edgeGetShortDescription,
-		Long:  edgeGetShortDescription,
+// LookupContainerPortNumberByName find containerPort number by its named port name
+func LookupContainerPortNumberByName(pod v1.Pod, name string) (int32, error) {
+	for _, ctr := range pod.Spec.Containers {
+		for _, ctrportspec := range ctr.Ports {
+			if ctrportspec.Name == name {
+				return ctrportspec.ContainerPort, nil
+			}
+		}
 	}
 
-	cmd.AddCommand(NewEdgePodGet())
-	cmd.AddCommand(NewEdgeDeviceGet())
-	return cmd
+	return int32(-1), fmt.Errorf("Pod '%s' does not have a named port '%s'", pod.Name, name)
 }

--- a/vendor/k8s.io/kubectl/pkg/util/qos/qos.go
+++ b/vendor/k8s.io/kubectl/pkg/util/qos/qos.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qos
+
+import (
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var supportedQoSComputeResources = sets.NewString(string(core.ResourceCPU), string(core.ResourceMemory))
+
+func isSupportedQoSComputeResource(name core.ResourceName) bool {
+	return supportedQoSComputeResources.Has(string(name))
+}
+
+// GetPodQOS returns the QoS class of a pod persisted in the PodStatus.QOSClass field.
+// If PodStatus.QOSClass is empty, it returns value of ComputePodQOS() which evaluates pod's QoS class.
+func GetPodQOS(pod *core.Pod) core.PodQOSClass {
+	if pod.Status.QOSClass != "" {
+		return pod.Status.QOSClass
+	}
+	return ComputePodQOS(pod)
+}
+
+// ComputePodQOS evaluates the list of containers to determine a pod's QoS class. This function is more
+// expensive than GetPodQOS which should be used for pods having a non-empty .Status.QOSClass.
+// A pod is besteffort if none of its containers have specified any requests or limits.
+// A pod is guaranteed only when requests and limits are specified for all the containers and they are equal.
+// A pod is burstable if limits and requests do not match across all containers.
+func ComputePodQOS(pod *core.Pod) core.PodQOSClass {
+	requests := core.ResourceList{}
+	limits := core.ResourceList{}
+	zeroQuantity := resource.MustParse("0")
+	isGuaranteed := true
+	// note, ephemeral containers are not considered for QoS as they cannot define resources
+	allContainers := []core.Container{}
+	allContainers = append(allContainers, pod.Spec.Containers...)
+	allContainers = append(allContainers, pod.Spec.InitContainers...)
+	for _, container := range allContainers {
+		// process requests
+		for name, quantity := range container.Resources.Requests {
+			if !isSupportedQoSComputeResource(name) {
+				continue
+			}
+			if quantity.Cmp(zeroQuantity) == 1 {
+				delta := quantity.DeepCopy()
+				if _, exists := requests[name]; !exists {
+					requests[name] = delta
+				} else {
+					delta.Add(requests[name])
+					requests[name] = delta
+				}
+			}
+		}
+		// process limits
+		qosLimitsFound := sets.NewString()
+		for name, quantity := range container.Resources.Limits {
+			if !isSupportedQoSComputeResource(name) {
+				continue
+			}
+			if quantity.Cmp(zeroQuantity) == 1 {
+				qosLimitsFound.Insert(string(name))
+				delta := quantity.DeepCopy()
+				if _, exists := limits[name]; !exists {
+					limits[name] = delta
+				} else {
+					delta.Add(limits[name])
+					limits[name] = delta
+				}
+			}
+		}
+
+		if !qosLimitsFound.HasAll(string(core.ResourceMemory), string(core.ResourceCPU)) {
+			isGuaranteed = false
+		}
+	}
+	if len(requests) == 0 && len(limits) == 0 {
+		return core.PodQOSBestEffort
+	}
+	// Check is requests match limits for all resources.
+	if isGuaranteed {
+		for name, req := range requests {
+			if lim, exists := limits[name]; !exists || lim.Cmp(req) != 0 {
+				isGuaranteed = false
+				break
+			}
+		}
+	}
+	if isGuaranteed &&
+		len(requests) == len(limits) {
+		return core.PodQOSGuaranteed
+	}
+	return core.PodQOSBurstable
+}

--- a/vendor/k8s.io/kubectl/pkg/util/rbac/rbac.go
+++ b/vendor/k8s.io/kubectl/pkg/util/rbac/rbac.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"reflect"
+	"strings"
+)
+
+type simpleResource struct {
+	Group             string
+	Resource          string
+	ResourceNameExist bool
+	ResourceName      string
+}
+
+// CompactRules combines rules that contain a single APIGroup/Resource, differ only by verb, and contain no other attributes.
+// this is a fast check, and works well with the decomposed "missing rules" list from a Covers check.
+func CompactRules(rules []rbacv1.PolicyRule) ([]rbacv1.PolicyRule, error) {
+	compacted := make([]rbacv1.PolicyRule, 0, len(rules))
+
+	simpleRules := map[simpleResource]*rbacv1.PolicyRule{}
+	for _, rule := range rules {
+		if resource, isSimple := isSimpleResourceRule(&rule); isSimple {
+			if existingRule, ok := simpleRules[resource]; ok {
+				// Add the new verbs to the existing simple resource rule
+				if existingRule.Verbs == nil {
+					existingRule.Verbs = []string{}
+				}
+				existingVerbs := sets.NewString(existingRule.Verbs...)
+				for _, verb := range rule.Verbs {
+					if !existingVerbs.Has(verb) {
+						existingRule.Verbs = append(existingRule.Verbs, verb)
+					}
+				}
+
+			} else {
+				// Copy the rule to accumulate matching simple resource rules into
+				simpleRules[resource] = rule.DeepCopy()
+			}
+		} else {
+			compacted = append(compacted, rule)
+		}
+	}
+
+	// Once we've consolidated the simple resource rules, add them to the compacted list
+	for _, simpleRule := range simpleRules {
+		compacted = append(compacted, *simpleRule)
+	}
+
+	return compacted, nil
+}
+
+// isSimpleResourceRule returns true if the given rule contains verbs, a single resource, a single API group, at most one Resource Name, and no other values
+func isSimpleResourceRule(rule *rbacv1.PolicyRule) (simpleResource, bool) {
+	resource := simpleResource{}
+
+	// If we have "complex" rule attributes, return early without allocations or expensive comparisons
+	if len(rule.ResourceNames) > 1 || len(rule.NonResourceURLs) > 0 {
+		return resource, false
+	}
+	// If we have multiple api groups or resources, return early
+	if len(rule.APIGroups) != 1 || len(rule.Resources) != 1 {
+		return resource, false
+	}
+
+	// Test if this rule only contains APIGroups/Resources/Verbs/ResourceNames
+	simpleRule := &rbacv1.PolicyRule{APIGroups: rule.APIGroups, Resources: rule.Resources, Verbs: rule.Verbs, ResourceNames: rule.ResourceNames}
+	if !reflect.DeepEqual(simpleRule, rule) {
+		return resource, false
+	}
+
+	if len(rule.ResourceNames) == 0 {
+		resource = simpleResource{Group: rule.APIGroups[0], Resource: rule.Resources[0], ResourceNameExist: false}
+	} else {
+		resource = simpleResource{Group: rule.APIGroups[0], Resource: rule.Resources[0], ResourceNameExist: true, ResourceName: rule.ResourceNames[0]}
+	}
+
+	return resource, true
+}
+
+// BreakdownRule takes a rule and builds an equivalent list of rules that each have at most one verb, one
+// resource, and one resource name
+func BreakdownRule(rule rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	subrules := []rbacv1.PolicyRule{}
+	for _, group := range rule.APIGroups {
+		for _, resource := range rule.Resources {
+			for _, verb := range rule.Verbs {
+				if len(rule.ResourceNames) > 0 {
+					for _, resourceName := range rule.ResourceNames {
+						subrules = append(subrules, rbacv1.PolicyRule{APIGroups: []string{group}, Resources: []string{resource}, Verbs: []string{verb}, ResourceNames: []string{resourceName}})
+					}
+
+				} else {
+					subrules = append(subrules, rbacv1.PolicyRule{APIGroups: []string{group}, Resources: []string{resource}, Verbs: []string{verb}})
+				}
+
+			}
+		}
+	}
+
+	// Non-resource URLs are unique because they only combine with verbs.
+	for _, nonResourceURL := range rule.NonResourceURLs {
+		for _, verb := range rule.Verbs {
+			subrules = append(subrules, rbacv1.PolicyRule{NonResourceURLs: []string{nonResourceURL}, Verbs: []string{verb}})
+		}
+	}
+
+	return subrules
+}
+
+// SortableRuleSlice is used to sort rule slice
+type SortableRuleSlice []rbacv1.PolicyRule
+
+func (s SortableRuleSlice) Len() int      { return len(s) }
+func (s SortableRuleSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s SortableRuleSlice) Less(i, j int) bool {
+	return strings.Compare(s[i].String(), s[j].String()) < 0
+}

--- a/vendor/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/vendor/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
+// containers of the pod. If pod overhead is non-nil, the pod overhead is added to the
+// total container resource requests and to the total container limits which have a
+// non-zero quantity.
+func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
+	return podRequests(pod), podLimits(pod)
+}
+
+// podRequests is a simplified form of PodRequests from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
+// feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
+func podRequests(pod *corev1.Pod) corev1.ResourceList {
+	// attempt to reuse the maps if passed, or allocate otherwise
+	reqs := corev1.ResourceList{}
+
+	containerStatuses := map[string]*corev1.ContainerStatus{}
+	for i := range pod.Status.ContainerStatuses {
+		containerStatuses[pod.Status.ContainerStatuses[i].Name] = &pod.Status.ContainerStatuses[i]
+	}
+
+	for _, container := range pod.Spec.Containers {
+		containerReqs := container.Resources.Requests
+		cs, found := containerStatuses[container.Name]
+		if found {
+			if pod.Status.Resize == corev1.PodResizeStatusInfeasible {
+				containerReqs = cs.AllocatedResources.DeepCopy()
+			} else {
+				containerReqs = max(container.Resources.Requests, cs.AllocatedResources)
+			}
+		}
+		addResourceList(reqs, containerReqs)
+	}
+
+	restartableInitContainerReqs := corev1.ResourceList{}
+	initContainerReqs := corev1.ResourceList{}
+
+	for _, container := range pod.Spec.InitContainers {
+		containerReqs := container.Resources.Requests
+
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			// and add them to the resulting cumulative container requests
+			addResourceList(reqs, containerReqs)
+
+			// track our cumulative restartable init container resources
+			addResourceList(restartableInitContainerReqs, containerReqs)
+			containerReqs = restartableInitContainerReqs
+		} else {
+			tmp := corev1.ResourceList{}
+			addResourceList(tmp, containerReqs)
+			addResourceList(tmp, restartableInitContainerReqs)
+			containerReqs = tmp
+		}
+		maxResourceList(initContainerReqs, containerReqs)
+	}
+
+	maxResourceList(reqs, initContainerReqs)
+
+	// Add overhead for running a pod to the sum of requests if requested:
+	if pod.Spec.Overhead != nil {
+		addResourceList(reqs, pod.Spec.Overhead)
+	}
+
+	return reqs
+}
+
+// podLimits is a simplified form of PodLimits from k8s.io/kubernetes/pkg/api/v1/resource that doesn't check
+// feature gate enablement and avoids adding a dependency on k8s.io/kubernetes/pkg/apis/core/v1 for kubectl.
+func podLimits(pod *corev1.Pod) corev1.ResourceList {
+	limits := corev1.ResourceList{}
+
+	for _, container := range pod.Spec.Containers {
+		addResourceList(limits, container.Resources.Limits)
+	}
+
+	restartableInitContainerLimits := corev1.ResourceList{}
+	initContainerLimits := corev1.ResourceList{}
+
+	for _, container := range pod.Spec.InitContainers {
+		containerLimits := container.Resources.Limits
+		// Is the init container marked as a restartable init container?
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			addResourceList(limits, containerLimits)
+
+			// track our cumulative restartable init container resources
+			addResourceList(restartableInitContainerLimits, containerLimits)
+			containerLimits = restartableInitContainerLimits
+		} else {
+			tmp := corev1.ResourceList{}
+			addResourceList(tmp, containerLimits)
+			addResourceList(tmp, restartableInitContainerLimits)
+			containerLimits = tmp
+		}
+
+		maxResourceList(initContainerLimits, containerLimits)
+	}
+
+	maxResourceList(limits, initContainerLimits)
+
+	// Add overhead to non-zero limits if requested:
+	if pod.Spec.Overhead != nil {
+		for name, quantity := range pod.Spec.Overhead {
+			if value, ok := limits[name]; ok && !value.IsZero() {
+				value.Add(quantity)
+				limits[name] = value
+			}
+		}
+	}
+
+	return limits
+}
+
+// max returns the result of max(a, b) for each named resource and is only used if we can't
+// accumulate into an existing resource list
+func max(a corev1.ResourceList, b corev1.ResourceList) corev1.ResourceList {
+	result := corev1.ResourceList{}
+	for key, value := range a {
+		if other, found := b[key]; found {
+			if value.Cmp(other) <= 0 {
+				result[key] = other.DeepCopy()
+				continue
+			}
+		}
+		result[key] = value.DeepCopy()
+	}
+	for key, value := range b {
+		if _, found := result[key]; !found {
+			result[key] = value.DeepCopy()
+		}
+	}
+	return result
+}
+
+// addResourceList adds the resources in newList to list
+func addResourceList(list, new corev1.ResourceList) {
+	for name, quantity := range new {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+		} else {
+			value.Add(quantity)
+			list[name] = value
+		}
+	}
+}
+
+// maxResourceList sets list to the greater of list/newList for every resource
+// either list
+func maxResourceList(list, new corev1.ResourceList) {
+	for name, quantity := range new {
+		if value, ok := list[name]; !ok {
+			list[name] = quantity.DeepCopy()
+			continue
+		} else {
+			if quantity.Cmp(value) > 0 {
+				list[name] = quantity.DeepCopy()
+			}
+		}
+	}
+}
+
+// ExtractContainerResourceValue extracts the value of a resource
+// in an already known container
+func ExtractContainerResourceValue(fs *corev1.ResourceFieldSelector, container *corev1.Container) (string, error) {
+	divisor := resource.Quantity{}
+	if divisor.Cmp(fs.Divisor) == 0 {
+		divisor = resource.MustParse("1")
+	} else {
+		divisor = fs.Divisor
+	}
+
+	switch fs.Resource {
+	case "limits.cpu":
+		return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
+	case "limits.memory":
+		return convertResourceMemoryToString(container.Resources.Limits.Memory(), divisor)
+	case "limits.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Limits.StorageEphemeral(), divisor)
+	case "requests.cpu":
+		return convertResourceCPUToString(container.Resources.Requests.Cpu(), divisor)
+	case "requests.memory":
+		return convertResourceMemoryToString(container.Resources.Requests.Memory(), divisor)
+	case "requests.ephemeral-storage":
+		return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
+	}
+	// handle extended standard resources with dynamic names
+	// example: requests.hugepages-<pageSize> or limits.hugepages-<pageSize>
+	if strings.HasPrefix(fs.Resource, "requests.") {
+		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "requests."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Requests.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
+	if strings.HasPrefix(fs.Resource, "limits.") {
+		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "limits."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Limits.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
+	return "", fmt.Errorf("Unsupported container resource : %v", fs.Resource)
+}
+
+// convertResourceCPUToString converts cpu value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceCPUToString(cpu *resource.Quantity, divisor resource.Quantity) (string, error) {
+	c := int64(math.Ceil(float64(cpu.MilliValue()) / float64(divisor.MilliValue())))
+	return strconv.FormatInt(c, 10), nil
+}
+
+// convertResourceMemoryToString converts memory value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceMemoryToString(memory *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+// convertResourceHugePagesToString converts hugepages value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceHugePagesToString(hugePages *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(hugePages.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+// convertResourceEphemeralStorageToString converts ephemeral storage value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceEphemeralStorageToString(ephemeralStorage *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(ephemeralStorage.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+var standardContainerResources = sets.NewString(
+	string(corev1.ResourceCPU),
+	string(corev1.ResourceMemory),
+	string(corev1.ResourceEphemeralStorage),
+)
+
+// IsStandardContainerResourceName returns true if the container can make a resource request
+// for the specified resource
+func IsStandardContainerResourceName(str string) bool {
+	return standardContainerResources.Has(str) || IsHugePageResourceName(corev1.ResourceName(str))
+}
+
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name corev1.ResourceName) bool {
+	return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/service_port.go
+++ b/vendor/k8s.io/kubectl/pkg/util/service_port.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// LookupContainerPortNumberByServicePort implements
+// the handling of resolving container named port, as well as ignoring targetPort when clusterIP=None
+// It returns an error when a named port can't find a match (with -1 returned), or when the service does not
+// declare such port (with the input port number returned).
+func LookupContainerPortNumberByServicePort(svc v1.Service, pod v1.Pod, port int32) (int32, error) {
+	for _, svcportspec := range svc.Spec.Ports {
+		if svcportspec.Port != port {
+			continue
+		}
+		if svc.Spec.ClusterIP == v1.ClusterIPNone {
+			return port, nil
+		}
+		if svcportspec.TargetPort.Type == intstr.Int {
+			if svcportspec.TargetPort.IntValue() == 0 {
+				// targetPort is omitted, and the IntValue() would be zero
+				return svcportspec.Port, nil
+			}
+			return int32(svcportspec.TargetPort.IntValue()), nil
+		}
+		return LookupContainerPortNumberByName(pod, svcportspec.TargetPort.String())
+	}
+	return port, fmt.Errorf("Service %s does not have a service port %d", svc.Name, port)
+}
+
+// LookupServicePortNumberByName find service port number by its named port name
+func LookupServicePortNumberByName(svc v1.Service, name string) (int32, error) {
+	for _, svcportspec := range svc.Spec.Ports {
+		if svcportspec.Name == name {
+			return svcportspec.Port, nil
+		}
+	}
+
+	return int32(-1), fmt.Errorf("Service '%s' does not have a named port '%s'", svc.Name, name)
+}

--- a/vendor/k8s.io/kubectl/pkg/util/storage/storage.go
+++ b/vendor/k8s.io/kubectl/pkg/util/storage/storage.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
+)
+
+// TODO(yue9944882): Remove this helper package once it's copied to k/api
+
+// IsDefaultStorageClassAnnotation represents a StorageClass annotation that
+// marks a class as the default StorageClass
+const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+
+// BetaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
+const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
+
+// IsDefaultAnnotationText returns a pretty Yes/No String if
+// the annotation is set
+func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
+	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+		return "Yes"
+	}
+	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+		return "Yes"
+	}
+
+	return "No"
+}
+
+// GetAccessModesAsString returns a string representation of an array of access modes.
+// modes, when present, are always in the same order: RWO,ROX,RWX,RWOP.
+func GetAccessModesAsString(modes []v1.PersistentVolumeAccessMode) string {
+	modes = removeDuplicateAccessModes(modes)
+	modesStr := []string{}
+	if ContainsAccessMode(modes, v1.ReadWriteOnce) {
+		modesStr = append(modesStr, "RWO")
+	}
+	if ContainsAccessMode(modes, v1.ReadOnlyMany) {
+		modesStr = append(modesStr, "ROX")
+	}
+	if ContainsAccessMode(modes, v1.ReadWriteMany) {
+		modesStr = append(modesStr, "RWX")
+	}
+	if ContainsAccessMode(modes, v1.ReadWriteOncePod) {
+		modesStr = append(modesStr, "RWOP")
+	}
+	return strings.Join(modesStr, ",")
+}
+
+// removeDuplicateAccessModes returns an array of access modes without any duplicates
+func removeDuplicateAccessModes(modes []v1.PersistentVolumeAccessMode) []v1.PersistentVolumeAccessMode {
+	accessModes := []v1.PersistentVolumeAccessMode{}
+	for _, m := range modes {
+		if !ContainsAccessMode(accessModes, m) {
+			accessModes = append(accessModes, m)
+		}
+	}
+	return accessModes
+}
+
+func ContainsAccessMode(modes []v1.PersistentVolumeAccessMode, mode v1.PersistentVolumeAccessMode) bool {
+	for _, m := range modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}
+
+// GetPersistentVolumeClass returns StorageClassName.
+func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
+	// Use beta annotation first
+	if class, found := volume.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	return volume.Spec.StorageClassName
+}
+
+// GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
+// requested, it returns "".
+func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
+	// Use beta annotation first
+	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
+		return class
+	}
+
+	if claim.Spec.StorageClassName != nil {
+		return *claim.Spec.StorageClassName
+	}
+
+	return ""
+}

--- a/vendor/k8s.io/kubectl/pkg/util/umask.go
+++ b/vendor/k8s.io/kubectl/pkg/util/umask.go
@@ -1,5 +1,8 @@
+//go:build !windows
+// +build !windows
+
 /*
-Copyright 2024 The KubeEdge Authors.
+Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,23 +17,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package get
+package util
 
-import "github.com/spf13/cobra"
-
-var (
-	edgeGetShortDescription = `Get resources in edge node`
+import (
+	"golang.org/x/sys/unix"
 )
 
-// NewEdgeGet returns KubeEdge edge resources get command.
-func NewEdgeGet() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get",
-		Short: edgeGetShortDescription,
-		Long:  edgeGetShortDescription,
-	}
-
-	cmd.AddCommand(NewEdgePodGet())
-	cmd.AddCommand(NewEdgeDeviceGet())
-	return cmd
+// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
+func Umask(mask int) (old int, err error) {
+	return unix.Umask(mask), nil
 }

--- a/vendor/k8s.io/kubectl/pkg/util/umask_windows.go
+++ b/vendor/k8s.io/kubectl/pkg/util/umask_windows.go
@@ -1,5 +1,8 @@
+//go:build windows
+// +build windows
+
 /*
-Copyright 2024 The KubeEdge Authors.
+Copyright 2014 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,23 +17,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package get
+package util
 
-import "github.com/spf13/cobra"
-
-var (
-	edgeGetShortDescription = `Get resources in edge node`
+import (
+	"errors"
 )
 
-// NewEdgeGet returns KubeEdge edge resources get command.
-func NewEdgeGet() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "get",
-		Short: edgeGetShortDescription,
-		Long:  edgeGetShortDescription,
-	}
-
-	cmd.AddCommand(NewEdgePodGet())
-	cmd.AddCommand(NewEdgeDeviceGet())
-	return cmd
+// Umask returns an error on Windows
+func Umask(mask int) (int, error) {
+	return 0, errors.New("platform and architecture is not supported")
 }

--- a/vendor/k8s.io/kubectl/pkg/util/util.go
+++ b/vendor/k8s.io/kubectl/pkg/util/util.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ParseRFC3339 parses an RFC3339 date in either RFC3339Nano or RFC3339 format.
+func ParseRFC3339(s string, nowFn func() metav1.Time) (metav1.Time, error) {
+	if t, timeErr := time.Parse(time.RFC3339Nano, s); timeErr == nil {
+		return metav1.Time{Time: t}, nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return metav1.Time{}, err
+	}
+	return metav1.Time{Time: t}, nil
+}
+
+// HashObject returns the hash of a Object hash by a Codec
+func HashObject(obj runtime.Object, codec runtime.Codec) (string, error) {
+	data, err := runtime.Encode(codec, obj)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", md5.Sum(data)), nil
+}
+
+// ParseFileSource parses the source given.
+//
+//	Acceptable formats include:
+//	 1.  source-path: the basename will become the key name
+//	 2.  source-name=source-path: the source-name will become the key name and
+//	     source-path is the path to the key file.
+//
+// Key names cannot include '='.
+func ParseFileSource(source string) (keyName, filePath string, err error) {
+	numSeparators := strings.Count(source, "=")
+	switch {
+	case numSeparators == 0:
+		return path.Base(filepath.ToSlash(source)), source, nil
+	case numSeparators == 1 && strings.HasPrefix(source, "="):
+		return "", "", fmt.Errorf("key name for file path %v missing", strings.TrimPrefix(source, "="))
+	case numSeparators == 1 && strings.HasSuffix(source, "="):
+		return "", "", fmt.Errorf("file path for key name %v missing", strings.TrimSuffix(source, "="))
+	case numSeparators > 1:
+		return "", "", errors.New("key names or file paths cannot contain '='")
+	default:
+		components := strings.Split(source, "=")
+		return components[0], components[1], nil
+	}
+}
+
+// ParseLiteralSource parses the source key=val pair into its component pieces.
+// This functionality is distinguished from strings.SplitN(source, "=", 2) since
+// it returns an error in the case of empty keys, values, or a missing equals sign.
+func ParseLiteralSource(source string) (keyName, value string, err error) {
+	// leading equal is invalid
+	if strings.Index(source, "=") == 0 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+	// split after the first equal (so values can have the = character)
+	items := strings.SplitN(source, "=", 2)
+	if len(items) != 2 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+
+	return items[0], items[1], nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -304,6 +304,9 @@ github.com/evanphx/json-patch/v5
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 ## explicit
 github.com/exponent-io/jsonpath
+# github.com/fatih/camelcase v1.0.0
+## explicit
+github.com/fatih/camelcase
 # github.com/fatih/color v1.13.0
 ## explicit; go 1.13
 github.com/fatih/color
@@ -2287,14 +2290,26 @@ k8s.io/kube-scheduler/extender/v1
 ## explicit; go 1.21
 k8s.io/kubectl/pkg/cmd/get
 k8s.io/kubectl/pkg/cmd/util
+k8s.io/kubectl/pkg/cmd/util/editor
+k8s.io/kubectl/pkg/cmd/util/editor/crlf
+k8s.io/kubectl/pkg/describe
 k8s.io/kubectl/pkg/rawhttp
 k8s.io/kubectl/pkg/scale
 k8s.io/kubectl/pkg/scheme
+k8s.io/kubectl/pkg/util
+k8s.io/kubectl/pkg/util/certificate
+k8s.io/kubectl/pkg/util/deployment
+k8s.io/kubectl/pkg/util/event
+k8s.io/kubectl/pkg/util/fieldpath
 k8s.io/kubectl/pkg/util/i18n
 k8s.io/kubectl/pkg/util/interrupt
 k8s.io/kubectl/pkg/util/openapi
 k8s.io/kubectl/pkg/util/podutils
+k8s.io/kubectl/pkg/util/qos
+k8s.io/kubectl/pkg/util/rbac
+k8s.io/kubectl/pkg/util/resource
 k8s.io/kubectl/pkg/util/slice
+k8s.io/kubectl/pkg/util/storage
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

In edge computing scenarios, edge nodes are usually under different networks from the cloud and are often offline due to network fluctuations and other issues.  If the edge node is offline, users can only wait for the edge node to come online to perform operations from the cloud if they find any abnormality in the pod or device.

However, the data related to pods and devices are stored locally on the edge nodes, and due to the existence of edged, it is feasible in principle to obtain the data and operate the resources on the edge nodes.  The support of this feature will reduce the network resource consumption of the edge node for debugging and resource adjustment, and avoid the situation that some functions of the KubeEdge platform are not available when the edge node is offline.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5587 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
