### PR TITLE
Automated cherry pick of #6533: Fix PolicyManager reconciliation:

### DIFF
--- a/cloud/pkg/policycontroller/policycontroller.go
+++ b/cloud/pkg/policycontroller/policycontroller.go
@@ -54,11 +54,11 @@ func NewAccessRoleControllerManager(ctx context.Context, kubeCfg *rest.Config) (
 }
 
 func setupControllers(ctx context.Context, mgr manager.Manager) error {
-	// This returned cli will directly acquire the unstructured objects from API Server which
+	// mgr.GetClient() will directly acquire the unstructured objects from API Server which
 	// have not be registered in the accessScheme.
-	cli := mgr.GetClient()
 	pc := &pm.Controller{
-		Client:       cli,
+		Client:       mgr.GetClient(),
+		Reader:       mgr.GetAPIReader(),
 		MessageLayer: messagelayer.PolicyControllerMessageLayer(),
 	}
 


### PR DESCRIPTION
Cherry pick of #6533 on release-1.19.

#6533: Fix PolicyManager reconciliation:

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.