### PR TITLE
Automated cherry pick of #6352: fix nodetask handler register in taskmanager

### DIFF
--- a/cloud/pkg/taskmanager/upstream/config_update.go
+++ b/cloud/pkg/taskmanager/upstream/config_update.go
@@ -104,7 +104,7 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 			wg.Done()
 		},
 	}
-	status.GetImagePrePullJobStatusUpdater().UpdateStatus(opts)
+	status.GetConfigeUpdateJobStatusUpdater().UpdateStatus(opts)
 	wg.Wait()
 	return err
 }

--- a/edge/pkg/taskmanager/actions/runner.go
+++ b/edge/pkg/taskmanager/actions/runner.go
@@ -34,7 +34,7 @@ var runners = map[string]*ActionRunner{}
 func Init() {
 	RegisterRunner(operationsv1alpha2.ResourceImagePrePullJob, newImagePrePullJobRunner())
 	RegisterRunner(operationsv1alpha2.ResourceConfigUpdateJob, newConfigUpdateJobRunner())
-	RegisterRunner(operationsv1alpha2.ResourceConfigUpdateJob, newConfigUpdateJobRunner())
+	RegisterRunner(operationsv1alpha2.ResourceConfigUpdateJob, newNodeUpgradeJobRunner())
 }
 
 // registerRunner registers the implementation of the job action runner.


### PR DESCRIPTION
Cherry pick of #6352 on release-1.21.

#6352: fix nodetask handler register in taskmanager

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.