### PR TITLE
keadm: add unit tests for ctl confirm and unhold

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package confirm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
+)
+
+func TestNewEdgeConfirm(t *testing.T) {
+	assert := assert.New(t)
+	cmd := NewEdgeConfirm()
+
+	assert.NotNil(cmd)
+	assert.Equal("confirm", cmd.Use)
+	assert.Equal("Send a confirmation signal to the MetaService API.", cmd.Short)
+	assert.NotNil(cmd.RunE)
+}
+
+func TestNewEdgeConfirmRunEKubeClientError(t *testing.T) {
+	patches := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return nil, errors.New("client init failed")
+	})
+	defer patches.Reset()
+
+	cmd := NewEdgeConfirm()
+	err := cmd.RunE(cmd, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client init failed")
+}
+
+func TestNewEdgeConfirmRunESuccess(t *testing.T) {
+	var method, path string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	clientset, err := testutil.NewCoreV1Clientset(server.URL, server.Client())
+	require.NoError(t, err)
+
+	patches := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return clientset, nil
+	})
+	defer patches.Reset()
+
+	cmd := NewEdgeConfirm()
+	err = cmd.RunE(cmd, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPost, method)
+	assert.Equal(t, "/api/v1/taskupgrade/confirm-upgrade", path)
+}
+
+func TestConfirmNodeUpgradeStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		require.NoError(t, json.NewEncoder(w).Encode(&metav1.Status{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Status",
+				APIVersion: "v1",
+			},
+			Status:  metav1.StatusFailure,
+			Message: "upgrade task not found",
+			Code:    http.StatusBadRequest,
+		}))
+	}))
+	defer server.Close()
+
+	clientset, err := testutil.NewCoreV1Clientset(server.URL, server.Client())
+	require.NoError(t, err)
+
+	err = confirmNodeUpgrade(context.Background(), clientset)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to confirm node upgrade")
+	assert.Contains(t, err.Error(), "status code: 400")
+	assert.Contains(t, err.Error(), "message: upgrade task not found")
+}
+
+func TestConfirmNodeUpgradeGenericError(t *testing.T) {
+	clientset, err := testutil.NewCoreV1Clientset("http://example.invalid", &http.Client{
+		Transport: testutil.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("request failed")
+		}),
+	})
+	require.NoError(t, err)
+
+	err = confirmNodeUpgrade(context.Background(), clientset)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send confirm request to MetaService API")
+	assert.Contains(t, err.Error(), "request failed")
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/testutil/clientset.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/testutil/clientset.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+)
+
+// NewCoreV1Clientset builds a real client-go clientset against a test HTTP server.
+func NewCoreV1Clientset(serverURL string, httpClient *http.Client) (*kubernetes.Clientset, error) {
+	config := &rest.Config{
+		Host:    serverURL,
+		APIPath: "/api",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &schema.GroupVersion{Version: "v1"},
+			NegotiatedSerializer: k8sscheme.Codecs.WithoutConversion(),
+		},
+	}
+	return kubernetes.NewForConfigAndClient(config, httpClient)
+}
+
+// RoundTripperFunc helps tests stub transport failures without package-local boilerplate.
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f RoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unhold
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
+)
+
+func TestNewEdgeUnholdUpgrade(t *testing.T) {
+	assert := assert.New(t)
+	cmd := NewEdgeUnholdUpgrade()
+
+	assert.NotNil(cmd)
+	assert.Equal("unhold-upgrade <resource-type> [<name>] [--namespace namespace]", cmd.Use)
+	assert.Equal("Unhold an upgrade for a pod or node-wide", cmd.Short)
+	assert.NotNil(cmd.RunE)
+	assert.Equal("namespace", cmd.Flags().Lookup("namespace").Name)
+}
+
+func TestNewEdgeUnholdUpgradePodRequiresName(t *testing.T) {
+	cmd := newSilencedUnholdCommand()
+	cmd.SetArgs([]string{"pod"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pod name is required")
+}
+
+func TestNewEdgeUnholdUpgradeUnknownResourceType(t *testing.T) {
+	cmd := newSilencedUnholdCommand()
+	cmd.SetArgs([]string{"service"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown resource type: service")
+}
+
+func TestNewEdgeUnholdUpgradePodSuccess(t *testing.T) {
+	var method, path, contentType, requestBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method = r.Method
+		path = r.URL.Path
+		contentType = r.Header.Get("Content-Type")
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requestBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	clientset, err := testutil.NewCoreV1Clientset(server.URL, server.Client())
+	require.NoError(t, err)
+
+	patches := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return clientset, nil
+	})
+	defer patches.Reset()
+
+	cmd := newSilencedUnholdCommand()
+	_ = cmd.Flags().Set("namespace", "test-ns")
+	cmd.SetArgs([]string{"pod", "test-pod"})
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPost, method)
+	assert.Equal(t, "/api/v1/pods/unhold-upgrade", path)
+	assert.Equal(t, "text/plain", contentType)
+	assert.Equal(t, "test-ns/test-pod", requestBody)
+}
+
+func TestNewEdgeUnholdUpgradeNodeUsesCurrentNodeName(t *testing.T) {
+	var path, requestBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requestBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	clientset, err := testutil.NewCoreV1Clientset(server.URL, server.Client())
+	require.NoError(t, err)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(getCurrentNodeName, func() (string, error) {
+		return "edge-node-1", nil
+	})
+	patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return clientset, nil
+	})
+
+	cmd := newSilencedUnholdCommand()
+	cmd.SetArgs([]string{"node"})
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/api/v1/nodes/unhold-upgrade", path)
+	assert.Equal(t, "edge-node-1", requestBody)
+}
+
+func TestNewEdgeUnholdUpgradeNodeLookupError(t *testing.T) {
+	patches := gomonkey.ApplyFunc(getCurrentNodeName, func() (string, error) {
+		return "", errors.New("node lookup failed")
+	})
+	defer patches.Reset()
+
+	cmd := newSilencedUnholdCommand()
+	cmd.SetArgs([]string{"node"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node lookup failed")
+}
+
+func TestUnholdResourceUpgradeKubeClientError(t *testing.T) {
+	patches := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return nil, errors.New("client init failed")
+	})
+	defer patches.Reset()
+
+	err := unholdResourceUpgrade("pods", "default/test-pod")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client init failed")
+}
+
+func TestUnholdResourceUpgradeStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		require.NoError(t, json.NewEncoder(w).Encode(&metav1.Status{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Status",
+				APIVersion: "v1",
+			},
+			Status:  metav1.StatusFailure,
+			Message: "upgrade is not on hold",
+			Code:    http.StatusConflict,
+		}))
+	}))
+	defer server.Close()
+
+	clientset, err := testutil.NewCoreV1Clientset(server.URL, server.Client())
+	require.NoError(t, err)
+
+	patches := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return clientset, nil
+	})
+	defer patches.Reset()
+
+	err = unholdResourceUpgrade("pods", "default/test-pod")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unhold pods upgrade")
+	assert.Contains(t, err.Error(), "status code: 409")
+	assert.Contains(t, err.Error(), "message: upgrade is not on hold")
+}
+
+func TestUnholdResourceUpgradeGenericError(t *testing.T) {
+	clientset, err := testutil.NewCoreV1Clientset("http://example.invalid", &http.Client{
+		Transport: testutil.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("request failed")
+		}),
+	})
+	require.NoError(t, err)
+
+	patches := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return clientset, nil
+	})
+	defer patches.Reset()
+
+	err = unholdResourceUpgrade("nodes", "edge-node-1")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send unhold request to MetaService API")
+	assert.Contains(t, err.Error(), "request failed")
+}
+
+func newSilencedUnholdCommand() *cobra.Command {
+	cmd := NewEdgeUnholdUpgrade()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	return cmd
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR adds unit tests for `keadm ctl confirm` and `keadm ctl unhold`.

The new tests cover:
- command construction and basic argument validation
- kube client initialization failures
- REST request success paths
- `StatusError` and generic error handling paths

To make the REST interaction testable, this PR extracts the internal REST request logic into private helper functions without changing the existing command behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This PR is limited to unit test coverage for `ctl/confirm` and `ctl/unhold`.
The small refactor in the command implementation only introduces private helpers for testing and does not change the external behavior.

**Does this PR introduce a user-facing change?**:

```release-note
NONE