### PR TITLE
Move over fuzzers from cncf-fuzzing

### DIFF
--- a/cloud/pkg/cloudhub/servers/udsserver/fuzz_test.go
+++ b/cloud/pkg/cloudhub/servers/udsserver/fuzz_test.go
@@ -1,0 +1,14 @@
+package udsserver
+
+import (
+	"testing"
+)
+
+func FuzzExtractMessage(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		msg, err := ExtractMessage(data)
+		if err != nil {
+			_ = feedbackError(err, msg)
+		}
+	})
+}

--- a/cloud/pkg/csidriver/fuzz_test.go
+++ b/cloud/pkg/csidriver/fuzz_test.go
@@ -1,0 +1,15 @@
+package csidriver
+
+import (
+	"testing"
+)
+
+func FuzzExtractMessage(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		result, err := extractMessage(string(data))
+		if err == nil {
+			_ = result.GetContent().(string)
+			_ = result.GetOperation()
+		}
+	})
+}

--- a/cloud/pkg/router/utils/fuzz_test.go
+++ b/cloud/pkg/router/utils/fuzz_test.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"testing"
+)
+
+func FuzzRuleContains(f *testing.F) {
+	f.Fuzz(func(t *testing.T, path1, path2 string) {
+		RuleContains(path1, path2)
+	})
+}

--- a/edge/pkg/devicetwin/dtmanager/fuzz_test.go
+++ b/edge/pkg/devicetwin/dtmanager/fuzz_test.go
@@ -1,0 +1,57 @@
+package dtmanager
+
+import (
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin/dtcontext"
+	"testing"
+)
+
+var fuzzActions = map[int]string{
+	0:  "dealTwinUpdate",
+	1:  "dealTwinGet",
+	2:  "dealTwinSync",
+	3:  "dealDeviceAttrUpdate",
+	4:  "dealDeviceStateUpdate",
+	5:  "dealSendToCloud",
+	6:  "dealSendToEdge",
+	7:  "dealLifeCycle",
+	8:  "dealConfirm",
+	9:  "dealMembershipGet",
+	10: "dealMembershipUpdate",
+	11: "dealMembershipDetail",
+}
+
+func FuzzDeal(f *testing.F) {
+	f.Fuzz(func(t *testing.T, device string, content []byte, actionType uint8) {
+		msg := &model.Message{
+			Content: content,
+		}
+		context, _ := dtcontext.InitDTContext()
+		switch fuzzActions[int(actionType)%len(fuzzActions)] {
+		case "dealTwinUpdate":
+			dealTwinUpdate(context, device, msg)
+		case "dealTwinGet":
+			dealTwinGet(context, device, msg)
+		case "dealTwinSync":
+			dealTwinSync(context, device, msg)
+		case "dealDeviceAttrUpdate":
+			dealDeviceAttrUpdate(context, device, msg)
+		case "dealDeviceStateUpdate":
+			dealDeviceStateUpdate(context, device, msg)
+		case "dealSendToCloud":
+			dealSendToCloud(context, device, msg)
+		case "dealSendToEdge":
+			dealSendToEdge(context, device, msg)
+		case "dealLifeCycle":
+			dealLifeCycle(context, device, msg)
+		case "dealConfirm":
+			dealConfirm(context, device, msg)
+		case "dealMembershipGet":
+			dealMembershipGet(context, device, msg)
+		case "dealMembershipUpdate":
+			dealMembershipUpdate(context, device, msg)
+		case "dealMembershipDetail":
+			dealMembershipDetail(context, device, msg)
+		}
+	})
+}

--- a/pkg/metaserver/fuzz_test.go
+++ b/pkg/metaserver/fuzz_test.go
@@ -1,0 +1,11 @@
+package metaserver
+
+import (
+	"testing"
+)
+
+func FuzzParseKey(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data string) {
+		_, _, _ = ParseKey(data)
+	})
+}

--- a/pkg/stream/fuzz_test.go
+++ b/pkg/stream/fuzz_test.go
@@ -1,0 +1,12 @@
+package stream
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzReadMessageFromTunnel(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ReadMessageFromTunnel(bytes.NewReader(data))
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind cleanup
/kind test


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Currently KubeEdge has a series of fuzzers at [the CNCF-Fuzzing repository](https://github.com/cncf/cncf-fuzzing/tree/main/projects/kubeedge). OSS-Fuzz runs these from there which works fine. When KubeEdge changes its upstream APIs that the fuzzers test, the build breaks, and there is an added overhead of fixing the fuzz build by having the fuzzers in the CNCF-Fuzzing repo. This PR moves the fuzzers upstream to KubeEdges repository, so that they can be easily managed and run.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
