### PR TITLE
Enhance --set param to support configs like RegisterWithTaints

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/set.go
+++ b/keadm/cmd/keadm/app/cmd/util/set.go
@@ -317,6 +317,13 @@ func convertTargetValue(targetType reflect.Type, valueToSet reflect.Value) (refl
 	if targetType.Kind() == valueToSet.Kind() && valueToSet.Type().ConvertibleTo(targetType) {
 		return valueToSet.Convert(targetType), nil
 	}
+	// support point value
+	if targetType.Kind() == reflect.Ptr && valueToSet.Type().ConvertibleTo(targetType.Elem()) {
+		ptr := reflect.New(targetType.Elem())
+		convertedValue := valueToSet.Convert(targetType.Elem())
+		ptr.Elem().Set(convertedValue)
+		return ptr, nil
+	}
 	// use JSON Marshal & Unmarshal to handle map to struct & map to map conversion
 	if targetType.Kind() == reflect.Struct || targetType.Kind() == reflect.Map {
 		jsonNewValue, err := json.Marshal(valueToSet.Interface())

--- a/keadm/cmd/keadm/app/cmd/util/set.go
+++ b/keadm/cmd/keadm/app/cmd/util/set.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -107,7 +108,7 @@ func parseValue(s string) interface{} {
 	if boolvalue, err := strconv.ParseBool(s); err == nil {
 		return boolvalue
 	}
-	return s
+	return trimStringVal(s)
 }
 
 // ParseMap parses the value of map.
@@ -163,10 +164,20 @@ func parseArray(s string) interface{} {
 	default:
 		stringArray := make([]string, len(vals))
 		for i, v := range vals {
-			stringArray[i] = strings.TrimSpace(v)
+			stringArray[i] = trimStringVal(v)
 		}
 		return stringArray
 	}
+}
+
+func trimStringVal(s string) string {
+	// trim space
+	s = strings.TrimSpace(s)
+	if (strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) || (strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")) {
+		// trim paired single or double quotation marks
+		s = s[1 : len(s)-1]
+	}
+	return s
 }
 
 // ParseType parses the type of array and interprets it to int, float64, string.
@@ -223,12 +234,13 @@ func setCommonValue(structPtr interface{}, fieldPath string, value interface{}) 
 		}
 	}
 
+	// Set new value
 	val := reflect.ValueOf(value)
-
-	if fieldVal.Type() != val.Type() {
-		return fmt.Errorf("%s: Provided value type %s does not match field type %s", fieldPath, val.Type(), fieldVal.Type())
+	targetValue, err := convertTargetValue(fieldVal.Type(), val)
+	if err != nil {
+		return fmt.Errorf("%s: Convert to target value failed, err: %s", fieldPath, err)
 	}
-	fieldVal.Set(val)
+	fieldVal.Set(targetValue)
 
 	return nil
 }
