### PR TITLE
Automated cherry pick of #5994: Fixed the hub client certificate doesn't have any IP address

### DIFF
--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -95,4 +96,12 @@ func (c *Configure) UpdateCerts(cert, key []byte) {
 	if key != nil {
 		c.Key = key
 	}
+}
+
+func (c *Configure) ConvAdvertiseAddressToIPs() []net.IP {
+	ips := make([]net.IP, 0, len(c.AdvertiseAddress))
+	for _, addr := range c.AdvertiseAddress {
+		ips = append(ips, net.ParseIP(addr))
+	}
+	return ips
 }

--- a/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
@@ -154,6 +154,10 @@ func signEdgeCert(r io.ReadCloser, usagesStr string) (*pem.Block, error) {
 		hubconfig.Config.CaKey,
 		usages,
 		edgeCertSigningDuration,
+		&certutil.AltNames{
+			IPs:      hubconfig.Config.ConvAdvertiseAddressToIPs(),
+			DNSNames: hubconfig.Config.DNSNames,
+		},
 	))
 	if err != nil {
 		return nil, fmt.Errorf("fail to signCerts, err: %v", err)

--- a/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"net"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -108,12 +107,7 @@ func createCertsToSecret(ctx context.Context) error {
 		if err != nil {
 			klog.Info("CloudCoreCert and key don't exist in the secret, and will be signed by CA")
 
-			ips := make([]net.IP, 0, len(hubconfig.Config.AdvertiseAddress))
-			for _, addr := range hubconfig.Config.AdvertiseAddress {
-				ips = append(ips, net.ParseIP(addr))
-			}
 			h := certs.GetHandler(certs.HandlerTypeX509)
-
 			keywrap, err := h.GenPrivateKey()
 			if err != nil {
 				return fmt.Errorf("faield to generate the private key, err: %v", err)
@@ -129,7 +123,7 @@ func createCertsToSecret(ctx context.Context) error {
 				Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 				AltNames: certutil.AltNames{
 					DNSNames: hubconfig.Config.DNSNames,
-					IPs:      ips,
+					IPs:      hubconfig.Config.ConvAdvertiseAddressToIPs(),
 				},
 			}, hubconfig.Config.Ca, hubconfig.Config.CaKey, key.Public(), year100)
 			certPEM, err := h.SignCerts(opts)

--- a/pkg/security/certs/types.go
+++ b/pkg/security/certs/types.go
@@ -59,7 +59,12 @@ type SignCertsOptions struct {
 	expiration time.Duration
 }
 
-func SignCertsOptionsWithCA(cfg certutil.Config, caDER, caKeyDER []byte, publicKey any, expiration time.Duration) SignCertsOptions {
+func SignCertsOptionsWithCA(
+	cfg certutil.Config,
+	caDER, caKeyDER []byte,
+	publicKey any,
+	expiration time.Duration,
+) SignCertsOptions {
 	return SignCertsOptions{
 		cfg:        cfg,
 		caDER:      caDER,
@@ -69,8 +74,13 @@ func SignCertsOptionsWithCA(cfg certutil.Config, caDER, caKeyDER []byte, publicK
 	}
 }
 
-func SignCertsOptionsWithCSR(csrDER, caDER, caKeyDER []byte, usages []x509.ExtKeyUsage, expiration time.Duration) SignCertsOptions {
-	return SignCertsOptions{
+func SignCertsOptionsWithCSR(
+	csrDER, caDER, caKeyDER []byte,
+	usages []x509.ExtKeyUsage,
+	expiration time.Duration,
+	alt *certutil.AltNames,
+) SignCertsOptions {
+	opts := SignCertsOptions{
 		csrDER:   csrDER,
 		caDER:    caDER,
 		caKeyDER: caKeyDER,
@@ -79,9 +89,17 @@ func SignCertsOptionsWithCSR(csrDER, caDER, caKeyDER []byte, usages []x509.ExtKe
 		},
 		expiration: expiration,
 	}
+	if alt != nil {
+		opts.cfg.AltNames = *alt
+	}
+	return opts
 }
 
-func SignCertsOptionsWithK8sCSR(csrDER []byte, usages []x509.ExtKeyUsage, expiration time.Duration) SignCertsOptions {
+func SignCertsOptionsWithK8sCSR(
+	csrDER []byte,
+	usages []x509.ExtKeyUsage,
+	expiration time.Duration,
+) SignCertsOptions {
 	return SignCertsOptions{
 		csrDER: csrDER,
 		cfg: certutil.Config{

--- a/pkg/security/certs/x509_ca_certs_test.go
+++ b/pkg/security/certs/x509_ca_certs_test.go
@@ -33,7 +33,7 @@ func TestSignX509Certs(t *testing.T) {
 	}, certpkw, nil)
 
 	opts := SignCertsOptionsWithCSR(csrblock.Bytes, cablock.Bytes, capkw.DER(),
-		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, 24*time.Hour)
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, 24*time.Hour, nil)
 	certblock, err := certh.SignCerts(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/certs/x509_certs.go
+++ b/pkg/security/certs/x509_certs.go
@@ -76,9 +76,13 @@ func (h x509CertsHandler) SignCerts(opts SignCertsOptions) (*pem.Block, error) {
 		}
 		opts.cfg.CommonName = csr.Subject.CommonName
 		opts.cfg.Organization = csr.Subject.Organization
-		opts.cfg.AltNames.DNSNames = csr.DNSNames
-		opts.cfg.AltNames.IPs = csr.IPAddresses
 		pubkey = csr.PublicKey
+		if len(csr.DNSNames) > 0 {
+			opts.cfg.AltNames.DNSNames = csr.DNSNames
+		}
+		if len(csr.IPAddresses) > 0 {
+			opts.cfg.AltNames.IPs = csr.IPAddresses
+		}
 	}
 	if len(opts.cfg.CommonName) == 0 {
 		return nil, errors.New("must specify a CommonName")


### PR DESCRIPTION
Cherry pick of #5994 on release-1.18.

#5994: Fixed the hub client certificate doesn't have any IP address

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.