### PR TITLE
[test]:improv coverage of token.go in pkg/security

### DIFF
--- a/pkg/security/token/token_test.go
+++ b/pkg/security/token/token_test.go
@@ -17,6 +17,7 @@ package token
 
 import (
 	"encoding/pem"
+	"strings"
 	"testing"
 )
 
@@ -68,43 +69,146 @@ UaWMXvECgYEAlhQUBLZ/ZTPXQWb7VA5Mur/s0ptrs4CAP+KBc9xyBfKrPEmjMcxJ
 2788MXYbnGzwpY0Nk/ruUNJ+PFPy4GgGWnZp7Fqi5qGIrFkuazQaulRQJwTZkIzJ
 x0KJ+pjtT+89L1r7murZAJcPL+TyRYeg295NTfcjAfSdcBfIjzURYVg=
 -----END RSA PRIVATE KEY-----`
+
+	testAltCA = `-----BEGIN CERTIFICATE-----
+MIIDEDCCAfigAwIBAgIIMmFz7zU7iyQwDQYJKoZIhvcNAQELBQAwJjEOMAwGA1UE
+BhMFQ2hpbmExCTAHBgNVBAoTADEJMAcGA1UECxMAMB4XDTI0MDQwODEwMDczN1oX
+DTM0MDQwNjEwMDczN1owJjEOMAwGA1UEBhMFQ2hpbmExCTAHBgNVBAoTADEJMAcG
+A1UECxMAMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5LnmwXmba7lH
+mllpyNQNxr3P5VDz98TGS9G9qRnGY9HZSRg4OZTGTM4ueJoqY8WpfU7KpBIQbxlJ
+RHa2wpUCb0Kw39WpLEDZRnl14AFBCUQin85YZa4LOkj9EcQzQrTnNUbGFt45Y9WX
+cg+2ouOBrFM7dEwgBNZ+KVZA19j5qG2sWVmX+V9iucA6ZHMFl5q7MyPQY/MJDisj
++YKe6zRMpawJ/VfR3huYLplFKtPHtlgqQFmNpIt9FKz0CZTtOJwJ/NjO5aoLCZ9d
+/F5nZ0jIAtqmm8CmHuDx6z15fNgHs0/+Z+7CtbHGx0GWx2zFUj/UWQ9VwJ/nQIGO
+eKfZ6kW0cQIDAQABo0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB
+/zAdBgNVHQ4EFgQUR+IUW6h9DNK4YX9l65GQK7bxVFUwDQYJKoZIhvcNAQELBQAD
+ggEBAKpG+hGmNb4TP2y/aFJbD9g8GYdWsXpNvRTp9SixZUz9xrn6r9GbsiyLmEcW
+Wjn3wZfYQXTR5cCsIQO4T5K3H7Z0e6z+IQtTqxq0Jch3kBaGlBcDGGm6FhPu/3qV
+zLY6XrTR5chgPnCgbAXUbPOD7xWvJYGZ3sIFUNZcEi/XsXyHs6I6qxcYfXhNnG/3
+7kX4TKDFuQrlKV5oaJZ3/Chs7x8EzQ82XQJrjTJJL9Q+nPJMvHx1M/uHzTpXVbRL
+GIdbAKp9HzWuWZ0GZo2+3rLdKQkYHQXEcUQvPxyYqXA6Y5g6MvdwrC/AUr58n5kp
+QEJCjtBMVHWyXDLk4KliPHpfq64=
+-----END CERTIFICATE-----`
 )
 
 func TestToken(t *testing.T) {
 	var token string
 
-	_, caDer := pem.Decode([]byte(testCA))
-	_, cakeyDer := pem.Decode([]byte(testCAKey))
+	caBlock, _ := pem.Decode([]byte(testCA))
+	if caBlock == nil {
+		t.Fatal("failed to decode CA certificate PEM")
+	}
+
+	caKeyBlock, _ := pem.Decode([]byte(testCAKey))
+	if caKeyBlock == nil {
+		t.Fatal("failed to decode CA key PEM")
+	}
 
 	t.Run("test Create", func(t *testing.T) {
 		var err error
-		token, err = Create(caDer, cakeyDer, 1)
+		token, err = Create(caBlock.Bytes, caKeyBlock.Bytes, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if len(token) == 0 {
 			t.Fatal("failed to get token")
+		}
+
+		parts := strings.Split(token, ".")
+		if len(parts) != 4 {
+			t.Fatalf("token should have 4 parts, got %d", len(parts))
+		}
+
+		caHash := hashCA(caBlock.Bytes)
+		if parts[0] != caHash {
+			t.Fatalf("first part should be CA hash, expected %s, got %s", caHash, parts[0])
 		}
 	})
 
 	t.Run("test VerifyCAAndGetRealToken", func(t *testing.T) {
 		var err error
-		token, err = VerifyCAAndGetRealToken(token, caDer)
+		jwtToken, err := VerifyCAAndGetRealToken(token, caBlock.Bytes)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(token) == 0 {
-			t.Fatal("failed to get token")
+		if len(jwtToken) == 0 {
+			t.Fatal("failed to get JWT token")
+		}
+
+		parts := strings.Split(jwtToken, ".")
+		if len(parts) != 3 {
+			t.Fatalf("JWT token should have 3 parts, got %d", len(parts))
 		}
 	})
 
 	t.Run("test Verify", func(t *testing.T) {
-		b, err := Verify(token, cakeyDer)
+		jwtToken, err := VerifyCAAndGetRealToken(token, caBlock.Bytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b, err := Verify(jwtToken, caKeyBlock.Bytes)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !b {
-			t.Fatalf("invalid token %s", token)
+			t.Fatalf("invalid token %s", jwtToken)
+		}
+	})
+
+	t.Run("test Create with invalid interval", func(t *testing.T) {
+		_, err := Create(caBlock.Bytes, caKeyBlock.Bytes, 0)
+		if err != nil {
+			t.Fatal("Create should work with 0 interval, but got error:", err)
+		}
+
+		_, err = Create(caBlock.Bytes, caKeyBlock.Bytes, -1)
+		if err != nil {
+			t.Fatal("Create should work with negative interval, but got error:", err)
+		}
+	})
+
+	t.Run("test VerifyCAAndGetRealToken with invalid token format", func(t *testing.T) {
+		invalidTokenFormats := []string{
+			"invalid",
+			"single.part",
+			"too.many.parts.1.2.3",
+			"",
+		}
+
+		for _, invalidToken := range invalidTokenFormats {
+			_, err := VerifyCAAndGetRealToken(invalidToken, caBlock.Bytes)
+			if err == nil {
+				t.Fatalf("VerifyCAAndGetRealToken should fail with invalid token format: %s", invalidToken)
+			}
+		}
+	})
+
+	t.Run("test VerifyCAAndGetRealToken with mismatched CA", func(t *testing.T) {
+		// Decode the alternative CA
+		altCABlock, _ := pem.Decode([]byte(testAltCA))
+		if altCABlock == nil {
+			t.Fatal("failed to decode alternative CA certificate PEM")
+		}
+
+		// The token was created with testCA, verify with altCA (should fail)
+		_, err := VerifyCAAndGetRealToken(token, altCABlock.Bytes)
+		if err == nil {
+			t.Fatal("VerifyCAAndGetRealToken should fail with mismatched CA")
+		}
+	})
+
+	t.Run("test Verify with invalid token", func(t *testing.T) {
+		invalidTokens := []string{
+			"invalid",                          // Completely invalid
+			"header.payload.invalid_signature", // Invalid JWT format
+		}
+
+		for _, invalidToken := range invalidTokens {
+			_, err := Verify(invalidToken, caKeyBlock.Bytes)
+			if err == nil {
+				t.Fatalf("Verify should fail with invalid token: %s", invalidToken)
+			}
 		}
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR improves the test coverage for the security token package by adding comprehensive test cases from 55%(mentioned in codecov report) to 90% .
Key improvements:
- Enhanced testing of token structure validation
- Added tests for various error conditions

These changes have increased the test coverage to over 90% for the token package.

**Which issue(s) this PR fixes**:
Part of #6101

**Special notes for your reviewer**:
This PR is part of the LFX Mentorship program to enhance KubeEdge testing coverage.

**Does this PR introduce a user-facing change?**:

NONE

![image](https://github.com/user-attachments/assets/37563ba8-4da2-4975-847d-f468e1b0b81b)
