### PR TITLE
update setup-envtest version to release-0.20 to fix make integration test failure

### DIFF
--- a/cloud/test/integration/scripts/execute.sh
+++ b/cloud/test/integration/scripts/execute.sh
@@ -22,11 +22,11 @@ ENVTEST_BIN_DIR=""
 
 function do_preparation() {
     which setup-envtest &> /dev/null || {
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
+        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
         sudo cp $GOPATH/bin/setup-envtest /usr/bin/
     }
 
-    ENVTEST_BIN_DIR=$(setup-envtest use 1.22.1 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
+    ENVTEST_BIN_DIR=$(setup-envtest use 1.23.5 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
 
     which ginkgo &>/dev/null || {
         go install github.com/onsi/ginkgo/ginkgo@latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind failing-test 
```
cp: cannot stat '/bin/setup-envtest': No such file or directory
unable to fetch hash for requested version: unable fetch metadata for kubebuilder-tools-1.22.1-linux-amd64.tar.gz -- got status "401 Unauthorized" from GCS
```

https://github.com/kubernetes-sigs/controller-runtime/pull/2915 old version setup-envtest download binary from gcp, after 0.20.0, total gcp support is drop.

https://github.com/kubernetes-sigs/controller-runtime/blob/e4c1c38bcbdb6e37d85481909787891a6ffc0a67/README.md?plain=1#L58
> v0.20 minimum Go version is 1.23 

as for update binary from 1.22.1 to 1.23.5, https://github.com/kubernetes-sigs/controller-tools/blob/release-0.20/envtest-releases.yaml show minimum version is 1.23.5 no 1.22.x version supported.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
