### PR TITLE
Automated cherry pick of #6063: fix: multiple --set parameters in keadm join command

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -93,7 +93,7 @@ type JoinOptions struct {
 	CertPort              string
 	CGroupDriver          string
 	Labels                []string
-	Sets                  string
+	Sets                  []string
 
 	// WithMQTT ...
 	// Deprecated: the mqtt broker is alreay managed by the DaemonSet in the cloud

--- a/keadm/cmd/keadm/app/cmd/edge/join_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_others.go
@@ -93,7 +93,7 @@ func AddJoinOtherFlags(cmd *cobra.Command, joinOptions *common.JoinOptions) {
 	cmd.Flags().StringVar(&joinOptions.HubProtocol, common.HubProtocol, joinOptions.HubProtocol,
 		`Use this key to decide which communication protocol the edge node adopts.`)
 
-	cmd.Flags().StringVar(&joinOptions.Sets, common.FlagNameSet, joinOptions.Sets,
+	cmd.Flags().StringArrayVar(&joinOptions.Sets, common.FlagNameSet, joinOptions.Sets,
 		`Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)`)
 }
 
@@ -169,8 +169,10 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 		edgeCoreConfig.Modules.Edged.NodeLabels = setEdgedNodeLabels(opt)
 	}
 	if len(opt.Sets) > 0 {
-		if err := util.ParseSet(edgeCoreConfig, opt.Sets); err != nil {
-			return err
+		for _, set := range opt.Sets {
+			if err := util.ParseSet(edgeCoreConfig, set); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/keadm/cmd/keadm/app/cmd/edge/join_windows.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_windows.go
@@ -81,7 +81,7 @@ func AddJoinOtherFlags(cmd *cobra.Command, joinOptions *common.JoinOptions) {
 	cmd.Flags().StringVar(&joinOptions.HubProtocol, common.HubProtocol, joinOptions.HubProtocol,
 		`Use this key to decide which communication protocol the edge node adopts.`)
 
-	cmd.Flags().StringVar(&joinOptions.Sets, common.FlagNameSet, joinOptions.Sets,
+	cmd.Flags().StringArrayVar(&joinOptions.Sets, common.FlagNameSet, joinOptions.Sets,
 		`Set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)`)
 }
 
@@ -157,8 +157,10 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 	}
 
 	if len(opt.Sets) > 0 {
-		if err := util.ParseSet(edgeCoreConfig, opt.Sets); err != nil {
-			return err
+		for _, set := range opt.Sets {
+			if err := util.ParseSet(edgeCoreConfig, set); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #6063 on release-1.18.

#6063: fix: multiple --set parameters in keadm join command

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.