### PR TITLE
Improve/Test/Coverage/keadm/helm/value.go

### DIFF
--- a/keadm/cmd/keadm/app/cmd/helm/values_test.go
+++ b/keadm/cmd/keadm/app/cmd/helm/values_test.go
@@ -16,10 +16,166 @@ limitations under the License.
 package helm
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
 
+func TestOptionsWithEmptyValues(t *testing.T) {
+	opts := &Options{}
+	values, err := opts.MergeValues()
+	if err != nil {
+		t.Fatalf("Unexpected error with empty options: %v", err)
+	}
+	if len(values) != 0 {
+		t.Errorf("Expected empty map, got %v", values)
+	}
+}
+
+func TestOptionsWithMultipleValueTypes(t *testing.T) {
+	jsonFile, err := os.CreateTemp("", "test-json-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp JSON file: %v", err)
+	}
+	defer os.Remove(jsonFile.Name())
+	_, err = jsonFile.Write([]byte(`{"key": "value"}`))
+	if err != nil {
+		t.Fatalf("Failed to write to temp JSON file: %v", err)
+	}
+	jsonFile.Close()
+
+	yamlFile, err := os.CreateTemp("", "test-yaml-*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create temp YAML file: %v", err)
+	}
+	defer os.Remove(yamlFile.Name())
+	_, err = yamlFile.Write([]byte(`base:
+  key: value`))
+	if err != nil {
+		t.Fatalf("Failed to write to temp YAML file: %v", err)
+	}
+	yamlFile.Close()
+
+	opts := &Options{
+		ValueFiles:    []string{yamlFile.Name()},
+		Values:        []string{"set.key=value"},
+		StringValues:  []string{"string.key=value"},
+		FileValues:    []string{`file.content=` + jsonFile.Name()},
+		LiteralValues: []string{"literal.key=value"},
+	}
+
+	values, err := opts.MergeValues()
+	if err != nil {
+		t.Fatalf("Unexpected error merging multiple value types: %v", err)
+	}
+
+	expectedKeys := []string{"base", "set", "string", "file", "literal"}
+	for _, key := range expectedKeys {
+		if _, exists := values[key]; !exists {
+			t.Errorf("Expected key %s to exist in merged values", key)
+		}
+	}
+}
+
+func TestReadFileFromStdin(t *testing.T) {
+	oldStdin := os.Stdin
+	defer func() { os.Stdin = oldStdin }()
+
+	r, w, _ := os.Pipe()
+	os.Stdin = r
+
+	go func() {
+		if _, err := w.Write([]byte("test stdin content")); err != nil {
+			t.Error("Failed to write to pipe:", err)
+		}
+		w.Close()
+	}()
+
+	content, err := readFile("-")
+	if err != nil {
+		t.Fatalf("Unexpected error reading from stdin: %v", err)
+	}
+
+	if string(content) != "test stdin content" {
+		t.Errorf("Unexpected stdin content: got %s, want 'test stdin content'", string(content))
+	}
+}
+
+func TestMergeMapEdgeCases(t *testing.T) {
+	testCases := []struct {
+		name     string
+		mapA     map[string]interface{}
+		mapB     map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "Empty maps",
+			mapA:     map[string]interface{}{},
+			mapB:     map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "Overwriting nested map with new values",
+			mapA: map[string]interface{}{
+				"nested": map[string]interface{}{"key1": "value1"},
+			},
+			mapB: map[string]interface{}{
+				"nested": "simple_value",
+			},
+			expected: map[string]interface{}{
+				"nested": "simple_value",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := mergeMaps(tc.mapA, tc.mapB)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("mergeMaps() = %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestErrorCases(t *testing.T) {
+	testCases := []struct {
+		name        string
+		opts        *Options
+		expectError bool
+	}{
+		{
+			name: "Invalid JSON input",
+			opts: &Options{
+				JSONValues: []string{"{invalid json}"},
+			},
+			expectError: true,
+		},
+		{
+			name: "Invalid set input",
+			opts: &Options{
+				Values: []string{"invalid set format"},
+			},
+			expectError: true,
+		},
+		{
+			name: "Non-existent file",
+			opts: &Options{
+				ValueFiles: []string{"/path/to/non/existent/file"},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.opts.MergeValues()
+			if (err != nil) != tc.expectError {
+				t.Errorf("MergeValues() error = %v, wantErr %v", err, tc.expectError)
+			}
+		})
+	}
+}
 func TestMergeValues(t *testing.T) {
 	nestedMap := map[string]interface{}{
 		"foo": "bar",


### PR DESCRIPTION
<!--
Add one of the following kinds:
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind test  


## What this PR does / why we need it

This PR significantly improves test coverage for the `./keadm/cmd/keadm/app/cmd/helm/values.go` package. It increases the test coverage from **16.67% to 81.8%**, ensuring more comprehensive validation of:

- Functionality and logic within `values.go`
- Edge case handling
- Improved reliability of Helm-related commands  

## Which issue(s) this PR fixes

Part of [lfx-mentorship] Enhance KubeEdge testing coverage initiative #6101

## Screenshot
![Screenshot from 2025-02-07 00-48-10](https://github.com/user-attachments/assets/307ab24d-aaff-47ea-9106-2d2009905a86)
![Screenshot from 2025-02-07 01-05-43](https://github.com/user-attachments/assets/9450e97f-be7e-420d-8a80-6e2609116903)



## Command to test

- **File path:** `./keadm/cmd/keadm/app/cmd/helm/values.go`
- **Test execution command:**
  ```sh
  go test -coverprofile=coverage.out  ./keadm/cmd/keadm/app/cmd/helm/values.go
  go tool cover -html=coverage.out -o coverage.html
