### PR TITLE
CSI Driver `version flag` is inconsistent

### DIFF
--- a/cloud/cmd/csidriver/app/options/options.go
+++ b/cloud/cmd/csidriver/app/options/options.go
@@ -41,6 +41,5 @@ func (o *CSIDriverOptions) Flags() (fss cliflag.NamedFlagSets) {
 	fs.StringVar(&o.DriverName, "drivername", "csidriver", "name of the driver")
 	fs.StringVar(&o.NodeID, "nodeid", "", "node id determines which node will be used to create/delete volumes")
 	fs.StringVar(&o.KubeEdgeEndpoint, "kubeedge-endpoint", "unix:///kubeedge/kubeedge.sock", "kubeedge endpoint")
-	fs.StringVar(&o.Version, "version", "dev", "version")
 	return
 }

--- a/cloud/cmd/csidriver/app/options/options_test.go
+++ b/cloud/cmd/csidriver/app/options/options_test.go
@@ -46,7 +46,6 @@ func TestFlags(t *testing.T) {
 	assert.Equal("csidriver", opt.DriverName)
 	assert.Empty(opt.NodeID)
 	assert.Equal("unix:///kubeedge/kubeedge.sock", opt.KubeEdgeEndpoint)
-	assert.Equal("dev", opt.Version)
 
 	flagTests := []struct {
 		name         string
@@ -72,11 +71,6 @@ func TestFlags(t *testing.T) {
 			name:         "kubeedge-endpoint",
 			expectedType: "string",
 			usage:        "kubeedge endpoint",
-		},
-		{
-			name:         "version",
-			expectedType: "string",
-			usage:        "version",
 		},
 	}
 

--- a/cloud/cmd/csidriver/app/server_test.go
+++ b/cloud/cmd/csidriver/app/server_test.go
@@ -63,8 +63,8 @@ func TestNewCSIDriverCommand(t *testing.T) {
 
 	versionFlag := flags.Lookup("version")
 	assert.NotNil(versionFlag)
-	assert.Equal("version", versionFlag.Usage)
-	assert.Equal("dev", versionFlag.DefValue)
+	assert.Equal("Print version information and quit", versionFlag.Usage)
+	assert.Equal("false", versionFlag.DefValue)
 
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind bug


**What this PR does / why we need it**:

CSI driver `options.go` was defining its own version flag, but it conflicted 
with version flag implementation in `verflag` package). CI tests were failing because of this.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
