### PR TITLE
chore: fix typos

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,6 @@ linters-settings:
     ignore-words:
       - mosquitto
       - creater  # creater
-      - resouce  # resource
   revive:
     rules:
       - name: dot-imports

--- a/CHANGELOG/CHANGELOG-1.15.md
+++ b/CHANGELOG/CHANGELOG-1.15.md
@@ -114,11 +114,11 @@ Refer to the link for more details. ([#4914](https://github.com/kubeedge/kubeedg
 
 The device API is updated from `v1alpha2` to `v1beta1`, in v1beta1 API updates include:
 
-- The built-in protocols incude Modbus, Opc-UA and Bluetooth are removed in device instance, and the built-in mappers for these proytocols
-still exists and will be maintained and updated to latest verison.
+- The built-in protocols incude Modbus, Opc-UA and Bluetooth are removed in device instance, and the built-in mappers for these protocols
+still exists and will be maintained and updated to latest version.
 - Users must define the protocol config through `CustomizedValue` in `ProtocolConfig`.
 - DMI date plane related fields are added, users can config the collection and reporting frequency of device data, and the destination
-to whcih(such as database, httpserver) data is pushed.
+to which(such as database, httpserver) data is pushed.
 - Controls whether to report device data to cloud.
 
 Refer to the link for more details. ([#4983](https://github.com/kubeedge/kubeedge/pull/4983))

--- a/cloud/pkg/controllermanager/nodetask/reconcile_runner.go
+++ b/cloud/pkg/controllermanager/nodetask/reconcile_runner.go
@@ -118,7 +118,7 @@ func RunReconcile[T NodeJobType](
 	// The final phase does not need to be calculated.
 	if handler.IsFinalPhase(job) {
 		logger.V(2).Info("the node job is final phase")
-		// If job is in final phase, the the timeout job needs to be stopped.
+		// If job is in final phase, the timeout job needs to be stopped.
 		ReleaseTimeoutJob[T](ctx, req.Name, handler.GetResource())
 		return nil
 	}

--- a/docs/proposals/sig-node/5999-edge-node-tasks-ststus-enhancement/README.md
+++ b/docs/proposals/sig-node/5999-edge-node-tasks-ststus-enhancement/README.md
@@ -25,20 +25,20 @@ In addition, there is another problem that some errors in the processing process
 ## Proposal
 ### Node Job Status
 
-The node job status consists of phase and nodeStatus fields. The phase field is one of there values: Init, InProgress, Complated or Failure. 
+The node job status consists of phase and nodeStatus fields. The phase field is one of there values: Init, InProgress, Completed or Failure. 
 
 ```mermaid
 graph LR
 A[Init] --> B[InProgress]
 B --> C{Succ?}
-C --> |Y| D[Complated]
+C --> |Y| D[Completed]
 C --> |N| E[Failure]
 A --Fail--> E
 ```
 
 - **Init** - After creating a node job CR, ControllerManager will initialize the matching node and set the node job phase to "Init".
 - **InProgress** - The node job phase will be "InProgress" when any node starts processing the node task.
-- **Complated** - All node tasks are already final status and the number of node tasks failures is not greater than the defined failure rate, then set the phase to "Complated".
+- **Completed** - All node tasks are already final status and the number of node tasks failures is not greater than the defined failure rate, then set the phase to "Completed".
 - **Failure** - If the initialization of node tasks fails, or the number of failures for node tasks is greater than the defined failure rate, set the phase to "Failure".
 
 When each node reports the execution results, the node job phase will be calculated and updated. 
@@ -53,7 +53,7 @@ The node task status consists of phase, action, and reason. The phase field is o
 graph LR
 A[Pending] --> B[InProgress]
 B --> C{Succ?}
-C --> |Y| D[Complated]
+C --> |Y| D[Completed]
 C --> |N| E[Failure]
 C --> |no response| F[Unknown]
 B --> F
@@ -137,7 +137,7 @@ type JobPhase string
 const (
     JobPhaseInit       JobPhase = "Init"
     JobPhaseInProgress JobPhase = "InProgress"
-    JobPhaseComplated  JobPhase = "Complated"
+    JobPhaseCompleted  JobPhase = "Completed"
     JobPhaseFailure    JobPhase = "Failure"
 )
 
@@ -394,7 +394,7 @@ func RunReconcile[T operationsv1alpha2.NodeJobType](
 
     // 5. The final phase does not need to be calculated.
     if handler.IsFinalPhase(job) {
-        // If job is in final phase, the the timeout job needs to be stopped.
+        // If job is in final phase, the timeout job needs to be stopped.
         ...
         return nil
     }

--- a/docs/proposals/sig-node/configuration.md
+++ b/docs/proposals/sig-node/configuration.md
@@ -55,7 +55,7 @@ We recommend referring to the kubernetes component config api design to redesign
 
 ## Goals
 
-* KubeEdge components use one configuration file instead of the original 3 configuration files. It supports json or yaml format, defaut is yaml.
+* KubeEdge components use one configuration file instead of the original 3 configuration files. It supports json or yaml format, default is yaml.
 
 * Start the KubeEdge component with the --config flag, this flag set to the path of the component's config file. The component will then load its config from this file, if --config flag not set, component will read a default configuration file.
 
@@ -523,7 +523,7 @@ type Modules struct {
 	EdgeMesh *EdgeMesh `json:"edgeMesh,omitempty"`
 }
 
-// Edged indicates the config fo edged module
+// Edged indicates the config for edged module
 // edged is lighted-kubelet
 type Edged struct {
 	// Enable indicates whether edged is enabled,

--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -147,7 +147,7 @@ func (dw *DMIWorker) dealMetaDeviceOperation(_ *dtcontext.DTContext, _ string, m
 			dw.dmiCache.DeviceMu.Unlock()
 			err = dmiclient.DMIClientsImp.UpdateDevice(&device)
 			if err != nil {
-				klog.Errorf("udpate device %s failed with err: %v", device.Name, err)
+				klog.Errorf("update device %s failed with err: %v", device.Name, err)
 				return err
 			}
 		default:

--- a/edge/pkg/eventbus/mqtt/server.go
+++ b/edge/pkg/eventbus/mqtt/server.go
@@ -94,7 +94,7 @@ func (m *Server) Run() error {
 
 // onSubscribe will be called if the topic is matched in topic tree.
 func (m *Server) onSubscribe(msg *packet.Message) {
-	klog.Infof("OnSubscribe recevie msg from topic: %s", msg.Topic)
+	klog.Infof("OnSubscribe receive msg from topic: %s", msg.Topic)
 	NewMessageMux().Dispatch(msg.Topic, msg.Payload)
 }
 

--- a/pkg/viaduct/pkg/protos/message/message.pb.go
+++ b/pkg/viaduct/pkg/protos/message/message.pb.go
@@ -27,9 +27,9 @@ type MessageRouter struct {
 	// where the message will send to
 	Group string `protobuf:"bytes,2,opt,name=Group,proto3" json:"Group,omitempty"`
 	// what's the operation on resource
-	Operaion string `protobuf:"bytes,3,opt,name=Operaion,proto3" json:"Operaion,omitempty"`
+	Operation string `protobuf:"bytes,3,opt,name=Operation,proto3" json:"Operation,omitempty"`
 	// what's the resource want to operate
-	Resouce              string   `protobuf:"bytes,4,opt,name=Resouce,proto3" json:"Resouce,omitempty"`
+	Resource             string   `protobuf:"bytes,4,opt,name=Resource,proto3" json:"Resource,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -74,16 +74,16 @@ func (m *MessageRouter) GetGroup() string {
 	return ""
 }
 
-func (m *MessageRouter) GetOperaion() string {
+func (m *MessageRouter) GetOperation() string {
 	if m != nil {
-		return m.Operaion
+		return m.Operation
 	}
 	return ""
 }
 
-func (m *MessageRouter) GetResouce() string {
+func (m *MessageRouter) GetResource() string {
 	if m != nil {
-		return m.Resouce
+		return m.Resource
 	}
 	return ""
 }

--- a/pkg/viaduct/pkg/protos/message/message.proto
+++ b/pkg/viaduct/pkg/protos/message/message.proto
@@ -8,9 +8,9 @@ message MessageRouter {
     // where the message will send to
     string Group = 2;
     // what's the operation on resource
-    string Operaion = 3;
+    string Operation = 3;
     // what's the resource want to operate
-    string Resouce = 4;
+    string Resource = 4;
 }
 
 message MessageHeader {

--- a/pkg/viaduct/pkg/translator/message.go
+++ b/pkg/viaduct/pkg/translator/message.go
@@ -20,7 +20,7 @@ func NewTran() *MessageTranslator {
 
 func (t *MessageTranslator) protoToModel(src *message.Message, dst *model.Message) error {
 	dst.BuildHeader(src.Header.ID, src.Header.ParentID, int64(src.Header.Timestamp)).
-		BuildRouter(src.Router.Source, src.Router.Group, src.Router.Resouce, src.Router.Operaion).
+		BuildRouter(src.Router.Source, src.Router.Group, src.Router.Resource, src.Router.Operation).
 		FillBody(src.Content)
 
 	// TODO:
@@ -36,8 +36,8 @@ func (t *MessageTranslator) modelToProto(src *model.Message, dst *message.Messag
 	dst.Header.Sync = src.IsSync()
 	dst.Router.Source = src.GetSource()
 	dst.Router.Group = src.GetGroup()
-	dst.Router.Resouce = src.GetResource()
-	dst.Router.Operaion = src.GetOperation()
+	dst.Router.Resource = src.GetResource()
+	dst.Router.Operation = src.GetOperation()
 	if content := src.GetContent(); content != nil {
 		switch content := content.(type) {
 		case []byte:

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -99,7 +99,7 @@ type Modules struct {
 	EdgeStream *EdgeStream `json:"edgeStream,omitempty"`
 }
 
-// Edged indicates the config fo edged module
+// Edged indicates the config for edged module
 // edged is lighted-kubelet
 type Edged struct {
 	// Enable indicates whether edged is enabled,

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -96,7 +96,7 @@ type Modules struct {
 	TaskManager *TaskManager `json:"taskManager,omitempty"`
 }
 
-// Edged indicates the config fo edged module
+// Edged indicates the config for edged module
 // edged is lighted-kubelet
 type Edged struct {
 	// Enable indicates whether EdgeHub is enabled,

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/socket/broker/broker_test.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/socket/broker/broker_test.go
@@ -67,7 +67,7 @@ func TestMessageBroker_SendReceive(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to receive message, error: %+v", err)
 		}
-		fmt.Printf("recive message: %+v", message)
+		fmt.Printf("receive message: %+v", message)
 		if message.GetContent() != "hello" {
 			t.Fatalf("bad message content")
 		}
@@ -98,7 +98,7 @@ func TestMessageBroker_SendReceive(t *testing.T) {
 	select {
 	case _, ok := <-time.After(syncMessageTimeoutDefault):
 		if ok {
-			t.Fatalf("time out ti recive message")
+			t.Fatalf("time out to receive message")
 		}
 	case _, ok := <-stopChan:
 		if ok {


### PR DESCRIPTION
This commit fixes multiple spelling errors found throughout the project:

Core code fixes:
- Fix protobuf field names: Operaion → Operation, Resouce → Resource
- Fix error log messages: udpate → update, recevie/recive → receive
- Fix duplicate word "the the" in comments
- Fix API type comments: fo → for

Documentation fixes:
- Fix typos in CHANGELOG-1.15.md (proytocols, verison, whcih)
- Fix typos in proposals (defaut, Complated → Completed)

Also removed 'resouce' from .golangci.yml ignore list as it's now fixed.


