### PR TITLE
change `edged.rootDirectory` default to `/var/lib/kubelet`

### DIFF
--- a/staging/src/github.com/kubeedge/api/apis/common/constants/default_others.go
+++ b/staging/src/github.com/kubeedge/api/apis/common/constants/default_others.go
@@ -23,7 +23,7 @@ const (
 	BootstrapFile = "/etc/kubeedge/bootstrap-edgecore.conf"
 
 	// Edged
-	DefaultRootDir               = "/var/lib/edged"
+	DefaultRootDir               = "/var/lib/kubelet"
 	DefaultRemoteRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
 	DefaultRemoteImageEndpoint   = "unix:///run/containerd/containerd.sock"
 	DefaultCNIConfDir            = "/etc/cni/net.d"

--- a/staging/src/github.com/kubeedge/api/apis/common/constants/default_windows.go
+++ b/staging/src/github.com/kubeedge/api/apis/common/constants/default_windows.go
@@ -26,7 +26,7 @@ const (
 	BootstrapFile = "c:\\etc\\kubeedge\\bootstrap-edgecore.conf"
 
 	// Edged
-	DefaultRootDir               = "c:\\var\\lib\\edged"
+	DefaultRootDir               = "c:\\var\\lib\\kubelet"
 	DefaultRemoteRuntimeEndpoint = "npipe://./pipe/containerd-containerd"
 	DefaultRemoteImageEndpoint   = "npipe://./pipe/containerd-containerd"
 	DefaultCNIConfDir            = "c:\\etc\\cni\\net.d"

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -784,8 +784,8 @@ type TailoredKubeletFlag struct {
 	ContainerRuntimeOptions
 	// rootDirectory is the directory path to place kubelet files (volume
 	// mounts,etc).
-	// default "/var/lib/edged"
-	// The default will change to "/var/lib/kubelet" in KubeEdge v1.20.
+	// From v1.20, default changes to "/var/lib/kubelet".
+	// The previous default is "/var/lib/edged".
 	RootDirectory string `json:"rootDirectory,omitempty"`
 	// WindowsService should be set to true if kubelet is running as a service on Windows.
 	// Its corresponding flag only gets registered in Windows builds.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**


/kind feature



**What this PR does / why we need it**:

As #https://github.com/kubeedge/kubeedge/pull/5914 disscussed, we plan to change the default value of `edged.rootDirectory` to `/var/lib/kubelet`, which is consistent with kubelet. It will help to reduce maintain costs. In addition, kubeedge can seamlessly connect to native Kubernetes resources.