### PR TITLE
feat: add DisableCSINode feature gate to skip CSI initialization

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
 	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/volume"
 	csiplugin "k8s.io/kubernetes/pkg/volume/csi"
 
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
@@ -218,6 +219,14 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	}
 	edgedconfig.ConvertConfigEdgedFlagToConfigKubeletFlag(&edgedconfig.Config.TailoredKubeletFlag, &kubeletFlags)
 
+	// Register the DisableCSIVolumePlugin Custom feature gate.
+	featurekey := featuregate.Feature(kefeatures.DisableCSIVolumePlugin)
+	if err := utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+		featurekey: {Default: false, PreRelease: featuregate.Alpha},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to set default DisableCSIVolumePlugin feature gate : %w", err)
+	}
+
 	// set feature gates from initial flags-based config
 	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(kubeletConfig.FeatureGates); err != nil {
 		return nil, fmt.Errorf("failed to set feature gates from initial flags-based config: %w", err)
@@ -249,6 +258,8 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	}
 	MakeKubeClientBridge(kubeletDeps)
 
+	kubeletDeps.VolumePlugins = filterVolumePluginsByFeatureGate(kubeletDeps.VolumePlugins)
+
 	// source of all configuration
 	kubeletDeps.PodConfig = config.NewPodConfig(config.PodConfigNotificationIncremental, kubeletDeps.Recorder, kubeletDeps.PodStartupLatencyTracker)
 
@@ -263,6 +274,22 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	}
 
 	return ed, nil
+}
+
+// filterVolumePluginsByFeatureGate filters the list of volume plugins based on feature gate settings.
+func filterVolumePluginsByFeatureGate(plugins []volume.VolumePlugin) []volume.VolumePlugin {
+	// filter the current edged-supported CSI plugin enable/disable control through feature gates
+	res := []volume.VolumePlugin{}
+	for _, plugin := range plugins {
+		if plugin.GetPluginName() == csiplugin.CSIPluginName {
+			if utilfeature.DefaultFeatureGate.Enabled(kefeatures.DisableCSIVolumePlugin) {
+				klog.Infof("CSI plugin disabled by configuration, skipping %q", plugin.GetPluginName())
+				continue
+			}
+		}
+		res = append(res, plugin)
+	}
+	return res
 }
 
 func (e *edged) syncPod(podCfg *config.PodConfig) {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -37,6 +37,8 @@ const (
 	// DisableNodeTaskV1alpha2 disables the node task v1alpha2 feature, uses v1alpha1.
 	// TODO: After v1.23, this switch will be removed and only v1alpha2+ will be supported.
 	DisableNodeTaskV1alpha2 featuregate.Feature = "disableNodeTaskV1alpha2"
+	// DisableCSIVolumePlugin disables the in-tree CSI volume plugin support.
+	DisableCSIVolumePlugin featuregate.Feature = "DisableCSIVolumePlugin"
 )
 
 // defaultFeatureGates consists of all known Kubeedge-specific feature keys.


### PR DESCRIPTION
Introduce a new edgecore feature gate, DisableCSINode, to optionally disable CSI node initialization. This prevents Kubelet crashes in offline environments where CSINode creation fails due to API server unavailability, enhancing edgecore resilience.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6232

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
