### PR TITLE
keadm: add node selector utility for batch operations

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/nodeselect/selector.go
+++ b/keadm/cmd/keadm/app/cmd/util/nodeselect/selector.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeselect
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NodeSelector provides methods to select multiple nodes for batch operations.
+// It supports selection by explicit node names or by label selectors.
+type NodeSelector struct {
+	nodes    []string
+	selector map[string]string
+}
+
+// NewNodeSelector creates a new NodeSelector instance.
+func NewNodeSelector() *NodeSelector {
+	return &NodeSelector{
+		nodes:    []string{},
+		selector: make(map[string]string),
+	}
+}
+
+// AddNodes adds specific node names to the selector.
+// Multiple nodes can be provided as a comma-separated string.
+// Example: "node1,node2,node3"
+func (ns *NodeSelector) AddNodes(nodes string) {
+	if nodes == "" {
+		return
+	}
+	nodeList := strings.Split(nodes, ",")
+	for _, node := range nodeList {
+		trimmed := strings.TrimSpace(node)
+		if trimmed != "" {
+			ns.nodes = append(ns.nodes, trimmed)
+		}
+	}
+}
+
+// AddSelector adds a label selector key-value pair.
+// Example: AddSelector("region", "us-west")
+func (ns *NodeSelector) AddSelector(key, value string) {
+	if key != "" && value != "" {
+		ns.selector[key] = value
+	}
+}
+
+// GetNodes returns the list of explicitly selected node names.
+func (ns *NodeSelector) GetNodes() []string {
+	return ns.nodes
+}
+
+// HasSelector returns true if label selectors are configured.
+func (ns *NodeSelector) HasSelector() bool {
+	return len(ns.selector) > 0
+}
+
+// GetSelector returns the label selector map.
+func (ns *NodeSelector) GetSelector() map[string]string {
+	return ns.selector
+}
+
+// Validate ensures that the node selection is valid.
+// Returns an error if:
+// - Neither nodes nor selector is specified
+// - Both nodes and selector are specified (mutually exclusive)
+func (ns *NodeSelector) Validate() error {
+	hasNodes := len(ns.nodes) > 0
+	hasSelector := len(ns.selector) > 0
+
+	if !hasNodes && !hasSelector {
+		return fmt.Errorf("must specify either --nodes or --selector")
+	}
+	if hasNodes && hasSelector {
+		return fmt.Errorf("cannot specify both --nodes and --selector, they are mutually exclusive")
+	}
+	return nil
+}
+
+// Count returns the number of explicitly selected nodes.
+// Returns 0 if using selector-based selection.
+func (ns *NodeSelector) Count() int {
+	return len(ns.nodes)
+}
+
+// String returns a human-readable representation of the selector.
+func (ns *NodeSelector) String() string {
+	if len(ns.nodes) > 0 {
+		return fmt.Sprintf("nodes: %s", strings.Join(ns.nodes, ", "))
+	}
+	if len(ns.selector) > 0 {
+		var parts []string
+		for k, v := range ns.selector {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+		}
+		return fmt.Sprintf("selector: %s", strings.Join(parts, ", "))
+	}
+	return "empty selector"
+}

