### PR TITLE
fix: use `cp -rL` to copy symlink targets like /etc/resolv.conf

### DIFF
--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -152,7 +152,7 @@ const (
 	EdgeCoreServer = "127.0.0.1:10350"
 
 	// CmdCopyFile is the cmd to copy file
-	CmdCopyFile = "cp -r %s %s/"
+	CmdCopyFile = "cp -rL %s %s/"
 
 	/*system info*/
 	CmdDiskInfo    = "df -h > %s/disk"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

`keadm debug collect` previously used `cp -r`, which fails to copy symlinked files like `/etc/resolv.conf` on systems with systemd-resolved or NetworkManager.
Switch to `cp -rL` so that symlink targets are copied instead of links.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
