### PR TITLE
load previously registered mapper info and init DMI Client automatically after restarted edgecore

### DIFF
--- a/edge/pkg/devicetwin/dmiserver/server.go
+++ b/edge/pkg/devicetwin/dmiserver/server.go
@@ -120,7 +120,11 @@ func (s *server) MapperRegister(_ctx context.Context, in *pb.MapperRegisterReque
 		deviceModelList = append(deviceModelList, pbModel)
 	}
 
-	dmiclient.DMIClientsImp.CreateDMIClient(in.Mapper.Protocol, string(in.Mapper.Address))
+	err = dmiclient.DMIClientsImp.CreateDMIClient(in.Mapper.Protocol, string(in.Mapper.Address), false)
+	if err != nil {
+		klog.Warningf("fail to create dmi client for device mapper %s: %v", in.Mapper.Name, err)
+		return nil, err
+	}
 
 	return &pb.MapperRegisterResponse{
 		DeviceList: deviceList,

--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -244,7 +244,13 @@ func (dw *DMIWorker) initDeviceMapperInfoFromDB() {
 			return
 		}
 
+		err := dmiclient.DMIClientsImp.CreateDMIClient(deviceMapper.Protocol, string(deviceMapper.Address), true)
+		if err != nil {
+			klog.Warningf("fail to init dmi client for device mapper %s: %v", deviceMapper.Name, err)
+			continue
+		}
 		dw.dmiCache.PutMapper(&deviceMapper)
+		klog.V(3).Infof("device mapper %s loaded successfully", deviceMapper.Name)
 	}
 	klog.Infoln("success to init device mapper info from db")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Once edgecore restarts, the existing device mapper cannot be found using the current code,  the following error will occur:

`fail to get dmi client of protocol modbus`

the direct triggering factors are as follows：

```
dc, ok := dcs.clients[protocol]
if !ok {
	return nil, fmt.Errorf("fail to get dmi client of protocol %s", protocol)
}
```

After restarting edgecore, the previously registered device mapper is no longer found in **dcs.clients**.
The above phenomenon is abnormal for previously registered device mapper app, because the edgecore process is still running at this time, it has only restarted but not stopped.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Fixes the issue of mapper information being lost after edgecore restart.

**Special notes for your reviewer**:

All current release versions have this issue, therefore the target branch is master. 
Thanks.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
