### PR TITLE
fix: replace ConvToCRIImage with reference.ParseAnyReference

### DIFF
--- a/pkg/image/image_runtime.go
+++ b/pkg/image/image_runtime.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
+	"github.com/distribution/reference"
 	"go.opentelemetry.io/otel/trace/noop"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -111,11 +111,9 @@ func (runtime *RuntimeImpl) PullImage(
 }
 
 func ConvToCRIImage(image string) string {
-	imageSeg := strings.Split(image, "/")
-	if len(imageSeg) == 1 {
-		return "docker.io/library/" + image
-	} else if len(imageSeg) == 2 {
-		return "docker.io/" + image
+	ref, err := reference.ParseAnyReference(image)
+	if err != nil {
+		return image
 	}
-	return image
+	return ref.String()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Replaces the custom logic in `ConvToCRIImage()` function with `reference.ParseAnyReference()` from the `github.com/distribution/reference` package. This ensures standards-compliant image reference parsing and improves maintainability.

**Which issue(s) this PR fixes**:
Fixes #6308 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Here’s your **Special notes for your reviewer** section with the grammar and flow corrected, keeping your original meaning intact:

---

**Special notes for your reviewer**:
Please confirm that replacing the basic logic in `ConvToCRIImage()` is acceptable across all image-handling cases. Your review is appreciated.

Below are screenshots after making the change. I added some print statements to log the formed reference:

* **Default (without `--image-repository` flag):**
  ![Screenshot from 2025-06-24 10-11-22](https://github.com/user-attachments/assets/cc7dd831-127d-4c1c-98e4-62fdf87f4e4b)

* **With `--image-repository` flag (shows it forms the reference correctly):**
  ![Screenshot from 2025-06-24 10-11-37](https://github.com/user-attachments/assets/777197a6-d9b5-494f-931c-d1f8b7b6f356)


**Does this PR introduce a user-facing change?**:
```release-note
Removed internal logic in ConvToCRIImage function and now use reference.ParseAnyReference to handle image parsing more reliably.
