### PR TITLE
[Test]: Add unit tests for MQTTInstTool installation and teardown functionality

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/mqttinstaller_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/mqttinstaller_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commfake "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common/fake"
+)
+
+func TestMQTTInstToolInstallTools(t *testing.T) {
+	t.Run("install success", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		inst := &commfake.MockOSTypeInstaller{}
+		called := false
+
+		patches.ApplyFuncReturn(GetOSInterface, inst)
+		patches.ApplyMethod(inst, "InstallMQTT", func(*commfake.MockOSTypeInstaller) error {
+			called = true
+			return nil
+		})
+
+		tool := &MQTTInstTool{}
+		err := tool.InstallTools()
+		require.NoError(t, err)
+		assert.True(t, called, "InstallMQTT should be called")
+	})
+
+	t.Run("install error", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		inst := &commfake.MockOSTypeInstaller{}
+		patches.ApplyFuncReturn(GetOSInterface, inst)
+		patches.ApplyMethod(inst, "InstallMQTT", func(*commfake.MockOSTypeInstaller) error {
+			return errors.New("install mqtt failed")
+		})
+
+		tool := &MQTTInstTool{}
+		err := tool.InstallTools()
+		require.ErrorContains(t, err, "install mqtt failed")
+	})
+}
+
+func TestMQTTInstToolTearDown(t *testing.T) {
+	tool := &MQTTInstTool{}
+	err := tool.TearDown()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test

<!--
Add one of the following kinds:
/kind test

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
This PR improves the unit test coverage for the `mqttinstaller.go` file in `keadm/cmd/keadm/app/cmd/util`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes None.

**Special notes for your reviewer**:
- This is my first PR, so please let me know if you have any feedback.

**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->