### PR TITLE
Automated cherry pick of #6356: Fix some bugs in NodeUpgradeJob

### DIFF
--- a/cloud/pkg/taskmanager/status/node_upgrade.go
+++ b/cloud/pkg/taskmanager/status/node_upgrade.go
@@ -60,6 +60,7 @@ func tryUpdateNodeUpgradeJobStatus(ctx context.Context, cli crdcliset.Interface,
 	}
 
 	nodeStatus.Phase = opts.Phase
+	nodeStatus.Reason = opts.Reason
 	if opts.ExtendInfo != "" {
 		fromVer, toVer, err := taskmsg.ParseNodeUpgradeJobExtend(opts.ExtendInfo)
 		if err != nil {

--- a/edge/pkg/metamanager/metaserver/handlerfactory/extend_confirm_upgrade.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/extend_confirm_upgrade.go
@@ -97,7 +97,7 @@ func doUpgrade(jobname, nodename string, spec *operationsv1alpha2.NodeUpgradeJob
 		return fmt.Errorf("failed to marshal NodeUpgradeJobSpec to json, err: %v", err)
 	}
 	runner.RunAction(context.Background(), jobname, nodename,
-		string(operationsv1alpha2.NodeUpgradeJobActionUpgrade), specData)
+		string(operationsv1alpha2.NodeUpgradeJobActionBackUp), specData)
 	return nil
 }
 

--- a/edge/pkg/metamanager/metaserver/handlerfactory/extend_confirm_upgrade_test.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/extend_confirm_upgrade_test.go
@@ -171,7 +171,7 @@ func TestConfirmUpgradeDoUpgrade(t *testing.T) {
 			runActionCalled = true
 			assert.Equal(t, jobName, jobname)
 			assert.Equal(t, nodeName, nodename)
-			assert.Equal(t, string(operationsv1alpha2.NodeUpgradeJobActionUpgrade), action)
+			assert.Equal(t, string(operationsv1alpha2.NodeUpgradeJobActionBackUp), action)
 		})
 	err := doUpgrade(jobName, nodeName, &operationsv1alpha2.NodeUpgradeJobSpec{})
 	require.NoError(t, err)


### PR DESCRIPTION
Cherry pick of #6356 on release-1.21.

#6356: Fix some bugs in NodeUpgradeJob

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.