### PR TITLE
Change apt source to fix keadm deprecated e2e CI

### DIFF
--- a/tests/scripts/keadm_deprecated_e2e.sh
+++ b/tests/scripts/keadm_deprecated_e2e.sh
@@ -100,10 +100,18 @@ function run_test() {
   fi
 }
 
+function change_apt_source() {
+  sudo sed -i 's@//.*archive.ubuntu.com@//mirrors.ustc.edu.cn@g' /etc/apt/sources.list
+  sudo apt-get update
+}
+
 trap cleanup EXIT
 trap cleanup ERR
 
 echo -e "\nUsing latest commit code to do keadm_deprecated_e2e test..."
+
+echo -e "\nChange apt source"
+change_apt_source
 
 echo -e "\nBuilding keadm..."
 build_keadm


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When running the keadm deprecated e2e test, it was found that due to the failure of the apt default source, packages such as mosquitto could not be installed, so the test failed. This PR temporarily solves this problem by changing the apt source

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6293 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
