### PR TITLE
[test]:create test for server.go in cloud/pkg/csidriver

### DIFF
--- a/cloud/pkg/csidriver/server_test.go
+++ b/cloud/pkg/csidriver/server_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csidriver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/cloud/cmd/csidriver/app/options"
+)
+
+func TestNewCSIDriver(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *options.CSIDriverOptions
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid options",
+			opts: &options.CSIDriverOptions{
+				Endpoint:         "unix:///var/lib/kubelet/plugins/csi-hostpath/csi.sock",
+				DriverName:       "hostpath.csi.k8s.io",
+				NodeID:           "node1",
+				KubeEdgeEndpoint: "http://localhost:10000",
+				Version:          "1.0.0",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing endpoint",
+			opts: &options.CSIDriverOptions{
+				DriverName:       "hostpath.csi.k8s.io",
+				NodeID:           "node1",
+				KubeEdgeEndpoint: "http://localhost:10000",
+				Version:          "1.0.0",
+			},
+			wantErr: true,
+			errMsg:  "no driver endpoint provided",
+		},
+		{
+			name: "missing driver name",
+			opts: &options.CSIDriverOptions{
+				Endpoint:         "unix:///var/lib/kubelet/plugins/csi-hostpath/csi.sock",
+				NodeID:           "node1",
+				KubeEdgeEndpoint: "http://localhost:10000",
+				Version:          "1.0.0",
+			},
+			wantErr: true,
+			errMsg:  "no driver name provided",
+		},
+		{
+			name: "missing node ID",
+			opts: &options.CSIDriverOptions{
+				Endpoint:         "unix:///var/lib/kubelet/plugins/csi-hostpath/csi.sock",
+				DriverName:       "hostpath.csi.k8s.io",
+				KubeEdgeEndpoint: "http://localhost:10000",
+				Version:          "1.0.0",
+			},
+			wantErr: true,
+			errMsg:  "no node id provided",
+		},
+		{
+			name: "missing kubeedge endpoint",
+			opts: &options.CSIDriverOptions{
+				Endpoint:   "unix:///var/lib/kubelet/plugins/csi-hostpath/csi.sock",
+				DriverName: "hostpath.csi.k8s.io",
+				NodeID:     "node1",
+				Version:    "1.0.0",
+			},
+			wantErr: true,
+			errMsg:  "no kubeedge endpoint provided",
+		},
+		{
+			name: "missing version",
+			opts: &options.CSIDriverOptions{
+				Endpoint:         "unix:///var/lib/kubelet/plugins/csi-hostpath/csi.sock",
+				DriverName:       "hostpath.csi.k8s.io",
+				NodeID:           "node1",
+				KubeEdgeEndpoint: "http://localhost:10000",
+			},
+			wantErr: true,
+			errMsg:  "no version provided",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver, err := NewCSIDriver(tt.opts)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.errMsg)
+				assert.Nil(t, driver)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, driver)
+				assert.Equal(t, tt.opts.Endpoint, driver.Endpoint)
+				assert.Equal(t, tt.opts.DriverName, driver.DriverName)
+				assert.Equal(t, tt.opts.NodeID, driver.NodeID)
+				assert.Equal(t, tt.opts.KubeEdgeEndpoint, driver.KubeEdgeEndpoint)
+				assert.Equal(t, tt.opts.Version, driver.Version)
+			}
+		})
+	}
+}
+
+func TestCSIDriverRun(t *testing.T) {
+	opts := &options.CSIDriverOptions{
+		Endpoint:         "unix:///tmp/test.sock",
+		DriverName:       "test.csi.k8s.io",
+		NodeID:           "test-node",
+		KubeEdgeEndpoint: "http://localhost:10000",
+		Version:          "1.0.0",
+	}
+
+	driver, err := NewCSIDriver(opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, driver)
+
+	done := make(chan bool)
+	go func() {
+		driver.Run()
+		done <- true
+	}()
+}


### PR DESCRIPTION

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR adds unit tests for the CSIDriver server implementation in the cloud/pkg/csidriver package. The new tests cover:
- Validation of CSIDriver initialization with various input parameters
- Error handling for missing required fields
- Basic verification of server startup functionality

This work is part of the effort to enhance KubeEdge testing coverage as outlined in the LFX mentorship program.

**Which issue(s) this PR fixes**:

Related to #6101

**Special notes for your reviewer**:
- The tests follow the project's existing testing patterns and guidelines
- Test coverage focuses on the NewCSIDriver function and includes basic Run method testing
- Additional mocking for GRPC server testing could be added in future iterations if desired


**Does this PR introduce a user-facing change?**:

NONE
![image](https://github.com/user-attachments/assets/e2a0ccd8-4db5-4477-9842-d61b47e98a17)

