### PR TITLE
Automated cherry pick of #6541: upgrade ci cri-dockerd version

### DIFF
--- a/hack/lib/install.sh
+++ b/hack/lib/install.sh
@@ -192,7 +192,10 @@ EOF'
 }
 
 function install_docker() {
-  CRIDOCKERD_VERSION="v0.3.8"
+  CRIDOCKERD_VERSION=$(curl -s "https://api.github.com/repos/Mirantis/cri-dockerd/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  if [ -z "$CRIDOCKERD_VERSION" ]; then
+      CRIDOCKERD_VERSION="v0.3.21"
+  fi
   sudo apt-get update
   sudo apt-get install \
     apt-transport-https \


### PR DESCRIPTION
Cherry pick of #6541 on release-1.22.

#6541: upgrade ci cri-dockerd version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.