### PR TITLE
Add certificate expiration logging for better observability

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
@@ -81,9 +81,21 @@ func createCAToSecret(ctx context.Context) error {
 			}
 			caDER = caPem.Bytes
 			keyDER = pk.DER()
+			
+			// Log CA certificate expiration
+			if cert, err := x509.ParseCertificate(caDER); err == nil {
+				klog.Infof("CA certificate generated successfully, valid from %s to %s", 
+					cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+			}
 		} else {
 			caDER = caSecret.Data[CaDataName]
 			keyDER = caSecret.Data[CaKeyDataName]
+			
+			// Log existing CA certificate expiration
+			if cert, err := x509.ParseCertificate(caDER); err == nil {
+				klog.Infof("Using existing CA certificate, valid from %s to %s", 
+					cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+			}
 		}
 
 		hubconfig.Config.UpdateCA(caDER, keyDER)
@@ -147,9 +159,21 @@ func createCertsToSecret(ctx context.Context) error {
 			}
 			keyDER = keywrap.DER()
 			certDER = certPEM.Bytes
+			
+			// Log CloudCore certificate expiration
+			if cert, err := x509.ParseCertificate(certDER); err == nil {
+				klog.Infof("CloudCore certificate generated successfully, valid from %s to %s", 
+					cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+			}
 		} else {
 			certDER = cloudSecret.Data[CloudCoreCertName]
 			keyDER = cloudSecret.Data[CloudCoreKeyDataName]
+			
+			// Log existing CloudCore certificate expiration
+			if cert, err := x509.ParseCertificate(certDER); err == nil {
+				klog.Infof("Using existing CloudCore certificate, valid from %s to %s", 
+					cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+			}
 		}
 
 		hubconfig.Config.UpdateCerts(certDER, keyDER)


### PR DESCRIPTION
Add certificate expiration logging for better observability

This PR enhances certificate management by adding detailed logging of certificate validity periods. When certificates are generated or loaded from secrets, the system now logs the start and end dates of certificate validity in RFC3339 format. This improvement helps operators monitor certificate expiration and plan renewals proactively, reducing the risk of service disruptions due to expired certificates.

Changes include:
- Log CA certificate validity when generated or loaded from secret
- Log CloudCore certificate validity when generated or loaded from secret  
- Use standardized RFC3339 timestamp format for consistency