### PR TITLE
Fixed recreate secret when etcd error

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
@@ -65,8 +65,7 @@ func createCAToSecret(ctx context.Context) error {
 		caSecret, err := client.GetSecret(ctx, CaSecretName, constants.SystemNamespace)
 		if err != nil {
 			if !apierror.IsNotFound(err) {
-				klog.Errorf("get secret: %s error: %v", CaSecretName, err)
-				return err
+				return fmt.Errorf("get secret: %s error: %v", CaSecretName, err)
 			}
 
 			klog.Info("Ca and CaKey don't exist in the secret, and will be created by CloudCore")
@@ -113,8 +112,7 @@ func createCertsToSecret(ctx context.Context) error {
 		cloudSecret, err := client.GetSecret(ctx, CloudCoreSecretName, constants.SystemNamespace)
 		if err != nil {
 			if !apierror.IsNotFound(err) {
-				klog.Errorf("get secret: %s error: %v", CloudCoreSecretName, err)
-				return err
+				return fmt.Errorf("get secret: %s error: %v", CloudCoreSecretName, err)
 			}
 
 			klog.Info("CloudCoreCert and key don't exist in the secret, and will be signed by CA")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Fixed the wrong duplicate generation of certificate files if etcd fails when cloudcore start, or the old certificate will be overwrite then all edgecore will be not Ready

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6052

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
