### PR TITLE
fix: correct cloudcore.config.kubeedge.io to v1alpha1

### DIFF
--- a/build/cloud/05-configmap.yaml
+++ b/build/cloud/05-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     kubeedge: cloudcore
 data:
   cloudcore.yaml: |
-    apiVersion: cloudcore.config.kubeedge.io/v1alpha2
+    apiVersion: cloudcore.config.kubeedge.io/v1alpha1
     kind: CloudCore
     kubeAPIConfig:
       kubeConfig: ""

--- a/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- end }}
 data:
   cloudcore.yaml: |
-    apiVersion: cloudcore.config.kubeedge.io/v1alpha2
+    apiVersion: cloudcore.config.kubeedge.io/v1alpha1
     kind: CloudCore
     featureGates:
       requireAuthorization: {{ .Values.cloudCore.featureGates.requireAuthorization }}


### PR DESCRIPTION


Note: changelog should not be modified after release, so its wrong reference remains unchanged.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->
/kind bug

**What this PR does / why we need it**:
The apiVersion for cloudcore.config.kubeedge.io was incorrectly changed to v1alpha2 in a previous commit, but there is no v1alpha2 implementation in code.
Revert it back to v1alpha1.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
