### PR TITLE
Fix/tls min version cloudhub

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -50,6 +50,7 @@ func StartHTTPServer() error {
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			ClientAuth:   tls.RequestClientCert,
+			MinVersion:   tls.VersionTLS12,
 		},
 	}
 	return server.ListenAndServeTLS("", "")


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
This PR enforces a minimum TLS version of 1.2 for the CloudHub HTTP server component. By explicitly setting MinVersion: tls.VersionTLS12 in the TLS configuration, it disables older, insecure TLS versions (1.0, 1.1) that expose the CloudHub port to vulnerabilities reported by scanning tools. This improves the security posture of the CloudHub component.

Which issue(s) this PR fixes:
Fixes #6387

Special notes for your reviewer:
The TLS configuration was updated in cloud/pkg/cloudhub/servers/httpserver/server.go to include the minimum TLS version. Testing with openssl s_client confirms that TLS 1.1 connections are no longer accepted.

Does this PR introduce a user-facing change?:
No