### PR TITLE
Avoid unnecessary UpdateDevice calls in dealMetaDeviceOperation when device has no change

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

In `edge/pkg/devicetwin/dtmanager/dmiworker.go`, the `dealMetaDeviceOperation` method handles device operations via a `switch` on `message.GetOperation()`.

When receiving `UpdateOperation`, it always calls:

```
err = dmiclient.DMIClientsImp.UpdateDevice(&device)
```

However, even when the device `spec` has no changes compared to the previous state (only `status` is updated), the code still triggers `UpdateDevice`.

This leads to an unexpected behavior in mapper implementations:
Most default mapper frameworks restart the device as part of their update logic (stop → start).
As a result, the device keeps restarting repeatedly even though the `desired` configuration never changed — only the `status` got updated.

This behavior is not reasonable, as `status` updates should not trigger a device reconfiguration or restart.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
