### PR TITLE
Fix error wrapping in devicetwin util

### DIFF
--- a/edge/pkg/devicetwin/dtcommon/util.go
+++ b/edge/pkg/devicetwin/dtcommon/util.go
@@ -85,7 +85,7 @@ func ConvertDevice(device *v1beta1.Device) (*pb.Device, error) {
 		for k, v := range device.Spec.Protocol.ConfigData.Data {
 			anyValue, err := dataToAny(v)
 			if err != nil {
-				return nil, fmt.Errorf("failed to convert protocol config data: %v", err)
+				return nil, fmt.Errorf("failed to convert protocol config data: %w", err)
 			}
 			configAnyData[k] = anyValue
 		}
@@ -96,7 +96,7 @@ func ConvertDevice(device *v1beta1.Device) (*pb.Device, error) {
 	for i := range device.Spec.Properties {
 		property, err := convertDeviceProperty(&device.Spec.Properties[i])
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert property: %v", err)
+			return nil, fmt.Errorf("failed to convert property: %w", err)
 		}
 		edgePropertyVisitors = append(edgePropertyVisitors, property)
 	}
@@ -128,7 +128,7 @@ func convertDeviceProperty(prop *v1beta1.DeviceProperty) (*pb.DeviceProperty, er
 	item := new(pb.DeviceProperty)
 	propertyData, err := json.Marshal(prop)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal property: %v", err)
+		return nil, fmt.Errorf("failed to marshal property: %w", err)
 	}
 
 	err = json.Unmarshal(propertyData, item)
@@ -138,7 +138,7 @@ func convertDeviceProperty(prop *v1beta1.DeviceProperty) (*pb.DeviceProperty, er
 		for k, v := range prop.Visitors.ConfigData.Data {
 			anyValue, err := dataToAny(v)
 			if err != nil {
-				return nil, fmt.Errorf("failed to convert visitor config data: %v", err)
+				return nil, fmt.Errorf("failed to convert visitor config data: %w", err)
 			}
 			configAnyData[k] = anyValue
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR replaces `%v` with `%w` in `fmt.Errorf` calls within `edge/pkg/devicetwin/dtcommon/util.go`.

Using `%w` allows the underlying error to be wrapped properly. This enables callers to use `errors.Is` or `errors.As` to unwrap and inspect the original error cause, which improves error handling capabilities and adheres to modern Go best practices.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```