### PR TITLE
syncRules: update serviceaccountaccess .status.nodeList properly also when deleting serviceaccount objects from edge nodes

### DIFF
--- a/cloud/pkg/policycontroller/manager/reconcile.go
+++ b/cloud/pkg/policycontroller/manager/reconcile.go
@@ -410,7 +410,6 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 		return controllerruntime.Result{}, nil
 	}
 
-	addNodes := subtractSlice(acc.Status.NodeList, nodes)
 	deleteNodes := subtractSlice(nodes, acc.Status.NodeList)
 	sort.Slice(currentAcc.Spec.AccessRoleBinding, func(i, j int) bool {
 		return currentAcc.Spec.AccessRoleBinding[i].RoleBinding.Name < currentAcc.Spec.AccessRoleBinding[j].RoleBinding.Name
@@ -421,14 +420,6 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 	sort.Slice(nodes, func(i, j int) bool {
 		return nodes[i] < nodes[j]
 	})
-	if !equality.Semantic.DeepEqual(acc.Status.NodeList, nodes) {
-		acc.Status.NodeList = append([]string{}, nodes...)
-		if err := c.Client.Status().Update(ctx, acc); err != nil {
-			klog.Errorf("failed to update serviceaccountaccess status %s/%s, %v", acc.Namespace, acc.Name, err)
-			return controllerruntime.Result{Requeue: true}, err
-		}
-		klog.V(4).Infof("update serviceaccountaccess %s/%s status.nodeList %v", acc.Namespace, acc.Name, nodes)
-	}
 	if !equalAccessBindingSlice(acc.Spec.AccessClusterRoleBinding, currentAcc.Spec.AccessClusterRoleBinding) ||
 		!equalAccessBindingSlice(acc.Spec.AccessRoleBinding, currentAcc.Spec.AccessRoleBinding) ||
 		!equalServiceAccount(&acc.Spec.ServiceAccount, &currentAcc.Spec.ServiceAccount) ||
@@ -442,12 +433,26 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 		c.send2Edge(acc, nodes, model.UpdateOperation)
 	} else {
 		klog.V(4).Infof("serviceaccountaccess spec %s/%s is up to date", acc.Namespace, acc.Name)
-		if len(addNodes) != 0 {
-			c.send2Edge(acc, addNodes, model.InsertOperation)
-		}
+		// Send to every node, not only the ones missing from status.NodeList.
+		// cloudHub drops a message whose resourceVersion is not newer than the
+		// one recorded in that node's ObjectSync, so a node already in sync
+		// costs nothing on the wire, while a node that silently missed an
+		// earlier send is repaired instead of being stranded forever.
+		c.send2Edge(acc, nodes, model.UpdateOperation)
 	}
 	if len(deleteNodes) != 0 {
 		c.send2Edge(acc, deleteNodes, model.DeleteOperation)
+	}
+	// Record the node list only after the sends. A node written into
+	// status.NodeList but never sent to used to be unreachable afterwards,
+	// because the send list was derived from that same list on every later pass.
+	if !equality.Semantic.DeepEqual(acc.Status.NodeList, nodes) {
+		acc.Status.NodeList = append([]string{}, nodes...)
+		if err := c.Client.Status().Update(ctx, acc); err != nil {
+			klog.Errorf("failed to update serviceaccountaccess status %s/%s, %v", acc.Namespace, acc.Name, err)
+			return controllerruntime.Result{Requeue: true}, err
+		}
+		klog.V(4).Infof("update serviceaccountaccess %s/%s status.nodeList %v", acc.Namespace, acc.Name, nodes)
 	}
 	return controllerruntime.Result{}, nil
 }

--- a/cloud/pkg/policycontroller/manager/reconcile.go
+++ b/cloud/pkg/policycontroller/manager/reconcile.go
@@ -393,24 +393,25 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 	}
 	currentAcc.Spec.ServiceAccount = *newSA
 	currentAcc.Spec.ServiceAccountUID = newSA.UID
