### PR TITLE
fix: add OverrideDeviceInstanceConfig logic in dmiserver MapperRegister

### DIFF
--- a/edge/pkg/devicetwin/dmiserver/server.go
+++ b/edge/pkg/devicetwin/dmiserver/server.go
@@ -67,6 +67,142 @@ type DMICache struct {
 	DeviceList      map[string]*v1beta1.Device
 }
 
+// overrideDeviceInstanceConfig overrides device instance configuration with model defaults
+func (dmiCache *DMICache) OverrideDeviceInstanceConfig(device *v1beta1.Device) error {
+	if device.Spec.DeviceModelRef == nil {
+		return fmt.Errorf("device %s has no device model reference", device.Name)
+	}
+
+	// Get device model from cache
+	deviceModelID := util.GetResourceID(device.Namespace, device.Spec.DeviceModelRef.Name)
+	dmiCache.DeviceModelMu.Lock()
+	deviceModel, ok := dmiCache.DeviceModelList[deviceModelID]
+	if !ok {
+		dmiCache.DeviceModelMu.Unlock()
+		return fmt.Errorf("device model %s not found in cache for device %s", device.Spec.DeviceModelRef.Name, device.Name)
+	}
+	dmiCache.DeviceModelMu.Unlock()
+
+	klog.Infof("Overriding device properties for device %s using model %s", device.Name, deviceModel.Name)
+
+	// Store original device properties in temporary variables
+	originalProperties := make([]v1beta1.DeviceProperty, len(device.Spec.Properties))
+	copy(originalProperties, device.Spec.Properties)
+
+	// Apply model visitors
+	for i := range device.Spec.Properties {
+		deviceProp := &device.Spec.Properties[i]
+
+		// Find corresponding model property
+		if modelProp := findModelProperty(deviceModel.Spec.Properties, deviceProp.Name); modelProp != nil {
+			// Apply model visitors
+			if modelProp.Visitors != nil {
+				deviceProp.Visitors = *modelProp.Visitors
+				deviceProp.Visitors.ConfigData = deepCopyCustomizedValue(modelProp.Visitors.ConfigData)
+				klog.Infof("Applied model visitors to property %s of device %s", deviceProp.Name, device.Name)
+			}
+		}
+	}
+
+	// Merge with original instance data (instance data takes precedence)
+	for i, originalProp := range originalProperties {
+		deviceProp := &device.Spec.Properties[i]
+
+		// Merge visitors: keep model defaults but override with instance values
+		if originalProp.Visitors.ConfigData != nil && originalProp.Visitors.ConfigData.Data != nil {
+			// If device property has model visitors, merge the config data
+			if deviceProp.Visitors.ConfigData != nil && deviceProp.Visitors.ConfigData.Data != nil {
+				// Merge: instance data overrides model data
+				for key, value := range originalProp.Visitors.ConfigData.Data {
+					deviceProp.Visitors.ConfigData.Data[key] = value
+				}
+				klog.Infof("Merged instance visitors for property %s of device %s", deviceProp.Name, device.Name)
+			} else {
+				// No model visitors config data, use instance visitors config data directly
+				deviceProp.Visitors.ConfigData = originalProp.Visitors.ConfigData
+				klog.Infof("Used instance visitors config data for property %s of device %s", deviceProp.Name, device.Name)
+			}
+		}
+		// If original property has no visitors config, keep the model visitors (already applied above)
+	}
+
+	// Handle protocol config data
+	// Store original protocol config
+	originalProtocolConfig := device.Spec.Protocol.ConfigData
+
+	// Apply model protocol config (may be nil)
+	device.Spec.Protocol.ConfigData = deepCopyCustomizedValue(deviceModel.Spec.ProtocolConfigData)
+	if deviceModel.Spec.ProtocolConfigData != nil {
+		klog.Infof("Applied model protocol config data to device %s", device.Name)
+	}
+
+	// Merge with instance protocol config if exists (instance data takes precedence)
+	if originalProtocolConfig != nil && originalProtocolConfig.Data != nil {
+		if device.Spec.Protocol.ConfigData != nil && device.Spec.Protocol.ConfigData.Data != nil {
+			// Merge: instance data overrides model data
+			for key, value := range originalProtocolConfig.Data {
+				device.Spec.Protocol.ConfigData.Data[key] = value
+			}
+			klog.Infof("Merged instance protocol config data for device %s", device.Name)
+		} else {
+			// No model config data, use instance config directly
+			device.Spec.Protocol.ConfigData = originalProtocolConfig
+			klog.Infof("Used instance protocol config data for device %s", device.Name)
+		}
+	}
+
+	return nil
+}
+
+// findModelProperty finds a model property by name
+func findModelProperty(properties []v1beta1.ModelProperty, name string) *v1beta1.ModelProperty {
+	for i := range properties {
+		if properties[i].Name == name {
+			return &properties[i]
+		}
+	}
+	return nil
+}
+
+// deepCopyCustomizedValue creates a deep copy of CustomizedValue
+func deepCopyCustomizedValue(src *v1beta1.CustomizedValue) *v1beta1.CustomizedValue {
+	// deepCopyValue is a recursive function to deep copy interface{} values
+	// as long as they are composed of maps, slices, and basic types.
+	var deepCopyValue func(interface{}) interface{}
+	deepCopyValue = func(v interface{}) interface{} {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			newMap := make(map[string]interface{})
+			for k, v2 := range val {
+				newMap[k] = deepCopyValue(v2)
+			}
+			return newMap
+		case []interface{}:
+			newSlice := make([]interface{}, len(val))
+			for i, v2 := range val {
+				newSlice[i] = deepCopyValue(v2)
+			}
+			return newSlice
+		default:
+			return val
+		}
+	}
+
+	if src == nil {
+		return nil
+	}
+	cp := &v1beta1.CustomizedValue{}
+	if src.Data == nil {
+		return cp
+	}
+
+	cp.Data = make(map[string]interface{})
+	for key, value := range src.Data {
+		cp.Data[key] = deepCopyValue(value)
+	}
+	return cp
+}
+
 func (s *server) MapperRegister(_ context.Context, in *pb.MapperRegisterRequest) (*pb.MapperRegisterResponse, error) {
 	if !s.limiter.Allow() {
 		return nil, fmt.Errorf("fail to register mapper because of too many request: %s", in.Mapper.Name)
@@ -96,6 +232,12 @@ func (s *server) MapperRegister(_ context.Context, in *pb.MapperRegisterRequest)
 	s.dmiCache.DeviceMu.Lock()
 	for _, device := range s.dmiCache.DeviceList {
 		if device.Spec.Protocol.ProtocolName == in.Mapper.Protocol {
+			err := s.dmiCache.OverrideDeviceInstanceConfig(device)
+			if err != nil {
+				klog.Errorf("override device instance config failed for device %s: %v", device.Name, err)
+				continue
+			}
+
 			dev, err := dtcommon.ConvertDevice(device)
 			if err != nil {
 				klog.Errorf("fail to convert device %s with err: %v", device.Name, err)

--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -104,101 +104,6 @@ func (dw *DMIWorker) initDMIActionCallBack() {
 	dw.dmiActionCallBack[dtcommon.MetaDeviceOperation] = dw.dealMetaDeviceOperation
 }
 
-// overrideDeviceInstanceConfig overrides device instance configuration with model defaults
-func (dw *DMIWorker) overrideDeviceInstanceConfig(device *v1beta1.Device) error {
-	if device.Spec.DeviceModelRef == nil {
-		return fmt.Errorf("device %s has no device model reference", device.Name)
-	}
-
-	// Get device model from cache
-	deviceModelID := util.GetResourceID(device.Namespace, device.Spec.DeviceModelRef.Name)
-	dw.dmiCache.DeviceModelMu.Lock()
-	deviceModel, ok := dw.dmiCache.DeviceModelList[deviceModelID]
-	if !ok {
-		return fmt.Errorf("device model %s not found in cache for device %s", device.Spec.DeviceModelRef.Name, device.Name)
-	}
-	dw.dmiCache.DeviceModelMu.Unlock()
-
-	klog.Infof("Overriding device properties for device %s using model %s", device.Name, deviceModel.Name)
-
-	// Store original device properties in temporary variables
-	originalProperties := make([]v1beta1.DeviceProperty, len(device.Spec.Properties))
-	copy(originalProperties, device.Spec.Properties)
-
-	// Apply model visitors
-	for i := range device.Spec.Properties {
-		deviceProp := &device.Spec.Properties[i]
-
-		// Find corresponding model property
-		if modelProp := findModelProperty(deviceModel.Spec.Properties, deviceProp.Name); modelProp != nil {
-			// Apply model visitors
-			if modelProp.Visitors != nil {
-				deviceProp.Visitors = *modelProp.Visitors
-				klog.Infof("Applied model visitors to property %s of device %s", deviceProp.Name, device.Name)
-			}
-		}
-	}
-
-	// Merge with original instance data (instance data takes precedence)
-	for i, originalProp := range originalProperties {
-		deviceProp := &device.Spec.Properties[i]
-
-		// Merge visitors: keep model defaults but override with instance values
-		if originalProp.Visitors.ConfigData != nil && originalProp.Visitors.ConfigData.Data != nil {
-			// If device property has model visitors, merge the config data
-			if deviceProp.Visitors.ConfigData != nil && deviceProp.Visitors.ConfigData.Data != nil {
-				// Merge: instance data overrides model data
-				for key, value := range originalProp.Visitors.ConfigData.Data {
-					deviceProp.Visitors.ConfigData.Data[key] = value
-				}
-				klog.Infof("Merged instance visitors for property %s of device %s", deviceProp.Name, device.Name)
-			} else {
-				// No model visitors config data, use instance visitors config data directly
-				deviceProp.Visitors.ConfigData = originalProp.Visitors.ConfigData
-				klog.Infof("Used instance visitors config data for property %s of device %s", deviceProp.Name, device.Name)
-			}
-		}
-		// If original property has no visitors config, keep the model visitors (already applied above)
-	}
-
-	// Handle protocol config data
-	// Store original protocol config
-	originalProtocolConfig := device.Spec.Protocol.ConfigData
-
-	// Apply model protocol config (may be nil)
-	device.Spec.Protocol.ConfigData = deviceModel.Spec.ProtocolConfigData
-	if deviceModel.Spec.ProtocolConfigData != nil {
-		klog.Infof("Applied model protocol config data to device %s", device.Name)
-	}
-
-	// Merge with instance protocol config if exists (instance data takes precedence)
-	if originalProtocolConfig != nil && originalProtocolConfig.Data != nil {
-		if device.Spec.Protocol.ConfigData != nil && device.Spec.Protocol.ConfigData.Data != nil {
-			// Merge: instance data overrides model data
-			for key, value := range originalProtocolConfig.Data {
-				device.Spec.Protocol.ConfigData.Data[key] = value
-			}
-			klog.Infof("Merged instance protocol config data for device %s", device.Name)
-		} else {
-			// No model config data, use instance config directly
-			device.Spec.Protocol.ConfigData = originalProtocolConfig
-			klog.Infof("Used instance protocol config data for device %s", device.Name)
-		}
-	}
-
-	return nil
-}
-
-// findModelProperty finds a model property by name
-func findModelProperty(properties []v1beta1.ModelProperty, name string) *v1beta1.ModelProperty {
-	for i := range properties {
-		if properties[i].Name == name {
-			return &properties[i]
-		}
-	}
-	return nil
-}
-
 func (dw *DMIWorker) dealMetaDeviceOperation(_ *dtcontext.DTContext, _ string, msg interface{}) error {
 	message, ok := msg.(*model.Message)
 	if !ok {
@@ -220,7 +125,7 @@ func (dw *DMIWorker) dealMetaDeviceOperation(_ *dtcontext.DTContext, _ string, m
 		switch message.GetOperation() {
 		case model.InsertOperation:
 			// Override device instance config with model defaults before registering
-			err = dw.overrideDeviceInstanceConfig(&device)
+			err = dw.dmiCache.OverrideDeviceInstanceConfig(&device)
 			if err != nil {
 				klog.Errorf("override device instance config failed for device %s: %v", device.Name, err)
 				return err
@@ -244,7 +149,7 @@ func (dw *DMIWorker) dealMetaDeviceOperation(_ *dtcontext.DTContext, _ string, m
 			dw.dmiCache.DeviceMu.Unlock()
 		case model.UpdateOperation:
 			// Override device instance config with model defaults before updating
-			err = dw.overrideDeviceInstanceConfig(&device)
+			err = dw.dmiCache.OverrideDeviceInstanceConfig(&device)
 			if err != nil {
 				klog.Errorf("override device instance config failed for device %s: %v", device.Name, err)
 				return err


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In release 1.22, the kubeedge supports Device CRD to share DeviceModel CRD `protocolConfigData` and `visitors` fields #6457 #6458 [link](https://github.com/kubeedge/kubeedge/blob/master/CHANGELOG/CHANGELOG-1.22.md#device-model-update-based-on-thing-model-and-product-concept). This logic is implemented in `DMIWorker.overrideDeviceInstanceConfig`. This function is called when the cloudcore send Device CRD creation or update message to the edgecore. The edgecore use it to merge `protocolConfigData` and `visitors` from DeviceModel CRD to Device CRD, send it to mapper, and save merged Device CRD into dmiCache. However, the `MapperRegister` implementation in DMIServer does not have this logic. Hence, when the `MapperRegister` is called after the restart of edgecore, the edgecore will send the unmerged Device CRD to mapper. This is problematic.

In this PR, I add the logic of `OverrideDeviceInstanceConfig` in `MapperRegister` implementation to fix the problem.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
