### PR TITLE
feat: support anonymous access for discovery paths in metaserver

### DIFF
--- a/pkg/util/pass-through/pass_through.go
+++ b/pkg/util/pass-through/pass_through.go
@@ -1,22 +1,60 @@
 package passthrough
 
-type passRequest string
-
-const (
-	versionRequest passRequest = "/version::get"
-	healthRequest  passRequest = "/healthz::get" // deprecated: TODO remove this once it is gone
-	liveRequest    passRequest = "/livez::get"
-	readyRequest   passRequest = "/readyz::get"
+import (
+	"slices"
+	"strings"
 )
 
-var passThroughMap = map[passRequest]bool{
-	versionRequest: true,
-	healthRequest:  true,
-	liveRequest:    true,
-	readyRequest:   true,
+var commonDiscoveryPaths = []string{"/api", "/apis", "/version", "/healthz", "/livez", "/readyz", "/openapi/v2", "/openapi/v3"}
+
+// isDiscoveryPath determines whether the uri is a Kubernetes API discovery path.
+// Discovery paths are non-resource requests that allow anonymous access to get
+// API server capabilities and resource types.
+//
+// This is a helper function used by both IsPassThroughPath and IsDiscoveryPath
+// to ensure consistent path matching logic.
+func isDiscoveryPath(path string) bool {
+	// Normalize path by removing trailing slash and cleaning multiple slashes
+	path = strings.TrimSuffix(path, "/")
+	if path == "" {
+		return false
+	}
+
+	// Exact match for common discovery paths
+	if slices.Contains(commonDiscoveryPaths, path) {
+		return true
+	}
+
+	parts := strings.Split(path, "/")
+	// path starts with /, so parts[0] is always empty
+	// /api/v1 -> ["", "api", "v1"] (len 3)
+	// /apis/group/version -> ["", "apis", "group", "version"] (len 4)
+
+	// Need at least 3 parts (empty, api|apis, resource/version)
+	if len(parts) < 3 {
+		return false
+	}
+
+	// Match /api/v1 or /api/v1beta1
+	if parts[1] == "api" && len(parts) == 3 {
+		return true
+	}
+
+	// Match /apis/<group> or /apis/<group>/<version>
+	if parts[1] == "apis" && (len(parts) == 3 || len(parts) == 4) {
+		return true
+	}
+
+	return false
 }
 
 // IsPassThroughPath determining whether the uri can be passed through
 func IsPassThroughPath(path, verb string) bool {
-	return passThroughMap[passRequest(path+"::"+verb)]
+	// Only GET requests can be passed through for discovery paths
+	if verb != "get" {
+		return false
+	}
+
+	// Use the same discovery path logic as IsDiscoveryPath
+	return isDiscoveryPath(path)
 }

--- a/pkg/util/pass-through/pass_through_test.go
+++ b/pkg/util/pass-through/pass_through_test.go
@@ -63,6 +63,48 @@ func TestIsPassThroughPath(t *testing.T) {
 			verb: "get",
 			want: true,
 		},
+		{
+			name: "/api::get is pass through path",
+			path: "/api",
+			verb: "get",
+			want: true,
+		},
+		{
+			name: "/apis::get is pass through path",
+			path: "/apis",
+			verb: "get",
+			want: true,
+		},
+		{
+			name: "/api/v1/namespaces/kube-system/pods::get is not pass through path",
+			path: "/api/v1/namespaces/kube-system/pods",
+			verb: "get",
+			want: false,
+		},
+		{
+			name: "/api/v1::get is pass through path",
+			path: "/api/v1",
+			verb: "get",
+			want: true,
+		},
+		{
+			name: "/apis/discovery.k8s.io/v1::get is pass through path",
+			path: "/apis/discovery.k8s.io/v1",
+			verb: "get",
+			want: true,
+		},
+		{
+			name: "/version/::get is pass through path",
+			path: "/version/",
+			verb: "get",
+			want: true,
+		},
+		{
+			name: "/openapi/v2::get is pass through path",
+			path: "/openapi/v2",
+			verb: "get",
+			want: true,
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

1. Update metaserver to support anonymous authentication for discovery paths (e.g., /api, /apis, /version), aligning with K8s API Server behavior.
2. Implement `AlwaysAllowDiscoveryAuthorizer` to bypass RBAC for non-resource discovery requests.
3. Refactor `pkg/util/pass-through` to centralize discovery path logic and improve path matching.
4. Add comprehensive unit tests for discovery path identification.

The current pr allows you to run `"k8s.io/client-go/discovery".NewDiscoveryClientForConfigAndClient` through metaserver on the edge., This is the basis of controller-runtime.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
