### PR TITLE
fix(taskmanager): fix duplicate ResourceConfigUpdateJob registration

### DIFF
--- a/edge/pkg/taskmanager/actions/runner.go
+++ b/edge/pkg/taskmanager/actions/runner.go
@@ -32,9 +32,14 @@ var runners = map[string]*ActionRunner{}
 
 // Init registers the node job action runner.
 func Init() {
-	RegisterRunner(operationsv1alpha2.ResourceImagePrePullJob, newImagePrePullJobRunner())
-	RegisterRunner(operationsv1alpha2.ResourceConfigUpdateJob, newConfigUpdateJobRunner())
-	RegisterRunner(operationsv1alpha2.ResourceConfigUpdateJob, newNodeUpgradeJobRunner())
+	runnersToRegister := map[string]func() *ActionRunner{
+		operationsv1alpha2.ResourceImagePrePullJob: newImagePrePullJobRunner,
+		operationsv1alpha2.ResourceConfigUpdateJob: newConfigUpdateJobRunner,
+		operationsv1alpha2.ResourceNodeUpgradeJob:  newNodeUpgradeJobRunner,
+	}
+	for name, factory := range runnersToRegister {
+		RegisterRunner(name, factory())
+	}
 }
 
 // registerRunner registers the implementation of the job action runner.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
The fix changes the duplicate registration from `ResourceConfigUpdateJob` to `ResourceNodeUpgradeJob`, ensuring each resource type uses the correct runner.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6448

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
