### PR TITLE
edge: Use structured logging in standard_pass_through

### DIFF
--- a/edge/pkg/metamanager/metaserver/handlerfactory/handler_test.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/handler_test.go
@@ -738,7 +738,16 @@ func TestPassThroughWriteError(t *testing.T) {
 	patches := gomonkey.NewPatches()
 	defer patches.Reset()
 
-	patches.ApplyFunc(klog.Error, func(_ ...interface{}) {})
+	// Mock ErrorS to verify arguments and suppress output
+	patches.ApplyFunc(klog.ErrorS, func(err error, msg string, keysAndValues ...interface{}) {
+		assert.Equal(t, "failed to write passthrough response", msg)
+		// Expected keysAndValues: "path", path, "method", method, "remoteAddr", remoteAddr
+		// Convert to map for easier verification or check slice
+		// keysAndValues should be: ["path", "/api/...", "method", "GET", "remoteAddr", "192.0.2.1:1234"]
+		assert.Contains(t, keysAndValues, "path")
+		assert.Contains(t, keysAndValues, "method")
+		assert.Contains(t, keysAndValues, "remoteAddr")
+	})
 
 	mockResult := []byte(`{"kind":"ConfigMap","metadata":{"name":"test-config"}}`)
 	mockStorage := &storage.REST{}

--- a/edge/pkg/metamanager/metaserver/handlerfactory/standard_pass_through.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/standard_pass_through.go
@@ -35,8 +35,7 @@ func (f *Factory) PassThrough() http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write(result); err != nil {
-			// TODO: handle error
-			klog.Error(err)
+			klog.ErrorS(err, "failed to write passthrough response", "path", req.URL.Path, "method", req.Method, "remoteAddr", req.RemoteAddr)
 		}
 	})
 	return h


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, the pass-through handler uses `klog.Error` which lacks context about the request path and method when a write failure occurs.

This PR replaces `klog.Error` with `klog.ErrorS` in `standard_pass_through.go` to include the request path and method in the error logs, making it easier to debug issues.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged. 
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. 
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_* 
-->
Fixes #

**Special notes for your reviewer**:
I have verified the changes locally using unit tests (`TestPassThroughWriteError`), and the logs are correctly printed with the expected context.

**Does this PR introduce a user-facing change?**:
<!-- 
If no, just write "NONE" in the release-note block below. 
If yes, a release note is required: 
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required". 
-->
```release-note
NONE
```