### PR TITLE
Add freedisk step for CI

### DIFF
--- a/.github/workflows/cilium-e2e.yml
+++ b/.github/workflows/cilium-e2e.yml
@@ -53,6 +53,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Retrieve saved kubeedge/build-tools image
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,16 @@ jobs:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Making and packaging
         run: |
           if [ "${{ matrix.os }}" == "linux" ]; then
@@ -125,6 +135,16 @@ jobs:
           # 0 indicates all history for all branches and tags.
           # for `git describe --tags` in Makefile.
           fetch-depth: 0
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: install QEMU
         uses: docker/setup-qemu-action@v1
       - name: install Buildx

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -131,6 +131,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Retrieve saved kubeedge/build-tools image
         uses: actions/download-artifact@v4
         with:
@@ -183,6 +194,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Set up Helm
         uses: azure/setup-helm@v3


### PR DESCRIPTION


**What type of PR is this?**


/kind failing-test



**What this PR does / why we need it**:

We have added `free disk` for main CI jobs in PR #6528 , disk pressure issue appeared in making release and schedule tests as below:

https://github.com/kubeedge/kubeedge/actions/runs/20289707271
https://github.com/kubeedge/kubeedge/actions/runs/20276333464

so we add the step for all tests. 

To release previous patch version, we also need cherry-pick this PR to 1.19-1.22. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
