### PR TITLE
Fix generate-groups script error

### DIFF
--- a/hack/generate-groups.sh
+++ b/hack/generate-groups.sh
@@ -41,10 +41,10 @@ GENS="$1"
 OUTPUT_PKG="$2"
 APIS_PKG="$3"
 GROUPS_WITH_VERSIONS="$4"
-if [ $(go env GOBIN) != "" ]; then
-GOBIN=${GOBIN-$(go env GOBIN)}
+if [ -z "$(go env GOBIN)" ]; then
+  GOBIN=${GOBIN-$(go env GOPATH)/bin}
 else
-GOBIN=${GOBIN-$(go env GOPATH)/bin}
+  GOBIN=${GOBIN-$(go env GOBIN)}
 fi
 shift 4
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

It is mentioned in #6043 that an error message will appear when executing the `generate-groups` script. This is because in the original code ` if [ $(go env GOBIN) != "" ]`, when the `go env GOBIN` variable is empty, the statement will become` [ = ""]`, which is obviously incorrect and should add quotes to the `go env GOBIN` variable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6043

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