--- a/keadm/cmd/keadm/app/cmd/util/nodeselect/selector_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/nodeselect/selector_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeselect
+
+import (
+	"testing"
+)
+
+func TestNewNodeSelector(t *testing.T) {
+	ns := NewNodeSelector()
+	if ns == nil {
+		t.Fatal("NewNodeSelector returned nil")
+	}
+	if len(ns.nodes) != 0 {
+		t.Errorf("Expected empty nodes, got %d nodes", len(ns.nodes))
+	}
+	if len(ns.selector) != 0 {
+		t.Errorf("Expected empty selector, got %d selectors", len(ns.selector))
+	}
+}
+
+func TestNodeSelector_AddNodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "Single node",
+			input:    "node1",
+			expected: 1,
+		},
+		{
+			name:     "Multiple nodes",
+			input:    "node1,node2,node3",
+			expected: 3,
+		},
+		{
+			name:     "Nodes with spaces",
+			input:    "node1, node2 , node3",
+			expected: 3,
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			name:     "Empty elements",
+			input:    "node1,,node2",
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := NewNodeSelector()
+			ns.AddNodes(tt.input)
+			if len(ns.GetNodes()) != tt.expected {
+				t.Errorf("Expected %d nodes, got %d", tt.expected, len(ns.GetNodes()))
+			}
+		})
+	}
+}
+
+func TestNodeSelector_AddSelector(t *testing.T) {
+	ns := NewNodeSelector()
+	ns.AddSelector("region", "us-west")
+	ns.AddSelector("env", "production")
+
+	if !ns.HasSelector() {
+		t.Error("Expected HasSelector to return true")
+	}
+
+	selector := ns.GetSelector()
+	if len(selector) != 2 {
+		t.Errorf("Expected 2 selectors, got %d", len(selector))
+	}
+
+	if selector["region"] != "us-west" {
+		t.Errorf("Expected region=us-west, got %s", selector["region"])
+	}
+}
+
+func TestNodeSelector_AddSelector_EmptyValues(t *testing.T) {
+	ns := NewNodeSelector()
+	ns.AddSelector("", "value")
+	ns.AddSelector("key", "")
+	ns.AddSelector("", "")
+
+	if ns.HasSelector() {
+		t.Error("Expected HasSelector to return false for empty key/value pairs")
+	}
+}
+
+func TestNodeSelector_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodes     string
+		selector  map[string]string
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name:      "No selection",
+			nodes:     "",
+			selector:  map[string]string{},
+			wantError: true,
+			errorMsg:  "must specify either",
+		},
+		{
+			name:      "Valid nodes",
+			nodes:     "node1,node2",
+			selector:  map[string]string{},
+			wantError: false,
+		},
+		{
+			name:      "Valid selector",
+			nodes:     "",
+			selector:  map[string]string{"region": "us-west"},
+			wantError: false,
+		},
+		{
+			name:      "Both specified",
+			nodes:     "node1",
+			selector:  map[string]string{"key": "value"},
+			wantError: true,
+			errorMsg:  "cannot specify both",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := NewNodeSelector()
+			if tt.nodes != "" {
+				ns.AddNodes(tt.nodes)
+			}
+			for k, v := range tt.selector {
+				ns.AddSelector(k, v)
+			}
+
+			err := ns.Validate()
+			if (err != nil) != tt.wantError {
+				t.Errorf("Validate() error = %v, wantError %v", err, tt.wantError)
+				return
+			}
+
+			if err != nil && tt.errorMsg != "" {
+				if !contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Error message = %v, want to contain %v", err.Error(), tt.errorMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestNodeSelector_Count(t *testing.T) {
+	ns := NewNodeSelector()
+	
+	if ns.Count() != 0 {
+		t.Errorf("Expected count 0, got %d", ns.Count())
+	}
+
+	ns.AddNodes("node1,node2,node3")
+	if ns.Count() != 3 {
+		t.Errorf("Expected count 3, got %d", ns.Count())
+	}
+}
+
+func TestNodeSelector_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*NodeSelector)
+		expected string
+	}{
+		{
+			name:     "Empty selector",
+			setup:    func(ns *NodeSelector) {},
+			expected: "empty selector",
+		},
+		{
+			name: "With nodes",
+			setup: func(ns *NodeSelector) {
+				ns.AddNodes("node1,node2")
+			},
+			expected: "nodes:",
+		},
+		{
+			name: "With selector",
+			setup: func(ns *NodeSelector) {
+				ns.AddSelector("region", "us-west")
+			},
+			expected: "selector:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := NewNodeSelector()
+			tt.setup(ns)
+			result := ns.String()
+			if !contains(result, tt.expected) {
+				t.Errorf("String() = %v, want to contain %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// Helper function
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it:
This PR adds a reusable NodeSelector utility to support batch operations on multiple edge nodes. It provides the foundation for implementing batch EdgeHub control (#6609) and other multi-node operations in keadm.

## Which issue(s) this PR fixes:
Related to #6609

## Features:
- ✅ Select nodes by explicit names (`--nodes node1,node2,node3`)
- ✅ Select nodes by label selector (`--selector key=value`)
- ✅ Input validation to prevent conflicting selections
- ✅ Comprehensive unit tests with edge case coverage
- ✅ Clear error messages for invalid inputs

## Usage Example:
```go
// Example 1: Select specific nodes
ns := nodeselect.NewNodeSelector()
ns.AddNodes("edge-node-1,edge-node-2,edge-node-3")
if err := ns.Validate(); err != nil {
    return err
}

// Example 2: Select by label
ns := nodeselect.NewNodeSelector()
ns.AddSelector("region", "us-west")
if err := ns.Validate(); err != nil {
    return err
}
```

## Testing:
```bash
go test -v ./keadm/cmd/keadm/app/cmd/util/nodeselect/
```

All tests pass with 100% coverage of the core logic.

## Future Use:
This utility will be used in the upcoming batch EdgeHub control feature and can be extended for other batch operations like:
- Batch node upgrades
- Batch configuration updates
- Batch health checks

## Special notes for your reviewer:
This is a foundational utility with no external dependencies. It's designed to be simple, testable, and reusable across different keadm commands.

I'm working on the batch EdgeHub control feature for the LFX mentorship program and wanted to get this foundational piece reviewed early.

cc @luomengY @Shelley-BaoYue