### PR TITLE
fix: keadm config-update --set report err:`Modules.Edged.: No such field: in Config`

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/configupdate.go
+++ b/keadm/cmd/keadm/app/cmd/edge/configupdate.go
@@ -17,16 +17,20 @@ limitations under the License.
 package edge
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
-	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/helm"
 	upgrdeedge "github.com/kubeedge/kubeedge/pkg/upgrade/edge"
+	pkgutil "github.com/kubeedge/kubeedge/pkg/util"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 )
 
@@ -90,20 +94,21 @@ func (executor *configUpdateExecutor) configUpdate(opts ConfigUpdateOptions) err
 	if err != nil {
 		return fmt.Errorf("failed to read configfile %s, err: %v", opts.Config, err)
 	}
+	sets := strings.Split(opts.Sets, ",")
+	mergedData, err := helm.MergeSetsToBytes(data, sets)
+	if err != nil {
+		return fmt.Errorf("failed to merge sets to edgecore's config with err:%v", err)
+	}
 	edgeConfigure := &v1alpha2.EdgeCoreConfig{}
-	err = yaml.Unmarshal(data, edgeConfigure)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal configfile %s, err: %v", opts.Config, err)
+	//Check if there are any unknown fields in the set.
+	if err = yaml.UnmarshalStrict(mergedData, edgeConfigure); err != nil {
+		return err
 	}
