### PR TITLE
[test]:create factory_test.go in ./pkg/security/certs

### DIFF
--- a/pkg/security/certs/factory_test.go
+++ b/pkg/security/certs/factory_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certs
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetCAHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerType CAHandlerType
+		want        CAHandler
+	}{
+		{
+			name:        "x509 CA handler",
+			handlerType: CAHandlerTypeX509,
+			want:        &x509CAHandler{},
+		},
+		{
+			name:        "unknown handler type",
+			handlerType: "unknown",
+			want:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetCAHandler(tt.handlerType)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCAHandler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerType HanndlerType
+		want        Handler
+	}{
+		{
+			name:        "x509 certs handler",
+			handlerType: HandlerTypeX509,
+			want:        &x509CertsHandler{},
+		},
+		{
+			name:        "unknown handler type",
+			handlerType: "unknown",
+			want:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetHandler(tt.handlerType)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetHandler() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Add one of the following kinds:
/kind test
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind test

## What this PR does / why we need it  
This PR significantly improves test coverage for the `certs` package by adding comprehensive test cases for file   ./pkg/security/certs/factory.go . The changes include:  

- Implementation of table-driven tests for both `GetCAHandler` and `GetHandler` functions  
- Coverage of both successful and error cases  
- Validation of handler type behavior  
- Complete test coverage achieving 100% for the package  

## Which issue(s) this PR fixes  
Part of **[lfx-mentorship] Enhance KubeEdge testing coverage initiative #6101**  

## Test Coverage Improvement  

### **Before**  
 No existing test coverage (**0%**)  

### **After**  
Achieved **100% test coverage** by adding:  

##  Screenshots  
![Screenshot from 2025-02-09 06-21-28](https://github.com/user-attachments/assets/17287424-e7dc-4a41-b2c5-6480d608d5b1)


## Commands to Test  
- **File path:** `./pkg/security/certs/factory_test.go`  
- **Test execution commands:**  

  ```sh
  go test -coverprofile=coverage.out ./pkg/security/certs/...
  go tool cover -html=coverage.out -o coverage.html
