### PR TITLE
keadm: fall back to default db path in debug get validate

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/get.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get.go
@@ -227,7 +227,8 @@ func (g *GetOptions) Validate(args []string) error {
 		return fmt.Errorf("unrecognized resource type: %v. ", args[0])
 	}
 	if len(g.DataPath) == 0 {
-		fmt.Printf("not specified the EdgeCore database path, use the default path: %v. ", g.DataPath)
+		g.DataPath = edgecoreCfg.DataBaseDataSource
+		fmt.Printf("not specified the EdgeCore database path, use the default path: %v.\n", g.DataPath)
 	}
 	if !isFileExist(g.DataPath) {
 		return fmt.Errorf("edgeCore database file %v not exist. ", g.DataPath)

--- a/keadm/cmd/keadm/app/cmd/debug/get_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+
+	edgecoreCfg "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+)
+
+func TestValidateUsesDefaultDataPathWhenNotSpecified(t *testing.T) {
+	getOptions := NewGetOptions()
+	getOptions.DataPath = ""
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(isFileExist, func(path string) bool {
+		return path == edgecoreCfg.DataBaseDataSource
+	})
+	patches.ApplyFunc(InitDB, func(driverName, dbName, dataSource string) error {
+		assert.Equal(t, edgecoreCfg.DataBaseDataSource, dataSource)
+		return nil
+	})
+
+	err := getOptions.Validate([]string{"pod"})
+
+	assert.NoError(t, err)
+	assert.Equal(t, edgecoreCfg.DataBaseDataSource, getOptions.DataPath)
+}


### PR DESCRIPTION


**What this PR does / why we need it**:

This PR fixes the validation logic in `keadm debug get`.

Previously, when `edgedb-path` was not specified, the command printed that it would use the default database path, but it did not actually assign the default value before validating the file path.
As a result, validation still used an empty path and failed unexpectedly.

This change makes `keadm debug get` fall back to `edgecoreCfg.DataBaseDataSource` when the database path is empty.

A unit test is also added to verify this fallback behavior.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

This PR is intentionally scoped to the default database path fallback in `GetOptions.Validate`.
It does not change other debug get behaviors.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed `keadm debug get` so it correctly falls back to the default EdgeCore database path when `edgedb-path` is not specified.