### PR TITLE
Decouple e2e

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -58,7 +58,14 @@ kubeedge::version::get_version_info() {
   fi
 
   GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null)
+  if [[ -z "${GIT_VERSION}" ]]; then
+    echo 
+    echo "⚠️  No git tags found."
+    echo "⚠️  Falling back to default version: v0.0.0"
+    echo "⚠️  To avoid this, consider running: git fetch --tags"
 
+    GIT_VERSION="v0.0.0"
+  fi
   # This translates the "git describe" to an actual semver.org
   # compatible semantic version that looks something like this:
   #   v1.1.0-alpha.0.6+84c76d1142ea4d


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:
Adds a check for existing cloudcore and edgecore binaries before triggering a build.

Prevents unnecessary rebuilding during E2E runs if the binaries are already present.

Helps speed up local/dev and CI workflows by reusing previously built binaries when available.

Also introduces a fallback mechanism for missing git tags, defaulting to v0.0.0 instead of failing.

**Which issue(s) this PR fixes**:
Fallbacks to a default version
Uses the existing binaries while tests.



Fixes #6212

After this change is applied:
![Screenshot from 2025-06-21 19-28-44](https://github.com/user-attachments/assets/05610fa6-f4aa-4c84-80d6-16bc354f1337)

Exits with build error as the git tag is set to defualt.
