### PR TITLE
remove import kubeedge/kubeedge in staging

### DIFF
--- a/edge/cmd/edgemark/hollow_edgecore.go
+++ b/edge/cmd/edgemark/hollow_edgecore.go
@@ -56,6 +56,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/edged"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager"
+	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
 type hollowEdgeNodeConfig struct {
@@ -140,6 +141,7 @@ func EdgeCoreConfig(config *hollowEdgeNodeConfig) *v1alpha2.EdgeCoreConfig {
 	trueFlag := true
 
 	// overWrite config
+	edgeCoreConfig.EdgeCoreVersion = version.Get().String()
 	edgeCoreConfig.DataBase.DataSource = "/edgecore.db"
 	edgeCoreConfig.Modules.EdgeHub.Token = config.Token
 	edgeCoreConfig.Modules.EdgeHub.HTTPServer = config.HTTPServer

--- a/edge/test/integration/utils/test_setup.go
+++ b/edge/test/integration/utils/test_setup.go
@@ -9,6 +9,7 @@ import (
 
 	edgecore "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/edge/test/integration/utils/edge"
+	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
 const (
@@ -19,6 +20,7 @@ const (
 
 func CreateEdgeCoreConfigFile(nodeName string) error {
 	c := edgecore.NewDefaultEdgeCoreConfig()
+	c.EdgeCoreVersion = version.Get().String()
 	c.Modules.Edged.HostnameOverride = nodeName
 	c.Modules.EdgeHub.TLSCAFile = "/tmp/edgecore/rootCA.crt"
 	c.Modules.EdgeHub.TLSCertFile = "/tmp/edgecore/kubeedge.crt"

--- a/keadm/cmd/keadm/app/cmd/edge/join_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_others.go
@@ -44,6 +44,7 @@ import (
 	pkgutil "github.com/kubeedge/kubeedge/pkg/util"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 	"github.com/kubeedge/kubeedge/pkg/util/files"
+	"github.com/kubeedge/kubeedge/pkg/version"
 	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
 )
 
@@ -118,6 +119,7 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 		edgeCoreConfig = v1alpha2.NewDefaultEdgeCoreConfig()
 	}
 
+	edgeCoreConfig.EdgeCoreVersion = version.Get().String()
 	// TODO: remove this after release 1.14
 	// this is for keeping backward compatibility
 	// don't save token in configuration edgecore.yaml

--- a/keadm/cmd/keadm/app/cmd/edge/join_windows.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_windows.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	pkgutil "github.com/kubeedge/kubeedge/pkg/util"
 	"github.com/kubeedge/kubeedge/pkg/util/files"
+	"github.com/kubeedge/kubeedge/pkg/version"
 	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
 )
 
@@ -112,6 +113,7 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 		edgeCoreConfig = v1alpha2.NewDefaultEdgeCoreConfig()
 	}
 
+	edgeCoreConfig.EdgeCoreVersion = version.Get().String()
 	// TODO: remove this after release 1.14
 	// this is for keeping backward compatibility
 	// don't save token in configuration edgecore.yaml

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -551,6 +551,7 @@ func ExecShellFilter(c string) (string, error) {
 
 func ParseEdgecoreConfig(edgecorePath string) (*v1alpha2.EdgeCoreConfig, error) {
 	edgeCoreConfig := v1alpha2.NewDefaultEdgeCoreConfig()
+	edgeCoreConfig.EdgeCoreVersion = pkgversion.Get().String()
 	if err := edgeCoreConfig.Parse(edgecorePath); err != nil {
 		return nil, err
 	}

--- a/keadm/cmd/keadm/app/cmd/util/edgecoreinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/edgecoreinstaller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation"
 	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 	"github.com/kubeedge/kubeedge/pkg/util"
+	"github.com/kubeedge/kubeedge/pkg/version"
 	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
 )
 
@@ -93,6 +94,7 @@ func (ku *KubeEdgeInstTool) createEdgeConfigFiles() error {
 	}
 
 	edgeCoreConfig := v1alpha2.NewDefaultEdgeCoreConfig()
+	edgeCoreConfig.EdgeCoreVersion = version.Get().String()
 	if ku.EdgeNodeName != "" {
 		edgeCoreConfig.Modules.Edged.HostnameOverride = ku.EdgeNodeName
 	}

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -27,7 +27,6 @@ import (
 	"github.com/kubeedge/api/apis/common/constants"
 	metaconfig "github.com/kubeedge/api/apis/componentconfig/meta/v1alpha1"
 	"github.com/kubeedge/api/apis/util"
-	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
 // NewDefaultEdgeCoreConfig returns a full EdgeCoreConfig object
@@ -160,7 +159,6 @@ func NewDefaultEdgeCoreConfig() (config *EdgeCoreConfig) {
 				Enable: false,
 			},
 		},
-		EdgeCoreVersion: version.Get().String(),
 	}
 	return
 }
@@ -234,7 +232,6 @@ func NewMinEdgeCoreConfig() (config *EdgeCoreConfig) {
 				MqttMode:           MqttModeExternal,
 			},
 		},
-		EdgeCoreVersion: version.Get().String(),
 	}
 	return
 }

