### PR TITLE
[test]:improve coverage for pod in edge/pkg/metamanager/client

### DIFF
--- a/edge/pkg/metamanager/client/pod_test.go
+++ b/edge/pkg/metamanager/client/pod_test.go
@@ -21,12 +21,23 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao"
+)
+
+const (
+	testPodName       = "test-pod"
+	testContainerName = "test-container"
+	testImage         = "test-image"
+	testUpdatedImage  = "updated-image"
 )
 
 func TestNewPods(t *testing.T) {
@@ -43,7 +54,6 @@ func TestNewPods(t *testing.T) {
 func TestPods_Delete(t *testing.T) {
 	assert := assert.New(t)
 
-	podName := "test-pod"
 	deleteOptions := metav1.DeleteOptions{}
 
 	testCases := []struct {
@@ -76,7 +86,7 @@ func TestPods_Delete(t *testing.T) {
 				assert.Equal(modules.MetaGroup, message.GetGroup())
 				assert.Equal(modules.EdgedModuleName, message.GetSource())
 				assert.NotEmpty(message.GetID())
-				assert.Equal(fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, podName), message.GetResource())
+				assert.Equal(fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, testPodName), message.GetResource())
 				assert.Equal(model.DeleteOperation, message.GetOperation())
 
 				return test.respFunc(message)
@@ -84,7 +94,7 @@ func TestPods_Delete(t *testing.T) {
 
 			podsClient := newPods(namespace, mockSend)
 
-			err := podsClient.Delete(podName, deleteOptions)
+			err := podsClient.Delete(testPodName, deleteOptions)
 
 			if test.expectErr {
 				assert.Error(err)
@@ -98,17 +108,16 @@ func TestPods_Delete(t *testing.T) {
 func TestPods_Get(t *testing.T) {
 	assert := assert.New(t)
 
-	podName := "test-pod"
 	expectedPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
+			Name:      testPodName,
 			Namespace: namespace,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:  "test-container",
-					Image: "test-image",
+					Name:  testContainerName,
+					Image: testImage,
 				},
 			},
 		},
@@ -148,7 +157,7 @@ func TestPods_Get(t *testing.T) {
 				assert.Equal(modules.MetaGroup, message.GetGroup())
 				assert.Equal(modules.EdgedModuleName, message.GetSource())
 				assert.NotEmpty(message.GetID())
-				assert.Equal(fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, podName), message.GetResource())
+				assert.Equal(fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, testPodName), message.GetResource())
 				assert.Equal(model.QueryOperation, message.GetOperation())
 
 				return test.respFunc(message)
@@ -156,7 +165,7 @@ func TestPods_Get(t *testing.T) {
 
 			podsClient := newPods(namespace, mockSend)
 
-			pod, err := podsClient.Get(podName)
+			pod, err := podsClient.Get(testPodName)
 
 			if test.expectErr {
 				assert.Error(err)
@@ -183,14 +192,14 @@ func TestHandlePodFromMetaDB(t *testing.T) {
 			content: []byte(`["{\"metadata\":{\"name\":\"test-pod\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"name\":\"test-container\",\"image\":\"test-image\"}]}}"]`),
 			expectedPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
+					Name:      testPodName,
 					Namespace: "default",
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "test-container",
-							Image: "test-image",
+							Name:  testContainerName,
+							Image: testImage,
 						},
 					},
 				},
@@ -219,7 +228,7 @@ func TestHandlePodFromMetaDB(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			pod, err := handlePodFromMetaDB("test-pod", test.content)
+			pod, err := handlePodFromMetaDB(testPodName, test.content)
 
 			if test.expectedErr {
 				assert.Error(err)
@@ -230,6 +239,587 @@ func TestHandlePodFromMetaDB(t *testing.T) {
 				assert.Equal(test.expectedPod.ObjectMeta.Namespace, pod.ObjectMeta.Namespace)
 				assert.Equal(test.expectedPod.Spec.Containers[0].Name, pod.Spec.Containers[0].Name)
 				assert.Equal(test.expectedPod.Spec.Containers[0].Image, pod.Spec.Containers[0].Image)
+			}
+		})
+	}
+}
+
+func TestPods_Create(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  testContainerName,
+					Image: testImage,
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		respFunc  func(*model.Message) (*model.Message, error)
+		stdResult *corev1.Pod
+		expectErr bool
+	}{
+		{
+			name: "Create Pod Success",
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				podResp := PodResp{
+					Object: expectedPod,
+					Err:    apierrors.StatusError{},
+				}
+				respData, _ := json.Marshal(podResp)
+				resp.Content = respData
+				return resp, nil
+			},
+			stdResult: expectedPod,
+			expectErr: false,
+		},
+		{
+			name: "Create Pod Error in SendSync",
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				return nil, fmt.Errorf("test error")
+			},
+			stdResult: nil,
+			expectErr: true,
+		},
+		{
+			name: "Create Pod Error in GetContentData",
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = 123
+				return resp, nil
+			},
+			stdResult: nil,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			mockSend := &mockSendInterface{}
+			mockSend.sendSyncFunc = func(message *model.Message) (*model.Message, error) {
+				assert.Equal(modules.MetaGroup, message.GetGroup())
+				assert.Equal(modules.EdgedModuleName, message.GetSource())
+				assert.NotEmpty(message.GetID())
+				assert.Equal(fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, expectedPod.Name), message.GetResource())
+				assert.Equal(model.InsertOperation, message.GetOperation())
+
+				return test.respFunc(message)
+			}
+
+			patches := gomonkey.ApplyFunc(updatePodDB, func(resource string, pod *corev1.Pod) error {
+				return nil
+			})
+			defer patches.Reset()
+
+			podsClient := newPods(namespace, mockSend)
+
+			pod, err := podsClient.Create(expectedPod)
+
+			if test.expectErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.Equal(test.stdResult, pod)
+			}
+		})
+	}
+}
+
+func TestPods_Update(t *testing.T) {
+	assert := assert.New(t)
+
+	mockSend := &mockSendInterface{}
+	podsClient := newPods(namespace, mockSend)
+
+	err := podsClient.Update(&corev1.Pod{})
+	assert.Nil(err)
+}
+
+func TestPods_Patch(t *testing.T) {
+	assert := assert.New(t)
+
+	patchBytes := []byte(`{"spec":{"containers":[{"name":"test-container","image":"updated-image"}]}}`)
+	expectedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  testContainerName,
+					Image: testUpdatedImage,
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		podName   string
+		respFunc  func(*model.Message) (*model.Message, error)
+		stdResult *corev1.Pod
+		expectErr bool
+	}{
+		{
+			name:    "Patch Pod Success",
+			podName: testPodName,
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				podResp := PodResp{
+					Object: expectedPod,
+					Err:    apierrors.StatusError{},
+				}
+				respData, _ := json.Marshal(podResp)
+				resp.Content = respData
+				return resp, nil
+			},
+			stdResult: expectedPod,
+			expectErr: false,
+		},
+		{
+			name:    "Patch Pod Error in SendSync",
+			podName: testPodName,
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				return nil, fmt.Errorf("test error")
+			},
+			stdResult: nil,
+			expectErr: true,
+		},
+		{
+			name:    "Patch Pod Error in GetContentData",
+			podName: testPodName,
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = 123
+				return resp, nil
+			},
+			stdResult: nil,
+			expectErr: true,
+		},
+		{
+			name:    "Patch Response Error Operation",
+			podName: testPodName,
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Router.Operation = model.ResponseErrorOperation
+				resp.Content = "error message"
+				return resp, nil
+			},
+			stdResult: nil,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			mockSend := &mockSendInterface{}
+			mockSend.sendSyncFunc = test.respFunc
+
+			patches := gomonkey.ApplyFunc(updatePodDB, func(resource string, pod *corev1.Pod) error {
+				return nil
+			})
+			defer patches.Reset()
+
+			podsClient := newPods(namespace, mockSend)
+
+			pod, err := podsClient.Patch(test.podName, patchBytes)
+
+			if test.expectErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.Equal(test.stdResult, pod)
+			}
+		})
+	}
+}
+
+func TestPods_PatchMQTT(t *testing.T) {
+	assert := assert.New(t)
+
+	podName := constants.DefaultMosquittoContainerName
+	patchBytes := []byte(`{"spec":{"containers":[{"name":"mqtt","image":"updated-image"}]}}`)
+	expectedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "mqtt",
+					Image: "mosquitto",
+				},
+			},
+		},
+	}
+
+	podJSON, _ := json.Marshal(expectedPod)
+	metas := &[]string{string(podJSON)}
+
+	patches := gomonkey.ApplyFunc(dao.QueryMeta, func(key string, value string) (*[]string, error) {
+		assert.Equal("key", key)
+		assert.Equal(fmt.Sprintf("default/pod/%s", constants.DefaultMosquittoContainerName), value)
+		return metas, nil
+	})
+	defer patches.Reset()
+
+	mockSend := &mockSendInterface{}
+	mockSend.sendSyncFunc = func(message *model.Message) (*model.Message, error) {
+		t.Fail()
+		return nil, nil
+	}
+
+	podsClient := newPods(namespace, mockSend)
+
+	pod, err := podsClient.Patch(podName, patchBytes)
+
+	assert.NoError(err)
+	assert.Equal(expectedPod, pod)
+}
+
+func TestHandlePodResp(t *testing.T) {
+	assert := assert.New(t)
+
+	resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, testPodName)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  testContainerName,
+					Image: testImage,
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		podResp     PodResp
+		mockDBError error
+		expectedPod *corev1.Pod
+		expectedErr bool
+	}{
+		{
+			name: "Success Case",
+			podResp: PodResp{
+				Object: pod,
+				Err:    apierrors.StatusError{},
+			},
+			mockDBError: nil,
+			expectedPod: pod,
+			expectedErr: false,
+		},
+		{
+			name: "DB Error Case",
+			podResp: PodResp{
+				Object: pod,
+				Err:    apierrors.StatusError{},
+			},
+			mockDBError: fmt.Errorf("database error"),
+			expectedPod: nil,
+			expectedErr: true,
+		},
+		{
+			name: "API Error Case",
+			podResp: PodResp{
+				Object: pod,
+				Err:    apierrors.StatusError{ErrStatus: metav1.Status{Message: "API error"}},
+			},
+			mockDBError: nil,
+			expectedPod: pod,
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			patches := gomonkey.ApplyFunc(updatePodDB, func(resource string, pod *corev1.Pod) error {
+				return test.mockDBError
+			})
+			defer patches.Reset()
+
+			content, err := json.Marshal(test.podResp)
+			assert.NoError(err)
+
+			pod, err := handlePodResp(resource, content)
+
+			if test.expectedErr {
+				assert.Error(err)
+				if test.name == "DB Error Case" {
+					assert.Nil(pod)
+				}
+			} else {
+				assert.NoError(err)
+				assert.Equal(test.expectedPod, pod)
+			}
+		})
+	}
+}
+
+func TestHandlePodRespInvalidJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, testPodName)
+	content := []byte("invalid json")
+
+	pod, err := handlePodResp(resource, content)
+
+	assert.Error(err)
+	assert.Nil(pod)
+	assert.Contains(err.Error(), "unmarshal")
+}
+
+func TestUpdatePodDB(t *testing.T) {
+	assert := assert.New(t)
+
+	resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePodPatch, testPodName)
+	expectedKey := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypePod, testPodName)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  testContainerName,
+					Image: testImage,
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		mockDBError error
+		expectedErr bool
+	}{
+		{
+			name:        "Success Case",
+			mockDBError: nil,
+			expectedErr: false,
+		},
+		{
+			name:        "DB Error Case",
+			mockDBError: fmt.Errorf("database error"),
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			patches := gomonkey.ApplyFunc(dao.InsertOrUpdate, func(meta *dao.Meta) error {
+				assert.Equal(expectedKey, meta.Key)
+				assert.Equal(model.ResourceTypePod, meta.Type)
+				return test.mockDBError
+			})
+			defer patches.Reset()
+
+			err := updatePodDB(resource, pod)
+
+			if test.expectedErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestHandleMqttMeta(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.DefaultMosquittoContainerName,
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "mqtt",
+					Image: "mosquitto",
+				},
+			},
+		},
+	}
+	podJSON, _ := json.Marshal(expectedPod)
+
+	testCases := []struct {
+		name        string
+		metas       *[]string
+		mockDBError error
+		expectedPod *corev1.Pod
+		expectedErr bool
+	}{
+		{
+			name:        "Success Case",
+			metas:       &[]string{string(podJSON)},
+			mockDBError: nil,
+			expectedPod: expectedPod,
+			expectedErr: false,
+		},
+		{
+			name:        "Query Error Case",
+			metas:       nil,
+			mockDBError: fmt.Errorf("database error"),
+			expectedPod: nil,
+			expectedErr: true,
+		},
+		{
+			name:        "Invalid Meta Length",
+			metas:       &[]string{},
+			mockDBError: nil,
+			expectedPod: nil,
+			expectedErr: true,
+		},
+		{
+			name:        "Invalid JSON",
+			metas:       &[]string{"invalid json"},
+			mockDBError: nil,
+			expectedPod: nil,
+			expectedErr: true,
+		},
+		{
+			name:        "Multiple Metas",
+			metas:       &[]string{string(podJSON), string(podJSON)},
+			mockDBError: nil,
+			expectedPod: nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			patches := gomonkey.ApplyFunc(dao.QueryMeta, func(key string, value string) (*[]string, error) {
+				assert.Equal("key", key)
+				assert.Equal(fmt.Sprintf("default/pod/%s", constants.DefaultMosquittoContainerName), value)
+				return test.metas, test.mockDBError
+			})
+			defer patches.Reset()
+
+			pod, err := handleMqttMeta()
+
+			if test.expectedErr {
+				assert.Error(err)
+				assert.Nil(pod)
+			} else {
+				assert.NoError(err)
+				assert.Equal(test.expectedPod, pod)
+			}
+		})
+	}
+}
+
+func TestPods_DeleteWithDifferentContentTypes(t *testing.T) {
+	assert := assert.New(t)
+
+	deleteOptions := metav1.DeleteOptions{}
+
+	testCases := []struct {
+		name      string
+		content   interface{}
+		expectErr bool
+	}{
+		{
+			name:      "Success with OK string",
+			content:   constants.MessageSuccessfulContent,
+			expectErr: false,
+		},
+		{
+			name:      "Error with error content",
+			content:   fmt.Errorf("delete error"),
+			expectErr: true,
+		},
+		{
+			name:      "Error with unsupported content type",
+			content:   123,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			mockSend := &mockSendInterface{}
+			mockSend.sendSyncFunc = func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = test.content
+				return resp, nil
+			}
+
+			podsClient := newPods(namespace, mockSend)
+
+			err := podsClient.Delete(testPodName, deleteOptions)
+
+			if test.expectErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestPods_GetWithContentErrors(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name      string
+		respFunc  func(*model.Message) (*model.Message, error)
+		expectErr bool
+	}{
+		{
+			name: "Get Pod Error in GetContentData",
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = 123
+				return resp, nil
+			},
+			expectErr: true,
+		},
+		{
+			name: "Get Pod with Not Found Response",
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = []string{}
+				return resp, nil
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			mockSend := &mockSendInterface{}
+			mockSend.sendSyncFunc = test.respFunc
+
+			podsClient := newPods(namespace, mockSend)
+
+			pod, err := podsClient.Get(testPodName)
+
+			assert.Error(err)
+			assert.Nil(pod)
+
+			if test.name == "Get Pod with Not Found Response" {
+				statusErr, ok := err.(*apierrors.StatusError)
+				assert.True(ok)
+				assert.Equal(metav1.StatusReasonNotFound, statusErr.ErrStatus.Reason)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR
-->
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR significantly improves the test coverage for the Pod client implementation in the edge/pkg/metamanager/client package. The test coverage has been increased from 33% to 94% by adding comprehensive tests for all functions including Create, Update, Patch, Delete methods and their internal helper functions.


**Which issue(s) this PR fixes**:
Part of #6186 - Enhance KubeEdge testing coverage


**Does this PR introduce a user-facing change?**:

NONE
