### PR TITLE
Fix kubeconfig flag in keadm

### DIFF
--- a/keadm/cmd/keadm/app/cmd/reset_others.go
+++ b/keadm/cmd/keadm/app/cmd/reset_others.go
@@ -220,7 +220,7 @@ func cleanDirectories(isEdgeNode bool) error {
 }
 
 func addResetFlags(cmd *cobra.Command, resetOpts *common.ResetOptions) {
-	cmd.Flags().StringVar(&resetOpts.Kubeconfig, common.FlagNameCloudCoreIPPort, resetOpts.Kubeconfig,
+	cmd.Flags().StringVar(&resetOpts.Kubeconfig, common.FlagNameKubeConfig, resetOpts.Kubeconfig,
 		"Use this key to set kube-config path, eg: $HOME/.kube/config")
 	cmd.Flags().BoolVar(&resetOpts.Force, "force", resetOpts.Force,
 		"Reset the node without prompting for confirmation")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

The phenomenon that keadm cannot parse the kube-config flag has been described in the #5903. We find the 1.16 version of keadm incorrectly used `CloudCoreIPPort` as the flag of `kube-config` when setting the flag, causing this problem. This PR fixed the wrong flag setting.
![image](https://github.com/user-attachments/assets/6c81ebae-9384-48c1-bcb3-b0596da98f24)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5903 

**Special notes for your reviewer**:

Since this problem only appears in version 1.16, we only fix it in this version

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
