### PR TITLE
Enhancement: make hollow_edgecore database path configurable

### DIFF
--- a/edge/cmd/edgemark/hollow_edgecore.go
+++ b/edge/cmd/edgemark/hollow_edgecore.go
@@ -143,7 +143,11 @@ func EdgeCoreConfig(config *hollowEdgeNodeConfig) *v1alpha2.EdgeCoreConfig {
 
 	// overWrite config
 	edgeCoreConfig.EdgeCoreVersion = version.Get().String()
-	edgeCoreConfig.DataBase.DataSource = "/edgecore.db"
+	dataPath := os.Getenv("EDGEMARK_DB_PATH")
+	if dataPath == "" {
+		dataPath = "/var/lib/kubeedge/edgecore.db"
+	}
+	edgeCoreConfig.DataBase.DataSource = dataPath
 	edgeCoreConfig.Modules.EdgeHub.Token = config.Token
 	edgeCoreConfig.Modules.EdgeHub.HTTPServer = config.HTTPServer
 	edgeCoreConfig.Modules.EdgeHub.WebSocket.Server = config.WebsocketServer


### PR DESCRIPTION
## Motivation
The `hollow_edgecore.go` file currently hardcodes the database path as `/edgecore.db`.
This may cause permission issues when running in non-root or container environments.

## Changes
- Replace hardcoded database path with a configurable one.
- Default path: `/var/lib/kubeedge/edgecore.db`
- Allow overriding via environment variable `EDGEMARK_DB_PATH`.

## Benefits
- More flexible and secure configuration.
- Prevents write permission errors in restricted environments.
- Consistent with other KubeEdge components (which use `/var/lib/kubeedge/` as data root).