@@ -271,24 +283,53 @@ func setArrayValue(structPtr interface{}, fieldPath string, index int, newValue 
 	if fieldVal.Kind() != reflect.Array && fieldVal.Kind() != reflect.Slice && fieldVal.Kind() != reflect.Map {
 		return fmt.Errorf("%s is not an array,slice and map", pathParts[len(pathParts)-1])
 	}
-	// If it is an array or slice, you need to check whether the index is within the range
-	if index < 0 || index >= fieldVal.Len() {
-		return fmt.Errorf("index out of range for %s", pathParts[len(pathParts)-1])
-	}
 
-	//Extend array or slice length
-	if index >= fieldVal.Len() {
-		newSlice := reflect.MakeSlice(fieldVal.Type(), index+1, index+1)
-		reflect.Copy(newSlice, fieldVal)
-		fieldVal.Set(newSlice)
+	if fieldVal.Kind() == reflect.Array {
+		// If it is an array, you need to check whether the index is within the range
+		if index < 0 || index >= fieldVal.Len() {
+			return fmt.Errorf("index out of range for %s", pathParts[len(pathParts)-1])
+		}
+	} else if fieldVal.Kind() == reflect.Slice {
+		if index < 0 {
+			return fmt.Errorf("index out of range for %s", pathParts[len(pathParts)-1])
+		}
+		// If it is a slice, you need to ensure its capacity
+		if index >= fieldVal.Len() {
+			newSlice := reflect.MakeSlice(fieldVal.Type(), index+1, index+1)
+			reflect.Copy(newSlice, fieldVal)
+			fieldVal.Set(newSlice)
+		}
 	}
-	//Set new value
-	elem := reflect.ValueOf(newValue)
-	if elem.Type() != fieldVal.Type().Elem() {
-		return fmt.Errorf("type mismatch for field %s", pathParts[len(pathParts)-1])
+	// Set new value
+	valueToSet := reflect.ValueOf(newValue)
+	elemType := fieldVal.Type().Elem()
+	targetValue, err := convertTargetValue(elemType, valueToSet)
+	if err != nil {
+		return fmt.Errorf("%s: Convert to elem value failed, err: %s", fieldPath, err)
 	}
-	fieldVal.Index(index).Set(elem)
+	fieldVal.Index(index).Set(targetValue)
 	return nil
+}
+
+// convertTargetValue convert newValue to targetType
+// use JSON Marshal & Unmarshal to handle map to struct & map to map conversion
+func convertTargetValue(targetType reflect.Type, valueToSet reflect.Value) (reflect.Value, error) {
+	if valueToSet.Type().AssignableTo(targetType) {
+		return valueToSet, nil
+	}
+	if (targetType.Kind() == reflect.Struct || targetType.Kind() == reflect.Map) && valueToSet.Kind() == reflect.Map {
+		jsonNewValue, err := json.Marshal(valueToSet.Interface())
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		targetValue := reflect.New(targetType).Interface()
+		err = json.Unmarshal(jsonNewValue, targetValue)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return reflect.Indirect(reflect.ValueOf(targetValue)), nil
+	}
+	return reflect.Value{}, fmt.Errorf("Provided value type %s does not match target type %s", valueToSet.Type(), targetType)
 }
 
 // ParseFieldPath1 parses the names in form of "name1.name2.(...).nameM[N]".

--- a/keadm/cmd/keadm/app/cmd/util/set_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/set_test.go
@@ -460,8 +460,11 @@ func TestSetVariableValue(t *testing.T) {
 	}
 
 	err = setVariableValue(config, "Name1.Name2[2].Variable1", 200)
-	if err == nil {
-		t.Error("Expected error for updating out of range index, but got nil")
+	if err != nil {
+		t.Errorf("Error updating field: %v", err)
+	}
+	if config.Name1.Name2[2].Variable1 != 200 {
+		t.Errorf("Variable1 not updated properly")
 	}
 }
 
@@ -487,8 +490,11 @@ func TestSetVariableValue_EmptySlice(t *testing.T) {
 	}
 
 	err := setVariableValue(config, "Name1.Name2[0].Variable1", 100)
-	if err == nil {
-		t.Error("Expected error for updating empty slice, but got nil")
+	if err != nil {
+		t.Errorf("Error updating field: %v", err)
+	}
+	if config.Name1.Name2[0].Variable1 != 100 {
+		t.Errorf("Variable1 not updated properly")
 	}
 }
 
@@ -503,6 +509,9 @@ func TestEdgeCoreConfig(t *testing.T) {
 func TestSetEdgeCoreConfigRegisterWithTaints(t *testing.T) {
 	cfg := v1alpha2.NewDefaultEdgeCoreConfig()
 	if err := ParseSet(cfg, `Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[0]={"key":"node-role.kubernetes.io/edge","value":"","effect":"NoSchedule"}`); err != nil {
+		t.Fatal(err)
+	}
+	if err := ParseSet(cfg, `Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[1].Key=node-role.kubernetes.io/edge,Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[1].Value=edge-node-01,Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[1].Effect=NoExecute`); err != nil {
 		t.Fatal(err)
 	}
 	t.Log(cfg.Modules.Edged.TailoredKubeletConfig.RegisterWithTaints)

--- a/keadm/cmd/keadm/app/cmd/util/set_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/set_test.go
@@ -516,3 +516,14 @@ func TestSetEdgeCoreConfigRegisterWithTaints(t *testing.T) {
 	}
 	t.Log(cfg.Modules.Edged.TailoredKubeletConfig.RegisterWithTaints)
 }
+
+func TestSetEdgeCoreConfigWithPtrValue(t *testing.T) {
+	cfg := v1alpha2.NewDefaultEdgeCoreConfig()
+	// ImageGCHighThresholdPercent *int32
+	// RegisterNode *bool
+	// ReportEvent bool
+	if err := ParseSet(cfg, `Modules.Edged.TailoredKubeletConfig.ImageGCHighThresholdPercent=90,Modules.Edged.TailoredKubeletConfig.RegisterNode=true,Modules.Edged.ReportEvent=true`); err != nil {
+		t.Fatal(err)
+	}
+	t.Log(*cfg.Modules.Edged.TailoredKubeletConfig.ImageGCHighThresholdPercent, *cfg.Modules.Edged.TailoredKubeletConfig.RegisterNode, cfg.Modules.Edged.ReportEvent)
+}

--- a/keadm/cmd/keadm/app/cmd/util/set_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/set_test.go
@@ -162,6 +162,11 @@ func TestParseValue(t *testing.T) {
 			s:            "false",
 			expectResult: false,
 		},
+		// Test case 8: JSON input
+		{
+			s:            `{"key":"value"}`,
+			expectResult: map[string]string{"key": "value"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -190,7 +195,17 @@ func TestParseArray(t *testing.T) {
 		// Test case 3: String array input
 		{
 			s:            `{"apple", "banana", "cherry"}`,
-			expectResult: []string{`"apple"`, `"banana"`, `"cherry"`},
+			expectResult: []string{"apple", "banana", "cherry"},
+		},
+		// Test case 4: String array input without quotation marks
+		{
+			s:            `{apple, banana, cherry}`,
+			expectResult: []string{"apple", "banana", "cherry"},
+		},
+		// Test case 5: String number array input
+		{
+			s:            `{"1", "2", "3"}`,
+			expectResult: []string{"1", "2", "3"},
 		},
 	}
 
@@ -326,9 +341,13 @@ func TestParseAndSetArrayValue(t *testing.T) {
 func TestSetArrayValue(t *testing.T) {
 	type Config struct {
 		ArrayField [3]string
+		SliceField []string
 	}
 	// Initialize a test struct
-	testStruct := Config{ArrayField: [3]string{"1", "2", "3"}}
+	testStruct := Config{
+		ArrayField: [3]string{"1", "2", "3"},
+		SliceField: []string{"1", "2", "3"},
+	}
 
 	// Test case 1: Set array value
 	err := setArrayValue(&testStruct, "ArrayField", 1, "10")
@@ -341,7 +360,7 @@ func TestSetArrayValue(t *testing.T) {
 	}
 
 	// Test case 2: Set value to non-existent index
-	err = setArrayValue(&testStruct, "ArrayField", 10, 5)
+	err = setArrayValue(&testStruct, "ArrayField", 10, "5")
 	if err == nil {
 		t.Error("Expected an error for setting value to non-existent index, but got nil")
 	}
@@ -350,6 +369,24 @@ func TestSetArrayValue(t *testing.T) {
 	err = setArrayValue(&testStruct, "ArrayField", 1, 1)
 	if err == nil {
 		t.Error("Expected an error for setting incorrect value type, but got nil")
+	}
+
+	// Test case 4: Set slice value
+	err = setArrayValue(&testStruct, "SliceField", 1, "10")
+	if err != nil {
+		t.Errorf("Failed to set slice value: %v", err)
+	}
+	if testStruct.SliceField[1] != "10" {
+		t.Errorf("Failed to set slice value. Expected '10', got '%s'", testStruct.SliceField[1])
+	}
+
+	// Test case 5: Extend slice value
+	err = setArrayValue(&testStruct, "SliceField", 4, "10")
+	if err != nil {
+		t.Errorf("Failed to Extend slice value: %v", err)
+	}
+	if len(testStruct.SliceField) != 5 || testStruct.SliceField[4] != "10" {
+		t.Errorf("Failed to Extend slice value. Expected '10', got '%s'", testStruct.SliceField[1])
 	}
 }
 
@@ -461,4 +498,12 @@ func TestEdgeCoreConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(cfg.DataBase.AliasName, cfg.DataBase.DriverName, cfg.Modules.DBTest.Enable, cfg.Modules.Edged.TailoredKubeletFlag.HostnameOverride, cfg.Modules.MetaManager.MetaServer.ServiceAccountIssuers, cfg.FeatureGates)
+}
+
+func TestSetEdgeCoreConfigRegisterWithTaints(t *testing.T) {
+	cfg := v1alpha2.NewDefaultEdgeCoreConfig()
+	if err := ParseSet(cfg, `Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[0]={"key":"node-role.kubernetes.io/edge","value":"","effect":"NoSchedule"}`); err != nil {
+		t.Fatal(err)
+	}
+	t.Log(cfg.Modules.Edged.TailoredKubeletConfig.RegisterWithTaints)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind feature
/kind api-change

**What this PR does / why we need it**:
Basically, I was intend to add a Taint to edge node once it registered and I do find it in edgecore confg, but when I call `keadm join --set Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[1].Key=node-role.kubernetes.io/edge`, as used in helm, I just got a **index out of range** error. 

So I enhanced the `--set` param to support more complex path expression, new features list as below:

|  field type  |  --set expression  |  before  |  after  | why |
|  ----  |  ----  | ----  | ----  | ----  |
|  map[string]string  | --set mapField={"key":"value"}  | map[string]string{""key"": ""value""} |  map[string]string{"key": "value"}  |  Surround quotes usually not really as string content  |
|  struct  | --set taint={"key":"node-role.kubernetes.io/edge","value":"","effect":"NoSchedule"}  | type mismatch error |  {node-role.kubernetes.io/edge  NoSchedule \<nil\>}  |  Support json to struct |
|  slice  | --set RegisterWithTaints[0]={"key":"node-role.kubernetes.io/edge","value":"","effect":"NoSchedule"}  | index out of range error |  [{node-role.kubernetes.io/edge  NoSchedule \<nil\>}]  |  Auto extend slice capacity |
|  slice  | --set RegisterWithTaints[1].Key=node-role.kubernetes.io/edge,RegisterWithTaints[1].Effect=NoSchedule  | index out of range error |  [{node-role.kubernetes.io/edge  NoSchedule \<nil\>}]  |  Auto extend slice capacity and support write single value of a element |
|  *bool  | --set RegisterNode=true  | type mismatch error |  true  |  Support pointer value |

Here is an example which use enhanced --set param:
```shell
#!/bin/bash

keadm join --edgenode-name="${1}" --token="${2}" \
  --cloudcore-ipport=cloudcore.ep.example.com:10000 \
  --kubeedge-version=v1.20.0 \
  --certport=10002 \
  --cgroupdriver=systemd \
  --remote-runtime-endpoint=unix:///run/containerd/containerd.sock \
  --image-repository=harbor.example.com/docker.io/kubeedge \
  --set FeatureGates={"requireAuthorization":true} \
  --set Modules.EdgeStream.Enable=true \
  --set Modules.EdgeStream.TunnelServer=cloudcore.ep.example.com:10004 \
  --set Modules.EventBus.Enable=false \
  --set Modules.MetaManager.Enable=true \
  --set Modules.MetaManager.MetaServer.Enable=true \
  --set Modules.MetaManager.MetaServer.Server=127.0.0.1:10550 \
  --set Modules.Edged.TailoredKubeletConfig.ClusterDNS[0]=169.254.96.16 \
  --set Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[0].Key=node-role.kubernetes.io/edge \
  --set Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[0].Value= \
  --set Modules.Edged.TailoredKubeletConfig.RegisterWithTaints[0].Effect=NoSchedule

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enhance --set param to support slice of struct configs like RegisterWithTaints
```
