### PR TITLE
fix(edged,metaserver): avoid persistent Unauthorized after in-place edgecore restart

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -85,14 +85,15 @@ var DefaultRunLiteKubelet RunLiteKubelet = kubeletserver.Run
 
 // edged is the main edged implementation.
 type edged struct {
-	enable         bool
-	KubeletServer  *kubeletoptions.KubeletServer
-	KubeletDeps    *kubelet.Dependencies
-	FeatureGate    featuregate.FeatureGate
-	context        context.Context
-	nodeName       string
-	namespace      string
-	heldPodUpdates map[string][]kubelettypes.PodUpdate
+	enable                 bool
+	KubeletServer          *kubeletoptions.KubeletServer
+	KubeletDeps            *kubelet.Dependencies
+	FeatureGate            featuregate.FeatureGate
+	context                context.Context
+	nodeName               string
+	namespace              string
+	heldPodUpdates         map[string][]kubelettypes.PodUpdate
+	isInitialPodListSynced bool
 }
 
 var _ core.Module = (*edged)(nil)
@@ -322,14 +323,12 @@ func (e *edged) syncPod(podCfg *config.PodConfig) {
 					klog.Errorf("handle podList failed: %v", err)
 					continue
 				}
-				podCfg.SetInitPodReady(true)
 			} else if op == model.ResponseOperation && resID == "" && result.GetSource() == metamanager.CloudControllerModel {
 				err := e.handlePodListFromEdgeController(content, rawUpdateChan)
 				if err != nil {
 					klog.Errorf("handle podList failed: %v", err)
 					continue
 				}
-				podCfg.SetInitPodReady(true)
 			} else if op == model.UnholdUpgradeOperation {
 				key := fmt.Sprintf("%s/%s", ns, resID)
 				if updates, exists := e.heldPodUpdates[key]; exists {
@@ -528,7 +527,68 @@ func (e *edged) handlePodListFromMetaManager(content []byte, updatesChan chan<- 
 	updates := &kubelettypes.PodUpdate{Op: kubelettypes.SET, Pods: pods, Source: kubelettypes.ApiserverSource}
 	updatesChan <- *updates
 
+	// If it's the first time we received pods from MetaManager, we need to make sure
+	// that VolumeManager's DSWP has a chance to see these pods before Reconciler runs.
+	// This is to prevent Reconciler from seeing an empty DSW and unmounting existing volumes.
+	// We do this by ensuring SetInitPodReady is called only after pods are set.
+	// We check the kubelet readonly port to see if the pods are already synced to kubelet.
+	if !e.isInitialPodListSynced {
+		e.waitForPodsSynced(pods)
+		e.isInitialPodListSynced = true
+		e.KubeletDeps.PodConfig.SetInitPodReady(true)
+	}
+
 	return nil
+}
+
+func (e *edged) waitForPodsSynced(pods []*v1.Pod) {
+	if len(pods) == 0 {
+		return
+	}
+
+	// Poll Kubelet's read-only port to verify PodManager has been updated
+	// This is necessary because updatesChan is processed asynchronously by syncLoop
+	pollTimeout := 5 * time.Second
+	pollInterval := 100 * time.Millisecond
+	deadline := time.Now().Add(pollTimeout)
+
+	url := fmt.Sprintf("http://localhost:%d/pods", e.KubeletServer.ReadOnlyPort)
+
+	// Poll logic to ensure syncLoop has processed the updates
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err != nil {
+			klog.V(4).Infof("Failed to get pods from kubelet: %v. Retrying...", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		var podList v1.PodList
+		if err := json.NewDecoder(resp.Body).Decode(&podList); err != nil {
+			resp.Body.Close()
+			klog.Errorf("Failed to decode pods list: %v", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+		resp.Body.Close()
+
+		// Check if all pods are synced
+		if len(podList.Items) == len(pods) {
+			synced := true
+			for i, p := range pods {
+				if podList.Items[i].UID != p.UID {
+					synced = false
+					break
+				}
+			}
+			if synced {
+				klog.V(2).Infof("Initial pods synced successfully to Kubelet PodManager.")
+				return
+			}
+		}
+
+		time.Sleep(pollInterval)
+	}
 }
 
 func (e *edged) handlePodListFromEdgeController(content []byte, updatesChan chan<- interface{}) (err error) {
@@ -545,6 +605,14 @@ func (e *edged) handlePodListFromEdgeController(content []byte, updatesChan chan
 	}
 	updates := &kubelettypes.PodUpdate{Op: kubelettypes.SET, Pods: pods, Source: kubelettypes.ApiserverSource}
 	updatesChan <- *updates
+
+	// If it's the first time we received pods from EdgeController, we need to make sure
+	// that VolumeManager's DSWP has a chance to see these pods before Reconciler runs.
+	if !e.isInitialPodListSynced {
+		e.waitForPodsSynced(pods)
+		e.isInitialPodListSynced = true
+		e.KubeletDeps.PodConfig.SetInitPodReady(true)
+	}
 
 	return nil
 }

--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -10,11 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
+	"github.com/kubeedge/api/apis/common/constants"
 	policyv1alpha1 "github.com/kubeedge/api/apis/policy/v1alpha1"
 	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
+	metaserverconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/config"
 )
 
 // ServiceAccountTokenGetter is interface to get client service account token
@@ -87,6 +89,21 @@ func requiresRefresh(tr *authenticationv1.TokenRequest) bool {
 	return false
 }
 
+// normalizeAudiences normalizes the audiences slice.
+// According to Kubernetes API specification, when TokenRequest.Spec.Audiences is nil or empty,
+// the API server defaults to the Kubernetes apiserver audience.
+// This ensures that local cache lookups use the same audience key as stored tokens.
+func normalizeAudiences(audiences []string) []string {
+	if len(audiences) == 0 {
+		issuers := metaserverconfig.Config.ServiceAccountIssuers
+		if len(issuers) > 0 {
+			return issuers
+		}
+		return []string{constants.DefaultServiceAccountIssuer}
+	}
+	return audiences
+}
+
 // KeyFunc keys should be nonconfidential and safe to log
 func KeyFunc(name, namespace string, tr *authenticationv1.TokenRequest) string {
 	var exp int64
@@ -99,7 +116,9 @@ func KeyFunc(name, namespace string, tr *authenticationv1.TokenRequest) string {
 		ref = *tr.Spec.BoundObjectRef
 	}
 
-	return fmt.Sprintf("%q/%q/%#v/%#v/%#v", name, namespace, tr.Spec.Audiences, exp, ref)
+	audiences := normalizeAudiences(tr.Spec.Audiences)
+
+	return fmt.Sprintf("%q/%q/%#v/%#v/%#v", name, namespace, audiences, exp, ref)
 }
 
 func getTokenLocally(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When edgecore restarts in-place (node and existing containers keep running), serviceaccount authentication can get stuck in a permanently Unauthorized state and may not recover unless the node is rebooted.

This happens because the restart can leave token-related state inconsistent with what running containers are still using:
- If kubelet marks “initial pods ready” before the first PodList from MetaManager is applied and observed by the volume loops, the volume reconciler can treat the desired state as empty and unmount volumes that still belong to running containers. Projected serviceaccount token data then diverges from what the container expects, and auth failures can persist.
- When TokenRequest audiences is nil/empty, kube-apiserver applies a default audience, but the local token cache key previously used the raw nil/empty slice. After restart this can cause permanent cache key mismatch, so lookups keep missing and the wrong/missing token is reused.

Fix this by delaying InitPodReady until the initial PodList is applied (and given time to propagate), and by normalizing audiences in the token cache key to match apiserver defaulting. This prevents the in-place restart from entering a non-recoverable Unauthorized state without requiring a node reboot.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6625 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
