### PR TITLE
policy: Fix ServiceAccountAccess status not updated on pod deletion

### DIFF
--- a/cloud/pkg/policycontroller/manager/reconcile.go
+++ b/cloud/pkg/policycontroller/manager/reconcile.go
@@ -440,13 +440,15 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 	} else {
 		addNodes := subtractSlice(acc.Status.NodeList, nodes)
 		klog.V(4).Infof("serviceaccountaccess spec %s/%s is up to date", acc.Namespace, acc.Name)
-		if len(addNodes) != 0 {
+		if len(addNodes) != 0 || len(deleteNodes) != 0 {
 			acc.Status.NodeList = append([]string{}, nodes...)
 			if err := c.Client.Status().Update(ctx, acc); err != nil {
 				klog.Errorf("failed to update serviceaccountaccess status %s/%s, %v", acc.Namespace, acc.Name, err)
 				return controllerruntime.Result{Requeue: true}, err
 			}
-			c.send2Edge(acc, addNodes, model.InsertOperation)
+			if len(addNodes) != 0 {
+				c.send2Edge(acc, addNodes, model.InsertOperation)
+			}
 		}
 	}
 	return controllerruntime.Result{}, nil

--- a/cloud/pkg/policycontroller/manager/reconcile_test.go
+++ b/cloud/pkg/policycontroller/manager/reconcile_test.go
@@ -1720,6 +1720,21 @@ func TestSyncRules(t *testing.T) {
 			},
 			msgOpr: []string{},
 		},
+		{
+			name:            "delete node only without spec update",
+			input:           saa2.DeepCopy(),
+			obj:             []client.Object{saa2.DeepCopy(), pod2.DeepCopy(), sa1.DeepCopy(), rb1.DeepCopy(), role1.DeepCopy(), crb1.DeepCopy(), cr1.DeepCopy()},
+			reconcileResult: controllerruntime.Result{},
+			output: &policyv1alpha1.ServiceAccountAccess{ObjectMeta: metav1.ObjectMeta{Name: "sa1", Namespace: "my-namespace"},
+				Spec: policyv1alpha1.AccessSpec{
+					ServiceAccount:           *sa1.DeepCopy(),
+					AccessRoleBinding:        []policyv1alpha1.AccessRoleBinding{{RoleBinding: *rb1.DeepCopy(), Rules: role1.Rules}},
+					AccessClusterRoleBinding: []policyv1alpha1.AccessClusterRoleBinding{{ClusterRoleBinding: *crb1.DeepCopy(), Rules: cr1.Rules}},
+				},
+				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node-2"}},
+			},
+			msgOpr: []string{model.DeleteOperation},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When a pod is deleted, the ServiceAccountAccess permission is correctly removed from the edge node via a delete message, but the status.NodeList field is not updated to reflect this removal.

This stale status causes an issue when a pod is recreated on the same node. The controller sees the node name in the existing status and assumes the permission already exists, failing to send a new ServiceAccountAccess creation message to the edge.

This commit fixes the issue by updating the status whenever nodes are removed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
