### PR TITLE
[Test]: increase test coverage% for Metamanager Pkg

### DIFF
--- a/edge/pkg/metamanager/client/secret_test.go
+++ b/edge/pkg/metamanager/client/secret_test.go
@@ -129,3 +129,36 @@ func TestHandleSecretFromMetaManager(t *testing.T) {
 	assert.Equal("partial-secret", result.Name)
 	assert.Nil(result.Data)
 }
+
+// TODO: for now just testing current impl but need to change latter
+func TestSecrets_Create(t *testing.T) {
+	assert := assert.New(t)
+
+	// For now, just test the nil implementation
+	s := newSecrets("default", newSend())
+	result, err := s.Create(&api.Secret{})
+
+	assert.Nil(result)
+	assert.NoError(err)
+}
+
+func TestSecrets_Update(t *testing.T) {
+	assert := assert.New(t)
+
+	// For now, just test the nil implementation
+	s := newSecrets("default", newSend())
+	err := s.Update(&api.Secret{})
+
+	assert.NoError(err)
+}
+
+func TestSecrets_Delete(t *testing.T) {
+	assert := assert.New(t)
+
+	// For now, just test the nil implementation
+	s := newSecrets("default", newSend())
+	err := s.Delete("test-secret")
+
+	assert.NoError(err)
+}
+


### PR DESCRIPTION
Signed-off-by: vaidikcode <vaidikbhardwaj00@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
This PR enhances test coverage for the serviceaccount package while working around DB operation limitations. The current test coverage is impacted by direct DB operations that can't be easily mocked.
- Why Full Coverage is Challenging
Direct DB operations through dao.QueryMeta
No DB interface that could be mocked
Tight coupling with DB operations

- To achieve higher coverage, we should consider:

Adding a DB interface layer for better testability

![Screenshot 2025-02-16 025154](https://github.com/user-attachments/assets/e1062bb3-800f-4aa7-9651-8efb92c6700c)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # Increase %Test Coverage

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
