### PR TITLE
fix: keadm config-update cant work with numeric type like int32

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/set.go
+++ b/keadm/cmd/keadm/app/cmd/util/set.go
@@ -207,6 +207,17 @@ func getNameFormStatus(s string) int {
 	return -1
 }
 
+func isNumericKind(k reflect.Kind) bool {
+	switch k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
 // SetCommonValue modifies the new value of the name in the config represented by struct.
 // The type of new value may be int, float, string, splic.
 // The name is represented by name1.name2.(...).nameM.
@@ -225,12 +236,38 @@ func setCommonValue(structPtr interface{}, fieldPath string, value interface{}) 
 
 	val := reflect.ValueOf(value)
 
+	newVal, err := convertTargetValue(fieldVal.Type(), val)
+	if err == nil {
+		val = newVal
+	}
+
 	if fieldVal.Type() != val.Type() {
 		return fmt.Errorf("%s: Provided value type %s does not match field type %s", fieldPath, val.Type(), fieldVal.Type())
 	}
 	fieldVal.Set(val)
 
 	return nil
+}
+
+func convertTargetValue(targetType reflect.Type, valueToSet reflect.Value) (reflect.Value, error) {
+	if targetType.Kind() == valueToSet.Kind() && valueToSet.Type().ConvertibleTo(targetType) {
+		return valueToSet.Convert(targetType), nil
+	}
+	// support numeric convert
+	if isNumericKind(targetType.Kind()) && isNumericKind(valueToSet.Kind()) {
+		if valueToSet.Type().ConvertibleTo(targetType) {
+			return valueToSet.Convert(targetType), nil
+		}
+	}
+	// support point value
+	if targetType.Kind() == reflect.Ptr && valueToSet.Type().ConvertibleTo(targetType.Elem()) {
+		ptr := reflect.New(targetType.Elem())
+		if valueToSet.Type().ConvertibleTo(targetType.Elem()) {
+			ptr.Elem().Set(valueToSet.Convert(targetType.Elem()))
+			return ptr, nil
+		}
+	}
+	return reflect.Value{}, fmt.Errorf("value type %s is not assignable to field type %s", valueToSet.Type(), targetType)
 }
 
 // GetFieldValue gets the fieldname of the struct.
@@ -284,6 +321,12 @@ func setArrayValue(structPtr interface{}, fieldPath string, index int, newValue 
 	}
 	//Set new value
 	elem := reflect.ValueOf(newValue)
+
+	newElem, err := convertTargetValue(fieldVal.Type().Elem(), elem)
+	if err == nil {
+		elem = newElem
+	}
+
 	if elem.Type() != fieldVal.Type().Elem() {
 		return fmt.Errorf("type mismatch for field %s", pathParts[len(pathParts)-1])
 	}
@@ -365,6 +408,12 @@ func setVariableValue(obj interface{}, fieldPath string, value interface{}) erro
 	}
 
 	valueToSet := reflect.ValueOf(value)
+
+	newVal, err := convertTargetValue(targetFieldValue.Type(), valueToSet)
+	if err == nil {
+		valueToSet = newVal
+	}
+
 	if !valueToSet.Type().AssignableTo(targetFieldValue.Type()) {
 		return fmt.Errorf("value type %s is not assignable to field %s type %s", valueToSet.Type(), targetFieldName, targetFieldValue.Type())
 	}

--- a/keadm/cmd/keadm/app/cmd/util/set_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/set_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 )
 
@@ -461,4 +463,19 @@ func TestEdgeCoreConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(cfg.DataBase.AliasName, cfg.DataBase.DriverName, cfg.Modules.DBTest.Enable, cfg.Modules.Edged.TailoredKubeletFlag.HostnameOverride, cfg.Modules.MetaManager.MetaServer.ServiceAccountIssuers, cfg.FeatureGates)
+}
+
+func TestSetEdgeCoreConfigWithMultiIntValue(t *testing.T) {
+	cfg := v1alpha2.NewDefaultEdgeCoreConfig()
+	// MaxPods int32
+	// MaxOpenFiles int64
+	// ServiceBus.Port int
+	// MqttQOS uint8
+	if err := ParseSet(cfg, `Modules.Edged.TailoredKubeletConfig.MaxPods=111,Modules.Edged.TailoredKubeletConfig.MaxOpenFiles=1000001,Modules.ServiceBus.Port=9061,Modules.EventBus.MqttQOS=1`); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, int32(111), cfg.Modules.Edged.TailoredKubeletConfig.MaxPods)
+	assert.Equal(t, int64(1000001), cfg.Modules.Edged.TailoredKubeletConfig.MaxOpenFiles)
+	assert.Equal(t, int(9061), cfg.Modules.ServiceBus.Port)
+	assert.Equal(t, uint8(1), cfg.Modules.EventBus.MqttQOS)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
same like https://github.com/kubeedge/kubeedge/pull/6578 but for release-1.19

Due to significant code differences between 1.19 and master, cherry-pick conflicts occurred, so a pull request was manually created to fix this issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
