### PR TITLE
fix serviceaccountaccess status sync

### DIFF
--- a/cloud/pkg/policycontroller/manager/reconcile.go
+++ b/cloud/pkg/policycontroller/manager/reconcile.go
@@ -440,12 +440,14 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 	} else {
 		addNodes := subtractSlice(acc.Status.NodeList, nodes)
 		klog.V(4).Infof("serviceaccountaccess spec %s/%s is up to date", acc.Namespace, acc.Name)
-		if len(addNodes) != 0 {
+		if !equality.Semantic.DeepEqual(acc.Status.NodeList, nodes) {
 			acc.Status.NodeList = append([]string{}, nodes...)
 			if err := c.Client.Status().Update(ctx, acc); err != nil {
 				klog.Errorf("failed to update serviceaccountaccess status %s/%s, %v", acc.Namespace, acc.Name, err)
 				return controllerruntime.Result{Requeue: true}, err
 			}
+		}
+		if len(addNodes) != 0 {
 			c.send2Edge(acc, addNodes, model.InsertOperation)
 		}
 	}

--- a/cloud/pkg/policycontroller/manager/reconcile_test.go
+++ b/cloud/pkg/policycontroller/manager/reconcile_test.go
@@ -1696,6 +1696,22 @@ func TestSyncRules(t *testing.T) {
 			msgOpr: []string{model.InsertOperation},
 		},
 		{
+			name:  "delete only updates status",
+			input: saa2.DeepCopy(),
+			obj: []client.Object{saa2.DeepCopy(), pod1.DeepCopy(), sa1.DeepCopy(), rb1.DeepCopy(),
+				crb1.DeepCopy(), cr1.DeepCopy(), role1.DeepCopy()},
+			reconcileResult: controllerruntime.Result{},
+			output: &policyv1alpha1.ServiceAccountAccess{ObjectMeta: metav1.ObjectMeta{Name: "sa1", Namespace: "my-namespace"},
+				Spec: policyv1alpha1.AccessSpec{
+					ServiceAccount:           *sa1.DeepCopy(),
+					AccessRoleBinding:        []policyv1alpha1.AccessRoleBinding{{RoleBinding: *rb1.DeepCopy(), Rules: role1.Rules}},
+					AccessClusterRoleBinding: []policyv1alpha1.AccessClusterRoleBinding{{ClusterRoleBinding: *crb1.DeepCopy(), Rules: cr1.Rules}},
+				},
+				Status: policyv1alpha1.AccessStatus{NodeList: []string{"my-node"}},
+			},
+			msgOpr: []string{model.DeleteOperation},
+		},
+		{
 			name:  "reconcile failed cause serviceaccountaccess not found",
 			input: saaDiffName.DeepCopy(),
 			obj: []client.Object{saa1.DeepCopy(), pod1.DeepCopy(), pod2.DeepCopy(), sa1.DeepCopy(), rb1.DeepCopy(),


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When the reconciled spec is unchanged, the controller already sends `DeleteOperation` for nodes that no longer need the access object, but it only updates `status.nodeList` when there are added nodes. That leaves stale nodes in status.
A stale `status.nodeList` can later suppress the re-insert path, so the controller thinks the edge node already has the `ServiceAccountAccess` object even though it was deleted from edge storage.

This PR updates `status.nodeList` whenever the computed node set changes, including delete-only reconciliations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6581

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
