### PR TITLE
add prerun and postrun shell hooks for keadm edge commands

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -23,6 +23,12 @@ const (
 
 	// FlagNameKubeEdgeVersion sets the version of KubeEdge to be used
 	FlagNameKubeEdgeVersion = "kubeedge-version"
+
+	// FlagNamePreRun ...
+	FlagNamePreRun = "pre-run"
+
+	// FlagNamePostRun ...
+	FlagNamePostRun = "post-run"
 )
 
 // Cloud init and upgrade common flag names

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -94,6 +94,8 @@ type JoinOptions struct {
 	CGroupDriver          string
 	Labels                []string
 	Sets                  string
+	PreRun                string
+	PostRun               string
 
 	// WithMQTT ...
 	// Deprecated: the mqtt broker is alreay managed by the DaemonSet in the cloud
@@ -132,6 +134,8 @@ type ResetOptions struct {
 	Kubeconfig string
 	Force      bool
 	Endpoint   string
+	PreRun     string
+	PostRun    string
 }
 
 type GettokenOptions struct {

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -59,6 +59,12 @@ func NewEdgeJoin() *cobra.Command {
 		Example:      edgeJoinExample,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if joinOptions.PreRun != "" {
+				step.Printf("Executing pre-run script: %s\n", joinOptions.PreRun)
+				if err := util.RunScript(joinOptions.PreRun); err != nil {
+					return err
+				}
+			}
 			step.Printf("Check KubeEdge edgecore process status")
 			running, err := util.IsKubeEdgeProcessRunning(util.KubeEdgeBinaryName)
 			if err != nil {
@@ -95,6 +101,15 @@ func NewEdgeJoin() *cobra.Command {
 				return fmt.Errorf("edge node join failed: %v", err)
 			}
 
+			return nil
+		},
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			if joinOptions.PostRun != "" {
+				fmt.Printf("Executing post-run script: %s\n", joinOptions.PostRun)
+				if err := util.RunScript(joinOptions.PostRun); err != nil {
+					fmt.Printf("Execute post-run script: %s failed: %v\n", joinOptions.PostRun, err)
+				}
+			}
 			return nil
 		},
 	}

--- a/keadm/cmd/keadm/app/cmd/edge/join_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_others.go
@@ -95,6 +95,12 @@ func AddJoinOtherFlags(cmd *cobra.Command, joinOptions *common.JoinOptions) {
 
 	cmd.Flags().StringVar(&joinOptions.Sets, common.FlagNameSet, joinOptions.Sets,
 		`Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)`)
+
+	cmd.Flags().StringVar(&joinOptions.PreRun, common.FlagNamePreRun, joinOptions.PreRun,
+		`Execute the prescript before joining the node. (for example: keadm join --pre-run=./test-script.sh ...)`)
+
+	cmd.Flags().StringVar(&joinOptions.PostRun, common.FlagNamePostRun, joinOptions.PostRun,
+		`Execute the postscript after joining the node. (for example: keadm join --post-run=./test-script.sh ...)`)
 }
 
 func createEdgeConfigFiles(opt *common.JoinOptions) error {

--- a/keadm/cmd/keadm/app/cmd/util/scriptrun.go
+++ b/keadm/cmd/keadm/app/cmd/util/scriptrun.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func RunScript(scriptPath string) error {
+	// Create a command to execute the script
+	cmd := exec.Command("/bin/bash", scriptPath)
+
+	// Redirect the script's standard output and standard error to the main program's output
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Run the script and check for errors
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute script %s: %v", scriptPath, err)
+	}
+
+	return nil
+}

--- a/keadm/cmd/keadm/app/cmd/util/scriptrun_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/scriptrun_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunScript(t *testing.T) {
+	// Create a temporary directory to store script files
+	tmpDir := t.TempDir()
+
+	// Test Case 1: Script executes successfully
+	t.Run("ScriptExecutesSuccessfully", func(t *testing.T) {
+		// Create a temporary script file
+		scriptPath := filepath.Join(tmpDir, "success.sh")
+		scriptContent := "#!/bin/bash\necho 'Hello, World!'\n"
+		if err := os.WriteFile(scriptPath, []byte(scriptContent), 0700); err != nil {
+			t.Fatalf("failed to create script: %v", err)
+		}
+
+		// Run the test
+		err := RunScript(scriptPath)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	// Test Case 2: Script does not exist
+	t.Run("ScriptDoesNotExist", func(t *testing.T) {
+		// Define a path that does not exist
+		invalidPath := filepath.Join(tmpDir, "non_existent.sh")
+		err := RunScript(invalidPath)
+		if err == nil {
+			t.Error("expected an error, got nil")
+		}
+	})
+
+	// Test Case 3: Script without execution permission
+	t.Run("ScriptWithoutExecutionPermission", func(t *testing.T) {
+		// Create a temporary script file without execution permissions
+		scriptPath := filepath.Join(tmpDir, "no_exec.sh")
+		scriptContent := "#!/bin/bash\necho 'No execution permission'\n"
+		if err := os.WriteFile(scriptPath, []byte(scriptContent), 0000); err != nil {
+			t.Fatalf("failed to create script: %v", err)
+		}
+
+		// Run the test
+		err := RunScript(scriptPath)
+		if err == nil {
+			t.Error("expected an error due to lack of execute permission, got nil")
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Previously, we discussed in the issue https://github.com/kubeedge/kubeedge/issues/5745 about automatically installing the container runtime before executing the keadm join command. The conclusion is that there are many implementations and versions of container runtimes, and it will be a huge effort for the KubeEdge community to maintain them.

Therefore, we thought of using prerun and postrun shell hooks to handle container runtime installation and uninstallation, as well as more flexible applications. E.g., keadm join --preun install-constainerd.sh, keadm reset --postrun uninstall-containerd.sh.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes a part of https://github.com/kubeedge/kubeedge/issues/5940

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