--- a/staging/src/github.com/kubeedge/api/go.mod
+++ b/staging/src/github.com/kubeedge/api/go.mod
@@ -22,7 +22,6 @@ require (
 )
 
 require (
-	github.com/kubeedge/kubeedge v1.20.0
 	k8s.io/apiserver v0.30.7
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
 )
@@ -48,6 +47,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker v23.0.3+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
@@ -89,7 +89,10 @@ require (
 	github.com/mrunalp/fileutils v0.5.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/onsi/ginkgo/v2 v2.17.1 // indirect
+	github.com/onsi/gomega v1.32.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runc v1.1.14 // indirect
 	github.com/opencontainers/runtime-spec v1.1.0 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect

--- a/staging/src/github.com/kubeedge/api/go.sum
+++ b/staging/src/github.com/kubeedge/api/go.sum
@@ -227,8 +227,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/kubeedge/kubeedge v1.20.0 h1:gu3cs6FnVWieAxZnnEqw1ePzcPl9If1PQo0LRJQiLoQ=
-github.com/kubeedge/kubeedge v1.20.0/go.mod h1:cv1IhD3rjggExW2UF4qt14oB+sPwN9OdYatIh93YhUE=
 github.com/kubeedge/kubernetes v1.30.7-kubeedge1 h1:pidFPokdDApb5CQvDN/y6u1XaVGVdP5YWKC4zH9IBdw=
 github.com/kubeedge/kubernetes v1.30.7-kubeedge1/go.mod h1:hV3c+sqOEO0eVqgSo0KW5dOJ6UjGJ2l3Pd9+Qvft8UI=
 github.com/kubeedge/kubernetes/staging/src/k8s.io/api v1.30.7-kubeedge1 h1:TrmRRvLTDWmiZtSS8cZgddXFJjfJg5XiJX1xfXdRp8U=
@@ -289,7 +287,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.17.1 h1:V++EzdbhI4ZV4ev0UTIj0PzhzOcReJFyJaLjtSF55M8=
 github.com/onsi/ginkgo/v2 v2.17.1/go.mod h1:llBI3WDLL9Z6taip6f33H76YcWtJv+7R3HigUjbIBOs=
 github.com/onsi/gomega v1.32.0 h1:JRYU78fJ1LPxlckP6Txi/EYqJvjtMrDC04/MM5XRHPk=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:

We should not import “github.com/kubeedge/kubeedge” in staging repo.  This does not meet the requirement for the independence of the staging repository. Moreover, it will cause a lot of trouble. For example, when upgrading the Kubernetes version, the old version of kubeedge referenced by the staging repository still needs to depend on the old version of Kubernetes, which will lead to conflicts. 

