### PR TITLE
feat: auto-generate certificates for admission in chart

### DIFF
--- a/manifests/charts/cloudcore/templates/_helpers.tpl
+++ b/manifests/charts/cloudcore/templates/_helpers.tpl
@@ -34,3 +34,26 @@ streamCA.crt: {{ $ca.Cert | b64enc }}
 stream.crt: {{ $cert.Cert | b64enc }}
 stream.key: {{ $cert.Key | b64enc }}
 {{- end -}}
+
+{{/*
+Return admission cert secret name
+*/}}
+{{- define "kubeedge.admission.certsSecretName" -}}
+{{- if .Values.admission.certsSecretName -}}
+{{ .Values.admission.certsSecretName }}
+{{- else -}}
+{{ printf "%s-admission-certs" .Release.Name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate certificates for kubeedge admission
+*/}}
+{{- define "admission.gen-certs" -}}
+{{- $altNames := list "kubeedge-admission-service" (printf "%s.%s" "kubeedge-admission-service" .Release.Namespace) (printf "%s.%s.svc" "kubeedge-admission-service" .Release.Namespace) -}}
+{{- $ca := genCA (printf "%s.%s.svc" "kubeedge-admission-service" .Release.Namespace) 365 -}}
+{{- $cert := genSignedCert (printf "%s.%s.svc" "kubeedge-admission-service" .Release.Namespace) nil $altNames 365 $ca -}}
+ca.crt: {{ $ca.Cert | b64enc }}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/manifests/charts/cloudcore/templates/deployment_admission.yaml
+++ b/manifests/charts/cloudcore/templates/deployment_admission.yaml
@@ -36,11 +36,9 @@ spec:
       {{- end }}
       containers:
         - args:
-            {{- if .Values.admission.certsSecretName }}
             - --tls-cert-file=/admission.local.config/certificates/tls.crt
             - --tls-private-key-file=/admission.local.config/certificates/tls.key
             - --ca-cert-file=/admission.local.config/certificates/ca.crt
-            {{- end }}
             - --webhook-namespace=kubeedge
             - --webhook-service-name=kubeedge-admission-service
             - --alsologtostderr
@@ -56,17 +54,13 @@ spec:
           ports:
           - containerPort: 443
             protocol: TCP
-          {{- if .Values.admission.certsSecretName }}
           volumeMounts:
             - mountPath: /admission.local.config/certificates
               name: admission-certs
               readOnly: true
-          {{- end }}
-      {{- if .Values.admission.certsSecretName }}
       volumes:
         - name: admission-certs
           secret:
             defaultMode: 420
-            secretName: {{ .Values.admission.certsSecretName }}
-      {{- end }}
+            secretName: {{ include "kubeedge.admission.certsSecretName" . }}
 {{- end }}

--- a/manifests/charts/cloudcore/templates/secret_admission.yaml
+++ b/manifests/charts/cloudcore/templates/secret_admission.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.admission.enable (not .Values.admission.certsSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kubeedge.admission.certsSecretName" . }}
+  {{- with .Values.admission.labels }}
+  labels: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+{{ include "admission.gen-certs" . | indent 2 }}
+{{- end }}

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -146,6 +146,8 @@ controllerManager:
 admission:
   enable: false
   replicaCount: 1
+  # If empty, will auto-generate certificates and create a Secret
+  # If set, the existing Secret will be used
   certsSecretName: ""
   image:
     repository: "kubeedge/admission"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Currently, by default, a Helm installation does not enable the admission component because enable is set to false in [values.yaml](https://github.com/kubeedge/kubeedge/blob/e5e12547e29aa344a5c5e3382ce88984d0a50e25/manifests/charts/cloudcore/values.yaml#L147). However, even if it is enabled, admission still fails to start successfully. There are two issues:

1. The alsologtostderr flag is no longer supported by the program (#6591).
2. A certificate file is strictly required; otherwise, the following error is reported:
`Error: unable to read cacert file: open : no such file or directory`. This can be generated by running build/admission/gen-admission-secret.sh. this PR try to implement this using Helm’s [genca](https://helm.sh/docs/chart_template_guide/function_list/#genca).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