-	if len(nodes) == 0 && len(acc.Status.NodeList) == 0 {
-		klog.Warningf("no nodes found for serviceaccountaccess %s/%s", acc.Namespace, acc.Name)
-		return controllerruntime.Result{}, nil
-	}
-	deleteNodes := subtractSlice(nodes, acc.Status.NodeList)
-	if len(deleteNodes) != 0 {
-		// no nodes in the current acc status, delete the acc
-		if len(nodes) == 0 {
-			if err = c.Client.Delete(ctx, acc); err != nil {
-				klog.Errorf("failed to delete serviceaccountaccess %s/%s, %v", acc.Namespace, acc.Name, err)
-				return controllerruntime.Result{Requeue: true}, err
-			}
-			klog.V(4).Infof("delete serviceaccountaccess %s/%s", acc.Namespace, acc.Name)
-			c.send2Edge(acc, deleteNodes, model.DeleteOperation)
+
+	if len(nodes) == 0 {
+		if len(acc.Status.NodeList) == 0 {
+			klog.Warningf("no nodes found for serviceaccountaccess %s/%s", acc.Namespace, acc.Name)
 			return controllerruntime.Result{}, nil
 		}
-		c.send2Edge(acc, deleteNodes, model.DeleteOperation)
+
+		// no nodes in the current acc status, delete the acc
+		if err = c.Client.Delete(ctx, acc); err != nil {
+			klog.Errorf("failed to delete serviceaccountaccess %s/%s, %v", acc.Namespace, acc.Name, err)
+			return controllerruntime.Result{Requeue: true}, err
+		}
+		klog.V(4).Infof("delete serviceaccountaccess %s/%s", acc.Namespace, acc.Name)
+		c.send2Edge(acc, acc.Status.NodeList, model.DeleteOperation)
+		return controllerruntime.Result{}, nil
 	}
+
+	addNodes := subtractSlice(acc.Status.NodeList, nodes)
+	deleteNodes := subtractSlice(nodes, acc.Status.NodeList)
 	sort.Slice(currentAcc.Spec.AccessRoleBinding, func(i, j int) bool {
 		return currentAcc.Spec.AccessRoleBinding[i].RoleBinding.Name < currentAcc.Spec.AccessRoleBinding[j].RoleBinding.Name
 	})
@@ -420,6 +421,14 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 	sort.Slice(nodes, func(i, j int) bool {
 		return nodes[i] < nodes[j]
 	})
+	if !equality.Semantic.DeepEqual(acc.Status.NodeList, nodes) {
+		acc.Status.NodeList = append([]string{}, nodes...)
+		if err := c.Client.Status().Update(ctx, acc); err != nil {
+			klog.Errorf("failed to update serviceaccountaccess status %s/%s, %v", acc.Namespace, acc.Name, err)
+			return controllerruntime.Result{Requeue: true}, err
+		}
+		klog.V(4).Infof("update serviceaccountaccess %s/%s status.nodeList %v", acc.Namespace, acc.Name, nodes)
+	}
 	if !equalAccessBindingSlice(acc.Spec.AccessClusterRoleBinding, currentAcc.Spec.AccessClusterRoleBinding) ||
 		!equalAccessBindingSlice(acc.Spec.AccessRoleBinding, currentAcc.Spec.AccessRoleBinding) ||
 		!equalServiceAccount(&acc.Spec.ServiceAccount, &currentAcc.Spec.ServiceAccount) ||
@@ -429,27 +438,16 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 			klog.Errorf("failed to update serviceaccountaccess %s/%s, %v", acc.Namespace, acc.Name, err)
 			return controllerruntime.Result{Requeue: true}, err
 		}
-		if !equality.Semantic.DeepEqual(acc.Status.NodeList, nodes) {
-			acc.Status.NodeList = append([]string{}, nodes...)
-			if err := c.Client.Status().Update(ctx, acc); err != nil {
-				klog.Errorf("failed to update serviceaccountaccess status %s/%s, %v", acc.Namespace, acc.Name, err)
-				return controllerruntime.Result{Requeue: true}, err
-			}
-		}
+		klog.V(4).Infof("update serviceaccountaccess %s/%s", acc.Namespace, acc.Name)
 		c.send2Edge(acc, nodes, model.UpdateOperation)
 	} else {
-		addNodes := subtractSlice(acc.Status.NodeList, nodes)
 		klog.V(4).Infof("serviceaccountaccess spec %s/%s is up to date", acc.Namespace, acc.Name)
-		if !equality.Semantic.DeepEqual(acc.Status.NodeList, nodes) {
-			acc.Status.NodeList = append([]string{}, nodes...)
-			if err := c.Client.Status().Update(ctx, acc); err != nil {
-				klog.Errorf("failed to update serviceaccountaccess status %s/%s, %v", acc.Namespace, acc.Name, err)
-				return controllerruntime.Result{Requeue: true}, err
-			}
-		}
 		if len(addNodes) != 0 {
 			c.send2Edge(acc, addNodes, model.InsertOperation)
 		}
+	}
+	if len(deleteNodes) != 0 {
+		c.send2Edge(acc, deleteNodes, model.DeleteOperation)
 	}
 	return controllerruntime.Result{}, nil
 }

