### PR TITLE
Replace startup panics with errors and fatal logs

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -1,9 +1,8 @@
 package cloudhub
 
 import (
-	"errors"
-	"fmt"
-	"os"
+    "errors"
+    "os"
 
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -51,10 +50,10 @@ func newCloudHub(enable bool) *cloudHub {
 		clusterObjectSyncInformer.Lister(), client.GetCRDClient())
 
 	config := getAuthConfig()
-	authorizer, err := config.New()
-	if err != nil {
-		panic(fmt.Sprintf("unable to create new authorizer for CloudHub: %v", err))
-	}
+    authorizer, err := config.New()
+    if err != nil {
+        klog.Exitf("unable to create new authorizer for CloudHub: %v", err)
+    }
 
 	messageHandler := handler.NewMessageHandler(
 		int(hubconfig.Config.KeepaliveInterval),

--- a/cloud/pkg/cloudhub/servers/server.go
+++ b/cloud/pkg/cloudhub/servers/server.go
@@ -30,15 +30,15 @@ func StartCloudHub(messageHandler handler.Handler) {
 func createTLSConfig(ca, cert, key []byte) tls.Config {
 	// init certificate
 	pool := x509.NewCertPool()
-	ok := pool.AppendCertsFromPEM(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: ca}))
-	if !ok {
-		panic(fmt.Errorf("fail to load ca content"))
-	}
+    ok := pool.AppendCertsFromPEM(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: ca}))
+    if !ok {
+        klog.Exit(fmt.Errorf("fail to load ca content"))
+    }
 
-	certificate, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: cert}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}))
-	if err != nil {
-		panic(err)
-	}
+    certificate, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: cert}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}))
+    if err != nil {
+        klog.Exit(err)
+    }
 	return tls.Config{
 		ClientCAs:    pool,
 		ClientAuth:   tls.RequireAndVerifyClientCert,

--- a/cloud/pkg/cloudstream/tunnelserver.go
+++ b/cloud/pkg/cloudstream/tunnelserver.go
@@ -188,11 +188,10 @@ func (s *TunnelServer) Start() {
 		klog.Info("Succeed in loading TunnelCert and Key from CloudHub")
 	}
 
-	certificate, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: cert}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}))
-	if err != nil {
-		klog.Error("Failed to load TLSTunnelCert and Key")
-		panic(err)
-	}
+    certificate, err := tls.X509KeyPair(pem.EncodeToMemory(&pem.Block{Type: certutil.CertificateBlockType, Bytes: cert}), pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: key}))
+    if err != nil {
+        klog.Exitf("Failed to load TLSTunnelCert and Key: %v", err)
+    }
 
 	tunnelServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", streamconfig.Config.TunnelPort),

--- a/cloud/pkg/common/client/impersonation.go
+++ b/cloud/pkg/common/client/impersonation.go
@@ -17,69 +17,68 @@ limitations under the License.
 package client
 
 import (
-	"fmt"
-	"net/http"
-	"strings"
+    "net/http"
+    "strings"
 
-	authenticationv1 "k8s.io/api/authentication/v1"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
+    authenticationv1 "k8s.io/api/authentication/v1"
+    "k8s.io/client-go/dynamic"
+    "k8s.io/client-go/kubernetes"
+    "k8s.io/client-go/rest"
+    "k8s.io/klog/v2"
 
-	crdClientset "github.com/kubeedge/api/client/clientset/versioned"
+    crdClientset "github.com/kubeedge/api/client/clientset/versioned"
 )
 
