### PR TITLE
keadm: add edgehub subcommand skeleton for batch enable/disable

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cmd_others.go
+++ b/keadm/cmd/keadm/app/cmd/cmd_others.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/debug"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/deprecated"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/edge"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/edgehub"
 )
 
 var (
@@ -82,6 +83,7 @@ func NewKubeedgeCommand() *cobra.Command {
 	// recommended cmds
 	cmds.AddCommand(edge.NewEdgeJoin())
 	cmds.AddCommand(edge.NewEdgeBatchProcess())
+	cmds.AddCommand(edgehub.NewEdgeHubCmd())
 	cmds.AddCommand(cloud.NewCloudInit())
 	cmds.AddCommand(cloud.NewManifestGenerate())
 	cmds.AddCommand(newCmdConfig())

--- a/keadm/cmd/keadm/app/cmd/edgehub/disable.go
+++ b/keadm/cmd/keadm/app/cmd/edgehub/disable.go
@@ -1,0 +1,16 @@
+package edgehub
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func NewDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable",
+		Short: "Disable EdgeHub on specified edge nodes",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("EdgeHub disable command invoked (TODO)")
+		},
+	}
+}

--- a/keadm/cmd/keadm/app/cmd/edgehub/edgehub.go
+++ b/keadm/cmd/keadm/app/cmd/edgehub/edgehub.go
@@ -1,0 +1,20 @@
+package edgehub
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewEdgeHubCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edgehub",
+		Short: "Manage EdgeHub on edge nodes",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewEnableCmd())
+	cmd.AddCommand(NewDisableCmd())
+
+	return cmd
+}

--- a/keadm/cmd/keadm/app/cmd/edgehub/enable.go
+++ b/keadm/cmd/keadm/app/cmd/edgehub/enable.go
@@ -1,0 +1,16 @@
+package edgehub
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+func NewEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable",
+		Short: "Enable EdgeHub on specified edge nodes",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("EdgeHub enable command invoked (TODO)")
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This PR introduces a new `keadm edgehub` command group as the initial CLI foundation for the LFX Mentorship project:

**Batch enable/disable EdgeHub on edge nodes**

It adds placeholder subcommands:

- `keadm edgehub enable`
- `keadm edgehub disable`

These commands will be extended in follow-up PRs with node selection flags and the actual EdgeHub switch logic.

The goal is to allow administrators to temporarily disable EdgeHub communication on selected edge nodes in bandwidth-limited environments.


**Which issue(s) this PR fixes**:

Fixes # (N/A - initial command skeleton for mentorship project)


**Special notes for your reviewer**:

This is an initial incremental step focusing only on CLI structure and command registration.
No functional EdgeHub enable/disable logic is implemented yet.
Feedback on command naming and placement is appreciated before continuing with batch support.


**Does this PR introduce a user-facing change?**:

```release-note
Added a new `keadm edgehub` command group with enable/disable subcommands as a foundation for batch EdgeHub management on edge nodes.
```
