### PR TITLE
fix: manual PR in reference to 6366 for release 1.20 : convCRI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
+	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v23.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v23.0.3+incompatible // indirect

--- a/keadm/cmd/keadm/app/cmd/util/image.go
+++ b/keadm/cmd/keadm/app/cmd/util/image.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
+	"github.com/distribution/reference"
 	"github.com/google/uuid"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	internalapi "k8s.io/cri-api/pkg/apis"
@@ -78,13 +78,11 @@ type CRIRuntime struct {
 }
 
 func convertCRIImage(image string) string {
-	imageSeg := strings.Split(image, "/")
-	if len(imageSeg) == 1 {
-		return "docker.io/library/" + image
-	} else if len(imageSeg) == 2 {
-		return "docker.io/" + image
+	ref, err := reference.ParseAnyReference(image)
+	if err != nil {
+		return image
 	}
-	return image
+	return ref.String()
 }
 
 func (runtime *CRIRuntime) PullImages(images []string) error {

--- a/keadm/cmd/keadm/app/cmd/util/image_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/image_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/keadm/cmd/keadm/app/cmd/util/image_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/image_test.go
@@ -1,0 +1,108 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvToCRIImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "malformed name - return as-is",
+			input:    "invalid@@image!!name",
+			expected: "invalid@@image!!name",
+		},
+		{
+			name:     "docker.io with tag",
+			input:    "docker.io/kubeedge/installation-package:v1.20.0",
+			expected: "docker.io/kubeedge/installation-package:v1.20.0",
+		},
+		{
+			name:     "docker.io default registry",
+			input:    "kubeedge/cloudcore:v1.21.0",
+			expected: "docker.io/kubeedge/cloudcore:v1.21.0",
+		},
+		{
+			name:     "docker.io with digest",
+			input:    "docker.io/kubeedge/installation-package@sha256:abcd1234",
+			expected: "docker.io/kubeedge/installation-package@sha256:abcd1234",
+		},
+		{
+			name:     "docker.io without tag",
+			input:    "docker.io/kubeedge/installation-package",
+			expected: "docker.io/kubeedge/installation-package",
+		},
+		{
+			name:     "no registry or tag - default to docker.io",
+			input:    "kubeedge/installation-package",
+			expected: "docker.io/kubeedge/installation-package",
+		},
+		{
+			name:     "private registry with tag",
+			input:    "registry.example.com/kubeedge/installation-package:v1.20.0",
+			expected: "registry.example.com/kubeedge/installation-package:v1.20.0",
+		},
+		{
+			name:     "private registry without tag",
+			input:    "registry.example.com/kubeedge/installation-package",
+			expected: "registry.example.com/kubeedge/installation-package",
+		},
+		{
+			name:     "internal registry no namespace",
+			input:    "internal-registry.net/cloudcore:v1.20.0",
+			expected: "internal-registry.net/cloudcore:v1.20.0",
+		},
+		{
+			name:     "internal registry without tag",
+			input:    "internal-registry.net/installation-package",
+			expected: "internal-registry.net/installation-package",
+		},
+		{
+			name:     "port registry no namespace",
+			input:    "registry.local:5000/cloudcore:v1.20.0",
+			expected: "registry.local:5000/cloudcore:v1.20.0",
+		},
+		{
+			name:     "port registry with namespace",
+			input:    "registry.local:5000/kubeedge/installation-package:latest",
+			expected: "registry.local:5000/kubeedge/installation-package:latest",
+		},
+		{
+			name:     "port registry no tag",
+			input:    "registry.local:5000/kubeedge/installation-package",
+			expected: "registry.local:5000/kubeedge/installation-package",
+		},
+		{
+			name:     "port registry no namespace (alt)",
+			input:    "registry:5000/cloudcore:v1.20.0",
+			expected: "registry:5000/cloudcore:v1.20.0",
+		},
+		{
+			name:     "port registry with namespace (alt)",
+			input:    "registry:5000/kubeedge/installation-package:latest",
+			expected: "registry:5000/kubeedge/installation-package:latest",
+		},
+		{
+			name:     "port registry no tag (alt)",
+			input:    "registry:5000/kubeedge/installation-package",
+			expected: "registry:5000/kubeedge/installation-package",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output := convertCRIImage(tc.input)
+			require.Equal(t, tc.expected, output)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Replaces the custom logic in `ConvToCRIImage()` function with `reference.ParseAnyReference()` from the `github.com/distribution/reference` package. This ensures standards-compliant image reference parsing and improves maintainability.

**Which issue(s) this PR fixes**:
Fixes #6308 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
Please confirm that replacing the basic logic in `ConvToCRIImage()` is acceptable across all image-handling cases. Your review is appreciated.

Below are screenshots after making the change. I added some print statements to log the formed reference:

* **Default (without `--image-repository` flag):**
  ![Screenshot from 2025-06-24 10-11-22](https://github.com/user-attachments/assets/cc7dd831-127d-4c1c-98e4-62fdf87f4e4b)

* **With `--image-repository` flag (shows it forms the reference correctly):**
  ![Screenshot from 2025-06-24 10-11-37](https://github.com/user-attachments/assets/777197a6-d9b5-494f-931c-d1f8b7b6f356)


**Does this PR introduce a user-facing change?**:
```release-note
Removed internal logic in ConvToCRIImage function and now use reference.ParseAnyReference to handle image parsing more reliably.
