### PR TITLE
fix: upgrade cri-dockerd version to fix docker e2e tests

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -192,7 +192,10 @@ EOF'
 }
 
 function install_docker() {
-  CRIDOCKERD_VERSION="v0.3.8"
+  CRIDOCKERD_VERSION=$(curl -s "https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  if [ -z "$CRIDOCKERD_VERSION" ]; then
+      CRIDOCKERD_VERSION="v0.3.21"
+  fi
   sudo apt-get update
   sudo apt-get install \
     apt-transport-https \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**


/kind failing-test



**What this PR does / why we need it**:

As cri-dockerd version v0.3.8 is no longer compatible with docker version on gitaction machine, so upgrade the version to latest. 


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
