### PR TITLE
fix: prevent timer and ackMessageCache leak in sendMessageWithRetry

### DIFF
--- a/cloud/pkg/cloudhub/session/node_session.go
+++ b/cloud/pkg/cloudhub/session/node_session.go
@@ -125,10 +125,8 @@ func (ns *NodeSession) KeepAliveMessage() {
 
 // ReceiveMessageAck receive the message ack from edge node
 func (ns *NodeSession) ReceiveMessageAck(parentID string) {
-	ackChan, exist := ns.ackMessageCache.Load(parentID)
-	if exist {
-		close(ackChan.(chan struct{}))
-		ns.ackMessageCache.Delete(parentID)
+	if ch, loaded := ns.ackMessageCache.LoadAndDelete(parentID); loaded {
+		close(ch.(chan struct{}))
 	}
 }
 
@@ -239,6 +237,14 @@ func (ns *NodeSession) Terminating() {
 
 		// ignore close error
 		_ = ns.connection.Close()
+
+		// Clean up any remaining ack channels to unblock waiting goroutines
+		ns.ackMessageCache.Range(func(key, value interface{}) bool {
+			if ch, loaded := ns.ackMessageCache.LoadAndDelete(key); loaded {
+				close(ch.(chan struct{}))
+			}
+			return true
+		})
 	})
 }
 
@@ -337,11 +343,16 @@ func (ns *NodeSession) syncAckMessage() (bool, error) {
 
 func (ns *NodeSession) sendMessageWithRetry(copyMsg, msg *beehivemodel.Message) error {
 	ackChan := make(chan struct{})
-	ns.ackMessageCache.Store(copyMsg.GetID(), ackChan)
+	msgID := copyMsg.GetID()
+	ns.ackMessageCache.Store(msgID, ackChan)
 
-	// initialize retry count and timer for sending message
 	retryCount := 0
 	ticker := time.NewTimer(sendRetryInterval)
+
+	defer func() {
+		ticker.Stop()
+		ns.ackMessageCache.Delete(msgID)
+	}()
 
 	err := ns.connection.WriteMessageAsync(copyMsg)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes a resource lifecycle issue in CloudHub session handling that could lead to **unbounded memory growth** during edge–cloud communication failures.

Previously, `sendMessageWithRetry` did not reliably clean up retry timers or `ackMessageCache` entries when messages failed, timed out, or sessions terminated. Cleanup depended on ACK reception, which does not occur in many failure scenarios. Over time, this could cause `ackMessageCache` growth and increased timer heap usage in unstable networks.

This change ensures deterministic cleanup on all execution paths and improves shutdown safety.

---

## Fix

**1) Guaranteed cleanup in `sendMessageWithRetry`**
A `defer` now stops the retry timer and removes the cache entry on all return paths.

```go
defer func() {
    ticker.Stop()
    ns.ackMessageCache.Delete(msgID)
}()
```

---

**2) Atomic ack handling**
`ReceiveMessageAck` now uses `LoadAndDelete` to safely retrieve and close ack channels, preventing races and double-closes.

---

**3) Session termination cleanup**
`Terminating()` now clears remaining ack channels to avoid orphaned entries and blocked goroutines.

---

### Result

* Prevents `ackMessageCache` growth under failures
* Ensures timers are not left running
* Improves session shutdown correctness
* No behavior change on successful ACK paths
* All existing tests pass

---

/kind bug
/kind cleanup
