### PR TITLE
fixes "Leases" being parsed as "Leas"

### DIFF
--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -57,6 +57,7 @@ func UnsafeResourceToKind(r string) string {
 		"nodestatus":                   "NodeStatus",
 		"customresourcedefinitions":    "CustomResourceDefinition",
 		"customresourcedefinitionlist": "CustomResourceDefinitionList",
+		"leases":                       "Leases",
 	}
 	if v, isUnusual := unusualResourceToKind[r]; isUnusual {
 		return v
@@ -84,6 +85,7 @@ func UnsafeKindToResource(k string) string {
 		"NodeStatus":                   "nodestatus",
 		"CustomResourceDefinition":     "customresourcedefinitions",
 		"CustomResourceDefinitionList": "customresourcedefinitionlist",
+		"Leases":                       "leases",
 	}
 	if v, isUnusual := unusualKindToResource[k]; isUnusual {
 		return v


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
This PR fixes a defect found while working #6484 
the `leases.coordination.k8s.io` type was getting rewritten as `leas.coordination.k8s.io`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note
fixes ability to interact with leases.coordination.k8s.io thru metaserver
```
