### PR TITLE
Add a CI workflow to build binaries for linux/arm64

### DIFF
--- a/.github/workflows/main-arm64.yaml
+++ b/.github/workflows/main-arm64.yaml
@@ -1,0 +1,69 @@
+name: ARM64 CI WorkFlow
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '**/OWNERS'
+      - '**/MAINTAINERS'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '**/OWNERS'
+      - '**/MAINTAINERS'
+
+env:
+  CONTAINER_RUN_OPTIONS: " "
+  GINKGO_VERSION: "v2.9.5"
+
+jobs:
+  image-prepare:
+    runs-on: openeuler-linux-arm64
+    timeout-minutes: 30
+    name: Prepare kubeedge/build-tools image
+    steps:
+      - name: Pull kubeedge/build-tools image
+        run: |
+          docker pull kubeedge/build-tools:1.21.11-ke1
+          mkdir -p /home/runner/build-tools/
+          docker save kubeedge/build-tools:1.21.11-ke1 > /home/runner/build-tools/build-tools.tar
+
+      - name: Temporarily save kubeedge/build-tools image
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-tools-docker-artifact-arm64
+          path: /home/runner/build-tools
+
+  docker_build:
+    runs-on: openeuler-linux-arm64
+    timeout-minutes: 40
+    name: Multiple build
+    needs: image-prepare
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Retrieve saved kubeedge/build-tools image
+        uses: actions/download-artifact@v4
+        with:
+          name: build-tools-docker-artifact-arm64
+          path: /home/runner/build-tools
+
+      - name: docker load kubeedge/build-tools image
+        run: docker load < /home/runner/build-tools/build-tools.tar
+
+      - run: make
+
+      - run: make smallbuild


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind test

**What this PR does / why we need it**:

This PR is the first step of adding testing on Linux ARM64 to main.yaml It adds a second runner (named `ARM64` at the moment) - it is self-hosted and managed by the openEuler team until the official ones provided by the CNCF team are available.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5951 

**Special notes for your reviewer**:

At the moment the Docker image creating jobs are extended to use the ARM64 runner. Soon more jobs will be updated too!

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE