### PR TITLE
Add the capability to query Node resources from the edge.

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -480,7 +480,7 @@ func noAckRequired(msg *beehivemodel.Message) bool {
 	default:
 		if msg.GetSource() == modules.EdgeControllerModuleName {
 			resourceType, _ := messagelayer.GetResourceType(*msg)
-			if resourceType == beehivemodel.ResourceTypeNode ||
+			if resourceType == beehivemodel.ResourceTypeNode && msg.GetOperation() != beehivemodel.UpdateOperation ||
 				resourceType == beehivemodel.ResourceTypeLease ||
 				resourceType == beehivemodel.ResourceTypeNodePatch ||
 				resourceType == beehivemodel.ResourceTypePodPatch ||

--- a/edge/pkg/edged/kubeclientbridge/typed/core/v1/node_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/core/v1/node_bridge.go
@@ -32,6 +32,7 @@ import (
 	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+	v2 "github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/v2"
 )
 
 // NodesBridge implements NodeInterface
@@ -42,17 +43,17 @@ type NodesBridge struct {
 
 // Create takes the representation of a node and create it in cluster
 func (c *NodesBridge) Create(_ context.Context, node *corev1.Node, _ metav1.CreateOptions) (*corev1.Node, error) {
-	return c.MetaClient.Nodes(metav1.NamespaceDefault).Create(node)
+	return c.MetaClient.Nodes(v2.NullNamespace).Create(node)
 }
 
 // Get takes name of the node, and returns the corresponding node object
 func (c *NodesBridge) Get(_ context.Context, name string, _ metav1.GetOptions) (result *corev1.Node, err error) {
-	return c.MetaClient.Nodes(metav1.NamespaceDefault).Get(name)
+	return c.MetaClient.Nodes(v2.NullNamespace).Get(name)
 }
 
 // Update takes the representation of a node and updates it
 func (c *NodesBridge) Update(_ context.Context, node *corev1.Node, _ metav1.UpdateOptions) (result *corev1.Node, err error) {
-	err = c.MetaClient.Nodes(metav1.NamespaceDefault).Update(node)
+	err = c.MetaClient.Nodes(v2.NullNamespace).Update(node)
 	if err != nil {
 		return nil, err
 	}
@@ -61,5 +62,5 @@ func (c *NodesBridge) Update(_ context.Context, node *corev1.Node, _ metav1.Upda
 
 // Patch takes the node patch bytes and updates node status
 func (c *NodesBridge) Patch(_ context.Context, name string, _ kubetypes.PatchType, patchBytes []byte, _ metav1.PatchOptions, _ ...string) (result *corev1.Node, err error) {
-	return c.MetaClient.Nodes(metav1.NamespaceDefault).Patch(name, patchBytes)
+	return c.MetaClient.Nodes(v2.NullNamespace).Patch(name, patchBytes)
 }

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -114,7 +114,6 @@ func requireRemoteQuery(resType string) bool {
 		resType == constants.ResourceTypePersistentVolume ||
 		resType == constants.ResourceTypePersistentVolumeClaim ||
 		resType == constants.ResourceTypeVolumeAttachment ||
-		resType == model.ResourceTypeNode ||
 		resType == model.ResourceTypeServiceAccountToken ||
 		resType == model.ResourceTypeLease ||
 		resType == model.ResourceTypeCSR ||
@@ -256,7 +255,9 @@ func (m *metaManager) processUpdate(message model.Message) {
 		resp := message.NewRespByMessage(&message, OK)
 		sendToEdged(resp, message.IsSync())
 	case cloudmodules.EdgeControllerModuleName, cloudmodules.DynamicControllerModuleName:
-		sendToEdged(&message, message.IsSync())
+		if resType != model.ResourceTypeNode {
+			sendToEdged(&message, message.IsSync())
+		}
 		resp := message.NewRespByMessage(&message, OK)
 		sendToCloud(resp)
 	case cloudmodules.DeviceControllerModuleName:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
In the underlying layer of edged, multiple modules need to retrieve Node resources from the API server, such as: nodestatusmanager, volumemanager, evictionmanager, and podmanager. Calls from these modules are typically made in a periodic polling manner. In edgecore, queries for Node resources from edged are handled through the metaclient, which forwards the requests via the cloud-edge channel through cloudcore to the API server. The Node resources obtained from the API server are then returned to the edge node's edgecore through the same cloud-edge channel.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubeedge/kubeedge/issues/6491

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
