### PR TITLE
edgepp resource overrider enhancement

### DIFF
--- a/cloud/pkg/controllermanager/edgeapplication/overridemanager/resourcesoverrider_test.go
+++ b/cloud/pkg/controllermanager/edgeapplication/overridemanager/resourcesoverrider_test.go
@@ -51,6 +51,10 @@ func TestResourcesOverrider_ApplyOverrides(t *testing.T) {
 										"cpu":    "100m",
 										"memory": "128Mi",
 									},
+									"requests": map[string]interface{}{
+										"cpu":    "100m",
+										"memory": "128Mi",
+									},
 								},
 							},
 						},
@@ -83,6 +87,10 @@ func TestResourcesOverrider_ApplyOverrides(t *testing.T) {
 									"cpu":    "200m",
 									"memory": "256Mi",
 								},
+								"requests": map[string]interface{}{
+									"cpu":    "100m",
+									"memory": "128Mi",
+								},
 							},
 						},
 					},
@@ -103,8 +111,12 @@ func TestResourcesOverrider_ApplyOverrides(t *testing.T) {
 										"name": "container1",
 										"resources": map[string]interface{}{
 											"limits": map[string]interface{}{
-												"cpu":    "100m",
-												"memory": "128Mi",
+												"cpu":    "800m",
+												"memory": "1024Mi",
+											},
+											"requests": map[string]interface{}{
+												"cpu":    "800m",
+												"memory": "512Mi",
 											},
 										},
 									},
@@ -121,8 +133,10 @@ func TestResourcesOverrider_ApplyOverrides(t *testing.T) {
 							ContainerName: "container1",
 							Value: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("200m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
+									corev1.ResourceCPU: resource.MustParse("200m"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("100m"),
 								},
 							},
 						},
@@ -140,7 +154,11 @@ func TestResourcesOverrider_ApplyOverrides(t *testing.T) {
 									"resources": map[string]interface{}{
 										"limits": map[string]interface{}{
 											"cpu":    "200m",
-											"memory": "256Mi",
+											"memory": "1024Mi",
+										},
+										"requests": map[string]interface{}{
+											"cpu":    "100m",
+											"memory": "512Mi",
 										},
 									},
 								},
@@ -244,14 +262,14 @@ func TestBuildResourcesPatches(t *testing.T) {
 			},
 			expectedPatches: []overrideOption{
 				{
-					Op:   "replace",
-					Path: "/spec/containers/0/resources",
-					Value: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("200m"),
-							corev1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
+					Op:    "replace",
+					Path:  "/spec/containers/0/resources/limits/cpu",
+					Value: "200m",
+				},
+				{
+					Op:    "replace",
+					Path:  "/spec/containers/0/resources/limits/memory",
+					Value: "256Mi",
 				},
 			},
 			expectedError: false,
@@ -285,14 +303,14 @@ func TestBuildResourcesPatches(t *testing.T) {
 			},
 			expectedPatches: []overrideOption{
 				{
-					Op:   "replace",
-					Path: "/spec/template/spec/containers/0/resources",
-					Value: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("200m"),
-							corev1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
+					Op:    "replace",
+					Path:  "/spec/template/spec/containers/0/resources/limits/cpu",
+					Value: "200m",
+				},
+				{
+					Op:    "replace",
+					Path:  "/spec/template/spec/containers/0/resources/limits/memory",
+					Value: "256Mi",
 				},
 			},
 			expectedError: false,
@@ -333,7 +351,7 @@ func TestBuildResourcesPatches(t *testing.T) {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
-				assert.Equal(tt.expectedPatches, patches)
+				assert.ElementsMatch(tt.expectedPatches, patches)
 			}
 		})
 	}
@@ -378,14 +396,14 @@ func TestBuildResourcesPatchesWithPath(t *testing.T) {
 			},
 			expectedPatches: []overrideOption{
 				{
-					Op:   "replace",
-					Path: "/spec/containers/1/resources",
-					Value: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("200m"),
-							corev1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
+					Op:    "replace",
+					Path:  "/spec/containers/1/resources/limits/cpu",
+					Value: "200m",
+				},
+				{
+					Op:    "replace",
+					Path:  "/spec/containers/1/resources/limits/memory",
+					Value: "256Mi",
 				},
 			},
 			expectedError: false,
@@ -401,9 +419,6 @@ func TestBuildResourcesPatchesWithPath(t *testing.T) {
 								"containers": []interface{}{
 									map[string]interface{}{
 										"name": "container1",
-									},
-									map[string]interface{}{
-										"name": "container2",
 									},
 								},
 							},
