### PR TITLE
keadm: return on edgecore config parse failure in debug collect

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/collect.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect.go
@@ -96,7 +96,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 	edgeconfig, err := util.ParseEdgecoreConfig(collectOptions.Config)
 
 	if err != nil {
-		fmt.Printf("fail to load edgecore config: %s", err.Error())
+		return fmt.Errorf("fail to load edgecore config: %w", err)
 	}
 	err = collectEdgecoreData(fmt.Sprintf("%s/edgecore", tmpName), edgeconfig, collectOptions)
 	if err != nil {

--- a/keadm/cmd/keadm/app/cmd/debug/collect_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect_test.go
@@ -562,6 +562,24 @@ func TestExecuteCollect(t *testing.T) {
 	})
 	defer collectSystemSuccessPatch.Reset()
 
+	parseConfigPatch.Reset()
+	parseConfigErrorPatch := gomonkey.ApplyFunc(util.ParseEdgecoreConfig, func(configPath string) (*v1alpha2.EdgeCoreConfig, error) {
+		return nil, errors.New("config parse failed")
+	})
+	defer parseConfigErrorPatch.Reset()
+
+	err = ExecuteCollect(opts)
+	assert.Error(err)
+	assert.Contains(err.Error(), "fail to load edgecore config")
+	assert.Contains(err.Error(), "config parse failed")
+
+	parseConfigErrorPatch.Reset()
+	parseConfigSuccessPatch := gomonkey.ApplyFunc(util.ParseEdgecoreConfig, func(configPath string) (*v1alpha2.EdgeCoreConfig, error) {
+		assert.Equal(opts.Config, configPath)
+		return config, nil
+	})
+	defer parseConfigSuccessPatch.Reset()
+
 	compressPatch.Reset()
 	compressErrorPatch := gomonkey.ApplyFunc(util.Compress, func(zipName string, sources []string) error {
 		return errors.New("compression failed")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes the error handling in `keadm debug collect`.

Previously, when parsing the edgecore config failed, `ExecuteCollect` only printed the error and continued executing.
This could pass a nil config into the following collection flow and lead to unexpected failures.

This change makes `keadm debug collect` return immediately when edgecore config parsing fails.

A corresponding test case is added to cover this failure path.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

This PR is intentionally scoped to the config parse failure path in `ExecuteCollect`.
It does not change other debug collect behaviors.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed `keadm debug collect` to return immediately when parsing the edgecore config fails.