### PR TITLE
Automated cherry pick of #5960: add metadata uid for crio

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -130,6 +131,7 @@ func (runtime *CRIRuntime) CopyResources(edgeImage string, files map[string]stri
 	psc := &runtimeapi.PodSandboxConfig{
 		Metadata: &runtimeapi.PodSandboxMetadata{
 			Name:      KubeEdgeBinaryName,
+			Uid:       uuid.New().String(),
 			Namespace: constants.SystemNamespace,
 		},
 		Linux: &runtimeapi.LinuxPodSandboxConfig{


### PR DESCRIPTION
Cherry pick of #5960 on release-1.19.

#5960: add metadata uid for crio

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.