### PR TITLE
keadm: add tests for ctl commands

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package confirm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	fakerest "k8s.io/client-go/rest/fake"
+	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
+)
+
+func TestNewEdgeConfirm(t *testing.T) {
+	cmd := NewEdgeConfirm()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "confirm", cmd.Use)
+}
+
+func TestConfirmNodeUpgrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		expectedErrMsg string
+		wantErr        bool
+		connErr        bool
+	}{
+		{
+			name:    "confirm success",
+			status:  http.StatusOK,
+			wantErr: false,
+		},
+		{
+			name:           "confirm failed with 500 status error",
+			status:         http.StatusInternalServerError,
+			wantErr:        true,
+			expectedErrMsg: "failed to confirm node upgrade, status code: 500",
+		},
+		{
+			name:           "confirm failed with connection error",
+			wantErr:        true,
+			expectedErrMsg: "failed to send confirm request to MetaService API",
+			connErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakerest.RESTClient{
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					if tt.connErr {
+						return nil, fmt.Errorf("connection refused")
+					}
+					return &http.Response{
+						StatusCode: tt.status,
+						Body:       http.NoBody,
+					}, nil
+				}),
+			}
+
+			mockClient := &testutil.MockClientset{
+				MockCoreV1: &testutil.MockCoreV1{
+					RestClient: client,
+				},
+			}
+
+			err := confirmNodeUpgrade(context.Background(), mockClient)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edit
+
+import (
+	"context"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
+
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+func TestNewEditDeviceOpts(t *testing.T) {
+	opts := NewEditDeviceOpts()
+	assert.NotNil(t, opts)
+}
+
+func TestEditDevice(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		nodeName       string
+		device         *v1beta1.Device
+		wantErr        bool
+		expectedErrMsg string
+		cancelled      bool
+	}{
+		{
+			name:     "edit success",
+			args:     []string{"test-device"},
+			nodeName: "test-node",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-device",
+					Namespace: "default",
+				},
+				Spec: v1beta1.DeviceSpec{
+					NodeName: "test-node",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "too many args",
+			args:           []string{"device1", "device2"},
+			wantErr:        true,
+			expectedErrMsg: "too many args",
+		},
+		{
+			name:     "device node name mismatch",
+			args:     []string{"test-device"},
+			nodeName: "test-node",
+			device: &v1beta1.Device{
+				Spec: v1beta1.DeviceSpec{
+					NodeName: "other-node",
+				},
+			},
+			wantErr: false, // it just logs an error
+		},
+		{
+			name:     "edit cancelled",
+			args:     []string{"test-device"},
+			nodeName: "test-node",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-device",
+					Namespace: "default",
+				},
+				Spec: v1beta1.DeviceSpec{
+					NodeName: "test-node",
+				},
+			},
+			wantErr:        true,
+			expectedErrMsg: "no changes made",
+			cancelled:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyFunc(util.ParseEdgecoreConfig, func(path string) (*cfgv1alpha2.EdgeCoreConfig, error) {
+				return &cfgv1alpha2.EdgeCoreConfig{
+					Modules: &cfgv1alpha2.Modules{
+						Edged: &cfgv1alpha2.Edged{
+							TailoredKubeletFlag: cfgv1alpha2.TailoredKubeletFlag{
+								HostnameOverride: tt.nodeName,
+							},
+						},
+					},
+				}, nil
+			})
+
+			patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "GetDevice", func(_ *client.DeviceRequest, _ context.Context) (*v1beta1.Device, error) {
+				return tt.device, nil
+			})
+
+			patches.ApplyFunc(editor.NewDefaultEditor, func(envs []string) editor.Editor {
+				return editor.Editor{}
+			})
+
+			patches.ApplyMethod(reflect.TypeOf(editor.Editor{}), "LaunchTempFile", func(_ editor.Editor, prefix, suffix string, r io.Reader) ([]byte, string, error) {
+				if tt.cancelled {
+					data, _ := io.ReadAll(r)
+					return data, "fake-file", nil
+				}
+				// Return valid JSON that is different from the input YAML
+				return []byte("{\"metadata\":{\"name\":\"test-device\",\"namespace\":\"default\"},\"spec\":{\"nodeName\":\"test-node\"}}"), "fake-file", nil
+			})
+
+			patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "UpdateDevice", func(_ *client.DeviceRequest, _ context.Context, _ *v1beta1.Device) (*rest.Result, error) {
+				return nil, nil
+			})
+
+			o := NewEditDeviceOpts()
+			err := o.editDevice(tt.args)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
@@ -17,13 +17,111 @@ limitations under the License.
 package restart
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	fakerest "k8s.io/client-go/rest/fake"
+	"k8s.io/kubectl/pkg/scheme"
 
