### PR TITLE
[test]:improve coverage for uds in cloud/pkg/csidriver

### DIFF
--- a/cloud/pkg/csidriver/uds_test.go
+++ b/cloud/pkg/csidriver/uds_test.go
@@ -17,23 +17,170 @@ limitations under the License.
 package csidriver
 
 import (
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+func createTempSocketPath(t *testing.T) string {
+	dir := t.TempDir()
+	return filepath.Join(dir, "test.sock")
+}
+
+func setupSocket(_ *testing.T, path string) (net.Listener, error) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	return listener, nil
+}
+
 func TestNewUnixDomainSocket(t *testing.T) {
 	assert := assert.New(t)
 
-	// Using default buffer size
 	us := NewUnixDomainSocket("/tmp/test.sock")
 	assert.NotNil(us)
 	assert.Equal("/tmp/test.sock", us.filename)
 	assert.Equal(DefaultBufferSize, us.buffersize)
 
-	// Using custom buffer size
 	us = NewUnixDomainSocket("/tmp/test.sock", 2048)
 	assert.NotNil(us)
 	assert.Equal("/tmp/test.sock", us.filename)
 	assert.Equal(2048, us.buffersize)
+}
+
+func TestConnect(t *testing.T) {
+	assert := assert.New(t)
+
+	us := NewUnixDomainSocket("invalid://endpoint")
+	conn, err := us.Connect()
+	assert.Error(err)
+	assert.Nil(conn)
+
+	socketPath := createTempSocketPath(t)
+
+	listener, err := setupSocket(t, socketPath)
+	if err != nil {
+		t.Fatalf("Failed to setup socket: %v", err)
+	}
+	defer listener.Close()
+
+	connected := make(chan struct{})
+	go func() {
+		defer close(connected)
+		conn, err := listener.Accept()
+		if err == nil && conn != nil {
+			conn.Close()
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	us = NewUnixDomainSocket("unix://" + socketPath)
+	conn, err = us.Connect()
+	assert.NoError(err)
+	assert.NotNil(conn)
+	if conn != nil {
+		conn.Close()
+	}
+
+	<-connected
+
+	us = NewUnixDomainSocket("unix:///nonexistent/path/sock")
+	conn, err = us.Connect()
+	assert.Error(err)
+	assert.Nil(conn)
+}
+
+func TestSend(t *testing.T) {
+	assert := assert.New(t)
+	socketPath := createTempSocketPath(t)
+
+	listener, err := setupSocket(t, socketPath)
+	if err != nil {
+		t.Fatalf("Failed to setup socket: %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 1024)
+		if _, err := conn.Read(buf); err != nil {
+			return
+		}
+
+		if _, err := conn.Write([]byte("response message")); err != nil {
+			return
+		}
+	}()
+
+	us := NewUnixDomainSocket("unix://" + socketPath)
+	conn, err := us.Connect()
+	assert.NoError(err)
+	assert.NotNil(conn)
+
+	if conn != nil {
+		response, err := us.Send(conn, "test message")
+		assert.NoError(err)
+		assert.Equal("response message", response)
+		conn.Close()
+	}
+
+	<-done
+}
+
+func TestSendWithBufferSizeLimit(t *testing.T) {
+	assert := assert.New(t)
+	socketPath := createTempSocketPath(t)
+
+	listener, err := setupSocket(t, socketPath)
+	if err != nil {
+		t.Fatalf("Failed to setup socket: %v", err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		if _, err := conn.Write([]byte("this is a response message that exceeds the small buffer size")); err != nil {
+			return
+		}
+	}()
+
+	us := NewUnixDomainSocket("unix://"+socketPath, 10)
+	conn, err := us.Connect()
+	assert.NoError(err)
+	assert.NotNil(conn)
+
+	if conn != nil {
+		response, err := us.Send(conn, "test")
+		assert.NoError(err)
+		assert.Len(response, 10)
+		conn.Close()
+	}
+
+	<-done
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR improves the test coverage for the UnixDomainSocket implementation in the CSI driver package. It adds comprehensive test cases for socket creation, connection handling, message sending, and buffer size management. The test coverage has been improved from 20% to 83%.

Key improvements include:
- Added test cases for socket initialization with default and custom buffer sizes
- Added connection handling tests for valid and invalid endpoints
- Added message sending tests with various scenarios
- Added buffer size limit testing
- Improved test reliability with proper resource cleanup
- Added proper synchronization for concurrent operations

**Which issue(s) this PR fixes**:
Part of #6101 [lfx-mentorship] Enhance KubeEdge testing coverage

**Special notes for your reviewer**:
- All tests are self-contained and clean up their resources
- Tests use temporary directories to avoid conflicts
- Added proper synchronization to prevent race conditions
- Maintained existing functionality while improving coverage

**Does this PR introduce a user-facing change?**:
NONE
 
![image](https://github.com/user-attachments/assets/cf36f35b-70f1-4675-aaba-a2e746247230)

