### PR TITLE
Automated cherry pick of #5929: update default version to 1.19.0

### DIFF
--- a/manifests/charts/cloudcore/Chart.yaml
+++ b/manifests/charts/cloudcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cloudcore
-version: 1.15.1
-appVersion: 1.15.1
+version: 1.19.0
+appVersion: 1.19.0
 description: The KubeEdge cloudcore component.
 sources:
 - https://github.com/kubeedge/kubeedge

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -1,14 +1,14 @@
 # Default values for kubeedge.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-appVersion: "1.15.1"
+appVersion: "1.19.0"
 
 cloudCore:
   replicaCount: 1
   hostNetWork: true
   image:
     repository: "kubeedge/cloudcore"
-    tag: "v1.15.1"
+    tag: "v1.19.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -78,7 +78,7 @@ iptablesManager:
   hostNetWork: true
   image:
     repository: "kubeedge/iptables-manager"
-    tag: "v1.12.0"
+    tag: "v1.19.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -111,7 +111,7 @@ controllerManager:
   enable: false
   image:
     repository: "kubeedge/controller-manager"
-    tag: "v1.15.1"
+    tag: "v1.19.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   labels:

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -1,14 +1,14 @@
 # Default values for kubeedge.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-appVersion: "1.15.1"
+appVersion: "1.19.0"
 
 cloudCore:
   replicaCount: 1
   hostNetWork: true
   image:
     repository: "kubeedge/cloudcore"
-    tag: "v1.15.1"
+    tag: "v1.19.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -71,7 +71,7 @@ iptablesManager:
   hostNetWork: true
   image:
     repository: "kubeedge/iptables-manager"
-    tag: "v1.15.1"
+    tag: "v1.19.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -104,7 +104,7 @@ controllerManager:
   enable: false
   image:
     repository: "kubeedge/controller-manager"
-    tag: "v1.15.1"
+    tag: "v1.19.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   labels:


### PR DESCRIPTION
Cherry pick of #5929 on release-1.19.

#5929: update default version to 1.19.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.