### PR TITLE
fix: docker-e2e-test

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -253,6 +253,7 @@ function start_edgecore {
   if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
     sed -i 's|imageServiceEndpoint: .*|imageServiceEndpoint: unix:///var/run/cri-dockerd.sock|' ${EDGE_CONFIGFILE}
     sed -i 's|containerRuntimeEndpoint: .*|containerRuntimeEndpoint: unix:///var/run/cri-dockerd.sock|' ${EDGE_CONFIGFILE}
+    sed -i 's|cgroupDriver: .*|cgroupDriver: systemd|' ${EDGE_CONFIGFILE}
   fi
 
   if [[ "${CONTAINER_RUNTIME}" = "cri-o" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or run the appropriate tests for your PR

-->

**What type of PR is this?**  
/kind failing-test

**What this PR does / why we need it**:  
This PR fixes the pod sandbox creation failure in Docker-based edge nodes due to an incorrect cgroup configuration. The root cause was that in edgecore.yaml, the cgroupDriver was defined as cgroupfs, whereas Docker was using systemd.

To resolve this, a `sed` statement was added to enforce `cgroupDriver: systemd` in the EdgeCore configuration (`edgecore.yaml`). This aligns the runtime configuration with Docker’s systemd expectations and restores pod creation, unblocking Docker E2E tests.

**Which issue(s) this PR fixes**:  
Fixes #6323

**Special notes for your reviewer**:  
- Verified against Docker E2E locally  
- Fixed in specific target environments where a cgroup driver mismatch existed

Screenshots of the test run are attached.

![Screenshot from 2025-06-25 23-34-43](https://github.com/user-attachments/assets/b017917b-c52c-47c7-8470-e82c409f4024)
![Screenshot from 2025-06-25 23-33-44](https://github.com/user-attachments/assets/82bfc095-6f14-49e8-8168-c60aa2b5d50a)
![Screenshot from 2025-06-25 23-32-58](https://github.com/user-attachments/assets/c786a104-05b7-413f-a52d-aedf9b9debd2)

**Does this PR introduce a user-facing change?**:  No
```release-note
Fixed pod sandbox creation failure in Docker + systemd environments by ensuring EdgeCore uses the correct cgroup driver configuration.

