### PR TITLE
Fix: set safer file permission for cleanupToken in edgecore

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -171,7 +171,8 @@ func cleanupToken(config v1alpha2.EdgeCoreConfig, file string) error {
 		return err
 	}
 
-	return os.WriteFile(file, d, 0640)
+	// 安全权限，只有拥有者可读写
+	return os.WriteFile(file, d, 0600)
 }
 
 // environmentCheck check the environment before edgecore start


### PR DESCRIPTION
## Motivation
The original `cleanupToken` function writes the configuration file with permissions `0640`, which means:
- Owner: read/write ✅
- Group: read ✅
- Others: no access ❌

This allows members of the same group to read the edgecore token, posing a security risk.

## Changes Made
- Updated the file permission to `0600` when writing the token cleanup file:
  - Owner: read/write ✅
  - Group & Others: no access ✅
- Ensures that sensitive token data is only accessible by the edgecore process.

## Benefits
1. Improves security by preventing token leakage.
2. Enforces stricter file permissions, aligning with common security best practices.
3. Consistent with other sensitive configuration files in the project.

## Notes
- Does not affect edgecore’s ability to read or clean up the token.
- Compatible with Linux/macOS; Windows file permissions are handled by the OS default behavior.