-
-	err = util.ParseSet(edgeConfigure, opts.Sets)
-	if err != nil {
-		return fmt.Errorf("failed to parse sets value to config file: %v", err)
+	if errs := validation.ValidateEdgeCoreConfiguration(edgeConfigure); len(errs) > 0 {
+		return errors.New(pkgutil.SpliceErrors(errs.ToAggregate().Errors()))
 	}
-
-	err = edgeConfigure.WriteTo(opts.Config)
-	if err != nil {
-		return fmt.Errorf("failed to write new edgecore config: %v", err)
+	if err = writeFile(opts.Config, mergedData); err != nil {
+		return err
 	}
 
 	cmd := execs.NewCommand("sudo systemctl restart edgecore.service")
@@ -111,6 +116,15 @@ func (executor *configUpdateExecutor) configUpdate(opts ConfigUpdateOptions) err
 	if err != nil {
 		return fmt.Errorf("failed restart edgecore %v", err)
 	}
-
 	return nil
+}
+
+func writeFile(filename string, data []byte) error {
+	fileInfo, err := os.Stat(filename)
+	if err != nil {
+		// If the file does not exist, the default permissions are 0644.
+		return os.WriteFile(filename, data, 0644)
+	}
+	// Write the file using the original file permissions.
+	return os.WriteFile(filename, data, fileInfo.Mode())
 }

--- a/keadm/cmd/keadm/app/cmd/edge/join_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_others.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/helm"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/extsystem"
 	"github.com/kubeedge/kubeedge/pkg/containers"
@@ -172,12 +173,22 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 	if len(opt.Labels) > 0 {
 		edgeCoreConfig.Modules.Edged.NodeLabels = setEdgedNodeLabels(opt)
 	}
+
 	if len(opt.Sets) > 0 {
-		for _, set := range opt.Sets {
-			if err := util.ParseSet(edgeCoreConfig, set); err != nil {
-				return err
-			}
+		data, err := yaml.Marshal(edgeCoreConfig)
+		if err != nil {
+			return err
 		}
+		mergedData, err := helm.MergeSetsToBytes(data, opt.Sets)
+		if err != nil {
+			return fmt.Errorf("failed to merge sets to edgecore's config with err:%v", err)
+		}
+		edgeConfigure := &v1alpha2.EdgeCoreConfig{}
+		//Check if there are any unknown fields in the set.
+		if err := yaml.UnmarshalStrict(mergedData, edgeConfigure); err != nil {
+			return err
+		}
+		edgeCoreConfig = edgeConfigure
 	}
 
 	if errs := validation.ValidateEdgeCoreConfiguration(edgeCoreConfig); len(errs) > 0 {

--- a/keadm/cmd/keadm/app/cmd/edge/join_windows.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_windows.go
@@ -30,13 +30,14 @@ import (
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
 	apiconsts "github.com/kubeedge/api/apis/common/constants"
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/helm"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	extsys "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/extsystem"
 	pkgutil "github.com/kubeedge/kubeedge/pkg/util"
@@ -165,11 +166,20 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 	}
 
 	if len(opt.Sets) > 0 {
-		for _, set := range opt.Sets {
-			if err := util.ParseSet(edgeCoreConfig, set); err != nil {
-				return err
-			}
+		data, err := yaml.Marshal(edgeCoreConfig)
+		if err != nil {
+			return err
 		}
+		mergedData, err := helm.MergeSetsToBytes(data, opt.Sets)
+		if err != nil {
+			return fmt.Errorf("failed to merge sets to edgecore's config with err:%v", err)
+		}
+		edgeConfigure := &v1alpha2.EdgeCoreConfig{}
+		//Check if there are any unknown fields in the set.
+		if err := yaml.UnmarshalStrict(mergedData, edgeConfigure); err != nil {
+			return err
+		}
+		edgeCoreConfig = edgeConfigure
 	}
 
 	if errs := validation.ValidateEdgeCoreConfiguration(edgeCoreConfig); len(errs) > 0 {

--- a/keadm/cmd/keadm/app/cmd/helm/values.go
+++ b/keadm/cmd/keadm/app/cmd/helm/values.go
@@ -129,3 +129,22 @@ func readFile(filePath string) ([]byte, error) {
 	}
 	return os.ReadFile(filePath)
 }
+
+func MergeSetsToBytes(data []byte, sets []string) ([]byte, error) {
+	valuesMap := make(map[string]interface{})
+	var originalMap map[string]interface{}
+	if err := yaml.Unmarshal(data, &originalMap); err != nil {
+		return nil, err
+	}
+	for _, set := range sets {
+		if err := strvals.ParseInto(set, valuesMap); err != nil {
+			return nil, err
+		}
+	}
+	mergedMap := mergeMaps(originalMap, valuesMap)
+	mergedData, err := yaml.Marshal(mergedMap)
+	if err != nil {
+		return nil, err
+	}
+	return mergedData, nil
+}

--- a/keadm/cmd/keadm/app/cmd/helm/values_test.go
+++ b/keadm/cmd/keadm/app/cmd/helm/values_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"sigs.k8s.io/yaml"
 )
 
 func TestOptionsWithEmptyValues(t *testing.T) {
@@ -236,5 +238,88 @@ func TestReadFile(t *testing.T) {
 	_, err := readFile(filePath)
 	if err == nil {
 		t.Fatalf("Expected error when has special strings")
+	}
+}
+
+func TestMergeSetsToBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		sets    []string
+		wantMap map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name:    "merge with additional key",
+			data:    []byte("foo: bar\n"),
+			sets:    []string{"baz=qux"},
+			wantMap: map[string]interface{}{"foo": "bar", "baz": "qux"},
+		},
+		{
+			name:    "override existing key",
+			data:    []byte("foo: bar\n"),
+			sets:    []string{"foo=new"},
+			wantMap: map[string]interface{}{"foo": "new"},
+		},
+		{
+			name: "nested key merge",
+			data: []byte("a:\n  b: 1\n"),
+			sets: []string{"a.c=2"},
+			wantMap: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": float64(1),
+					"c": float64(2),
+				},
+			},
+		},
+		{
+			name:    "empty data with sets",
+			data:    []byte("{}\n"),
+			sets:    []string{"key=value"},
+			wantMap: map[string]interface{}{"key": "value"},
+		},
+		{
+			name:    "empty sets, data unchanged",
+			data:    []byte("foo: bar\n"),
+			sets:    nil,
+			wantMap: map[string]interface{}{"foo": "bar"},
+		},
+		{
+			name:    "invalid yaml data",
+			data:    []byte("invalid: : yaml"),
+			sets:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "invalid set format",
+			data:    []byte("foo: bar\n"),
+			sets:    []string{"invalid set without equals"},
+			wantErr: true,
+		},
+		{
+			name:    "multiple sets",
+			data:    []byte("existing: value\n"),
+			sets:    []string{"new1=val1", "new2=val2"},
+			wantMap: map[string]interface{}{"existing": "value", "new1": "val1", "new2": "val2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBytes, err := MergeSetsToBytes(tt.data, tt.sets)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MergeSetsToBytes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			var gotMap map[string]interface{}
+			if err := yaml.Unmarshal(gotBytes, &gotMap); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if !reflect.DeepEqual(gotMap, tt.wantMap) {
+				t.Errorf("MergeSetsToBytes() gotMap = %v, want %v", gotMap, tt.wantMap)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
`--set` did not consider anonymous referencing of structures. for example:

type Edged struct {
......
	TailoredKubeletConfig *TailoredKubeletConfiguration `json:"tailoredKubeletConfig"`
......
}


Unified use of the helm interface for processing sets, abandoning set.go in KubeEdge.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeedge/kubeedge/issues/6721

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
