### PR TITLE
fix/copyResourcesCmd in container_runtime.go

### DIFF
--- a/pkg/containers/container_runtime.go
+++ b/pkg/containers/container_runtime.go
@@ -18,9 +18,12 @@ package containers
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
-	"time"
+    "fmt"
+    "path"           
+    "path/filepath"
+    "sort"
+    "strings"        
+    "time"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -157,14 +160,26 @@ func (runtime *ContainerRuntimeImpl) CopyResources(
 }
 
 func copyResourcesCmd(files map[string]string) string {
+	keys := make([]string, 0, len(files))
+	for containerPath := range files {
+		keys = append(keys, containerPath)
+	}
+	sort.Strings(keys)
+
 	var copyCmd string
 	first := true
-	for containerPath, hostPath := range files {
+	for _, containerPath := range keys {
+		hostPath := files[containerPath]
+
+		safeContainer := strings.ReplaceAll(containerPath, "'", "'\\''")
+		safeHost := strings.ReplaceAll(hostPath, "'", "'\\''")
+
+		cp := fmt.Sprintf("cp '%s' '%s'", safeContainer, path.Join("/tmp", safeHost))
 		if first {
-			copyCmd = copyCmd + fmt.Sprintf("cp %s %s", containerPath, filepath.Join("/tmp", hostPath))
+			copyCmd = cp
 			first = false
 		} else {
-			copyCmd = copyCmd + fmt.Sprintf(" && cp %s %s", containerPath, filepath.Join("/tmp", hostPath))
+			copyCmd = copyCmd + " && " + cp
 		}
 	}
 	return copyCmd


### PR DESCRIPTION
**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:

Fixed `copyResourcesCmd` in `container_runtime.go` , map iteration in Go is randomized, this means the generated shell command changes order on every run. While functionally it still copies all files, it is non-deterministic and makes the command unpredictable for debugging, logging, and any reproducibility guarantees. The fix is to sort the keys before building the command.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Fixed the function copyResourcesCmd in container_runtime.go to sort the keys before building the command using sort.

**Does this PR introduce a user-facing change?**:


```release-note
NONE
```
