### PR TITLE
cloudhub: register node message pool before connect event

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -215,6 +215,10 @@ func (md *messageDispatcher) PubToController(info *model.HubInfo, msg *beehivemo
 
 func (md *messageDispatcher) enqueueNoAckMessage(nodeID string, msg *beehivemodel.Message) {
 	nodeMessagePool := md.GetNodeMessagePool(nodeID)
+	if nodeMessagePool == nil {
+		klog.Errorf("drop no-ack message for node %s, no message pool registered: %s", nodeID, msg.String())
+		return
+	}
 
 	messageKey, err := common.NoAckMessageKeyFunc(msg)
 	if err != nil {
@@ -235,6 +239,10 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 	}
 
 	nodeMessagePool := md.GetNodeMessagePool(nodeID)
+	if nodeMessagePool == nil {
+		klog.Errorf("drop ack message for node %s, no message pool registered: %s", nodeID, msg.String())
+		return
+	}
 	nodeQueue := nodeMessagePool.AckMessageQueue
 	nodeStore := nodeMessagePool.AckMessageStore
 
@@ -503,14 +511,16 @@ func isVolumeOperation(op string) bool {
 		op == commonconst.CSIOperationTypeControllerUnpublishVolume
 }
 
-// GetNodeMessagePool returns the message pool for given node
+// GetNodeMessagePool returns the message pool for given node, or nil if the
+// node has no registered pool. Returning nil here is deliberate: silently
+// auto-creating a pool masks lifecycle ordering bugs (the newly-created pool
+// would be overwritten by the real AddNodeMessagePool call, and any messages
+// enqueued to it in the interim would be lost).
 func (md *messageDispatcher) GetNodeMessagePool(nodeID string) *common.NodeMessagePool {
 	nsp, exist := md.NodeMessagePools.Load(nodeID)
 	if !exist {
-		klog.Warningf("message pool for edge node %s not found and created now", nodeID)
-		nodeMessagePool := common.InitNodeMessagePool(nodeID)
-		md.NodeMessagePools.Store(nodeID, nodeMessagePool)
-		return nodeMessagePool
+		klog.Errorf("message pool for edge node %s not found, dropping message", nodeID)
+		return nil
 	}
 
 	return nsp.(*common.NodeMessagePool)

--- a/cloud/pkg/cloudhub/handler/message_handler.go
+++ b/cloud/pkg/cloudhub/handler/message_handler.go
@@ -133,18 +133,22 @@ func (mh *messageHandler) HandleConnection(connection conn.Connection) {
 
 	nodeInfo := &model.HubInfo{ProjectID: projectID, NodeID: nodeID}
 
+	// Register the node message pool in the dispatcher BEFORE publishing the
+	// connect event or starting the session, so any downstream dispatch for
+	// this node routes into this pool rather than into a silently-created
+	// orphan pool that would be overwritten later.
+	nodeMessagePool := common.InitNodeMessagePool(nodeID)
+	mh.MessageDispatcher.AddNodeMessagePool(nodeID, nodeMessagePool)
+
 	if err := mh.OnEdgeNodeConnect(nodeInfo, connection); err != nil {
 		klog.Errorf("publish connect event for node %s, err %v", nodeInfo.NodeID, err)
+		mh.MessageDispatcher.DeleteNodeMessagePool(nodeID, nodeMessagePool)
 		return
 	}
 
 	// start a goroutine for serving the node connection
 	go func() {
 		klog.Infof("edge node %s for project %s connected", nodeInfo.NodeID, nodeInfo.ProjectID)
-
-		// init node message pool and add to the dispatcher
-		nodeMessagePool := common.InitNodeMessagePool(nodeID)
-		mh.MessageDispatcher.AddNodeMessagePool(nodeID, nodeMessagePool)
 
 		keepaliveInterval := time.Duration(mh.KeepaliveInterval) * time.Second
 		// create a node session for each edge node


### PR DESCRIPTION
 /kind bug                                                                                                                                                                   

## What this PR does / why we need it                                                                                                                                       

I found a race condition in how CloudHub registers node message pools when edge nodes connect. Basically, when a new edge node connects, CloudHub publishes a "node connected" event before actually registering the node's message pool in the dispatcher. During that tiny window between the event being published and the pool being registered, if any downstream messages get dispatched for that node, they end up in a silently auto-created pool that gets immediately overwritten. So those messages just disappear.      

The fix is simple: register the message pool first, then publish the connect event. That way any messages that come in during the connect flow go to the right pool. I also   hardened the `GetNodeMessagePool` function to stop silently creating throwaway pools. Now if a pool isn't found, it logs an error and returns nil instead. This makes any similar lifecycle bugs obvious instead of silently dropping messages.                                                                                                       
                                                                                                                                                             
  
  ## Special notes for your reviewer

  The changes are in two files:
  - `message_handler.go`: moved pool registration before the connect event publish, and added rollback if the connect fails
  - `message_dispatcher.go`: changed `GetNodeMessagePool` to fail loudly on miss instead of auto-creating, and updated both enqueue functions to handle nil pools             
This is a pretty small change but it fixes a real edge case that could cause workloads on edge nodes to silently get stale config after reconnects.                                                                                                                                                                                                       
 
 ## Does this PR introduce a user-facing change?                                                                                                                             

  ```release-note
Fixed a race condition in CloudHub where edge node message pools could be silently orphaned during node reconnection, potentially causing loss of downstream messages like pod specs and config updates.        