--- a/cloud/pkg/policycontroller/manager/reconcile_test.go
+++ b/cloud/pkg/policycontroller/manager/reconcile_test.go
@@ -1603,7 +1603,7 @@ func TestSyncRules(t *testing.T) {
 				},
 				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node", "my-node-2"}},
 			},
-			msgOpr: []string{model.DeleteOperation, model.UpdateOperation},
+			msgOpr: []string{model.DeleteOperation, model.UpdateOperation, model.UpdateOperation},
 		},
 		{
 			name:            "rolebinding updated and inserted new node with none old node",
@@ -1710,6 +1710,22 @@ func TestSyncRules(t *testing.T) {
 				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node"}},
 			},
 			msgOpr: []string{model.DeleteOperation},
+		},
+		{
+			name:  "insert/delete only",
+			input: saa3.DeepCopy(),
+			obj: []client.Object{saa3.DeepCopy(), pod1.DeepCopy(), sa1.DeepCopy(), rb1.DeepCopy(),
+				crb1.DeepCopy(), cr1.DeepCopy(), role1.DeepCopy()},
+			reconcileResult: controllerruntime.Result{},
+			output: &policyv1alpha1.ServiceAccountAccess{ObjectMeta: metav1.ObjectMeta{Name: "sa1", Namespace: "my-namespace"},
+				Spec: policyv1alpha1.AccessSpec{
+					ServiceAccount:           *sa1.DeepCopy(),
+					AccessRoleBinding:        []policyv1alpha1.AccessRoleBinding{{RoleBinding: *rb1.DeepCopy(), Rules: role1.Rules}},
+					AccessClusterRoleBinding: []policyv1alpha1.AccessClusterRoleBinding{{ClusterRoleBinding: *crb1.DeepCopy(), Rules: cr1.Rules}},
+				},
+				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node"}},
+			},
+			msgOpr: []string{model.InsertOperation, model.DeleteOperation},
 		},
 		{
 			name:  "reconcile failed cause serviceaccountaccess not found",

--- a/cloud/pkg/policycontroller/manager/reconcile_test.go
+++ b/cloud/pkg/policycontroller/manager/reconcile_test.go
@@ -1693,7 +1693,7 @@ func TestSyncRules(t *testing.T) {
 				},
 				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node", "my-node-2"}},
 			},
-			msgOpr: []string{model.InsertOperation},
+			msgOpr: []string{model.UpdateOperation, model.UpdateOperation}, // both nodes, not just the added one
 		},
 		{
 			name:  "delete only updates status",
@@ -1709,7 +1709,7 @@ func TestSyncRules(t *testing.T) {
 				},
 				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node"}},
 			},
-			msgOpr: []string{model.DeleteOperation},
+			msgOpr: []string{model.UpdateOperation, model.DeleteOperation}, // the remaining node is refreshed too
 		},
 		{
 			name:  "insert/delete only",
@@ -1725,7 +1725,7 @@ func TestSyncRules(t *testing.T) {
 				},
 				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node"}},
 			},
-			msgOpr: []string{model.InsertOperation, model.DeleteOperation},
+			msgOpr: []string{model.UpdateOperation, model.DeleteOperation}, // the added node gets an update, not an insert
 		},
 		{
 			name:  "reconcile failed cause serviceaccountaccess not found",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
policymanager reconciliation (syncRules) does not record serviceaccount objectsync deletion in serviceaccountaccess .status.nodeList properly, so it is not re-created afterwards properly

**Which issue(s) this PR fixes**: #6672 

```release-note

NONE
```
