### PR TITLE
docs: fix typo/markdown format in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ The goal of the community is to develop a cloud native edge computing platform b
 
 - Fork the repository on GitHub
 - Read the [setup](https://kubeedge.io/docs/setup/install-with-keadm) for deployment.
-- Read the [Developer Guide][https://kubeedge.io/docs/category/developer-guide]
+- Read the [Developer Guide](https://kubeedge.io/docs/category/developer-guide)
+
 
 
 # Your First Contribution


### PR DESCRIPTION
- Corrected markdown syntax for the link.

## What this PR does
Fixes a broken markdown link for the Developer Guide in the CONTRIBUTING.md file.

## Why it's needed
It improves developer experience by pointing them to the correct docs page.

Fixes #
typo/markdown format in CONTRIBUTING.md
