### PR TITLE
Fixed the hub client certificate doesn't have any IP address

### DIFF
--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -95,4 +96,12 @@ func (c *Configure) UpdateCerts(cert, key []byte) {
 	if key != nil {
 		c.Key = key
 	}
+}
+
+func (c *Configure) ConvAdvertiseAddressToIPs() []net.IP {
+	ips := make([]net.IP, 0, len(c.AdvertiseAddress))
+	for _, addr := range c.AdvertiseAddress {
+		ips = append(ips, net.ParseIP(addr))
+	}
+	return ips
 }

--- a/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
@@ -154,6 +154,10 @@ func signEdgeCert(r io.ReadCloser, usagesStr string) (*pem.Block, error) {
 		hubconfig.Config.CaKey,
 		usages,
 		edgeCertSigningDuration,
+		&certutil.AltNames{
+			IPs:      hubconfig.Config.ConvAdvertiseAddressToIPs(),
+			DNSNames: hubconfig.Config.DNSNames,
+		},
 	))
 	if err != nil {
 		return nil, fmt.Errorf("fail to signCerts, err: %v", err)

--- a/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"net"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -108,12 +107,7 @@ func createCertsToSecret(ctx context.Context) error {
 		if err != nil {
 			klog.Info("CloudCoreCert and key don't exist in the secret, and will be signed by CA")
 
-			ips := make([]net.IP, 0, len(hubconfig.Config.AdvertiseAddress))
-			for _, addr := range hubconfig.Config.AdvertiseAddress {
-				ips = append(ips, net.ParseIP(addr))
-			}
 			h := certs.GetHandler(certs.HandlerTypeX509)
-
 			keywrap, err := h.GenPrivateKey()
 			if err != nil {
 				return fmt.Errorf("faield to generate the private key, err: %v", err)
@@ -129,7 +123,7 @@ func createCertsToSecret(ctx context.Context) error {
 				Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 				AltNames: certutil.AltNames{
 					DNSNames: hubconfig.Config.DNSNames,
-					IPs:      ips,
+					IPs:      hubconfig.Config.ConvAdvertiseAddressToIPs(),
 				},
 			}, hubconfig.Config.Ca, hubconfig.Config.CaKey, key.Public(), year100)
 			certPEM, err := h.SignCerts(opts)

--- a/pkg/security/certs/types.go
+++ b/pkg/security/certs/types.go
@@ -59,7 +59,12 @@ type SignCertsOptions struct {
 	expiration time.Duration
 }
 
-func SignCertsOptionsWithCA(cfg certutil.Config, caDER, caKeyDER []byte, publicKey any, expiration time.Duration) SignCertsOptions {
+func SignCertsOptionsWithCA(
+	cfg certutil.Config,
+	caDER, caKeyDER []byte,
+	publicKey any,
+	expiration time.Duration,
+) SignCertsOptions {
 	return SignCertsOptions{
 		cfg:        cfg,
 		caDER:      caDER,
@@ -69,8 +74,13 @@ func SignCertsOptionsWithCA(cfg certutil.Config, caDER, caKeyDER []byte, publicK
 	}
 }
 
-func SignCertsOptionsWithCSR(csrDER, caDER, caKeyDER []byte, usages []x509.ExtKeyUsage, expiration time.Duration) SignCertsOptions {
-	return SignCertsOptions{
+func SignCertsOptionsWithCSR(
+	csrDER, caDER, caKeyDER []byte,
+	usages []x509.ExtKeyUsage,
+	expiration time.Duration,
+	alt *certutil.AltNames,
+) SignCertsOptions {
+	opts := SignCertsOptions{
 		csrDER:   csrDER,
 		caDER:    caDER,
 		caKeyDER: caKeyDER,
@@ -79,9 +89,17 @@ func SignCertsOptionsWithCSR(csrDER, caDER, caKeyDER []byte, usages []x509.ExtKe
 		},
 		expiration: expiration,
 	}
+	if alt != nil {
+		opts.cfg.AltNames = *alt
+	}
+	return opts
 }
 
-func SignCertsOptionsWithK8sCSR(csrDER []byte, usages []x509.ExtKeyUsage, expiration time.Duration) SignCertsOptions {
+func SignCertsOptionsWithK8sCSR(
+	csrDER []byte,
+	usages []x509.ExtKeyUsage,
+	expiration time.Duration,
+) SignCertsOptions {
 	return SignCertsOptions{
 		csrDER: csrDER,
 		cfg: certutil.Config{

--- a/pkg/security/certs/x509_ca_certs_test.go
+++ b/pkg/security/certs/x509_ca_certs_test.go
@@ -33,7 +33,7 @@ func TestSignX509Certs(t *testing.T) {
 	}, certpkw, nil)
 
 	opts := SignCertsOptionsWithCSR(csrblock.Bytes, cablock.Bytes, capkw.DER(),
-		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, 24*time.Hour)
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, 24*time.Hour, nil)
 	certblock, err := certh.SignCerts(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/certs/x509_certs.go
+++ b/pkg/security/certs/x509_certs.go
@@ -76,9 +76,13 @@ func (h x509CertsHandler) SignCerts(opts SignCertsOptions) (*pem.Block, error) {
 		}
 		opts.cfg.CommonName = csr.Subject.CommonName
 		opts.cfg.Organization = csr.Subject.Organization
-		opts.cfg.AltNames.DNSNames = csr.DNSNames
-		opts.cfg.AltNames.IPs = csr.IPAddresses
 		pubkey = csr.PublicKey
+		if len(csr.DNSNames) > 0 {
+			opts.cfg.AltNames.DNSNames = csr.DNSNames
+		}
+		if len(csr.IPAddresses) > 0 {
+			opts.cfg.AltNames.IPs = csr.IPAddresses
+		}
 	}
 	if len(opts.cfg.CommonName) == 0 {
 		return nil, errors.New("must specify a CommonName")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

The hub client certificate doesn't have any IP address

- **Before**
  ```bash
  > openssl x509 -in /etc/kubeedge/certs/server.crt -noout -text
  # Output
  Certificate:
      Data:
          Version: 3 (0x2)
          Serial Number: 3648225863082331355 (0x32a11a17e56a4cdb)
          Signature Algorithm: ecdsa-with-SHA256
          Issuer: CN = KubeEdge
          Validity
              Not Before: Nov 27 03:07:19 2024 GMT
              Not After : Nov 27 03:07:19 2025 GMT
          Subject: O = system:nodes, CN = system:node:hw-test-01
          Subject Public Key Info:
              Public Key Algorithm: id-ecPublicKey
                  Public-Key: (256 bit)
                  pub:
                      04:93:87:e2:55:e1:a1:24:44:9d:a3:20:64:4a:c5:
                      bb:6c:f2:a2:91:86:21:c5:e1:1a:a4:81:d8:fa:02:
                      e8:af:b4:34:64:6b:32:2e:c8:ef:9e:62:0a:9d:30:
                      c6:5e:29:dd:ba:5b:ed:43:0b:20:22:69:32:71:21:
                      10:a9:b4:b1:ac
                  ASN1 OID: prime256v1
                  NIST CURVE: P-256
          X509v3 extensions:
              X509v3 Key Usage: critical
                  Digital Signature, Key Encipherment
              X509v3 Extended Key Usage:
                  TLS Web Client Authentication
              X509v3 Authority Key Identifier:
                  keyid:A4:9E:F8:B5:75:40:0C:BE:6D:A1:4E:E6:02:D2:37:C1:CA:F7:65:0B
  
      Signature Algorithm: ecdsa-with-SHA256
           30:44:02:20:4a:07:e7:56:ff:ff:fd:af:51:25:a4:ab:aa:c7:
           0b:22:a5:44:b6:f7:f1:2d:6f:11:92:57:e6:a4:e4:1f:bf:45:
           02:20:12:6b:fa:b1:4b:dc:f6:88:52:59:f6:83:c7:11:34:59:
           98:a2:33:09:17:58:e2:ce:1d:10:5c:03:7e:a0:4f:74
  ```
- **After**
  ```bash
  > openssl x509 -in /etc/kubeedge/certs/server.crt -noout -text
  # Output
  Certificate:
      Data:
          Version: 3 (0x2)
          Serial Number: 1661580820818150539 (0x170f1ef3fe77c48b)
          Signature Algorithm: ecdsa-with-SHA256
          Issuer: CN = KubeEdge
          Validity
              Not Before: Nov 27 03:20:31 2024 GMT
              Not After : Nov 27 03:20:31 2025 GMT
          Subject: O = system:nodes, CN = system:node:hw-test-01
          Subject Public Key Info:
              Public Key Algorithm: id-ecPublicKey
                  Public-Key: (256 bit)
                  pub:
                      04:c8:a0:85:2d:8c:30:5c:b5:85:37:e0:a5:52:86:
                      1d:0c:65:20:bf:39:5d:79:cf:06:7a:fc:c2:d0:5c:
                      00:e6:2f:e8:6f:00:bc:fa:6c:11:66:3e:a7:17:cc:
                      07:4e:36:50:51:d7:18:cb:f7:6a:65:a8:7f:75:3d:
                      17:2c:3a:39:66
                  ASN1 OID: prime256v1
                  NIST CURVE: P-256
          X509v3 extensions:
              X509v3 Key Usage: critical
                  Digital Signature, Key Encipherment
              X509v3 Extended Key Usage:
                  TLS Web Client Authentication
              X509v3 Authority Key Identifier:
                  keyid:A4:9E:F8:B5:75:40:0C:BE:6D:A1:4E:E6:02:D2:37:C1:CA:F7:65:0B
  
              X509v3 Subject Alternative Name:
                  DNS, IP Address:10.31.226.11, IP Address:FD00:0:0:0:0:0:0:1D
      Signature Algorithm: ecdsa-with-SHA256
           30:45:02:20:2e:38:fb:a7:d1:8b:5d:b9:4c:31:12:4e:8e:d7:
           55:22:e0:6d:f5:fb:61:3e:bf:cd:01:ba:3f:4b:42:34:19:06:
           02:21:00:c0:02:07:ee:0b:87:00:78:4b:db:31:3a:14:d0:4d:
           34:db:64:54:34:ec:2e:2e:e1:68:29:80:12:a4:64:8a:eb
  ```

This PR need to be rebase into release-1.18 and release-1.19.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
