### PR TITLE
cloudhub/dispatcher: improve coverage of message_dispatcher

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package dispatcher provides message dispatching functionality for cloudhub.
 package dispatcher
 
 import (

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -405,3 +405,138 @@ func TestDeleteNodeMessagePool(t *testing.T) {
 		t.Errorf("expected pool not exist but got it")
 	}
 }
+
+func TestEnqueueNoAckMessage(t *testing.T) {
+	client := &fake.Clientset{}
+	manager := session.NewSessionManager(10)
+
+	objectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ObjectSyncs()
+	clusterObjectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ClusterObjectSyncs()
+
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncInformer.Lister(),
+		clusterObjectSyncLister: clusterObjectSyncInformer.Lister(),
+	}
+
+	nmp := common.InitNodeMessagePool(tf.TestNodeID)
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp)
+
+	msg := beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/podlist", "response")
+	dispatcher.enqueueNoAckMessage(tf.TestNodeID, msg)
+
+	if nmp.NoAckMessageStore.List() == nil {
+		t.Errorf("expected message in store but got nil")
+	}
+}
+
+func TestIsVolumeOperation(t *testing.T) {
+	tests := []struct {
+		name string
+		op   string
+		want bool
+	}{
+		{name: "createvolume", op: "createvolume", want: true},
+		{name: "deletevolume", op: "deletevolume", want: true},
+		{name: "controllerpublishvolume", op: "controllerpublishvolume", want: true},
+		{name: "controllerunpublishvolume", op: "controllerunpublishvolume", want: true},
+		{name: "update", op: "update", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isVolumeOperation(tt.op); got != tt.want {
+				t.Errorf("isVolumeOperation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDeleteMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message *beehivemodel.Message
+		want    bool
+	}{
+		{
+			name:    "delete operation",
+			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/pod/test-pod", "delete"),
+			want:    true,
+		},
+		{
+			name:    "update operation",
+			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/pod/test-pod", "update"),
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDeleteMessage(tt.message); got != tt.want {
+				t.Errorf("isDeleteMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetNodeMessagePool_NotFound(t *testing.T) {
+	client := &fake.Clientset{}
+	manager := session.NewSessionManager(10)
+
+	objectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ObjectSyncs()
+	clusterObjectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ClusterObjectSyncs()
+
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncInformer.Lister(),
+		clusterObjectSyncLister: clusterObjectSyncInformer.Lister(),
+	}
+
+	pool := dispatcher.GetNodeMessagePool("non-existent-node")
+	if pool == nil {
+		t.Errorf("expected pool to be created but got nil")
+	}
+}
+
+func TestDeleteNodeMessagePool_NotFound(t *testing.T) {
+	client := &fake.Clientset{}
+	manager := session.NewSessionManager(10)
+
+	objectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ObjectSyncs()
+	clusterObjectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ClusterObjectSyncs()
+
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncInformer.Lister(),
+		clusterObjectSyncLister: clusterObjectSyncInformer.Lister(),
+	}
+
+	dispatcher.DeleteNodeMessagePool("non-existent-node", nil)
+}
+
+func TestDeleteNodeMessagePool_WrongPool(t *testing.T) {
+	client := &fake.Clientset{}
+	manager := session.NewSessionManager(10)
+
+	objectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ObjectSyncs()
+	clusterObjectSyncInformer := syncinformer.NewSharedInformerFactory(client, 0).Reliablesyncs().V1alpha1().ClusterObjectSyncs()
+
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncInformer.Lister(),
+		clusterObjectSyncLister: clusterObjectSyncInformer.Lister(),
+	}
+
+	nmp1 := common.InitNodeMessagePool(tf.TestNodeID)
+	nmp2 := common.InitNodeMessagePool(tf.TestNodeID)
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp1)
+
+	dispatcher.DeleteNodeMessagePool(tf.TestNodeID, nmp2)
+
+	_, exist := dispatcher.NodeMessagePools.Load(tf.TestNodeID)
+	if !exist {
+		t.Errorf("expected pool to still exist but it was deleted")
+	}
+}

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -36,6 +36,10 @@ import (
 	mockcon "github.com/kubeedge/kubeedge/pkg/viaduct/pkg/conn/testing"
 )
 
+const (
+	testNodeName = "edge-node"
+)
+
 func TestNoAckRequired(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -115,23 +119,24 @@ func TestGetNodeID(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "normal message",
+			name:    "pod update message",
 			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/pod/test-pod", "update").SetRoute("edgecontroller", "resource"),
-			want:    "edge-node",
+			want:    testNodeName,
 			wantErr: false,
 		},
 		{
-			name:    "normal message",
+			name:    "configmap update message",
 			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/default/configmap/kube-root-ca.crt", "update").SetRoute("edgecontroller", "resource"),
-			want:    "edge-node",
+			want:    testNodeName,
 			wantErr: false,
 		},
 		{
-			name:    "normal message",
+			name:    "membership detail message",
 			message: beehivemodel.NewMessage("").SetResourceOperation("node/edge-node/membership/detail", "update").SetRoute("devicecontroller", "resource"),
-			want:    "edge-node",
+			want:    testNodeName,
 			wantErr: false,
 		},
+
 		{
 			name:    "bad message",
 			message: beehivemodel.NewMessage("").SetResourceOperation("edge-node/membership/detail", "update").SetRoute("edgecontroller", "resource"),
@@ -498,7 +503,7 @@ func TestGetNodeMessagePool_NotFound(t *testing.T) {
 	}
 }
 
-func TestDeleteNodeMessagePool_NotFound(t *testing.T) {
+func TestDeleteNodeMessagePool_NotFound(_ *testing.T) {
 	client := &fake.Clientset{}
 	manager := session.NewSessionManager(10)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Added unit tests for previously untested functions in message_dispatcher.go. The added tests cover enqueueNoAckMessage, isVolumeOperation, isDeleteMessage, the not-found path in GetNodeMessagePool, and both edge cases in DeleteNodeMessagePool where the pool is not found and where a different pool instance is passed. Coverage improved from 46% to 53.5%.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The remaining uncovered functions like DispatchDownstream, DispatchUpstream and Publish require beehive context and session manager infrastructure that cannot be set up in unit tests without a full integration environment.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```