+	"github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
+
+func TestPodRestart(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		resp           *types.RestartResponse
+		wantErr        bool
+		expectedErrMsg string
+	}{
+		{
+			name:   "restart success",
+			status: http.StatusOK,
+			resp: &types.RestartResponse{
+				LogMessages: []string{"pod1 restarted"},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "restart failed - 500",
+			status:         http.StatusInternalServerError,
+			wantErr:        true,
+			expectedErrMsg: "error on the server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			respBytes, _ := json.Marshal(tt.resp)
+			client := &fakerest.RESTClient{
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.status,
+						Body:       io.NopCloser(bytes.NewReader(respBytes)),
+					}, nil
+				}),
+			}
+			mockClient := &testutil.MockClientset{
+				MockCoreV1: &testutil.MockCoreV1{
+					RestClient: client,
+				},
+			}
+
+			resp, err := podRestart(context.Background(), mockClient, "default", []string{"pod1"})
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.resp, resp)
+			}
+		})
+	}
+}
+
+func TestRestartPod(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	client := &fakerest.RESTClient{
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			resp := &types.RestartResponse{
+				LogMessages: []string{"restarted"},
+			}
+			respBytes, _ := json.Marshal(resp)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(respBytes)),
+			}, nil
+		}),
+	}
+	mockClient := &testutil.MockClientset{
+		MockCoreV1: &testutil.MockCoreV1{
+			RestClient: client,
+		},
+	}
+
+	patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return mockClient, nil
+	})
+
+	opts := NewRestartPodOpts()
+	err := opts.restartPod([]string{"pod1"})
+	assert.NoError(t, err)
+}
 
 func TestNewEdgePodRestart(t *testing.T) {
 	assert := assert.New(t)

--- a/keadm/cmd/keadm/app/cmd/ctl/testutil/mock_client.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/testutil/mock_client.go
@@ -1,0 +1,25 @@
+package testutil
+
+import (
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+type MockCoreV1 struct {
+	corev1.CoreV1Interface
+	RestClient rest.Interface
+}
+
+func (m *MockCoreV1) RESTClient() rest.Interface {
+	return m.RestClient
+}
+
+type MockClientset struct {
+	fake.Clientset
+	MockCoreV1 *MockCoreV1
+}
+
+func (m *MockClientset) CoreV1() corev1.CoreV1Interface {
+	return m.MockCoreV1
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unhold
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	fakerest "k8s.io/client-go/rest/fake"
+	"k8s.io/kubectl/pkg/scheme"
+
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
+)
+
+func TestNewEdgeUnholdUpgrade(t *testing.T) {
+	cmd := NewEdgeUnholdUpgrade()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "unhold-upgrade <resource-type> [<name>] [--namespace namespace]", cmd.Use)
+}
+
+func TestUnholdResourceUpgrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       string
+		target         string
+		status         int
+		expectedErrMsg string
+		wantErr        bool
+		kubeClientErr  bool
+	}{
+		{
+			name:     "unhold success",
+			resource: "pods",
+			target:   "default/test-pod",
+			status:   http.StatusOK,
+			wantErr:  false,
+		},
+		{
+			name:           "unhold failed - kube client error",
+			resource:       "pods",
+			target:         "default/test-pod",
+			wantErr:        true,
+			kubeClientErr:  true,
+			expectedErrMsg: "kube client error",
+		},
+		{
+			name:           "unhold failed - status error",
+			resource:       "nodes",
+			target:         "test-node",
+			status:         http.StatusInternalServerError,
+			wantErr:        true,
+			expectedErrMsg: "failed to unhold nodes upgrade, status code: 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			if tt.kubeClientErr {
+				patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+					return nil, fmt.Errorf("kube client error")
+				})
+			} else {
+				client := &fakerest.RESTClient{
+					NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+					Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: tt.status,
+							Body:       http.NoBody,
+						}, nil
+					}),
+				}
+				mockClient := &testutil.MockClientset{
+					MockCoreV1: &testutil.MockCoreV1{
+						RestClient: client,
+					},
+				}
+				patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+					return mockClient, nil
+				})
+			}
+
+			err := unholdResourceUpgrade(tt.resource, tt.target)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetCurrentNodeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *cfgv1alpha2.EdgeCoreConfig
+		wantErr  bool
+		err      error
+		expected string
+	}{
+		{
+			name: "get node name success",
+			config: &cfgv1alpha2.EdgeCoreConfig{
+				Modules: &cfgv1alpha2.Modules{
+					Edged: &cfgv1alpha2.Edged{
+						TailoredKubeletFlag: cfgv1alpha2.TailoredKubeletFlag{
+							HostnameOverride: "test-node",
+						},
+					},
+				},
+			},
+			expected: "test-node",
+			wantErr:  false,
+		},
+		{
+			name:    "parse config error",
+			err:     fmt.Errorf("parse error"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyFunc(util.ParseEdgecoreConfig, func(path string) (*cfgv1alpha2.EdgeCoreConfig, error) {
+				return tt.config, tt.err
+			})
+
+			nodeName, err := getCurrentNodeName()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, nodeName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added unit tests for keadm ctl commands to improve coverage.

Covered confirm, unhold, restart and edit commands. For confirm and unhold, added tests for success and failure cases like server errors and client issues. For restart, covered API response handling and basic restart flow. For edit, added tests for device edit flow including argument validation and mocked editor behavior.

Used simple table-driven tests and mocked API/client calls so tests don’t depend on a real cluster.

Fixes #6630