### PR TITLE
Automated cherry pick of #6093: update version for v1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,14 @@ KubeEdge consists of cloud part and edge part.
 
 ## Kubernetes compatibility
 
-|                        | Kubernetes 1.22 | Kubernetes 1.23 | Kubernetes 1.24 | Kubernetes 1.25 | Kubernetes 1.26 | Kubernetes 1.27 | Kubernetes 1.28 | Kubernetes 1.29 |
-|------------------------| --------------- | --------------- |-----------------| --------------- |-----------------| --------------- | --------------- | --------------- |
-| KubeEdge 1.14          | ✓               | ✓               | ✓               | -               | -               | -               | -               | -               |
-| KubeEdge 1.15          | +               | +               | ✓               | ✓               | ✓               | -               | -               | -               |
-| KubeEdge 1.16          | +               | +               | +               | ✓               | ✓               | ✓               | -               | -               |
-| KubeEdge 1.17          | +               | +               | +               | +               | ✓               | ✓               | ✓               | -               |
-| KubeEdge 1.18          | +               | +               | +               | +               | +               | ✓               | ✓               | ✓               |
-| KubeEdge 1.19          | +               | +               | +               | +               | +               | ✓               | ✓               | ✓               |
-| KubeEdge HEAD (master) | +               | +               | +               | +               | +               | ✓               | ✓               | ✓               |
+|                        | Kubernetes 1.25 | Kubernetes 1.26 | Kubernetes 1.27 | Kubernetes 1.28 | Kubernetes 1.29 | Kubernetes 1.30 | 
+|------------------------| --------------- |-----------------|-----------------| --------------- | --------------- |-----------------|
+| KubeEdge 1.16          | ✓               | ✓               | ✓               | -               | -               | -               |
+| KubeEdge 1.17          | +               | ✓               | ✓               | ✓               | -               | -               |
+| KubeEdge 1.18          | +               | +               | ✓               | ✓               | ✓               | -               |
+| KubeEdge 1.19          | +               | +               | ✓               | ✓               | ✓               | -               |
+| KubeEdge 1.20          | +               | +               | +               | ✓               | ✓               | ✓               |
+| KubeEdge HEAD (master) | +               | +               | +               | ✓               | ✓               | ✓               |
 
 Key:
 * `✓` KubeEdge and the Kubernetes version are exactly compatible.

--- a/README_zh.md
+++ b/README_zh.md
@@ -56,15 +56,14 @@ KubeEdge 由云端和边缘端部分构成：
 
 ### Kubernetes 版本兼容
 
-|                        | Kubernetes 1.22 | Kubernetes 1.23 | Kubernetes 1.24 | Kubernetes 1.25 | Kubernetes 1.26 | Kubernetes 1.27 | Kubernetes 1.28 | Kubernetes 1.29 |
-|------------------------| --------------- | --------------- |-----------------| --------------- |-----------------| --------------- | --------------- | --------------- |
-| KubeEdge 1.14          | ✓               | ✓               | ✓               | -               | -               | -               | -               | -               |
-| KubeEdge 1.15          | +               | +               | ✓               | ✓               | ✓               | -               | -               | -               |
-| KubeEdge 1.16          | +               | +               | +               | ✓               | ✓               | ✓               | -               | -               |
-| KubeEdge 1.17          | +               | +               | +               | +               | ✓               | ✓               | ✓               | -               |
-| KubeEdge 1.18          | +               | +               | +               | +               | +               | ✓               | ✓               | ✓               |
-| KubeEdge 1.19          | +               | +               | +               | +               | +               | ✓               | ✓               | ✓               |
-| KubeEdge HEAD (master) | +               | +               | +               | +               | +               | ✓               | ✓               | ✓               |
+|                        | Kubernetes 1.25 | Kubernetes 1.26 | Kubernetes 1.27 | Kubernetes 1.28 | Kubernetes 1.29 | Kubernetes 1.30 | 
+|------------------------| --------------- |-----------------|-----------------| --------------- | --------------- |-----------------|
+| KubeEdge 1.16          | ✓               | ✓               | ✓               | -               | -               | -               |
+| KubeEdge 1.17          | +               | ✓               | ✓               | ✓               | -               | -               |
+| KubeEdge 1.18          | +               | +               | ✓               | ✓               | ✓               | -               |
+| KubeEdge 1.19          | +               | +               | ✓               | ✓               | ✓               | -               |
+| KubeEdge 1.20          | +               | +               | +               | ✓               | ✓               | ✓               |
+| KubeEdge HEAD (master) | +               | +               | +               | ✓               | ✓               | ✓               |
 
 说明：
 * `✓` KubeEdge 和 Kubernetes 的版本是完全兼容的

--- a/build/cloud/07-deployment.yaml
+++ b/build/cloud/07-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
         - name: cloudcore
-          image: kubeedge/cloudcore:v1.8.0
+          image: kubeedge/cloudcore:v1.20.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 10000

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -126,7 +126,7 @@ const (
 	DefaultK8SMinimumVersion = 11
 
 	// DefaultKubeEdgeVersion is the default KubeEdge version, it must have no prefix 'v'
-	DefaultKubeEdgeVersion = "1.19.0"
+	DefaultKubeEdgeVersion = "1.20.0"
 
 	// Helm action
 	HelmInstallAction  = "install"

--- a/manifests/charts/cloudcore/Chart.yaml
+++ b/manifests/charts/cloudcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: cloudcore
-version: 1.19.0
-appVersion: 1.19.0
+version: 1.20.0
+appVersion: 1.20.0
 description: The KubeEdge cloudcore component.
 sources:
 - https://github.com/kubeedge/kubeedge

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -1,14 +1,14 @@
 # Default values for kubeedge.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-appVersion: "1.19.0"
+appVersion: "1.20.0"
 
 cloudCore:
   replicaCount: 1
   hostNetWork: true
   image:
     repository: "kubeedge/cloudcore"
-    tag: "v1.19.0"
+    tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -78,7 +78,7 @@ iptablesManager:
   hostNetWork: true
   image:
     repository: "kubeedge/iptables-manager"
-    tag: "v1.19.0"
+    tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -111,7 +111,7 @@ controllerManager:
   enable: false
   image:
     repository: "kubeedge/controller-manager"
-    tag: "v1.19.0"
+    tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   labels:

--- a/manifests/profiles/version.yaml
+++ b/manifests/profiles/version.yaml
@@ -1,14 +1,14 @@
 # Default values for kubeedge.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-appVersion: "1.19.0"
+appVersion: "1.20.0"
 
 cloudCore:
   replicaCount: 1
   hostNetWork: true
   image:
     repository: "kubeedge/cloudcore"
-    tag: "v1.19.0"
+    tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -76,7 +76,7 @@ iptablesManager:
   hostNetWork: true
   image:
     repository: "kubeedge/iptables-manager"
-    tag: "v1.19.0"
+    tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   securityContext:
@@ -109,7 +109,7 @@ controllerManager:
   enable: false
   image:
     repository: "kubeedge/controller-manager"
-    tag: "v1.19.0"
+    tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   labels:
@@ -145,7 +145,7 @@ admission:
   certsSecretName: ""
   image:
     repository: "kubeedge/admission"
-    tag: "v1.19.0"
+    tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
   labels:


### PR DESCRIPTION
Cherry pick of #6093 on release-1.20.

#6093: update version for v1.20.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.