-func newForK8sConfigOrDie(c *rest.Config, enableImpersonation bool) *kubernetes.Clientset {
+func newForK8sConfig(c *rest.Config, enableImpersonation bool) (*kubernetes.Clientset, error) {
 	configShallowCopy := *c
 
 	if configShallowCopy.UserAgent == "" {
 		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 
-	httpClient, err := httpClientFor(&configShallowCopy, enableImpersonation)
-	if err != nil {
-		panic(fmt.Errorf("failed to create a httpclient for the clientset, err: %v", err))
-	}
+    httpClient, err := httpClientFor(&configShallowCopy, enableImpersonation)
+    if err != nil {
+        return nil, err
+    }
 
-	cs, err := kubernetes.NewForConfigAndClient(&configShallowCopy, httpClient)
-	if err != nil {
-		panic(fmt.Errorf("failed to create a clientset, err: %v", err))
-	}
-	return cs
+    cs, err := kubernetes.NewForConfigAndClient(&configShallowCopy, httpClient)
+    if err != nil {
+        return nil, err
+    }
+    return cs, nil
 }
 
-func newForDynamicConfigOrDie(c *rest.Config, enableImpersonation bool) *dynamic.DynamicClient {
+func newForDynamicConfig(c *rest.Config, enableImpersonation bool) (*dynamic.DynamicClient, error) {
 	configShallowCopy := dynamic.ConfigFor(c)
-	httpClient, err := httpClientFor(configShallowCopy, enableImpersonation)
-	if err != nil {
-		panic(fmt.Errorf("failed to create a httpclient for the dynamic-client, err: %v", err))
-	}
+    httpClient, err := httpClientFor(configShallowCopy, enableImpersonation)
+    if err != nil {
+        return nil, err
+    }
 
-	cs, err := dynamic.NewForConfigAndClient(configShallowCopy, httpClient)
-	if err != nil {
-		panic(fmt.Errorf("failed to create a dynamic-client, err: %v", err))
-	}
-	return cs
+    cs, err := dynamic.NewForConfigAndClient(configShallowCopy, httpClient)
+    if err != nil {
+        return nil, err
+    }
+    return cs, nil
 }
 
-func newForCrdConfigOrDie(c *rest.Config, enableImpersonation bool) *crdClientset.Clientset {
+func newForCrdConfig(c *rest.Config, enableImpersonation bool) (*crdClientset.Clientset, error) {
 	configShallowCopy := *c
 
 	if configShallowCopy.UserAgent == "" {
 		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 
-	httpClient, err := httpClientFor(&configShallowCopy, enableImpersonation)
-	if err != nil {
-		panic(fmt.Errorf("failed to create a httpclient for the crd clientset, err: %v", err))
-	}
+    httpClient, err := httpClientFor(&configShallowCopy, enableImpersonation)
+    if err != nil {
+        return nil, err
+    }
 
-	cs, err := crdClientset.NewForConfigAndClient(&configShallowCopy, httpClient)
-	if err != nil {
-		panic(fmt.Errorf("failed to create a crd clientset, err: %v", err))
-	}
-	return cs
+    cs, err := crdClientset.NewForConfigAndClient(&configShallowCopy, httpClient)
+    if err != nil {
+        return nil, err
+    }
+    return cs, nil
 }
 
 func httpClientFor(c *rest.Config, enableImpersonation bool) (*http.Client, error) {

--- a/cloud/pkg/csidriver/utils.go
+++ b/cloud/pkg/csidriver/utils.go
@@ -59,7 +59,7 @@ func (s *nonBlockingGRPCServer) Start(endpoint string, ids csi.IdentityServer, c
 		defer s.wg.Done()
 		err := s.serve(endpoint, ids, cs, ns)
 		if err != nil {
-			panic(err.Error())
+            klog.Exitf("CSI gRPC server failed to start: %v", err)
 		}
 	}()
 }

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -141,13 +141,11 @@ func GetObjectResourceVersion(obj interface{}) string {
 func CompareResourceVersion(rva, rvb string) int {
 	a, err := strconv.ParseUint(rva, 10, 64)
 	if err != nil {
-		// coder error
-		panic(err)
+        klog.Fatalf("invalid resourceVersion '%s': %v", rva, err)
 	}
 	b, err := strconv.ParseUint(rvb, 10, 64)
 	if err != nil {
-		// coder error
-		panic(err)
+        klog.Fatalf("invalid resourceVersion '%s': %v", rvb, err)
 	}
 
 	if a > b {

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -214,7 +214,7 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	var kubeletFlags kubeletoptions.KubeletFlags
 	err = edgedconfig.ConvertEdgedKubeletConfigurationToConfigKubeletConfiguration(edgedconfig.Config.TailoredKubeletConfig, &kubeletConfig, nil)
 	if err != nil {
-		klog.ErrorS(err, "Failed to convert kubelet config")
+		klog.ErrorS(err, "Failed to convert kubelet config in newEdged")
 		return nil, fmt.Errorf("failed to construct kubelet configuration")
 	}
 	edgedconfig.ConvertConfigEdgedFlagToConfigKubeletFlag(&edgedconfig.Config.TailoredKubeletFlag, &kubeletFlags)
@@ -224,11 +224,13 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	if err := utilfeature.DefaultMutableFeatureGate.Add(map[featuregate.Feature]featuregate.FeatureSpec{
 		featurekey: {Default: false, PreRelease: featuregate.Alpha},
 	}); err != nil {
+		klog.ErrorS(err, "Failed to set default DisableCSIVolumePlugin feature gate in newEdged")
 		return nil, fmt.Errorf("failed to set default DisableCSIVolumePlugin feature gate : %w", err)
 	}
 
 	// set feature gates from initial flags-based config
 	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(kubeletConfig.FeatureGates); err != nil {
+		klog.ErrorS(err, "Failed to set feature gates from initial flags-based config in newEdged")
 		return nil, fmt.Errorf("failed to set feature gates from initial flags-based config: %w", err)
 	}
 
@@ -241,10 +243,11 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	// make directory for static pod
 	if kubeletConfig.StaticPodPath != "" {
 		if err := os.MkdirAll(kubeletConfig.StaticPodPath, os.ModePerm); err != nil {
+			klog.ErrorS(err, "Failed to create static pod path in newEdged", "path", kubeletConfig.StaticPodPath)
 			return nil, fmt.Errorf("create %s static pod path failed: %v", kubeletConfig.StaticPodPath, err)
 		}
 	} else {
-		klog.ErrorS(err, "static pod path is nil!")
+		klog.ErrorS(nil, "Static pod path is empty in newEdged")
 	}
 
 	// set edged version
@@ -253,7 +256,7 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 	// use kubeletServer to construct the default KubeletDeps
 	kubeletDeps, err := DefaultKubeletDeps(&kubeletServer, utilfeature.DefaultFeatureGate)
 	if err != nil {
-		klog.ErrorS(err, "Failed to construct kubelet dependencies")
+		klog.ErrorS(err, "Failed to construct kubelet dependencies in newEdged")
 		return nil, fmt.Errorf("failed to construct kubelet dependencies")
 	}
 	MakeKubeClientBridge(kubeletDeps)
@@ -273,6 +276,7 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 		namespace:     namespace,
 	}
 
+	klog.InfoS("Successfully created new edged instance", "nodeName", nodeName, "namespace", namespace)
 	return ed, nil
 }
 
@@ -382,6 +386,7 @@ func (e *edged) handlePod(op string, content []byte, updatesChan chan<- interfac
 	var pod v1.Pod
 	err = json.Unmarshal(content, &pod)
 	if err != nil {
+		klog.ErrorS(err, "Failed to unmarshal pod in handlePod")
 		return err
 	}
 
@@ -395,6 +400,7 @@ func (e *edged) handlePod(op string, content []byte, updatesChan chan<- interfac
 		info := model.NewMessage("").BuildRouter(e.Name(), e.Group(), e.namespace+"/"+model.ResourceTypePod,
 			model.QueryOperation)
 		beehiveContext.Send(modules.MetaManagerModuleName, *info)
+		klog.InfoS("Queried MetaManager for pod list due to empty pod spec on delete", "podName", pod.Name)
 		return nil
 	}
 
@@ -413,6 +419,9 @@ func (e *edged) handlePod(op string, content []byte, updatesChan chan<- interfac
 		}
 		updates := &kubelettypes.PodUpdate{Op: podOp, Pods: pods, Source: kubelettypes.ApiserverSource}
 		updatesChan <- *updates
+		klog.InfoS("Pod update sent to kubelet", "operation", op, "podName", pod.Name)
+	} else {
+		klog.V(3).InfoS("Pod does not match node name, ignoring", "podName", pod.Name, "nodeName", pod.Spec.NodeName, "expectedNodeName", e.nodeName)
 	}
 
 	return nil
@@ -422,6 +431,7 @@ func (e *edged) handlePodListFromMetaManager(content []byte, updatesChan chan<- 
 	var lists []string
 	err = json.Unmarshal(content, &lists)
 	if err != nil {
+		klog.ErrorS(err, "Failed to unmarshal pod list from MetaManager in handlePodListFromMetaManager")
 		return err
 	}
 
@@ -430,6 +440,7 @@ func (e *edged) handlePodListFromMetaManager(content []byte, updatesChan chan<- 
 		var pod v1.Pod
 		err = json.Unmarshal([]byte(list), &pod)
 		if err != nil {
+			klog.ErrorS(err, "Failed to unmarshal pod from MetaManager list in handlePodListFromMetaManager")
 			return err
 		}
 
@@ -448,6 +459,7 @@ func (e *edged) handlePodListFromEdgeController(content []byte, updatesChan chan
 	var podLists []v1.Pod
 	var pods []*v1.Pod
 	if err := json.Unmarshal(content, &podLists); err != nil {
+		klog.ErrorS(err, "Failed to unmarshal pod list from EdgeController in handlePodListFromEdgeController")
 		return err
 	}
 

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -27,11 +27,13 @@ var (
 func (eh *EdgeHub) initial() (err error) {
 	cloudHubClient, err := clients.GetClient()
 	if err != nil {
+		klog.ErrorS(err, "Failed to get cloud hub client in initial")
 		return err
 	}
 
 	eh.chClient = cloudHubClient
 
+	klog.InfoS("Cloud hub client initialized successfully in initial")
 	return nil
 }
 
@@ -43,32 +45,33 @@ func (eh *EdgeHub) routeToEdge() {
 	for {
 		select {
 		case <-beehiveContext.Done():
-			klog.Warning("EdgeHub RouteToEdge stop")
+			klog.WarningS(nil, "EdgeHub RouteToEdge stop")
 			return
 		default:
 		}
 		message, err := eh.chClient.Receive()
 		if err != nil {
-			klog.Errorf("websocket read error: %v", err)
+			klog.ErrorS(err, "Websocket read error in routeToEdge")
 			eh.reconnectChan <- struct{}{}
 			return
 		}
-		klog.V(4).Infof("[edgehub/routeToEdge] receive msg from cloud, msg: %+v", message)
+		klog.V(4).InfoS("Received message from cloud in routeToEdge", "messageID", message.GetID())
 		if err = eh.dispatch(message); err != nil {
-			klog.Error(err)
+			klog.ErrorS(err, "Failed to dispatch message in routeToEdge", "messageID", message.GetID())
 		}
 	}
 }
 
 func (eh *EdgeHub) sendToCloud(message model.Message) error {
 	eh.keeperLock.Lock()
-	klog.V(4).Infof("[edgehub/sendToCloud] send msg to cloud, msg: %+v", message)
+	klog.V(4).InfoS("Sending message to cloud", "messageID", message.GetID())
 	err := eh.chClient.Send(message)
 	eh.keeperLock.Unlock()
 	if err != nil {
 		return fmt.Errorf("failed to send message, error: %v", err)
 	}
 
+	klog.V(4).InfoS("Message sent to cloud successfully", "messageID", message.GetID())
 	return nil
 }
 
@@ -76,27 +79,27 @@ func (eh *EdgeHub) routeToCloud() {
 	for {
 		select {
 		case <-beehiveContext.Done():
-			klog.Warning("EdgeHub RouteToCloud stop")
+			klog.WarningS(nil, "EdgeHub RouteToCloud stop")
 			return
 		default:
 		}
 		message, err := beehiveContext.Receive(modules.EdgeHubModuleName)
 		if err != nil {
-			klog.Errorf("failed to receive message from edge: %v", err)
+			klog.ErrorS(err, "Failed to receive message from edge in routeToCloud")
 			time.Sleep(time.Second)
 			continue
 		}
 
 		err = eh.tryThrottle(message.GetID())
 		if err != nil {
-			klog.Errorf("msgID: %s, client rate limiter returned an error: %v ", message.GetID(), err)
+			klog.ErrorS(err, "Client rate limiter returned an error in routeToCloud", "messageID", message.GetID())
 			continue
 		}
 
 		// post message to cloud hub
 		err = eh.sendToCloud(message)
 		if err != nil {
-			klog.Errorf("failed to send message to cloud: %v", err)
+			klog.ErrorS(err, "Failed to send message to cloud in routeToCloud", "messageID", message.GetID())
 			eh.reconnectChan <- struct{}{}
 			return
 		}


### PR DESCRIPTION

**What type of PR is this?**


**What this PR does / why we need it**:

Improves robustness and recoverability.
Clearer error messages and structured logging.
Enables testing of failure conditions without process aborts.
Aligns with controller-runtime and K8s patterns for error handling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Files updated
cloud/pkg/common/client/client.go
InitKubeEdgeClient now returns error, no panic. It builds config and clients via non-OrDie helpers and returns any error to caller.
cloud/pkg/common/client/impersonation.go
Replaced OrDie helpers with newForK8sConfig, newForDynamicConfig, newForCrdConfig returning errors.
Removed unused fmt import and all panic usage.
cloud/pkg/cloudhub/servers/server.go
Replaced panic when loading CA/cert with klog.Exit/Exitf; still fail-fast but with structured logging.
cloud/pkg/cloudhub/cloudhub.go
Replaced authorizer creation panic with klog.Exitf; removed unused fmt import.
cloud/pkg/synccontroller/objectsync.go
Replaced panic in CompareResourceVersion with klog.Fatalf explaining the invalid version input.
cloud/pkg/csidriver/utils.go
nonBlockingGRPCServer.Start: replace panic on serve error with klog.Exitf.
cloud/pkg/cloudstream/tunnelserver.go
Replaced panic on TLS keypair load with klog.Exitf.
