### PR TITLE
admissioncontroller: set minimum TLS version to 1.2 in configTLS

### DIFF
--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -135,6 +135,7 @@ func configTLS(opt *options.AdmissionOptions, restConfig *restclient.Config) (*t
 
 		return &tls.Config{
 			Certificates: []tls.Certificate{sCert},
+			MinVersion:   tls.VersionTLS12,
 		}, nil
 	}
 
@@ -146,6 +147,7 @@ func configTLS(opt *options.AdmissionOptions, restConfig *restclient.Config) (*t
 
 		return &tls.Config{
 			Certificates: []tls.Certificate{sCert},
+			MinVersion:   tls.VersionTLS12,
 		}, nil
 	}
 	return nil, errors.New("tls: failed to find any tls config data")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
configTLS was creating tls.Config without setting MinVersion which means the admission webhook server would accept TLS 1.0 and TLS 1.1 connections. Both are deprecated by RFC 8996 and considered insecure. The admission webhook handles sensitive operations like device validation, rule validation and node upgrade jobs so accepting weak TLS versions is a real security gap. Added MinVersion: tls.VersionTLS12 to both return paths in configTLS.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The cloudhub server already sets MinVersion: tls.VersionTLS12 explicitly. This brings the admission controller in line with that same standard. Zero behavior impact for any client using TLS 1.2 or higher which is every modern Kubernetes component.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```