### PR TITLE
Fix policymanager reconciliation

### DIFF
--- a/cloud/pkg/policycontroller/policycontroller.go
+++ b/cloud/pkg/policycontroller/policycontroller.go
@@ -58,11 +58,11 @@ func NewAccessRoleControllerManager(ctx context.Context, kubeCfg *rest.Config) (
 }
 
 func setupControllers(ctx context.Context, mgr manager.Manager) error {
-	// This returned cli will directly acquire the unstructured objects from API Server which
+	// mgr.GetClient() will directly acquire the unstructured objects from API Server which
 	// have not be registered in the accessScheme.
-	cli := mgr.GetClient()
 	pc := &pm.Controller{
-		Client:       cli,
+		Client:       mgr.GetClient(),
+		Reader:       mgr.GetAPIReader(),
 		MessageLayer: messagelayer.PolicyControllerMessageLayer(),
 	}
 


### PR DESCRIPTION
- Use non-cached reader (returned by manager.GetAPIReader()) instead of
manager.GetClient() which returns cached client which does not always see recent Kubernetes object changes

Using cached client leads to wrong decisions during Reconcile() so sometime ssend2Edge() is not called for some nodes as Reconcile() does not see recently created Pods

Side-effect of using cached client: many Reconcile() errors like:

2025-11-03T15:58:30.713482Z stderr F E1103 15:58:30.713304       1 reconcile.go:218] failed to create serviceaccountaccess, serviceaccountaccesses.policy.kubeedge.io "default" already exists
2025-11-03T15:58:30.796016537Z stderr F E1103 15:58:30.795703       1 reconcile.go:472] failed to update serviceaccountaccess status ns01/default, Operation cannot be fulfilled on serviceaccountaccesses.policy.kubeedge.io "default": the object has been modified; please apply your changes to the latest version and try again

- Fix Reconcile() not triggered by Pods at least in DaemonSet case: DaemonSet Pods are created without the .Spec.NodeName first (and are filtered out by filterObject()), then Pod is patched but Reconcile() is not triggered when Pods are updated (by mapObjectFunc())

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
