### PR TITLE
[test+fix]: Improve coverage for utils.go in edge/pkg/devicetwin/dtcommon and refactor code structure

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/util_test.go
+++ b/edge/pkg/devicetwin/dtcommon/util_test.go
@@ -19,6 +19,13 @@ package dtcommon
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeedge/api/apis/devices/v1beta1"
 )
 
 // TestValidateValue is function to test ValidateValue
@@ -174,6 +181,438 @@ func TestValidateTwinValue(t *testing.T) {
 			if test.want != isValidate {
 				t.Errorf("ValidateTwinValue Case failed: wanted %v and got %v", test.want, isValidate)
 			}
+		})
+	}
+}
+func TestDataToAny(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   interface{}
+		want    *anypb.Any
+		wantErr bool
+	}{
+		{
+			name:  "string value",
+			input: "test",
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.String("test"))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "int value",
+			input: int(42),
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Int32(42))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "int8 value",
+			input: int8(8),
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Int32(8))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "int16 value",
+			input: int16(16),
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Int32(16))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "int32 value",
+			input: int32(32),
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Int32(32))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "int64 value",
+			input: int64(64),
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Int64(64))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "float32 value",
+			input: float32(3.14),
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Float(3.14))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "float64 value",
+			input: float64(6.28),
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Float(float32(6.28)))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:  "bool value",
+			input: true,
+			want: func() *anypb.Any {
+				a, _ := anypb.New(wrapperspb.Bool(true))
+				return a
+			}(),
+			wantErr: false,
+		},
+		{
+			name:    "unsupported type",
+			input:   make(chan int),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := dataToAny(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want.TypeUrl, got.TypeUrl)
+		})
+	}
+}
+
+func TestConvertDevice(t *testing.T) {
+	cases := []struct {
+		name    string
+		device  *v1beta1.Device
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil device",
+			device:  nil,
+			wantErr: true,
+			errMsg:  "device cannot be nil",
+		},
+		{
+			name: "empty ConfigData",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-empty-config",
+				},
+				Spec: v1beta1.DeviceSpec{
+					Protocol: v1beta1.ProtocolConfig{
+						ConfigData: &v1beta1.CustomizedValue{},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil DeviceModelRef",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-no-model",
+				},
+				Spec: v1beta1.DeviceSpec{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "device with invalid configData type",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-invalid-config",
+				},
+				Spec: v1beta1.DeviceSpec{
+					Protocol: v1beta1.ProtocolConfig{
+						ConfigData: &v1beta1.CustomizedValue{
+							Data: map[string]interface{}{
+								"invalid": make(chan int),
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "json: unsupported type: chan int",
+		},
+		{
+			name: "device with invalid property visitor config",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-invalid-visitor",
+				},
+				Spec: v1beta1.DeviceSpec{
+					Properties: []v1beta1.DeviceProperty{
+						{
+							Visitors: v1beta1.VisitorConfig{
+								ConfigData: &v1beta1.CustomizedValue{
+									Data: map[string]interface{}{
+										"invalid": make(chan int),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "json: unsupported type: chan int",
+		},
+		{
+			name: "device with nil property",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-nil-property",
+				},
+				Spec: v1beta1.DeviceSpec{
+					Properties: []v1beta1.DeviceProperty{{}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "device with multiple properties",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-multiple-props",
+				},
+				Spec: v1beta1.DeviceSpec{
+					Properties: []v1beta1.DeviceProperty{
+						{
+							Name: "temp",
+							Visitors: v1beta1.VisitorConfig{
+								ConfigData: &v1beta1.CustomizedValue{
+									Data: map[string]interface{}{
+										"topic": "temperature",
+									},
+								},
+							},
+						},
+						{
+							Name: "humidity",
+							Visitors: v1beta1.VisitorConfig{
+								ConfigData: &v1beta1.CustomizedValue{
+									Data: map[string]interface{}{
+										"topic": "humidity",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "protocol config data conversion error",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-protocol-error",
+				},
+				Spec: v1beta1.DeviceSpec{
+					Protocol: v1beta1.ProtocolConfig{
+						ConfigData: &v1beta1.CustomizedValue{
+							Data: map[string]interface{}{
+								"invalid": struct{}{},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "failed to convert protocol config data",
+		},
+		{
+			name: "property conversion error",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-device-property-error",
+				},
+				Spec: v1beta1.DeviceSpec{
+					Properties: []v1beta1.DeviceProperty{
+						{
+							Visitors: v1beta1.VisitorConfig{
+								ConfigData: &v1beta1.CustomizedValue{
+									Data: map[string]interface{}{
+										"bad": struct{}{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "failed to convert property",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertDevice(tt.device)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.device.Name, got.Name)
+			assert.Equal(t, tt.device.Namespace, got.Namespace)
+
+			if tt.device.Spec.DeviceModelRef != nil {
+				assert.Equal(t, tt.device.Spec.DeviceModelRef.Name, got.Spec.DeviceModelReference)
+			} else {
+				assert.Empty(t, got.Spec.DeviceModelReference)
+			}
+
+			// Verify properties were converted correctly
+			if len(tt.device.Spec.Properties) > 0 {
+				assert.Equal(t, len(tt.device.Spec.Properties), len(got.Spec.Properties))
+				for i, prop := range tt.device.Spec.Properties {
+					assert.Equal(t, prop.Name, got.Spec.Properties[i].Name)
+				}
+			}
+		})
+	}
+}
+func TestConvertDeviceModel(t *testing.T) {
+	cases := []struct {
+		name    string
+		model   *v1beta1.DeviceModel
+		wantErr bool
+	}{
+		{
+			name: "basic model conversion",
+			model: &v1beta1.DeviceModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-model",
+					Namespace: "default",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "model with complex data",
+			model: &v1beta1.DeviceModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-model-complex",
+					Namespace: "default",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceModel",
+					APIVersion: "devices.kubeedge.io/v1beta1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertDeviceModel(tt.model)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.model.Name, got.Name)
+			assert.Equal(t, tt.model.Namespace, got.Namespace)
+		})
+	}
+}
+func TestConvertDeviceProperty(t *testing.T) {
+	invalidValue := func() {}
+	type CustomValue struct {
+		Value interface{} `json:"value"`
+	}
+
+	cases := []struct {
+		name    string
+		prop    *v1beta1.DeviceProperty
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil property",
+			prop:    nil,
+			wantErr: true,
+			errMsg:  "property cannot be nil",
+		},
+		{
+			name: "marshal error case",
+			prop: &v1beta1.DeviceProperty{
+				Name: "test-prop",
+				Visitors: v1beta1.VisitorConfig{
+					ConfigData: &v1beta1.CustomizedValue{
+						Data: map[string]interface{}{
+							"test": invalidValue,
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "failed to marshal property",
+		},
+		{
+			name: "visitor config data conversion error",
+			prop: &v1beta1.DeviceProperty{
+				Name: "test-prop",
+				Visitors: v1beta1.VisitorConfig{
+					ConfigData: &v1beta1.CustomizedValue{
+						Data: map[string]interface{}{
+							"bad": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "failed to convert visitor config data",
+		},
+		{
+			name: "successful conversion",
+			prop: &v1beta1.DeviceProperty{
+				Name: "test-prop",
+				Visitors: v1beta1.VisitorConfig{
+					ConfigData: &v1beta1.CustomizedValue{
+						Data: map[string]interface{}{
+							"validKey": "validValue",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertDeviceProperty(tt.prop)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.prop.Name, got.Name)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Improves test coverage for the dtcommon package. From 20% to 80%.


**Which issue(s) this PR fixes**:
Part of #6101

**Special notes for your reviewer**:
This PR is part of the LFX Mentorship program to enhance KubeEdge testing coverage. The changes are limited to test files only and do not modify the core functionality.


**PR description**:
- Added null device check in ConvertDevice function
- Refactored property conversion into a separate helper function (convertDeviceProperty)
- Improved error handling with more descriptive messages
- Fixed potential null reference issues

**Does this PR introduce a user-facing change?**:
NONE
![image](https://github.com/user-attachments/assets/b5a98bf7-3fb5-4c14-86ff-96ea3dfa4547)
