### PR TITLE
Automated cherry pick of #6367 upstream release 1.21 : fix docker e2e test

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -253,6 +253,7 @@ function start_edgecore {
   if [[ "${CONTAINER_RUNTIME}" = "docker" ]]; then
     sed -i 's|imageServiceEndpoint: .*|imageServiceEndpoint: unix:///var/run/cri-dockerd.sock|' ${EDGE_CONFIGFILE}
     sed -i 's|containerRuntimeEndpoint: .*|containerRuntimeEndpoint: unix:///var/run/cri-dockerd.sock|' ${EDGE_CONFIGFILE}
+    sed -i 's|cgroupDriver: .*|cgroupDriver: systemd|' ${EDGE_CONFIGFILE}
   fi
 
   if [[ "${CONTAINER_RUNTIME}" = "cri-o" ]]; then


### PR DESCRIPTION
**What type of PR is this?**
Cherry picks the commits in PR #6367 for release 1.21
