### PR TITLE
[Test]:Improve of ./pkg/stream/edgedlogconnection.go

### DIFF
--- a/pkg/stream/edgedlogconnection_test.go
+++ b/pkg/stream/edgedlogconnection_test.go
@@ -17,12 +17,68 @@ limitations under the License.
 package stream
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+const (
+	defaultTestTimeout = 100 * time.Millisecond
+	defaultWaitTime    = 1 * time.Second
+)
+
+type mockSafeWriteTunneler struct {
+	written  []*Message
+	writeErr error
+	closeErr error
+	nextErr  error
+	nextType int
+	nextData []byte
+}
+
+func (m *mockSafeWriteTunneler) WriteMessage(msg *Message) error {
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+	m.written = append(m.written, msg)
+	return nil
+}
+
+func (m *mockSafeWriteTunneler) Close() error {
+	return m.closeErr
+}
+
+func (m *mockSafeWriteTunneler) WriteControl(_ int, _ []byte, _ time.Time) error {
+	return nil
+}
+
+func (m *mockSafeWriteTunneler) NextReader() (messageType int, r io.Reader, err error) {
+	if m.nextErr != nil {
+		return 0, nil, m.nextErr
+	}
+	return m.nextType, bytes.NewReader(m.nextData), nil
+}
+
+type mockReader struct {
+	buf     *bytes.Buffer
+	readErr error
+}
+
+func (m *mockReader) Read(p []byte) (n int, err error) {
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	return m.buf.Read(p)
+}
 
 func TestLogConnection_CreateConnectMessage(t *testing.T) {
 	assert := assert.New(t)
@@ -87,4 +143,184 @@ func TestLogConnection_CloseReadChannel(t *testing.T) {
 
 	_, ok := <-edgedLogsConn.ReadChan
 	assert.False(ok)
+}
+
+func TestLogConnection_receiveFromCloudStream(t *testing.T) {
+	assert := assert.New(t)
+
+	stop := make(chan struct{}, 1)
+	readChan := make(chan *Message, 2)
+
+	logs := &EdgedLogsConnection{
+		ReadChan: readChan,
+		MessID:   1,
+	}
+
+	defer close(logs.ReadChan)
+
+	go logs.receiveFromCloudStream(stop)
+
+	dataMsg := NewMessage(1, MessageTypeData, []byte("test data"))
+	logs.ReadChan <- dataMsg
+
+	select {
+	case <-stop:
+		assert.Fail("Should not receive stop signal for data message")
+	case <-time.After(defaultTestTimeout):
+	}
+
+	removeMsg := NewMessage(1, MessageTypeRemoveConnect, nil)
+	logs.ReadChan <- removeMsg
+
+	select {
+	case <-stop:
+	case <-time.After(defaultWaitTime):
+		assert.Fail("Should have received stop signal")
+	}
+}
+
+func TestEdgedLogsConnection_write2CloudStream(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name        string
+		input       string
+		readErr     error
+		writeErr    error
+		expectStop  bool
+		expectWrite bool
+	}{
+		{
+			name:        "successful write",
+			input:       "test log data",
+			expectStop:  true,
+			expectWrite: true,
+		},
+		{
+			name:        "EOF error",
+			input:       "",
+			readErr:     io.EOF,
+			expectStop:  true,
+			expectWrite: false,
+		},
+		{
+			name:        "read error",
+			input:       "test data",
+			readErr:     errors.New("read error"),
+			expectStop:  true,
+			expectWrite: false,
+		},
+		{
+			name:        "write error",
+			input:       "test data",
+			writeErr:    errors.New("write error"),
+			expectStop:  true,
+			expectWrite: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stop := make(chan struct{}, 1)
+
+			mockTunnel := &mockSafeWriteTunneler{
+				writeErr: tc.writeErr,
+			}
+
+			var buf bytes.Buffer
+			buf.WriteString(tc.input)
+			reader := bufio.NewReader(&mockReader{
+				buf:     &buf,
+				readErr: tc.readErr,
+			})
+
+			logs := &EdgedLogsConnection{
+				MessID: 1,
+			}
+
+			go logs.write2CloudStream(mockTunnel, *reader, stop)
+
+			select {
+			case <-stop:
+				if !tc.expectStop {
+					assert.Fail("Unexpected stop signal")
+				}
+			case <-time.After(100 * time.Millisecond):
+				if tc.expectStop {
+					assert.Fail("Should have received stop signal")
+				}
+			}
+
+			if tc.expectWrite {
+				assert.NotEmpty(mockTunnel.written, "Expected messages to be written")
+				if len(mockTunnel.written) > 0 {
+					assert.Equal(tc.input, string(mockTunnel.written[0].Data))
+				}
+			} else {
+				assert.Empty(mockTunnel.written, "Expected no messages to be written")
+			}
+		})
+	}
+}
+
+func TestEdgedLogsConnection_Serve(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name          string
+		serverHandler func(w http.ResponseWriter, r *http.Request)
+		expectError   bool
+	}{
+		{
+			name: "successful connection",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("test log data"))
+			},
+			expectError: false,
+		},
+		{
+			name: "server error",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(tc.serverHandler))
+			defer server.Close()
+
+			serverURL, _ := url.Parse(server.URL)
+
+			logs := &EdgedLogsConnection{
+				MessID:   1,
+				URL:      *serverURL,
+				Header:   http.Header{},
+				ReadChan: make(chan *Message),
+				Stop:     make(chan struct{}),
+			}
+
+			mockTunnel := &mockSafeWriteTunneler{}
+
+			errChan := make(chan error)
+			go func() {
+				errChan <- logs.Serve(mockTunnel)
+			}()
+
+			go func() {
+				time.Sleep(100 * time.Millisecond)
+				logs.Stop <- struct{}{}
+			}()
+
+			err := <-errChan
+			if tc.expectError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
 }

--- a/pkg/stream/edgedlogconnection_test.go
+++ b/pkg/stream/edgedlogconnection_test.go
@@ -311,7 +311,7 @@ func TestEdgedLogsConnection_Serve(t *testing.T) {
 			}()
 
 			go func() {
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(defaultTestTimeout)
 				logs.Stop <- struct{}{}
 			}()
 


### PR DESCRIPTION

/kind test

## What this PR does / why we need it  
This PR significantly improves test coverage for the `./pkg/stream/` package by adding comprehensive test cases for file   ./pkg/stream/edgedlogconnection . 
 

## Which issue(s) this PR fixes  
Part of **[lfx-mentorship] Enhance KubeEdge testing coverage initiative #6101**  

## Test Coverage Improvement  

### **Before**  
 existing test coverage (**11.54%**)  

### **After**  
Achieved  **81.5%** test coverage

##  Screenshots  
![Screenshot from 2025-02-11 16-00-50](https://github.com/user-attachments/assets/2128b7af-4b78-4030-991d-4da778257be5)


## Commands to Test  
- **File path:** `./pkg/stream/  
- **Test execution commands:**  

  ```sh
  go test -coverprofile=coverage.out ./pkg/stream/...
  go tool cover -html=coverage.out -o coverage.html
