### PR TITLE
Automated cherry pick of #6586: fix: keadm config-update cant work with numeric type like

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/set.go
+++ b/keadm/cmd/keadm/app/cmd/util/set.go
@@ -218,6 +218,17 @@ func getNameFormStatus(s string) int {
 	return -1
 }
 
+func isNumericKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
 // SetCommonValue modifies the new value of the name in the config represented by struct.
 // The type of new value may be int, float, string, splic.
 // The name is represented by name1.name2.(...).nameM.
@@ -316,6 +327,12 @@ func convertTargetValue(targetType reflect.Type, valueToSet reflect.Value) (refl
 	// string to int or int to string is intentionally forbid to avoid ambiguity
 	if targetType.Kind() == valueToSet.Kind() && valueToSet.Type().ConvertibleTo(targetType) {
 		return valueToSet.Convert(targetType), nil
+	}
+	// support numeric convert
+	if isNumericKind(targetType.Kind()) && isNumericKind(valueToSet.Kind()) {
+		if valueToSet.Type().ConvertibleTo(targetType) {
+			return valueToSet.Convert(targetType), nil
+		}
 	}
 	// support point value
 	if targetType.Kind() == reflect.Ptr && valueToSet.Type().ConvertibleTo(targetType.Elem()) {

--- a/keadm/cmd/keadm/app/cmd/util/set_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/set_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 )
 
@@ -526,4 +528,19 @@ func TestSetEdgeCoreConfigWithPtrValue(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(*cfg.Modules.Edged.TailoredKubeletConfig.ImageGCHighThresholdPercent, *cfg.Modules.Edged.TailoredKubeletConfig.RegisterNode, cfg.Modules.Edged.ReportEvent)
+}
+
+func TestSetEdgeCoreConfigWithMultiIntValue(t *testing.T) {
+	cfg := v1alpha2.NewDefaultEdgeCoreConfig()
+	// MaxPods int32
+	// MaxOpenFiles int64
+	// ServiceBus.Port int
+	// MqttQOS uint8
+	if err := ParseSet(cfg, `Modules.Edged.TailoredKubeletConfig.MaxPods=111,Modules.Edged.TailoredKubeletConfig.MaxOpenFiles=1000001,Modules.ServiceBus.Port=9061,Modules.EventBus.MqttQOS=1`); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, int32(111), cfg.Modules.Edged.TailoredKubeletConfig.MaxPods)
+	assert.Equal(t, int64(1000001), cfg.Modules.Edged.TailoredKubeletConfig.MaxOpenFiles)
+	assert.Equal(t, int(9061), cfg.Modules.ServiceBus.Port)
+	assert.Equal(t, uint8(1), cfg.Modules.EventBus.MqttQOS)
 }


### PR DESCRIPTION
Cherry pick of #6586 on release-1.22.

#6586: fix: keadm config-update cant work with numeric type like

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.