### PR TITLE
udsserver: fix partial read truncation in handleServerConn

### DIFF
--- a/cloud/pkg/cloudhub/servers/udsserver/uds.go
+++ b/cloud/pkg/cloudhub/servers/udsserver/uds.go
@@ -2,6 +2,7 @@ package udsserver
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -83,13 +84,16 @@ func (us *UnixDomainSocket) StartServer() error {
 // handleServerConn handler for server
 func (us *UnixDomainSocket) handleServerConn(c net.Conn) {
 	defer c.Close()
-	buf := make([]byte, us.buffersize)
-	nr, err := c.Read(buf)
+	data, err := io.ReadAll(io.LimitReader(c, int64(us.buffersize)+1))
 	if err != nil {
 		klog.Errorf("failed to read buffer: %v", err)
 		return
 	}
-	result := us.handleServerContext(string(buf[0:nr]))
+	if len(data) > us.buffersize {
+		klog.Errorf("failed to read buffer: request exceeds maximum size of %d bytes", us.buffersize)
+		return
+	}
+	result := us.handleServerContext(string(data))
 	_, err = c.Write([]byte(result))
 	if err != nil {
 		klog.Errorf("failed to write buffer: %v", err)

--- a/cloud/pkg/cloudhub/servers/udsserver/uds.go
+++ b/cloud/pkg/cloudhub/servers/udsserver/uds.go
@@ -2,6 +2,7 @@ package udsserver
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -83,13 +84,16 @@ func (us *UnixDomainSocket) StartServer() error {
 // handleServerConn handler for server
 func (us *UnixDomainSocket) handleServerConn(c net.Conn) {
 	defer c.Close()
-	buf := make([]byte, us.buffersize)
-	nr, err := c.Read(buf)
+	data, err := io.ReadAll(io.LimitReader(c, int64(us.buffersize)+1))
 	if err != nil {
 		klog.Errorf("failed to read buffer: %v", err)
 		return
 	}
-	result := us.handleServerContext(string(buf[0:nr]))
+	if len(data) > us.buffersize {
+		klog.Errorf("failed to read buffer: request exceeds maximum size of %d bytes, remote addr: %s", us.buffersize, c.RemoteAddr())
+		return
+	}
+	result := us.handleServerContext(string(data))
 	_, err = c.Write([]byte(result))
 	if err != nil {
 		klog.Errorf("failed to write buffer: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
handleServerConn was using a single c.Read call with a fixed size buffer to read incoming data. A single Read on a Unix domain socket or TCP connection is not guaranteed to return the full message — it can return a partial read if the message is larger than the buffer or if the kernel splits it. This meant messages larger than 10480 bytes would be silently truncated and the handler would process incomplete data with no error. Fixed by using io.ReadAll which reads until EOF ensuring the complete message is always received.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The buffersize field and DefaultBufferSize constant are kept for backwards compatibility since they are part of the exported API via NewUnixDomainSocket.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```