### PR TITLE
Add a note comment for default value modification of `edged.rootDirectory`

### DIFF
--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -766,6 +766,7 @@ type TailoredKubeletFlag struct {
 	// rootDirectory is the directory path to place kubelet files (volume
 	// mounts,etc).
 	// default "/var/lib/edged"
+	// The default will change to "/var/lib/kubelet" in KubeEdge v1.20.
 	RootDirectory string `json:"rootDirectory,omitempty"`
 	// WindowsService should be set to true if kubelet is running as a service on Windows.
 	// Its corresponding flag only gets registered in Windows builds.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**


/kind documentation


**What this PR does / why we need it**:

Add a note comment for change default value of `edged.rootDirectory`, from `/var/lib/edged` to `/var/lib/kubelet`, to keep consistent with kubelet.  

File directories consistent with kubelet can reduce maintain costs. In addition, kubeedge can seamlessly connect to native Kubernetes resources.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**: 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
In v1.20, the default value of edged.rootDirectory will be changed to "/var/lib/kubelet". If you want to continue using "/var/lib/edged", please modify the edgecore configuration. 
```