@@ -422,14 +437,14 @@ func TestBuildResourcesPatchesWithPath(t *testing.T) {
 			},
 			expectedPatches: []overrideOption{
 				{
-					Op:   "replace",
-					Path: "/spec/template/spec/containers/0/resources",
-					Value: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("300m"),
-							corev1.ResourceMemory: resource.MustParse("512Mi"),
-						},
-					},
+					Op:    "replace",
+					Path:  "/spec/template/spec/containers/0/resources/limits/cpu",
+					Value: "300m",
+				},
+				{
+					Op:    "replace",
+					Path:  "/spec/template/spec/containers/0/resources/limits/memory",
+					Value: "512Mi",
 				},
 			},
 			expectedError: false,
@@ -470,81 +485,33 @@ func TestBuildResourcesPatchesWithPath(t *testing.T) {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
-				assert.Equal(tt.expectedPatches, patches)
+				assert.ElementsMatch(tt.expectedPatches, patches)
 			}
 		})
 	}
 }
 
 func TestAcquireOverride(t *testing.T) {
-	assert := assert.New(t)
-
-	tests := []struct {
-		name           string
-		resourcesPath  string
-		resourcesValue corev1.ResourceRequirements
-		expectedOption overrideOption
-		expectedError  bool
-	}{
-		{
-			name:          "Valid path and resources",
-			resourcesPath: "/spec/containers/0/resources",
-			resourcesValue: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("200m"),
-					corev1.ResourceMemory: resource.MustParse("256Mi"),
-				},
-			},
-			expectedOption: overrideOption{
-				Op:   string(v1alpha1.OverriderOpReplace),
-				Path: "/spec/containers/0/resources",
-				Value: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("200m"),
-						corev1.ResourceMemory: resource.MustParse("256Mi"),
-					},
-				},
-			},
-			expectedError: false,
+	resourcesPath := "/spec/containers/0/resources"
+	resourcesValue := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
-		{
-			name:          "Invalid path (no leading slash)",
-			resourcesPath: "spec/containers/0/resources",
-			resourcesValue: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("200m"),
-					corev1.ResourceMemory: resource.MustParse("256Mi"),
-				},
-			},
-			expectedOption: overrideOption{},
-			expectedError:  true,
-		},
-		{
-			name:          "Empty resources",
-			resourcesPath: "/spec/containers/0/resources",
-			resourcesValue: corev1.ResourceRequirements{
-				Limits: corev1.ResourceList{},
-			},
-			expectedOption: overrideOption{
-				Op:    string(v1alpha1.OverriderOpReplace),
-				Path:  "/spec/containers/0/resources",
-				Value: corev1.ResourceRequirements{Limits: corev1.ResourceList{}},
-			},
-			expectedError: false,
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			option, err := acquireOverride(tt.resourcesPath, tt.resourcesValue)
-
-			if tt.expectedError {
-				assert.Error(err)
-				assert.Equal(tt.expectedOption, option)
-			} else {
-				assert.NoError(err)
-				assert.Equal(tt.expectedOption, option)
-			}
-		})
+	expectedPatches := []overrideOption{
+		{Op: "replace", Path: "/spec/containers/0/resources/requests/cpu", Value: "500m"},
+		{Op: "replace", Path: "/spec/containers/0/resources/requests/memory", Value: "128Mi"},
+		{Op: "replace", Path: "/spec/containers/0/resources/limits/cpu", Value: "500m"},
+		{Op: "replace", Path: "/spec/containers/0/resources/limits/memory", Value: "128Mi"},
 	}
+
+	patches, err := acquireOverride(resourcesPath, resourcesValue)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, expectedPatches, patches)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
The previous design of Resource override was to fully overwrite the Resource field in the template. This led to the situation where when users wanted to replace a single independent value, they also needed to repeatedly fill in the values that they did not want to overwrite, which did not conform to the user's intuitive perception. The main modification in this optimization is that it can support overwriting only the independent fields with actual values filled in by the users. For the fields without filled - in values, the template values are still used.

for example:
```yaml
template:
   Resource:
       limits:
         cpu: 800m
         memory: 800Mi
       requests:
         cpu: 600m
         memory: 600Mi

overrider:
   Resource:
       limits:
         cpu: 400m
       requests:
         memory: 400Mi

final result:
   Resource:
       limits:
         cpu: 400m
         memory: 800Mi
       requests:
         cpu: 600m
         memory: 400Mi
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
