### PR TITLE
fix: avoid modifying original object in StrategicMergeMapPatch

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -184,7 +184,7 @@ func MergePatchedResource(ctx context.Context, originalObj *unstructured.Unstruc
 		if err = patchutil.StrategicPatchObject(ctx, defaulter, originalObj, []byte((*metas)[0]), updatedResource, schemaReferenceObj, ""); err != nil {
 			return err
 		}
-		originalObj = updatedResource
+		*originalObj = *updatedResource
 	}
 	return nil
 }

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/util/patch.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/util/patch.go
@@ -48,7 +48,7 @@ func StrategicPatchObject(
 	schemaReferenceObj runtime.Object,
 	validationDirective string,
 ) error {
-	originalObjMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(originalObject)
+	originalObjMapCopy, err := runtime.DefaultUnstructuredConverter.ToUnstructured(originalObject.DeepCopyObject())
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func StrategicPatchObject(
 		}
 	}
 
-	return applyPatchToObject(requestContext, defaulter, originalObjMap, patchMap, objToUpdate, schemaReferenceObj, strictErrs, validationDirective)
+	return applyPatchToObject(requestContext, defaulter, originalObjMapCopy, patchMap, objToUpdate, schemaReferenceObj, strictErrs, validationDirective)
 }
 
 // applyPatchToObject applies a strategic merge patch of <patchMap> to


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
Prevent the original object from being modified when calling strategicpatch.StrategicMergeMapPatch by:
1. Creating a deep copy of the original object before processing
2. Correctly updating the original object via pointer dereference

This avoids unexpected side effects on the input object.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
