### PR TITLE
Add protobuf support for metaserver

### DIFF
--- a/edge/pkg/metamanager/metaserver/handlerfactory/standard_write.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/standard_write.go
@@ -33,23 +33,61 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/fakers"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/scope"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage"
 	"github.com/kubeedge/kubeedge/pkg/metaserver"
 	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
 )
 
 func (f *Factory) Create(req *request.RequestInfo) http.Handler {
-	s := scope.NewRequestScope()
-	s.Kind = schema.GroupVersionKind{
+	scope := wrapScope{RequestScope: scope.NewRequestScope()}
+	scope.Kind = schema.GroupVersionKind{
 		Group:   req.APIGroup,
 		Version: req.APIVersion,
 		Kind:    util.UnsafeResourceToKind(req.Resource),
 	}
-	h := handlers.CreateResource(f.storage, s, fakers.NewAlwaysAdmit())
-	return h
+	h := func(w http.ResponseWriter, req *http.Request) {
+		timeout := parseTimeout(req.URL.Query().Get("timeout"))
+		ctx, cancel := context.WithTimeout(req.Context(), timeout)
+		defer cancel()
+
+		createBytes, err := limitedReadBody(req, scope.MaxRequestBodyBytes)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+
+		options := &metav1.CreateOptions{}
+		if err := metainternalversionscheme.ParameterCodec.DecodeParameters(req.URL.Query(), scope.MetaGroupVersion, options); err != nil {
+			err = errors.NewBadRequest(err.Error())
+			scope.err(err, w, req)
+			return
+		}
+		if errs := validation.ValidateCreateOptions(options); len(errs) > 0 {
+			err := errors.NewInvalid(schema.GroupKind{Group: metav1.GroupName, Kind: "CreateOptions"}, "", errs)
+			scope.err(err, w, req)
+			return
+		}
+		options.TypeMeta.SetGroupVersionKind(metav1.SchemeGroupVersion.WithKind("CreateOptions"))
+
+		obj, err := storage.DecodeAndConvert(createBytes, scope.Kind.Group)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+
+		retObj, err := f.storage.Create(ctx, obj, nil, options)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+		responsewriters.WriteObjectNegotiated(scope.Serializer, scope, scope.Kind.GroupVersion(), w, req, 200, retObj, false)
+	}
+	return http.HandlerFunc(h)
 }
 
 func (f *Factory) Update(req *request.RequestInfo) http.Handler {
@@ -57,14 +95,51 @@ func (f *Factory) Update(req *request.RequestInfo) http.Handler {
 		h := updateEdgeDevice()
 		return h
 	}
-	s := scope.NewRequestScope()
-	s.Kind = schema.GroupVersionKind{
+	scope := wrapScope{RequestScope: scope.NewRequestScope()}
+	scope.Kind = schema.GroupVersionKind{
 		Group:   req.APIGroup,
 		Version: req.APIVersion,
 		Kind:    util.UnsafeResourceToKind(req.Resource),
 	}
-	h := handlers.UpdateResource(f.storage, s, fakers.NewAlwaysAdmit())
-	return h
+	h := func(w http.ResponseWriter, req *http.Request) {
+		timeout := parseTimeout(req.URL.Query().Get("timeout"))
+		ctx, cancel := context.WithTimeout(req.Context(), timeout)
+		defer cancel()
+
+		createBytes, err := limitedReadBody(req, scope.MaxRequestBodyBytes)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+
+		options := &metav1.UpdateOptions{}
+		if err := metainternalversionscheme.ParameterCodec.DecodeParameters(req.URL.Query(), scope.MetaGroupVersion, options); err != nil {
+			err = errors.NewBadRequest(err.Error())
+			scope.err(err, w, req)
+			return
+		}
+		if errs := validation.ValidateUpdateOptions(options); len(errs) > 0 {
+			err := errors.NewInvalid(schema.GroupKind{Group: metav1.GroupName, Kind: "UpdateOptions"}, "", errs)
+			scope.err(err, w, req)
+			return
+		}
+		options.TypeMeta.SetGroupVersionKind(metav1.SchemeGroupVersion.WithKind("UpdateOptions"))
+
+		obj, err := storage.DecodeAndConvert(createBytes, scope.Kind.Group)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+
+		objInfo := rest.DefaultUpdatedObjectInfo(obj)
+		retObj, _, err := f.storage.Update(ctx, "", objInfo, nil, nil, false, options)
+		if err != nil {
+			scope.err(err, w, req)
+			return
+		}
+		responsewriters.WriteObjectNegotiated(scope.Serializer, scope, scope.Kind.GroupVersion(), w, req, 200, retObj, false)
+	}
+	return http.HandlerFunc(h)
 }
 
 func (f *Factory) Delete() http.Handler {

--- a/edge/pkg/metamanager/metaserver/handlerfactory/standard_write_test.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/standard_write_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlerfactory
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage"
+)
+
+func TestFactoryCreateImplementation_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(storage.NewREST, func() (*storage.REST, error) {
+		return &storage.REST{}, nil
+	})
+
+	// DecodeAndConvert should return a typed object based on the input body
+	mockObj := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-deployment"},
+	}
+	patches.ApplyFunc(storage.DecodeAndConvert, func(_ []byte, _ string) (runtime.Object, error) {
+		return mockObj, nil
+	})
+
+	// Patch the storage Create method to return the object
+	patches.ApplyMethod((*storage.REST)(nil), "Create",
+		func(_ *storage.REST, _ context.Context, obj runtime.Object, _ rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
+			return mockObj, nil
+		})
+
+	factory := NewFactory()
+
+	reqInfo := &request.RequestInfo{
+		APIGroup:   "apps",
+		APIVersion: "v1",
+		Resource:   "deployments",
+	}
+	handler := factory.Create(reqInfo)
+
+	deployData := `{"kind":"Deployment","metadata":{"name":"nginx-deployment"}}`
+	req := httptest.NewRequest("POST", "/apis/apps/v1/namespaces/default/deployments", strings.NewReader(deployData))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), "nginx-deployment")
+}
+
+func TestFactoryCreateImplementation_StorageError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(storage.NewREST, func() (*storage.REST, error) {
+		return &storage.REST{}, nil
+	})
+
+	mockObj := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-deployment"},
+	}
+	patches.ApplyFunc(storage.DecodeAndConvert, func(_ []byte, _ string) (runtime.Object, error) {
+		return mockObj, nil
+	})
+
+	patches.ApplyMethod((*storage.REST)(nil), "Create",
+		func(_ *storage.REST, _ context.Context, _ runtime.Object, _ rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
+			return nil, errors.New("create error")
+		})
+
+	factory := NewFactory()
+
+	reqInfo := &request.RequestInfo{
+		APIGroup:   "apps",
+		APIVersion: "v1",
+		Resource:   "deployments",
+	}
+	handler := factory.Create(reqInfo)
+
+	deployData := `{"kind":"Deployment","metadata":{"name":"nginx-deployment"}}`
+	req := httptest.NewRequest("POST", "/apis/apps/v1/namespaces/default/deployments", strings.NewReader(deployData))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, 500, w.Code)
+	assert.Contains(t, w.Body.String(), "create error")
+}
+
+func TestFactoryUpdate_Implementation_Success(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(storage.NewREST, func() (*storage.REST, error) {
+		return &storage.REST{}, nil
+	})
+
+	mockObj := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-deployment"},
+	}
+	patches.ApplyFunc(storage.DecodeAndConvert, func(_ []byte, _ string) (runtime.Object, error) {
+		return mockObj, nil
+	})
+
+	patches.ApplyMethod((*storage.REST)(nil), "Update",
+		func(_ *storage.REST, _ context.Context, _ string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+			return mockObj, false, nil
+		})
+
+	factory := NewFactory()
+	reqInfo := &request.RequestInfo{
+		APIGroup:   "apps",
+		APIVersion: "v1",
+		Resource:   "deployments",
+	}
+
+	handler := factory.Update(reqInfo)
+
+	deployData := `{"kind":"Deployment","metadata":{"name":"nginx-deployment"},"spec":{"replicas":3}}`
+	req := httptest.NewRequest("PUT", "/apis/apps/v1/namespaces/default/deployments/nginx-deployment", strings.NewReader(deployData))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), "nginx-deployment")
+}
+
+func TestFactoryUpdate_Implementation_StorageError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(storage.NewREST, func() (*storage.REST, error) {
+		return &storage.REST{}, nil
+	})
+
+	mockObj := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: "nginx-deployment"},
+	}
+	patches.ApplyFunc(storage.DecodeAndConvert, func(_ []byte, _ string) (runtime.Object, error) {
+		return mockObj, nil
+	})
+
+	patches.ApplyMethod((*storage.REST)(nil), "Update",
+		func(_ *storage.REST, _ context.Context, _ string, _ rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+			return nil, false, errors.New("update error")
+		})
+
+	factory := NewFactory()
+	reqInfo := &request.RequestInfo{
+		APIGroup:   "apps",
+		APIVersion: "v1",
+		Resource:   "deployments",
+	}
+
+	handler := factory.Update(reqInfo)
+
+	deployData := `{"kind":"Deployment","metadata":{"name":"nginx-deployment"},"spec":{"replicas":3}}`
+	req := httptest.NewRequest("PUT", "/apis/apps/v1/namespaces/default/deployments/nginx-deployment", strings.NewReader(deployData))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, 500, w.Code)
+	assert.Contains(t, w.Body.String(), "update error")
+}

