### PR TITLE
edge: Use structured logging in sqlite store

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -63,7 +63,7 @@ func (s *store) watch(ctx context.Context, key string, opts storage.ListOptions,
 func (s *store) Get(ctx context.Context, key string, _ storage.GetOptions, objPtr runtime.Object) error {
 	resp, err := s.client.Get(context.TODO(), key)
 	if err != nil || len(*resp.Kvs) == 0 {
-		klog.Error(err)
+		klog.ErrorS(err, "Failed to get object from sqlite", "key", key)
 		return err
 	}
 	unstrObj := objPtr.(*unstructured.Unstructured)
@@ -93,7 +93,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 	resp, err := s.client.List(context.TODO(), key)
 
 	if err != nil || len(*resp.Kvs) == 0 {
-		klog.Error(err)
+		klog.ErrorS(err, "Failed to list objects from sqlite", "key", key)
 		return err
 	}
 	unstrList := listObj.(*unstructured.UnstructuredList)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, the sqlite store uses `klog.Error` which lacks context about the resource key when a get or list failure occurs.

This PR replaces `klog.Error` with `klog.ErrorS` in `store.go` to include the resource key in the error logs, making it easier to debug issues when interacting with the sqlite database.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged. 
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. 
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_* 
-->
Fixes #

**Special notes for your reviewer**:
I have verified the changes by building the `edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite` package, and it compiles successfully.

**Does this PR introduce a user-facing change?**:
<!-- 
If no, just write "NONE" in the release-note block below. 
If yes, a release note is required: 
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required". 
-->
```release-note
NONE
```