### PR TITLE
Fix iptablesmanager cause kubernetes service access failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
     name: publish to DockerHub
     strategy:
       matrix:
-        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptables-manager, edgemark, installation-package, controller-manager, conformance, nodeconformance]
+        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptables-manager, iptables-manager-nft, edgemark, installation-package, controller-manager, conformance, nodeconformance]
     outputs:
       hash-digest-cloudcore: ${{ steps.hash.outputs.hash-digest-cloudcore }}
       hash-digest-admission: ${{ steps.hash.outputs.hash-digest-admission }}
@@ -110,6 +110,7 @@ jobs:
       hash-digest-edgesite-server: ${{ steps.hash.outputs.hash-digest-edgesite-server }}
       hash-digest-csidriver: ${{ steps.hash.outputs.hash-digest-csidriver }}
       hash-digest-iptables-manager: ${{ steps.hash.outputs.hash-digest-iptables-manager }}
+      hash-digest-iptables-manager-nft: ${{ steps.hash.outputs.hash-digest-iptables-manager-nft }}
       hash-digest-edgemark: ${{ steps.hash.outputs.hash-digest-edgemark }}
       hash-digest-installation-package: ${{ steps.hash.outputs.hash-digest-installation-package }}
       hash-digest-controller-manager: ${{ steps.hash.outputs.hash-digest-controller-manager }}
@@ -157,7 +158,7 @@ jobs:
     needs: [publish-image-to-dockerhub]
     strategy:
       matrix:
-        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptables-manager, edgemark, installation-package, controller-manager, conformance, nodeconformance]
+        target: [cloudcore, admission, edgesite-agent, edgesite-server, csidriver, iptables-manager, iptables-manager-nft, edgemark, installation-package, controller-manager, conformance, nodeconformance]
     permissions:
       actions: read # for detecting the Github Actions environment.
       id-token: write # for creating OIDC tokens for signing.

--- a/build/iptablesmanager/iptablesmanager-nft.Dockerfile
+++ b/build/iptablesmanager/iptablesmanager-nft.Dockerfile
@@ -12,10 +12,7 @@ FROM debian:12
 
 COPY --from=builder /usr/local/bin/iptables-manager /usr/local/bin/iptables-manager
 
+# iptables in nft mode is used by default
 RUN apt-get update && apt-get -y install iptables
-
-# Switch the iptables mode from the default nft mode back to the legacy mode, refer to https://wiki.debian.org/iptables
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
-     && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 
 ENTRYPOINT ["iptables-manager"]

--- a/hack/make-rules/image.sh
+++ b/hack/make-rules/image.sh
@@ -31,6 +31,7 @@ ALL_IMAGES_AND_TARGETS=(
   edgesite-server:edgesite-server:build/edgesite/server-build.Dockerfile
   csidriver:csidriver:build/csidriver/Dockerfile
   iptablesmanager:iptables-manager:build/iptablesmanager/Dockerfile
+  iptablesmanager-nft:iptables-manager-nft:build/iptablesmanager/iptablesmanager-nft.Dockerfile
   edgemark:edgemark:build/edgemark/Dockerfile
   conformance:conformance:build/conformance/Dockerfile
   nodeconformance:nodeconformance:build/conformance/nodeconformance.Dockerfile

--- a/hack/make-rules/imageprocess.sh
+++ b/hack/make-rules/imageprocess.sh
@@ -32,6 +32,7 @@ ALL_IMAGES_AND_TARGETS=(
   edgesite-server:edgesite-server:build/edgesite/server-build.Dockerfile
   csidriver:csidriver:build/csidriver/Dockerfile
   iptables-manager:iptables-manager:build/iptablesmanager/Dockerfile
+  iptables-manager-nft:iptables-manager-nft:build/iptablesmanager/iptablesmanager-nft.Dockerfile
   edgemark:edgemark:build/edgemark/Dockerfile
   installation-package:installation-package:build/docker/installation-package/installation-package.dockerfile
   controller-manager:controller-manager:build/controllermanager/Dockerfile

--- a/manifests/charts/cloudcore/README.md
+++ b/manifests/charts/cloudcore/README.md
@@ -45,6 +45,7 @@ helm upgrade --install cloudcore ./cloudcore --namespace kubeedge --create-names
 ### iptables-manager
 - `iptablesManager.enable`,  default `true`
 - `iptablesManager.mode`,  default `external`, can be modified to `internal`. The external mode will set up a iptables manager component which shares the host network.
+- `iptablesManager.framework`,  default `legacy`, can be modified to `nft`. Iptables of different frameworks are not compatible in the same network environment and need to be configured according to the operating environment.
 - `iptablesManager.image.repository`, default `kubeedge`, defines the image repo.
 - `iptablesManager.image.tag`, default `v1.19.0`, defines the image tag.
 - `iptablesManager.image.pullPolicy`, default `IfNotPresent`, defines the policies to pull images.

--- a/manifests/charts/cloudcore/templates/daemonset_iptablesmanager.yaml
+++ b/manifests/charts/cloudcore/templates/daemonset_iptablesmanager.yaml
@@ -39,7 +39,11 @@ spec:
       containers:
       - name: iptables-manager
         command: ['iptables-manager']
+        {{- if eq .Values.iptablesManager.framework "nft" }}
+        image: {{ .Values.iptablesManager.image.nftRepository }}:{{ .Values.iptablesManager.image.tag }}
+        {{- else }}
         image: {{ .Values.iptablesManager.image.repository }}:{{ .Values.iptablesManager.image.tag }}
+        {{- end }}
         imagePullPolicy: {{ .Values.iptablesManager.image.pullPolicy }}
         {{- with .Values.iptablesManager.securityContext }}
         securityContext: {{ toYaml . | nindent 10 }}

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -75,9 +75,11 @@ cloudCore:
 iptablesManager:
   enable: true
   mode: "external"
+  framework: "legacy"
   hostNetWork: true
   image:
     repository: "kubeedge/iptables-manager"
+    nftRepository: "kubeedge/iptables-manager-nft"
     tag: "v1.20.0"
     pullPolicy: "IfNotPresent"
     pullSecrets: []


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

As mentioned in #6193, to solve the incompatibility problem of iptables framework, we need to change the iptables framework in the default iptablesmanager image to **legacy**, and provide a configuration option to switch to nft mode.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6193

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
