### PR TITLE
keadm: continue cleaning remaining directories when one path is missing

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/reset.go
+++ b/keadm/cmd/keadm/app/cmd/util/reset.go
@@ -73,7 +73,7 @@ func CleanDirectories(isEdgeNode bool) error {
 	for _, dir := range dirToClean {
 		klog.V(2).Infof("remove dir %s", dir)
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			return nil
+			continue
 		}
 		if err := os.RemoveAll(dir); err != nil {
 			klog.Warningf("failed to delete dir %s, err: %v", dir, err)

--- a/keadm/cmd/keadm/app/cmd/util/reset_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/reset_test.go
@@ -216,4 +216,32 @@ func TestCleanDirectories(t *testing.T) {
 			t.Errorf("CleanDirectories(false) with removal failure should still return nil, got: %v", err)
 		}
 	})
+
+	t.Run("MissingDirectoryDoesNotStopCleanup", func(t *testing.T) {
+		patches.Reset()
+
+		statCalls := 0
+
+		patches.ApplyFunc(os.Stat,
+			func(string) (os.FileInfo, error) {
+				statCalls++
+				if statCalls == 2 {
+					return nil, os.ErrNotExist
+				}
+				return nil, nil
+			})
+
+		patches.ApplyFunc(os.IsNotExist,
+			func(err error) bool {
+				return errors.Is(err, os.ErrNotExist)
+			})
+
+		if err := CleanDirectories(false); err != nil {
+			t.Errorf("CleanDirectories(false) failed: %v", err)
+		}
+
+		if statCalls != 4 {
+			t.Fatalf("expected cleanup to continue checking remaining directories, got %d stat calls", statCalls)
+		}
+	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes `CleanDirectories` in `keadm/cmd/keadm/app/cmd/util/reset.go`.

Previously, when one directory in the cleanup list did not exist, `CleanDirectories` returned immediately and skipped the remaining directories.
This change makes the cleanup continue with the rest of the paths instead of exiting early.

A regression test is also added to verify that a missing directory does not stop subsequent cleanup checks.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

This is a small behavior fix in the reset cleanup flow.
The change is limited to replacing the early return on `os.IsNotExist(err)` with `continue`, plus a regression test.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed `keadm reset` cleanup flow so that missing directories no longer stop