### PR TITLE
Automated cherry pick of #6490: fixes "Leases" being parsed as "Leas"

### DIFF
--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -57,6 +57,7 @@ func UnsafeResourceToKind(r string) string {
 		"nodestatus":                   "NodeStatus",
 		"customresourcedefinitions":    "CustomResourceDefinition",
 		"customresourcedefinitionlist": "CustomResourceDefinitionList",
+		"leases":                       "Leases",
 	}
 	if v, isUnusual := unusualResourceToKind[r]; isUnusual {
 		return v
@@ -84,6 +85,7 @@ func UnsafeKindToResource(k string) string {
 		"NodeStatus":                   "nodestatus",
 		"CustomResourceDefinition":     "customresourcedefinitions",
 		"CustomResourceDefinitionList": "customresourcedefinitionlist",
+		"Leases":                       "leases",
 	}
 	if v, isUnusual := unusualKindToResource[k]; isUnusual {
 		return v


### PR DESCRIPTION
Cherry pick of #6490 on release-1.20.

#6490: fixes "Leases" being parsed as "Leas"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.