### PR TITLE
Automated cherry pick of #6028: update configmap when delete cloudcore

### DIFF
--- a/build/iptablesmanager/iptablesmanager-ds.yaml
+++ b/build/iptablesmanager/iptablesmanager-ds.yaml
@@ -75,5 +75,8 @@ metadata:
     kubeedge: iptables-manager
 rules:
 - apiGroups: [""]
-  resources: ["pods", "configmaps"]
+  resources: ["configmaps"]
   verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]

--- a/build/iptablesmanager/iptablesmanager-ds.yaml
+++ b/build/iptablesmanager/iptablesmanager-ds.yaml
@@ -25,7 +25,7 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: Exists
               - key: node-role.kubernetes.io/control-plane
-                effect: Exists
+                operator: Exists
       restartPolicy: Always
       containers:
         - name: iptables-manager
@@ -75,5 +75,5 @@ metadata:
     kubeedge: iptables-manager
 rules:
 - apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "list", "watch"]
+  resources: ["pods", "configmaps"]
+  verbs: ["get", "list", "watch", "update"]

--- a/manifests/charts/cloudcore/README.md
+++ b/manifests/charts/cloudcore/README.md
@@ -44,9 +44,9 @@ helm upgrade --install cloudcore ./cloudcore --namespace kubeedge --create-names
 
 ### iptables-manager
 - `iptablesManager.enable`,  default `true`
-- `iptablesManager.mode`,  default `internal`, can be modified to `external`, the external mode will set up a iptables manager component which shares the host network. That mode can be enabled on version > v1.8.2. See pr https://github.com/kubeedge/kubeedge/pull/3265.
+- `iptablesManager.mode`,  default `external`, can be modified to `internal`. The external mode will set up a iptables manager component which shares the host network.
 - `iptablesManager.image.repository`, default `kubeedge`, defines the image repo.
-- `iptablesManager.image.tag`, default `v1.12.0`, defines the image tag.
+- `iptablesManager.image.tag`, default `v1.19.0`, defines the image tag.
 - `iptablesManager.image.pullPolicy`, default `IfNotPresent`, defines the policies to pull images.
 - `iptablesManager.image.pullSecrets`, defines the secrets to pull images.
 - `iptablesManager.labels`, defines the labels.

--- a/manifests/charts/cloudcore/templates/rbac_iptablesmanager.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_iptablesmanager.yaml
@@ -35,6 +35,9 @@ metadata:
   {{- end }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "configmaps"]
+    resources: ["configmaps"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
 {{- end }}

--- a/manifests/charts/cloudcore/templates/rbac_iptablesmanager.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_iptablesmanager.yaml
@@ -34,7 +34,7 @@ metadata:
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "configmaps"]
+    verbs: ["get", "list", "watch", "update"]
 {{- end }}

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -74,7 +74,7 @@ cloudCore:
 
 iptablesManager:
   enable: true
-  mode: "internal"
+  mode: "external"
   hostNetWork: true
   image:
     repository: "kubeedge/iptables-manager"

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -67,7 +67,7 @@ cloudCore:
 
 iptablesManager:
   enable: true
-  mode: "internal"
+  mode: "external"
   hostNetWork: true
   image:
     repository: "kubeedge/iptables-manager"


### PR DESCRIPTION
Cherry pick of #6028 on release-1.17.

#6028: update configmap when delete cloudcore

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.