### PR TITLE
Fix devicemodel update

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -96,9 +96,34 @@ func (dc *DownstreamController) deviceModelAdded(deviceModel *v1beta1.DeviceMode
 
 // deviceModelUpdated is function to process updated deviceModel
 func (dc *DownstreamController) deviceModelUpdated(deviceModel *v1beta1.DeviceModel) {
-	// nothing to do when deviceModel updated, only add in map
 	deviceModelID := util.GetResourceID(deviceModel.Namespace, deviceModel.Name)
 	dc.deviceModelManager.DeviceModel.Store(deviceModelID, deviceModel)
+
+	// key: NodeName
+	sentNodes := make(map[string]bool)
+
+	dc.deviceManager.Device.Range(func(k, v interface{}) bool {
+		device, ok := v.(*v1beta1.Device)
+		if !ok {
+			return true
+		}
+
+		if isDeviceMatchingModel(device, deviceModel) {
+			if !sentNodes[device.Spec.NodeName] {
+				dc.sendDeviceModelMsg(device, model.UpdateOperation)
+				sentNodes[device.Spec.NodeName] = true
+			}
+		}
+		return true
+	})
+}
+
+// isDeviceMatchingModel checks if the device is using the given deviceModel and scheduled to a node
+func isDeviceMatchingModel(device *v1beta1.Device, deviceModel *v1beta1.DeviceModel) bool {
+	return device.Namespace == deviceModel.Namespace &&
+		device.Spec.DeviceModelRef != nil &&
+		device.Spec.DeviceModelRef.Name == deviceModel.Name &&
+		device.Spec.NodeName != ""
 }
 
 // deviceModelDeleted is function to process deleted deviceModel


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: `https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md`
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR implements the missing logic in `deviceModelUpdated` function within `cloud/pkg/devicecontroller/controller/downstream.go`.

Previously, when a `DeviceModel` was updated, the controller only updated the local cache but failed to propagate the changes to the edge nodes. This caused inconsistency where edge devices would continue using the old model definition even after a cloud-side update.

This PR adds logic to:
1. Iterate through devices to identify those referencing the updated `DeviceModel`.
2. Send the updated `DeviceModel` to the corresponding edge nodes via message layer.
3. Ensure updates are deduplicated per node to avoid redundant messages.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue where DeviceModel updates were not propagated to edge nodes.
```