### PR TITLE
Automated cherry pick of #6018: fix `keadm ctl get pod -oyaml` and `keadm ctl get device -oyaml`  error:  "missing apiVersion or kind" issue.

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -306,3 +306,10 @@ const (
 	FlagNameShowEvents                   = "show-events"
 	FlagNameChunkSize                    = "chunk-size"
 )
+
+const (
+	PodAPIVersion    = "v1"
+	PodKind          = "Pod"
+	DeviceAPIVersion = "devices.kubeedge.io/v1beta1"
+	DeviceKind       = "Device"
+)

--- a/keadm/cmd/keadm/app/cmd/ctl/client/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/client/device.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/kubeedge/api/apis/devices/v1beta1"
 	"github.com/kubeedge/api/client/clientset/versioned/scheme"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
 
 type DeviceRequest struct {
@@ -43,6 +44,8 @@ func (deviceRequest *DeviceRequest) GetDevice(ctx context.Context) (*v1beta1.Dev
 	if err != nil {
 		return nil, err
 	}
+	device.APIVersion = common.DeviceAPIVersion
+	device.Kind = common.DeviceKind
 	return device, nil
 }
 

--- a/keadm/cmd/keadm/app/cmd/ctl/client/pod.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/client/pod.go
@@ -21,6 +21,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
 
 type PodRequest struct {
@@ -39,6 +41,8 @@ func (podRequest *PodRequest) GetPod(ctx context.Context) (*corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
+	pod.APIVersion = common.PodAPIVersion
+	pod.Kind = common.PodKind
 	return pod, nil
 }
 

--- a/keadm/cmd/keadm/app/cmd/ctl/common/print.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/common/print.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/cmd/get"
+)
+
+type ExtPrintFlags struct {
+	PrintFlags *get.PrintFlags
+}
+
+func (exPrintFlags *ExtPrintFlags) PrintToTable(obj runtime.Object, isAllNamespace bool, w io.Writer) error {
+	if isAllNamespace {
+		if err := exPrintFlags.PrintFlags.EnsureWithNamespace(); err != nil {
+			return err
+		}
+	}
+
+	printer, err := exPrintFlags.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+	return printer.PrintObj(obj, w)
+}
+
+func (exPrintFlags *ExtPrintFlags) PrintToJSONYaml(objectList []runtime.Object) error {
+	list := v1.List{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{},
+	}
+	var obj runtime.Object
+	if len(objectList) != 1 {
+		for _, info := range objectList {
+			if info == nil {
+				continue
+			}
+			o := info.DeepCopyObject()
+			list.Items = append(list.Items, runtime.RawExtension{Object: o})
+		}
+
+		listData, err := json.Marshal(list)
+		if err != nil {
+			return err
+		}
+
+		converted, err := runtime.Decode(unstructured.UnstructuredJSONScheme, listData)
+		if err != nil {
+			return err
+		}
+		obj = converted
+	} else {
+		obj = objectList[0]
+	}
+	return exPrintFlags.printGeneric(obj)
+}
+
+func (exPrintFlags *ExtPrintFlags) printGeneric(obj runtime.Object) error {
+	printer, err := exPrintFlags.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+	if meta.IsListType(obj) {
+		items, err := meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+
+		// take the items and create a new list for display
+		list := &unstructured.UnstructuredList{
+			Object: map[string]interface{}{
+				"kind":       "List",
+				"apiVersion": "v1",
+				"metadata":   map[string]interface{}{},
+			},
+		}
+		if listMeta, err := meta.ListAccessor(obj); err == nil {
+			list.Object["metadata"] = map[string]interface{}{
+				"selfLink":        listMeta.GetSelfLink(),
+				"resourceVersion": listMeta.GetResourceVersion(),
+			}
+		}
+
+		for _, item := range items {
+			list.Items = append(list.Items, *item.(*unstructured.Unstructured))
+		}
+		if err := printer.PrintObj(list, os.Stdout); err != nil {
+			return err
+		}
+	} else {
+		var value map[string]interface{}
+		data, err := json.Marshal(obj)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(data, &value); err != nil {
+			return err
+		}
+		if err := printer.PrintObj(&unstructured.Unstructured{Object: value}, os.Stdout); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Cherry pick of https://github.com/kubeedge/kubeedge/pull/6018 on release-1.20.

https://github.com/kubeedge/kubeedge/pull/6018: fix `keadm ctl get pod -oyaml` and `keadm ctl get device -oyaml` error: "missing apiVersion or kind" issue.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.