### PR TITLE
Automated cherry pick of #5894: Fix errors due to singular and plural conversion

### DIFF
--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -63,7 +63,7 @@ func UnsafeResourceToKind(r string) string {
 	switch {
 	case strings.HasSuffix(k, "ies"):
 		return strings.TrimSuffix(k, "ies") + "y"
-	case strings.HasSuffix(k, "es"):
+	case strings.HasSuffix(k, "ses"):
 		return strings.TrimSuffix(k, "es")
 	case strings.HasSuffix(k, "s"):
 		return strings.TrimSuffix(k, "s")


### PR DESCRIPTION
Cherry pick of #5894 on release-1.15.

#5894: Fix errors due to singular and plural conversion

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.