### PR TITLE
fix: enforce WebSocket read deadline to prevent indefinite connection hang

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -118,6 +118,14 @@ func (wsc *WebSocketClient) Send(message model.Message) error {
 // Receive reads the binary message through the connection
 func (wsc *WebSocketClient) Receive() (model.Message, error) {
 	message := model.Message{}
+	if wsc.connection == nil {
+		return message, fmt.Errorf("web socket connection is closed")
+	}
+	if wsc.config.ReadDeadline > 0 {
+		if err := wsc.connection.SetReadDeadline(time.Now().Add(wsc.config.ReadDeadline)); err != nil {
+			return message, err
+		}
+	}
 	err := wsc.connection.ReadMessage(&message)
 	return message, err
 }

--- a/pkg/viaduct/pkg/conn/ws.go
+++ b/pkg/viaduct/pkg/conn/ws.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -109,6 +110,7 @@ func (conn *WSConnection) handleMessage() {
 			}
 			conn.state.State = api.StatDisconnected
 			_ = conn.wsConn.Close()
+			conn.messageFifo.Close()
 
 			if conn.OnReadTransportErr != nil {
 				conn.OnReadTransportErr(conn.state.Headers.Get("node_id"),
@@ -151,12 +153,18 @@ func (conn *WSConnection) handleMessage() {
 
 func (conn *WSConnection) SetReadDeadline(t time.Time) error {
 	conn.ReadDeadline = t
-	return nil
+	if conn.wsConn == nil {
+		return fmt.Errorf("connection not established")
+	}
+	return conn.wsConn.SetReadDeadline(t)
 }
 
 func (conn *WSConnection) SetWriteDeadline(t time.Time) error {
 	conn.WriteDeadline = t
-	return nil
+	if conn.wsConn == nil {
+		return fmt.Errorf("connection not established")
+	}
+	return conn.wsConn.SetWriteDeadline(t)
 }
 
 func (conn *WSConnection) Read(raw []byte) (int, error) {


### PR DESCRIPTION
The configured read deadline was never actually applied to the underlying WebSocket connection `SetReadDeadline` on `WSConnection` stored the value but didn't call through to `wsConn.SetReadDeadline`, so connections would hang forever when the cloud went silent. On top of that, when the read goroutine exited on error it left the message fifo open, meaning `Receive()` would stay blocked even after the timeout fired. This fixes both issues and mirrors the existing write deadline pattern in `Send()`. Fix for the issue #6434