### PR TITLE
feat: add configuration validation with default values

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -74,9 +74,22 @@ func newCloudHub(enable bool) *cloudHub {
 	return ch
 }
 
+func validateConfig(hub *v1alpha1.CloudHub) {
+    if hub.KeepaliveInterval <= 0 {
+        hub.KeepaliveInterval = 30 
+        klog.Warningf("KeepaliveInterval not set, using default value: %d", hub.KeepaliveInterval)
+    }
+    
+    if hub.NodeLimit <= 0 {
+        hub.NodeLimit = 1000 
+        klog.Warningf("NodeLimit not set, using default value: %d", hub.NodeLimit)
+    }
+}
+
 func Register(hub *v1alpha1.CloudHub) {
-	hubconfig.InitConfigure(hub)
-	core.Register(newCloudHub(hub.Enable))
+	validateConfig(hub) 
+    hubconfig.InitConfigure(hub)
+    core.Register(newCloudHub(hub.Enable))
 }
 
 func (ch *cloudHub) Name() string {


### PR DESCRIPTION
This PR adds configuration validation for CloudHub to prevent runtime errors caused by misconfiguration. 

**Changes:**
- Validate `KeepaliveInterval` and `NodeLimit` parameters
- Set reasonable default values for invalid/missing configs  
- Add warning logs when defaults are applied

**Benefits:**
- Prevents deployment failures due to config errors
- Provides better user experience with sensible defaults
- Maintains full backward compatibility

Release note: Added configuration validation with default values for CloudHub settings.