### PR TITLE
remove protocol from device models

### DIFF
--- a/build/crds/devices/devices_v1beta1_devicemodel.yaml
+++ b/build/crds/devices/devices_v1beta1_devicemodel.yaml
@@ -154,9 +154,6 @@ spec:
                       type: object
                   type: object
                 type: array
-              protocol:
-                description: 'Required for DMI: Protocol name used by the device.'
-                type: string
             type: object
         type: object
     served: true
@@ -229,9 +226,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              protocol:
-                description: 'Required: Protocol name used by the device.'
-                type: string
             type: object
         type: object
     served: true

--- a/manifests/charts/cloudcore/crds/devices_v1beta1_devicemodel.yaml
+++ b/manifests/charts/cloudcore/crds/devices_v1beta1_devicemodel.yaml
@@ -154,9 +154,6 @@ spec:
                       type: object
                   type: object
                 type: array
-              protocol:
-                description: 'Required for DMI: Protocol name used by the device.'
-                type: string
             type: object
         type: object
     served: true
@@ -229,9 +226,6 @@ spec:
                       type: string
                   type: object
                 type: array
-              protocol:
-                description: 'Required: Protocol name used by the device.'
-                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
This PR removes protocol definitions from DeviceModel CRDs while keeping them in Device CRDs. This change improves the separation of concerns between device models and device instances.

### Justification for removing protocol from DeviceModel:
Its better if
   - DeviceModel should define *what* a device can do (capabilities/properties)
   - Device CRD should define *how* to connect to the device (protocol/connectivity)

&
   - Same device model can be used with different protocols
   - Better supports multi-protocol devices

**Reduced Duplication too**
   - Eliminates redundant protocol definitions
   - Single source of truth for protocol configuration
   - Simplifies maintenance and updates

## Changes Made:
1. Removed protocol field from DeviceModel CRD in:
   ```yaml
   # filepath: /build/crds/devices/devices_v1beta1_devicemodel.yaml
   # filepath: /manifests/charts/cloudcore/crds/devices_v1beta1_devicemodel.yaml
   ```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5969 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
