### PR TITLE
feat: Add support for local image repository in keadm init

### DIFF
--- a/keadm/cmd/keadm/app/cmd/helm/installer.go
+++ b/keadm/cmd/keadm/app/cmd/helm/installer.go
@@ -61,6 +61,7 @@ type KubeCloudHelmInstTool struct {
 	DryRun           bool
 	Action           string
 	existsProfile    bool
+	ImageRepository  string
 }
 
 // InstallTools downloads KubeEdge for the specified version
@@ -355,6 +356,13 @@ func (cu *KubeCloudHelmInstTool) checkProfile(baseHelmRoot string) error {
 func (cu *KubeCloudHelmInstTool) handleProfile(profileValue string) error {
 	// the current version
 	currentVersion := cu.Common.ToolVersion.String()
+
+	if cu.ImageRepository != "" {
+		cu.Sets = append(cu.Sets, fmt.Sprintf("%s=%s", "cloudCore.image.repository", cu.ImageRepository+"/cloudcore"))
+        cu.Sets = append(cu.Sets, fmt.Sprintf("%s=%s", "iptablesManager.image.repository", cu.ImageRepository+"/iptables-manager"))
+        cu.Sets = append(cu.Sets, fmt.Sprintf("%s=%s", "controllerManager.image.repository", cu.ImageRepository+"/controller-manager"))
+    }
+
 	switch cu.ProfileKey {
 	case VersionProfileKey:
 		if profileValue == "" {

--- a/keadm/cmd/keadm/app/cmd/helm/installer_test.go
+++ b/keadm/cmd/keadm/app/cmd/helm/installer_test.go
@@ -1,0 +1,58 @@
+package helm
+
+import (
+    "testing"
+)
+
+func TestHandleProfileWithImageRepository(t *testing.T) {
+    tests := []struct {
+        name            string
+        imageRepository string
+        expectedSets    []string
+    }{
+        {
+            name:            "with local registry",
+            imageRepository: "localhost:5000",
+            expectedSets: []string{
+                "cloudCore.image.repository=localhost:5000/cloudcore",
+                "iptablesManager.image.repository=localhost:5000/iptables-manager",
+                "controllerManager.image.repository=localhost:5000/controller-manager",
+            },
+        },
+        {
+            name:            "with empty repository",
+            imageRepository: "",
+            expectedSets:    []string{},
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            cu := &KubeCloudHelmInstTool{
+                ImageRepository: tt.imageRepository,
+            }
+
+            err := cu.handleProfile("")
+            if err != nil {
+                t.Errorf("handleProfile() error = %v", err)
+            }
+
+            if len(cu.Sets) != len(tt.expectedSets) {
+                t.Errorf("got %d sets, want %d sets", len(cu.Sets), len(tt.expectedSets))
+            }
+
+            for _, expected := range tt.expectedSets {
+                found := false
+                for _, actual := range cu.Sets {
+                    if actual == expected {
+                        found = true
+                        break
+                    }
+                }
+                if !found {
+                    t.Errorf("expected set %q not found in %v", expected, cu.Sets)
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
Signed-off-by: vaidikcode <vaidikbhardwaj00@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Adds support for pulling images from a local container registry during `keadm init`. This is particularly useful in air-gapped environments where internet access is restricted.

### Feature Implementation
- Added `ImageRepository` field to `KubeCloudHelmInstTool` struct
- Modified `handleProfile` to support custom image repositories
- Added unit tests to verify functionality

### Usage Example
```bash
# Initialize KubeEdge with local registry
keadm init --image-repository=localhost:5000
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6011 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
