### PR TITLE
Improving read timeout handling

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -117,6 +117,10 @@ func (wsc *WebSocketClient) Send(message model.Message) error {
 
 // Receive reads the binary message through the connection
 func (wsc *WebSocketClient) Receive() (model.Message, error) {
+	// Set the read deadline before reading
+	if err := wsc.connection.SetReadDeadline(time.Now().Add(wsc.config.ReadDeadline)); err != nil {
+		return model.Message{}, err
+	}
 	message := model.Message{}
 	err := wsc.connection.ReadMessage(&message)
 	return message, err

--- a/pkg/viaduct/pkg/conn/ws.go
+++ b/pkg/viaduct/pkg/conn/ws.go
@@ -151,6 +151,10 @@ func (conn *WSConnection) handleMessage() {
 
 func (conn *WSConnection) SetReadDeadline(t time.Time) error {
 	conn.ReadDeadline = t
+	// Actually set the deadline on the underlying websocket connection
+	if conn.wsConn != nil {
+		return conn.wsConn.SetReadDeadline(t)
+	}
 	return nil
 }
 


### PR DESCRIPTION
/kind bug

Corrected a bug in which the WebSocket read timeout was not being enforced correctly. This would cause connections to hang forever if the server doesn't reply, which is a functional flaw. By ensuring the deadline for reading is set and enforced, the incorrect behavior is fixed.


```
Now, if the cloud server does not reply within the read timeout configured, the edge node will notice the timeout and recover from it (e.g., reconnect), rather than waiting forever. This enhances user reliability and error recovery with edge nodes.

```
