### PR TITLE
[test]:improve coverage of persistentvolumeclaim in edge/pkg/metamanager

### DIFF
--- a/edge/pkg/metamanager/client/persistentvolumeclaim_test.go
+++ b/edge/pkg/metamanager/client/persistentvolumeclaim_test.go
@@ -18,13 +18,37 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 )
+
+// Common test constants used throughout the tests
+const (
+	testPVCName = "test-pvc"
+)
+
+// setupTest creates common test objects and returns them
+func setupTest(t *testing.T) (*assert.Assertions, SendInterface, *persistentvolumeclaims, *gomonkey.Patches) {
+	a := assert.New(t)
+	s := newSend()
+	pvcClient := newPersistentVolumeClaims(testNamespace, s)
+	patches := gomonkey.NewPatches()
+	t.Cleanup(func() {
+		patches.Reset()
+	})
+	return a, s, pvcClient, patches
+}
 
 func TestNewPersistentVolumeClaims(t *testing.T) {
 	assert := assert.New(t)
@@ -43,8 +67,8 @@ func TestHandlePersistentVolumeClaimFromMetaDB(t *testing.T) {
 	// Test case 1: Valid PersistentVolumeClaim JSON
 	pvc := &api.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
+			Name:      testPVCName,
+			Namespace: testNamespace,
 		},
 		Spec: api.PersistentVolumeClaimSpec{
 			AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
@@ -101,8 +125,8 @@ func TestHandlePersistentVolumeClaimFromMetaManager(t *testing.T) {
 	// Test case 1: Valid PersistentVolumeClaim JSON
 	pvc := &api.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pvc",
-			Namespace: "default",
+			Name:      testPVCName,
+			Namespace: testNamespace,
 		},
 		Spec: api.PersistentVolumeClaimSpec{
 			AccessModes: []api.PersistentVolumeAccessMode{api.ReadWriteOnce},
@@ -133,4 +157,135 @@ func TestHandlePersistentVolumeClaimFromMetaManager(t *testing.T) {
 	assert.Error(err)
 	assert.Nil(result)
 	assert.Contains(err.Error(), "unmarshal message to persistentvolumeclaim failed")
+}
+
+func TestPersistentVolumeClaimsStubMethods(t *testing.T) {
+	assert := assert.New(t)
+
+	s := newSend()
+	pvcClient := newPersistentVolumeClaims(testNamespace, s)
+
+	testPVC := &api.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPVCName,
+			Namespace: testNamespace,
+		},
+	}
+
+	result, err := pvcClient.Create(testPVC)
+	assert.Nil(result)
+	assert.NoError(err)
+
+	err = pvcClient.Update(testPVC)
+	assert.NoError(err)
+
+	err = pvcClient.Delete(testPVCName)
+	assert.NoError(err)
+}
+
+func TestPersistentVolumeClaimsGet(t *testing.T) {
+	t.Run("SendSync Error", func(t *testing.T) {
+		assert, s, pvcClient, patches := setupTest(t)
+
+		patches.ApplyMethod(s, "SendSync",
+			func(_ *send, _ *model.Message) (*model.Message, error) {
+				return nil, errors.New("send sync error")
+			})
+
+		result, err := pvcClient.Get(testPVCName, metav1.GetOptions{})
+
+		assert.Error(err)
+		assert.Nil(result)
+		assert.Contains(err.Error(), "get persistentvolumeclaim from metaManager failed")
+	})
+
+	t.Run("GetContentData Error", func(t *testing.T) {
+		assert, s, pvcClient, patches := setupTest(t)
+		mockMsg := &model.Message{}
+
+		patches.ApplyMethod(s, "SendSync",
+			func(_ *send, _ *model.Message) (*model.Message, error) {
+				return mockMsg, nil
+			})
+
+		patches.ApplyMethod(mockMsg, "GetContentData",
+			func(_ *model.Message) ([]byte, error) {
+				return nil, errors.New("get content data error")
+			})
+
+		result, err := pvcClient.Get(testPVCName, metav1.GetOptions{})
+
+		assert.Error(err)
+		assert.Nil(result)
+		assert.Contains(err.Error(), "parse message to persistentvolumeclaim failed")
+	})
+
+	t.Run("MetaManager Handler Error", func(t *testing.T) {
+		assert, s, pvcClient, patches := setupTest(t)
+		mockMsg := &model.Message{}
+
+		patches.ApplyMethod(s, "SendSync",
+			func(_ *send, _ *model.Message) (*model.Message, error) {
+				return mockMsg, nil
+			})
+
+		patches.ApplyMethod(mockMsg, "GetOperation",
+			func(_ *model.Message) string {
+				return "OtherOperation"
+			})
+
+		patches.ApplyMethod(mockMsg, "GetSource",
+			func(_ *model.Message) string {
+				return modules.MetaManagerModuleName
+			})
+
+		patches.ApplyMethod(mockMsg, "GetContentData",
+			func(_ *model.Message) ([]byte, error) {
+				return []byte(`{"invalid json`), nil
+			})
+
+		result, err := pvcClient.Get(testPVCName, metav1.GetOptions{})
+
+		assert.Error(err)
+		assert.Nil(result)
+		assert.Contains(err.Error(), "unmarshal message to persistentvolumeclaim failed")
+	})
+
+	t.Run("Test BuildMsg Parameters", func(t *testing.T) {
+		assert, s, pvcClient, patches := setupTest(t)
+
+		expectedResource := fmt.Sprintf("%s/%s/%s", testNamespace, "persistentvolumeclaim", testPVCName)
+
+		var capturedGroup, capturedResource, capturedSource, capturedDest string
+		var capturedOperation string
+		var capturedContent interface{}
+
+		patches.ApplyFunc(message.BuildMsg,
+			func(group, source, dest, resource string, operation string, content interface{}) *model.Message {
+				capturedGroup = group
+				capturedSource = source
+				capturedDest = dest
+				capturedResource = resource
+				capturedOperation = operation
+				capturedContent = content
+
+				return &model.Message{}
+			})
+
+		patches.ApplyMethod(s, "SendSync",
+			func(_ *send, _ *model.Message) (*model.Message, error) {
+				return nil, errors.New("some error")
+			})
+
+		result, err := pvcClient.Get(testPVCName, metav1.GetOptions{})
+
+		assert.Error(err)
+		assert.Nil(result)
+		assert.Equal(modules.MetaGroup, capturedGroup)
+		assert.Equal("", capturedSource)
+		assert.Equal(modules.EdgedModuleName, capturedDest)
+		assert.Equal(expectedResource, capturedResource)
+		assert.Equal(model.QueryOperation, capturedOperation)
+		assert.Nil(capturedContent)
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR
-->
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR significantly improves test coverage for the `persistentvolumeclaim.go` file in the edge/pkg/metamanager/client package, increasing the coverage from 56% to 96%. 


**Which issue(s) this PR fixes**:
Part of #6186


**Does this PR introduce a user-facing change?**:
```release-note
NONE