--- a/edge/pkg/metamanager/metaserver/kubernetes/serializer/serializer.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/serializer/serializer.go
@@ -7,6 +7,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 )
 
 // NewUnstructuredNegotiatedSerializer returns a simple, negotiated serializer
@@ -44,6 +46,20 @@ func (f WithoutConversionCodecFactory) SupportedMediaTypes() []runtime.Serialize
 			MediaTypeSubType: "yaml",
 			EncodesAsText:    true,
 			Serializer:       json.NewSerializerWithOptions(json.DefaultMetaFactory, f.creator, f.typer, json.SerializerOptions{Yaml: true}),
+		},
+		{
+			MediaType:        "application/vnd.kubernetes.protobuf",
+			MediaTypeType:    "application",
+			MediaTypeSubType: "vnd.kubernetes.protobuf",
+			EncodesAsText:    false,
+
+			Serializer:       protobuf.NewSerializer(legacyscheme.Scheme, legacyscheme.Scheme),
+			StrictSerializer: protobuf.NewSerializer(legacyscheme.Scheme, legacyscheme.Scheme),
+			StreamSerializer: &runtime.StreamSerializerInfo{
+				EncodesAsText: false,
+				Serializer:    protobuf.NewRawSerializer(legacyscheme.Scheme, legacyscheme.Scheme),
+				Framer:        protobuf.LengthDelimitedFramer,
+			},
 		},
 	}
 }

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/translator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/translator.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+)
+
+// decodeAndConvert uses the appropriate scheme to decode the raw JSON data into an
+// internal object and then converts it to its external (versioned) representation.
+// This is necessary because the protobuf serializer requires a typed, external object.
+func DecodeAndConvert(body []byte, group string) (runtime.Object, error) {
+	var decoder runtime.Decoder
+
+	switch group {
+	case "apiextensions.k8s.io":
+		decoder = apiextensionsscheme.Codecs.UniversalDecoder(apiextensionsv1.SchemeGroupVersion)
+	case "":
+		decoder = legacyscheme.Codecs.UniversalDeserializer()
+	default:
+		decoder = kubescheme.Codecs.UniversalDecoder(kubescheme.Scheme.PrioritizedVersionsAllGroups()...)
+	}
+	internalObj, gvk, err := decoder.Decode(body, nil, nil)
+	if err != nil {
+		// If the type is not registered in the scheme (e.g. a CRD), we can't convert it to a typed object
+		// for protobuf serialization. In this case, we fall back to returning a runtime.Unknown object,
+		// which will be serialized as JSON.
+		if runtime.IsNotRegisteredError(err) {
+			//if we are seeing this for a core api resource, then there is a problem with decoding
+			if strings.Contains(gvk.Group, ".k8s.io") || gvk.Group == "" {
+				klog.V(4).Infof("failed to decode core k8s object, this should not happen. Falling back to runtime.Unknown for gvk: %v, err: %v", gvk, err)
+				return &runtime.Unknown{Raw: body, ContentType: runtime.ContentTypeJSON}, nil
+			}
+			//crd's wont be registered so pass thru
+			return &runtime.Unknown{Raw: body, ContentType: runtime.ContentTypeJSON}, nil
+		}
+
+		return nil, fmt.Errorf("failed to decode response body: %w", err)
+	}
+
+	return internalObj, nil
+}

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/translator_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/translator_test.go
@@ -1,0 +1,190 @@
+package storage
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestDecodeAndConvertCore(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test core type (Pod)
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx:latest",
+				},
+			},
+		},
+	}
+
+	podJSON, err := json.Marshal(pod)
+	assert.NoError(err)
+
+	// Should successfully decode core type
+	result, err := DecodeAndConvert(podJSON, "")
+	assert.NoError(err)
+
+	resultPod, ok := result.(*corev1.Pod)
+	assert.True(ok)
+	assert.Equal("test-pod", resultPod.Name)
+	assert.Equal("nginx", resultPod.Spec.Containers[0].Name)
+}
+
+func TestDecodeAndConvertAPIExtensions(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test apiextensions type (CustomResourceDefinition)
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "widgets.example.com",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "example.com",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "widgets",
+				Singular: "widget",
+				Kind:     "Widget",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type: "object",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	crdJSON, err := json.Marshal(crd)
+	assert.NoError(err)
+
+	// Should successfully decode apiextensions type
+	result, err := DecodeAndConvert(crdJSON, "apiextensions.k8s.io")
+	assert.NoError(err)
+
+	resultCRD, ok := result.(*apiextensionsv1.CustomResourceDefinition)
+	assert.True(ok)
+	assert.Equal("widgets.example.com", resultCRD.Name)
+	assert.Equal("example.com", resultCRD.Spec.Group)
+}
+
+func TestDecodeAndConvertUnregisteredCRD(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test unregistered CRD type
+	customObj := map[string]interface{}{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata": map[string]interface{}{
+			"name": "test-widget",
+		},
+		"spec": map[string]interface{}{
+			"size":   "large",
+			"color":  "blue",
+			"weight": 100,
+		},
+	}
+
+	customJSON, err := json.Marshal(customObj)
+	assert.NoError(err)
+
+	// Should return runtime.Unknown for unregistered type
+	result, err := DecodeAndConvert(customJSON, "example.com")
+	assert.NoError(err)
+
+	unknown, ok := result.(*runtime.Unknown)
+	assert.True(ok)
+	assert.Equal(runtime.ContentTypeJSON, unknown.ContentType)
+
+	// Verify the raw JSON is preserved
+	var decoded map[string]interface{}
+	err = json.Unmarshal(unknown.Raw, &decoded)
+	assert.NoError(err)
+	assert.Equal("test-widget", decoded["metadata"].(map[string]interface{})["name"])
+}
+
+func TestDecodeAndConvertInvalidJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	// Should return error for invalid JSON
+	invalidJSON := []byte(`{"invalid": json`)
+	result, err := DecodeAndConvert(invalidJSON, "")
+	assert.Error(err)
+	assert.True(strings.Contains(err.Error(), "failed to decode"))
+	assert.Nil(result)
+}
+
+func TestDecodeAndConvertEmptyBody(t *testing.T) {
+	assert := assert.New(t)
+
+	// Should handle empty body gracefully
+	result, err := DecodeAndConvert([]byte{}, "")
+	assert.Error(err)
+	assert.True(strings.Contains(err.Error(), "failed to decode"))
+	assert.Nil(result)
+}
+
+func TestDecodeAndConvertList(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test list type
+	list := &corev1.PodList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PodList",
+		},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod1",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod2",
+				},
+			},
+		},
+	}
+
+	listJSON, err := json.Marshal(list)
+	assert.NoError(err)
+
+	// Should successfully decode list type
+	result, err := DecodeAndConvert(listJSON, "")
+	assert.NoError(err)
+
+	resultList, ok := result.(*corev1.PodList)
+	assert.True(ok)
+	assert.Len(resultList.Items, 2)
+	assert.Equal("pod1", resultList.Items[0].Name)
+	assert.Equal("pod2", resultList.Items[1].Name)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

/kind feature


**What this PR does / why we need it**:
starting in kubernetes 1.32 the client-go library defaults to sending requests in protobuf format.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6465
Replaces #6480

**Special notes for your reviewer**:
this change accepts incoming protobuf requests and responds back via protobuf for the core kubernetes api. If the concrete type is not found, it falls back to responding via json.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE

```release-note
adds application/vnd.kubernetes.protobuf support to metaserver
```
