### PR TITLE
Fix: unify exit handling in hollow_edgecore main function

### DIFF
--- a/edge/cmd/edgemark/hollow_edgecore.go
+++ b/edge/cmd/edgemark/hollow_edgecore.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -71,7 +70,8 @@ type hollowEdgeNodeConfig struct {
 func main() {
 	command := newHollowEdgeNodeCommand()
 	if err := command.Execute(); err != nil {
-		os.Exit(1)
+		//os.Exit(1)
+		klog.Exitf("Failed to execute hollow_edgecore: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation
The `hollow_edgecore.go` file currently uses `os.Exit(1)` in the main function.  
However, most other modules in KubeEdge (e.g., edgecore/server.go) use `klog.Exit(err)` for consistent error handling and logging.

## Changes
- Replace `os.Exit(1)` with `klog.Exitf` in the main function.
- Print detailed error messages for easier debugging.

## Benefits
- Consistent exit behavior across KubeEdge components.
- Improved debugging experience with unified logs.
- Minimal change, no risk to existing behavior.
