### PR TITLE
fix：devicemode key follows the "namespace/name" format In the DevInit method

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/device/device.go
@@ -293,12 +293,14 @@ func (d *DevPanel) DevInit(deviceList []*dmiapi.Device, deviceModelList []*dmiap
 	for i := range deviceModelList {
 		model := deviceModelList[i]
 		cur := parse.GetDeviceModelFromGrpc(model)
-		d.models[model.Name] = cur
+		modelID := parse.GetResourceID(model.Namespace, model.Name)
+		d.models[modelID] = cur
 	}
 
 	for i := range deviceList {
 		device := deviceList[i]
-		commonModel := d.models[device.Spec.DeviceModelReference]
+		modelID = parse.GetResourceID(device.Namespace, device.Spec.DeviceModelReference)
+		commonModel := d.models[modelID]
 		protocol, err := parse.BuildProtocolFromGrpc(device)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
fix: In the DevInit method, when initializing the devicemode, ensure that the key follows the "namespace/name" format.

**Which issue(s) this PR fixes**:
https://github.com/kubeedge/kubeedge/issues/6270
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
