### PR TITLE
Solve endpoints synchronization filtering not work

### DIFF
--- a/cloud/pkg/dynamiccontroller/filter/util.go
+++ b/cloud/pkg/dynamiccontroller/filter/util.go
@@ -1,36 +1,57 @@
 package filter
 
 import (
-	"strings"
+	"context"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
 	"k8s.io/klog/v2"
 
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	commoninformers "github.com/kubeedge/kubeedge/cloud/pkg/common/informers"
 	"github.com/kubeedge/kubeedge/cloud/pkg/controllermanager/nodegroup"
 )
 
 func IsBelongToSameGroup(targetNodeName string, epNodeName string) bool {
-	if strings.Compare(targetNodeName, epNodeName) == 0 {
+	// Return true if both node names are the same
+	if targetNodeName == epNodeName {
 		return true
 	}
-	targetNode, err := GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Lister().Get(targetNodeName)
-	if err != nil {
-		klog.Errorf("node informer get node %s error: %v", targetNodeName, err)
-		return false
+
+	var getNode func(string) (interface{}, error)
+
+	// Define a function to get the node based on whether the informer is synced
+	if !GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Informer().HasSynced() {
+		klog.Info("nodes informer has not synced yet")
+		getNode = func(nodeName string) (interface{}, error) {
+			return client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("nodes")).Get(context.TODO(), nodeName, metav1.GetOptions{})
+		}
+	} else {
+		getNode = func(nodeName string) (interface{}, error) {
+			return GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Lister().Get(nodeName)
+		}
 	}
-	targetAccessor, err := meta.Accessor(targetNode)
+
+	// Get the target node
+	targetNode, err := getNode(targetNodeName)
 	if err != nil {
-		klog.Error(err)
+		klog.Errorf("failed to get target node %s: %v", targetNodeName, err)
 		return false
 	}
 
-	epNode, err := GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Lister().Get(epNodeName)
+	// Get the endpoint node
+	epNode, err := getNode(epNodeName)
 	if err != nil {
-		klog.Errorf("node informer get endpoint slice belonging node %s error: %v", epNodeName, err)
+		klog.Errorf("failed to get endpoint node %s: %v", epNodeName, err)
+		return false
+	}
+
+	targetAccessor, err := meta.Accessor(targetNode)
+	if err != nil {
+		klog.Error(err)
 		return false
 	}
 	epNodeAccessor, err := meta.Accessor(epNode)
@@ -39,9 +60,9 @@ func IsBelongToSameGroup(targetNodeName string, epNodeName string) bool {
 		return false
 	}
 
+	// Compare the labels
 	return targetAccessor.GetLabels()[nodegroup.LabelBelongingTo] == epNodeAccessor.GetLabels()[nodegroup.LabelBelongingTo]
 }
-
 func GetDynamicResourceInformer(gvr schema.GroupVersionResource) informers.GenericInformer {
 	return commoninformers.GetInformersManager().GetDynamicInformerFactory().ForResource(gvr)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
There is no cache in the informer when synchronization starts, causing the filtering method to return false and not work. There is a cache later, and the edge  resource will not be updated if it has not changed.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubeedge/kubeedge/issues/6088
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
