### PR TITLE
admissioncontroller: fix JSON patch operation from replace to add for NodeUpgradeJob defaults

### DIFF
--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
@@ -94,10 +94,10 @@ func validateNodeUpgradeJob(upgrade *v1alpha1.NodeUpgradeJob) error {
 
 	// we must specify NodeNames or LabelSelector, and we can only specify only one
 	if len(upgrade.Spec.NodeNames) == 0 && upgrade.Spec.LabelSelector == nil {
-		return fmt.Errorf("both NodeNames and LabelSelctor are NOT specified")
+		return fmt.Errorf("both NodeNames and LabelSelector are NOT specified")
 	}
 	if len(upgrade.Spec.NodeNames) != 0 && upgrade.Spec.LabelSelector != nil {
-		return fmt.Errorf("both NodeNames and LabelSelctor are specified")
+		return fmt.Errorf("both NodeNames and LabelSelector are specified")
 	}
 
 	return nil
@@ -151,7 +151,7 @@ func generateNodeUpgradeJobPatch(spec v1alpha1.NodeUpgradeJobSpec) []patchValue 
 	// mutate .spec.concurrency to default value 1 if not specified
 	if spec.Concurrency == 0 {
 		patch = append(patch, patchValue{
-			Op:    "replace",
+			Op:    "add",
 			Path:  "/spec/concurrency",
 			Value: 1,
 		})
@@ -160,7 +160,7 @@ func generateNodeUpgradeJobPatch(spec v1alpha1.NodeUpgradeJobSpec) []patchValue 
 	if spec.TimeoutSeconds == nil {
 		var defaultTimeoutSeconds uint32 = 300
 		patch = append(patch, patchValue{
-			Op:    "replace",
+			Op:    "add",
 			Path:  "/spec/timeoutSeconds",
 			Value: &defaultTimeoutSeconds,
 		})

--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
@@ -84,7 +84,7 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 				},
 			},
 			expectedAllowed: false,
-			expectedError:   "both NodeNames and LabelSelctor are NOT specified",
+			expectedError:   "both NodeNames and LabelSelector are NOT specified",
 		},
 		{
 			name:      "Both NodeNames and LabelSelector",
@@ -97,7 +97,7 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 				},
 			},
 			expectedAllowed: false,
-			expectedError:   "both NodeNames and LabelSelctor are specified",
+			expectedError:   "both NodeNames and LabelSelector are specified",
 		},
 		{
 			name:      "Valid Update",
@@ -216,7 +216,7 @@ func TestValidateNodeUpgradeJob(t *testing.T) {
 					Version: "v1.0.0",
 				},
 			},
-			expectedErr: "both NodeNames and LabelSelctor are NOT specified",
+			expectedErr: "both NodeNames and LabelSelector are NOT specified",
 		},
 		{
 			name: "Both NodeNames and LabelSelector specified",
@@ -227,7 +227,7 @@ func TestValidateNodeUpgradeJob(t *testing.T) {
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
-			expectedErr: "both NodeNames and LabelSelctor are specified",
+			expectedErr: "both NodeNames and LabelSelector are specified",
 		},
 		{
 			name: "Valid upgrade job",
@@ -322,10 +322,10 @@ func TestMutatingNodeUpgradeJob(t *testing.T) {
 	err = json.Unmarshal(response.Patch, &patch)
 	assert.NoError(err)
 	assert.Len(patch, 2)
-	assert.Equal("replace", patch[0]["op"])
+	assert.Equal("add", patch[0]["op"])
 	assert.Equal("/spec/concurrency", patch[0]["path"])
 	assert.Equal(float64(1), patch[0]["value"])
-	assert.Equal("replace", patch[1]["op"])
+	assert.Equal("add", patch[1]["op"])
 	assert.Equal("/spec/timeoutSeconds", patch[1]["path"])
 	assert.Equal(float64(300), patch[1]["value"])
 }
@@ -356,12 +356,12 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 			expectedPatch: []patchValue{
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/concurrency",
 					Value: 1,
 				},
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/timeoutSeconds",
 					Value: func() *uint32 { v := uint32(300); return &v }(),
 				},
@@ -376,7 +376,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 			expectedPatch: []patchValue{
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/concurrency",
 					Value: 1,
 				},
@@ -391,7 +391,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 			expectedPatch: []patchValue{
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/timeoutSeconds",
 					Value: func() *uint32 { v := uint32(300); return &v }(),
 				},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`generateNodeUpgradeJobPatch` was using the "replace" JSON Patch operation to set default values for concurrency and `timeoutSeconds` when they are not specified in the spec. Per RFC 6902, the "replace" operation requires the target field to already exist in the object. If concurrency or `timeoutSeconds` are omitted from the spec entirely, the patch fails and the `NodeUpgradeJob` creation would be rejected with a confusing error. Changed both patch operations from "replace" to "add" which correctly handles the case where the field may not exist. Updated the tests to reflect the corrected operation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
RFC 6902 defines "replace" as requiring the target location to exist and "add" as creating the field if it does not exist. Using "replace" on an absent field causes the entire patch to fail.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```