### PR TITLE
Revert: Fixed the hub client certificate doesn't have any IP address

### DIFF
--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"net"
 	"sync"
 
 	"k8s.io/klog/v2"
@@ -96,12 +95,4 @@ func (c *Configure) UpdateCerts(cert, key []byte) {
 	if key != nil {
 		c.Key = key
 	}
-}
-
-func (c *Configure) ConvAdvertiseAddressToIPs() []net.IP {
-	ips := make([]net.IP, 0, len(c.AdvertiseAddress))
-	for _, addr := range c.AdvertiseAddress {
-		ips = append(ips, net.ParseIP(addr))
-	}
-	return ips
 }

--- a/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
@@ -154,10 +154,6 @@ func signEdgeCert(r io.ReadCloser, usagesStr string) (*pem.Block, error) {
 		hubconfig.Config.CaKey,
 		usages,
 		edgeCertSigningDuration,
-		&certutil.AltNames{
-			IPs:      hubconfig.Config.ConvAdvertiseAddressToIPs(),
-			DNSNames: hubconfig.Config.DNSNames,
-		},
 	))
 	if err != nil {
 		return nil, fmt.Errorf("fail to signCerts, err: %v", err)

--- a/pkg/security/certs/types.go
+++ b/pkg/security/certs/types.go
@@ -59,12 +59,7 @@ type SignCertsOptions struct {
 	expiration time.Duration
 }
 
-func SignCertsOptionsWithCA(
-	cfg certutil.Config,
-	caDER, caKeyDER []byte,
-	publicKey any,
-	expiration time.Duration,
-) SignCertsOptions {
+func SignCertsOptionsWithCA(cfg certutil.Config, caDER, caKeyDER []byte, publicKey any, expiration time.Duration) SignCertsOptions {
 	return SignCertsOptions{
 		cfg:        cfg,
 		caDER:      caDER,
@@ -74,13 +69,8 @@ func SignCertsOptionsWithCA(
 	}
 }
 
-func SignCertsOptionsWithCSR(
-	csrDER, caDER, caKeyDER []byte,
-	usages []x509.ExtKeyUsage,
-	expiration time.Duration,
-	alt *certutil.AltNames,
-) SignCertsOptions {
-	opts := SignCertsOptions{
+func SignCertsOptionsWithCSR(csrDER, caDER, caKeyDER []byte, usages []x509.ExtKeyUsage, expiration time.Duration) SignCertsOptions {
+	return SignCertsOptions{
 		csrDER:   csrDER,
 		caDER:    caDER,
 		caKeyDER: caKeyDER,
@@ -89,17 +79,9 @@ func SignCertsOptionsWithCSR(
 		},
 		expiration: expiration,
 	}
-	if alt != nil {
-		opts.cfg.AltNames = *alt
-	}
-	return opts
 }
 
-func SignCertsOptionsWithK8sCSR(
-	csrDER []byte,
-	usages []x509.ExtKeyUsage,
-	expiration time.Duration,
-) SignCertsOptions {
+func SignCertsOptionsWithK8sCSR(csrDER []byte, usages []x509.ExtKeyUsage, expiration time.Duration) SignCertsOptions {
 	return SignCertsOptions{
 		csrDER: csrDER,
 		cfg: certutil.Config{

--- a/pkg/security/certs/x509_ca_certs_test.go
+++ b/pkg/security/certs/x509_ca_certs_test.go
@@ -33,7 +33,7 @@ func TestSignX509Certs(t *testing.T) {
 	}, certpkw, nil)
 
 	opts := SignCertsOptionsWithCSR(csrblock.Bytes, cablock.Bytes, capkw.DER(),
-		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, 24*time.Hour, nil)
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, 24*time.Hour)
 	certblock, err := certh.SignCerts(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/certs/x509_certs.go
+++ b/pkg/security/certs/x509_certs.go
@@ -76,13 +76,9 @@ func (h x509CertsHandler) SignCerts(opts SignCertsOptions) (*pem.Block, error) {
 		}
 		opts.cfg.CommonName = csr.Subject.CommonName
 		opts.cfg.Organization = csr.Subject.Organization
+		opts.cfg.AltNames.DNSNames = csr.DNSNames
+		opts.cfg.AltNames.IPs = csr.IPAddresses
 		pubkey = csr.PublicKey
-		if len(csr.DNSNames) > 0 {
-			opts.cfg.AltNames.DNSNames = csr.DNSNames
-		}
-		if len(csr.IPAddresses) > 0 {
-			opts.cfg.AltNames.IPs = csr.IPAddresses
-		}
 	}
 	if len(opts.cfg.CommonName) == 0 {
 		return nil, errors.New("must specify a CommonName")


### PR DESCRIPTION
This reverts commit df855910a35fc3629b23edafa75cf03ca9e280e4.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Client certificate no Altname required.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
