### PR TITLE
fix: miss Kind in metaserver Event transform in some case

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
@@ -22,6 +22,7 @@ import (
 	v2 "github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/v2"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook"
 	"github.com/kubeedge/kubeedge/pkg/metaserver"
+	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
 )
 
 // imitator is a storage based on metav2 that imitate the behavior of etcd
@@ -250,6 +251,22 @@ func (s *imitator) Event(msg *model.Message) []watch.Event {
 			return ret
 		}
 	}
+
+	// robustness: check and complete Kind if missing
+	var objMap map[string]interface{}
+	if err = json.Unmarshal(bytes, &objMap); err == nil {
+		u := &unstructured.Unstructured{Object: objMap}
+		if u.GetKind() == "" {
+			if kind := util.UnsafeResourceToKind(resType); kind != "" {
+				u.SetKind(kind)
+				if newBytes, err := u.MarshalJSON(); err == nil {
+					bytes = newBytes
+					klog.V(4).Infof("patched missing Kind: %s", kind)
+				}
+			}
+		}
+	}
+
 	var op watch.EventType
 	switch msg.Router.Operation {
 	case model.InsertOperation:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

This problem is encountered when edgecore and cloudcore are restarted repeatedly due to resource issues, and the lack of a kind in the event prevents subsequent logic from proceeding.

in my case, Pod or Serviceaccountacces will miss kind sometimes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
