### PR TITLE
Fix: unify exit style when getting custom interface IP

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -122,8 +122,7 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 			if config.Modules.Edged.CustomInterfaceName != "" {
 				ip, err := netutil.ChooseBindAddressForInterface(config.Modules.Edged.CustomInterfaceName)
 				if err != nil {
-					klog.Errorf("Failed to get IP address by custom interface %s, err: %v", config.Modules.Edged.CustomInterfaceName, err)
-					os.Exit(1)
+					klog.Exitf("Failed to get IP address by custom interface %s, err: %v", config.Modules.Edged.CustomInterfaceName, err)
 				}
 				config.Modules.Edged.NodeIP = ip.String()
 				klog.Infof("Get IP address by custom interface successfully, %s: %s", config.Modules.Edged.CustomInterfaceName, config.Modules.Edged.NodeIP)


### PR DESCRIPTION
## Motivation
In server.go, when fetching IP from a custom interface, the code calls os.Exit(1) directly. 
Other errors in edgecore use klog.Exit, so this is inconsistent.

## Changes
- Replace os.Exit(1) with klog.Exitf
- Log detailed error while exiting
- Keep behavior unchanged, unify error handling style

## Benefits
- Consistent error handling across edgecore
- Easier to debug due to unified logs
