### PR TITLE
test/keadm/commom/config.go

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/config_test.go
+++ b/keadm/cmd/keadm/app/cmd/common/config_test.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrite2File(t *testing.T) {
+	// Temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "kubeedge-test-")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Test cases
+	testCases := []struct {
+		name     string
+		data     interface{}
+		fileName string
+		wantErr  bool
+	}{
+		{
+			name: "Write struct to file",
+			data: struct {
+				Name string `yaml:"name"`
+				Age  int    `yaml:"age"`
+			}{
+				Name: "John Doe",
+				Age:  30,
+			},
+			fileName: "test_struct.yaml",
+			wantErr:  false,
+		},
+		{
+			name:     "Write map to file",
+			data:     map[string]string{"key": "value"},
+			fileName: "test_map.yaml",
+			wantErr:  false,
+		},
+		{
+			name:     "Write nil data",
+			data:     nil,
+			fileName: "test_nil.yaml",
+			wantErr:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Construct full file path
+			filePath := filepath.Join(tempDir, tc.fileName)
+
+			// Call the function
+			err := Write2File(filePath, tc.data)
+
+			// Check for expected error
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Verify file was created
+			_, err = os.Stat(filePath)
+			assert.NoError(t, err)
+
+			// Read and verify file contents
+			content, err := os.ReadFile(filePath)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, content)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Add one of the following kinds:
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind test  


## What this PR does / why we need it

This PR significantly improves test coverage for the `./keadm/cmd/keadm/app/cmd/common/config.go` package. It ensures comprehensive test coverage by verifying:


## Which issue(s) this PR fixes

Part of [lfx-mentorship] Enhance KubeEdge testing coverage initiative **#6101**  

## Scree
![Screenshot from 2025-02-07 01-34-57](https://github.com/user-attachments/assets/2a4c4a5a-7de8-40a3-bb27-5237cb6ecaf8)
nshots  


## Command to test  

- **File path:** `./keadm/cmd/keadm/app/cmd/helm/values.go`  
- **Test execution command:**  

  ```sh
  go test -coverprofile=coverage.out ./keadm/cmd/keadm/app/cmd/common/...
  go tool cover -html=coverage.out -o coverage.html
