### PR TITLE
Fix: keadm reset cannot delete the /var/lib/edged folder

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common_windows.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_windows.go
@@ -44,6 +44,8 @@ const (
 
 	EdgeRootDir = "C:\\var\\lib\\edged"
 
+	EdgeCoreRunDirectory = "C:\\var\\lib\\edged"
+
 	EdgeKubeletDir = "C:\\var\\lib\\kubelet"
 
 	downloadFileScript = `


### PR DESCRIPTION
Signed-off-by: vaidikcode <vaidikbhardwaj00@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
1. Adding proper unmounting functionality before directory deletion
2. The implementation uses Windows-specific commands (`taskkill` and `mountvol`)
3. Errors during unmount operations are logged but don't block the cleanup process as the process might not exist and the path might not be mounted
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5843 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
