### PR TITLE
Allow cloudCore service type to be any valid Kubernetes type instead …

### DIFF
--- a/manifests/charts/cloudcore/templates/service_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/service_cloudcore.yaml
@@ -1,54 +1,50 @@
-{{- if and (.Values.cloudCore.service.enable) }}
+{{- if .Values.cloudCore.service.enable }}
 apiVersion: v1
 kind: Service
 metadata:
+  name: cloudcore
   {{- with .Values.cloudCore.service.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.cloudCore.labels }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: cloudcore
 spec:
-  {{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}
-  type: {{ .Values.cloudCore.service.type }}
-  {{- else }}
-  type: ClusterIP
-  {{- end }}
+  type: {{ .Values.cloudCore.service.type | default "ClusterIP" }}
   ports:
-  - port: 10000
-    targetPort: 10000
-    {{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}
-    nodePort: {{ .Values.cloudCore.service.cloudhubNodePort }}
-    {{- end }}
-    name: cloudhub
-  - port: 10001
-    targetPort: 10001
-    protocol: UDP
-    {{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}
-    nodePort: {{ .Values.cloudCore.service.cloudhubQuicNodePort }}
-    {{- end }}
-    name: cloudhub-quic
-  - port: 10002
-    targetPort: 10002
-    {{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}
-    nodePort: {{ .Values.cloudCore.service.cloudhubHttpsNodePort }}
-    {{- end }}
-    name: cloudhub-https
-  - port: 10003
-    targetPort: 10003
-    {{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}
-    nodePort: {{ .Values.cloudCore.service.cloudstreamNodePort }}
-    {{- end }}
-    name: cloudstream
-  - port: 10004
-    targetPort: 10004
-    {{- if and (eq .Values.cloudCore.service.type "NodePort") ( not .Values.cloudCore.hostNetWork) }}
-    nodePort: {{ .Values.cloudCore.service.tunnelNodePort }}
-    {{- end }}
-    name: tunnelport
+    - port: 10000
+      targetPort: 10000
+      {{- if eq .Values.cloudCore.service.type "NodePort" }}
+      nodePort: {{ .Values.cloudCore.service.cloudhubNodePort }}
+      {{- end }}
+      name: cloudhub
+    - port: 10001
+      targetPort: 10001
+      protocol: UDP
+      {{- if eq .Values.cloudCore.service.type "NodePort" }}
+      nodePort: {{ .Values.cloudCore.service.cloudhubQuicNodePort }}
+      {{- end }}
+      name: cloudhub-quic
+    - port: 10002
+      targetPort: 10002
+      {{- if eq .Values.cloudCore.service.type "NodePort" }}
+      nodePort: {{ .Values.cloudCore.service.cloudhubHttpsNodePort }}
+      {{- end }}
+      name: cloudhub-https
+    - port: 10003
+      targetPort: 10003
+      {{- if eq .Values.cloudCore.service.type "NodePort" }}
+      nodePort: {{ .Values.cloudCore.service.cloudstreamNodePort }}
+      {{- end }}
+      name: cloudstream
+    - port: 10004
+      targetPort: 10004
+      {{- if eq .Values.cloudCore.service.type "NodePort" }}
+      nodePort: {{ .Values.cloudCore.service.tunnelNodePort }}
+      {{- end }}
+      name: tunnelport
   selector:
-  {{- with .Values.cloudCore.labels }}
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- with .Values.cloudCore.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Allows the `cloudCore` Service type to respect any valid Kubernetes Service type (`ClusterIP`, `NodePort`, `LoadBalancer`) instead of forcing `ClusterIP` when using `keadm` or Helm values. This fixes cases where `--set cloudCore.service.type=LoadBalancer` was being ignored.

**Which issue(s) this PR fixes**:
Fixes #6550 

**Does this PR introduce a user-facing change?**:

cloudCore Service now respects the configured service type from Helm values or keadm flags, allowing LoadBalancer or NodePort without being overridden to ClusterIP.

