### PR TITLE
Add unit tests for pkg/util/flag

### DIFF
--- a/pkg/util/flag/flags_test.go
+++ b/pkg/util/flag/flags_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The KubeEdge Authors.
+Copyright 2025 The KubeEdge Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds unit tests for `pkg/util/flag` to improve test coverage.
It covers the `ConfigValue` type and its methods: `IsBoolFlag`, `Get`, `Set`, `String`, and `Type`.
It also adds tests for `PrintMinConfigAndExitIfRequested` and `PrintDefaultConfigAndExitIfRequested`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
```release-note
None
```