### PR TITLE
keadm: run pre-flight checks on Kubernetes cluster health before cloudcore installation

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -96,6 +96,9 @@ func addInitOtherFlags(cmd *cobra.Command, initOpts *types.InitOptions) {
 
 	cmd.Flags().StringVar(&initOpts.ImageRepository, types.FlagNameImageRepository, initOpts.ImageRepository,
 		"Choose a container image repository to pull the image of the kubedge component.")
+
+	cmd.Flags().BoolVar(&initOpts.SkipPreflightChecks, types.FlagNameSkipPreflightChecks, initOpts.SkipPreflightChecks,
+		"Skip pre-flight checks on the Kubernetes cluster health before installing cloudcore.")
 }
 
 func addHelmValueOptionsFlags(cmd *cobra.Command, initOpts *types.InitOptions) {

--- a/keadm/cmd/keadm/app/cmd/common/constant.go
+++ b/keadm/cmd/keadm/app/cmd/common/constant.go
@@ -61,7 +61,8 @@ const (
 // Cloud init flag names
 const (
 	// FlagNameSkipCRDs skip CRDs
-	FlagNameSkipCRDs = "skip-crds"
+	FlagNameSkipCRDs            = "skip-crds"
+	FlagNameSkipPreflightChecks = "skip-preflight-checks"
 
 	// FlagNameMaster sets the address of K8s master
 	// Deprecated: only used in deprecated/init.go

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -71,8 +71,9 @@ func (b CloudInitUpdateBase) HasSets(key string) bool {
 
 // InitOptions defines cloud init flags
 type InitOptions struct {
-	Manifests string
-	SkipCRDs  bool
+	Manifests           string
+	SkipCRDs            bool
+	SkipPreflightChecks bool
 	CloudInitUpdateBase
 }
 

--- a/keadm/cmd/keadm/app/cmd/common/types.go
+++ b/keadm/cmd/keadm/app/cmd/common/types.go
@@ -71,8 +71,9 @@ func (b CloudInitUpdateBase) HasSets(key string) bool {
 
 // InitOptions defines cloud init flags
 type InitOptions struct {
-	Manifests string
-	SkipCRDs  bool
+	Manifests            string
+	SkipCRDs             bool
+	SkipPreflightChecks  bool
 	CloudInitUpdateBase
 }
 

--- a/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
+++ b/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
@@ -106,6 +106,9 @@ func (c *CloudCoreHelmTool) Install(opts *types.InitOptions) error {
 	if err := c.Common.OSTypeInstaller.IsK8SComponentInstalled(c.Common.KubeConfig, c.Common.Master); err != nil {
 		return fmt.Errorf("failed to verify k8s component installed, err: %v", err)
 	}
+	if err := c.runPreflightChecks(opts.KubeConfig, opts.SkipPreflightChecks); err != nil {
+		return err
+	}
 
 	fmt.Printf("Kubernetes version verification passed, KubeEdge %s installation will start...\n", opts.KubeEdgeVersion)
 

--- a/keadm/cmd/keadm/app/cmd/helm/preflight.go
+++ b/keadm/cmd/keadm/app/cmd/helm/preflight.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package helm
+
+import (
+	"context"
+	"fmt"
+
+	authv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+func (c *CloudCoreHelmTool) runPreflightChecks(kubeConfig string, skip bool) error {
+	if skip {
+		fmt.Println("Skipping pre-flight checks.")
+		return nil
+	}
+
+	fmt.Println("Running pre-flight checks...")
+
+	cli, err := util.KubeClient(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("pre-flight check failed: cannot create kube client, err: %v", err)
+	}
+
+	if err := checkNodeReadiness(cli); err != nil {
+		return err
+	}
+	if err := checkCoreDNS(cli); err != nil {
+		return err
+	}
+	if err := checkCloudCorePermissions(cli); err != nil {
+		return err
+	}
+
+	fmt.Println("Pre-flight checks passed.")
+	return nil
+}
+
+// checkNodeReadiness verifies at least one node in the cluster is Ready.
+// cloudcore depends on the node registry being functional before it can schedule edge workloads.
+func checkNodeReadiness(cli kubernetes.Interface) error {
+	nodes, err := cli.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("pre-flight check failed: cannot list nodes, err: %v", err)
+	}
+	if len(nodes.Items) == 0 {
+		return fmt.Errorf("pre-flight check failed: no nodes found in the cluster")
+	}
+	for _, node := range nodes.Items {
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("pre-flight check failed: no node is Ready, the Kubernetes cluster may be unhealthy; " +
+		"run 'kubectl get nodes' to investigate before retrying")
+}
+
+// checkCoreDNS verifies that at least one CoreDNS (or kube-dns) pod is Ready in kube-system.
+// A missing DNS component causes cloudcore webhook and certificate operations to fail silently.
+func checkCoreDNS(cli kubernetes.Interface) error {
+	selectors := []string{"app=coredns", "k8s-app=kube-dns"}
+	for _, sel := range selectors {
+		pods, err := cli.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{
+			LabelSelector: sel,
+		})
+		if err != nil {
+			return fmt.Errorf("pre-flight check failed: cannot list pods in kube-system, err: %v", err)
+		}
+		for _, pod := range pods.Items {
+			if isPodReady(&pod) {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("pre-flight check failed: no Ready CoreDNS/kube-dns pod found in kube-system; " +
+		"DNS must be healthy before installing cloudcore")
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// checkCloudCorePermissions uses SelfSubjectAccessReview to verify the kubeconfig has
+// sufficient privileges for the operations cloudcore requires at install time.
+func checkCloudCorePermissions(cli kubernetes.Interface) error {
+	required := []authv1.ResourceAttributes{
+		{Verb: "list", Resource: "nodes"},
+		{Verb: "list", Resource: "pods"},
+		{Verb: "create", Resource: "namespaces"},
+		{Verb: "create", Resource: "clusterroles", Group: "rbac.authorization.k8s.io"},
+		{Verb: "create", Resource: "clusterrolebindings", Group: "rbac.authorization.k8s.io"},
+	}
+	for _, attr := range required {
+		attr := attr
+		sar := &authv1.SelfSubjectAccessReview{
+			Spec: authv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &attr,
+			},
+		}
+		result, err := cli.AuthorizationV1().SelfSubjectAccessReviews().Create(
+			context.Background(), sar, metav1.CreateOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("pre-flight check failed: cannot verify permissions for %s %s, err: %v",
+				attr.Verb, attr.Resource, err)
+		}
+		if !result.Status.Allowed {
+			return fmt.Errorf("pre-flight check failed: insufficient permissions to %s %s; "+
+				"ensure the kubeconfig has cluster-admin privileges before running keadm init",
+				attr.Verb, attr.Resource)
+		}
+	}
+	return nil
+}

--- a/keadm/cmd/keadm/app/cmd/helm/preflight_test.go
+++ b/keadm/cmd/keadm/app/cmd/helm/preflight_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package helm
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	authv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func newNode(name string, ready corev1.ConditionStatus) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: ready},
+			},
+		},
+	}
+}
+
+func newPod(name, namespace string, labels map[string]string, ready corev1.ConditionStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: ready},
+			},
+		},
+	}
+}
+
+func TestCheckNodeReadiness(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodes     []runtime.Object
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "no nodes in cluster",
+			nodes:     nil,
+			wantErr:   true,
+			errSubstr: "no nodes found",
+		},
+		{
+			name: "all nodes NotReady",
+			nodes: []runtime.Object{
+				newNode("n1", corev1.ConditionFalse),
+				newNode("n2", corev1.ConditionUnknown),
+			},
+			wantErr:   true,
+			errSubstr: "no node is Ready",
+		},
+		{
+			name: "at least one Ready node",
+			nodes: []runtime.Object{
+				newNode("n1", corev1.ConditionFalse),
+				newNode("n2", corev1.ConditionTrue),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset(tt.nodes...)
+			err := checkNodeReadiness(cli)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("checkNodeReadiness() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestCheckNodeReadinessListFails(t *testing.T) {
+	cli := fake.NewSimpleClientset()
+	cli.PrependReactor("list", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("api server unreachable")
+	})
+	err := checkNodeReadiness(cli)
+	if err == nil || !strings.Contains(err.Error(), "cannot list nodes") {
+		t.Fatalf("expected list-nodes error, got %v", err)
+	}
+}
+
+func TestCheckCoreDNS(t *testing.T) {
+	corednsLabels := map[string]string{"app": "coredns"}
+	kubeDNSLabels := map[string]string{"k8s-app": "kube-dns"}
+
+	tests := []struct {
+		name      string
+		pods      []runtime.Object
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "no DNS pods at all",
+			pods:      nil,
+			wantErr:   true,
+			errSubstr: "no Ready CoreDNS/kube-dns pod",
+		},
+		{
+			name: "coredns pod exists but not Ready",
+			pods: []runtime.Object{
+				newPod("coredns-1", "kube-system", corednsLabels, corev1.ConditionFalse),
+			},
+			wantErr:   true,
+			errSubstr: "no Ready CoreDNS/kube-dns pod",
+		},
+		{
+			name: "Ready coredns pod",
+			pods: []runtime.Object{
+				newPod("coredns-1", "kube-system", corednsLabels, corev1.ConditionTrue),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Ready kube-dns pod (legacy label)",
+			pods: []runtime.Object{
+				newPod("kube-dns-1", "kube-system", kubeDNSLabels, corev1.ConditionTrue),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset(tt.pods...)
+			err := checkCoreDNS(cli)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("checkCoreDNS() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestCheckCoreDNSListFails(t *testing.T) {
+	cli := fake.NewSimpleClientset()
+	cli.PrependReactor("list", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+	err := checkCoreDNS(cli)
+	if err == nil || !strings.Contains(err.Error(), "cannot list pods in kube-system") {
+		t.Fatalf("expected list-pods error, got %v", err)
+	}
+}
+
+func TestIsPodReady(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{
+			name: "PodReady=True",
+			pod: &corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			}}},
+			want: true,
+		},
+		{
+			name: "PodReady=False",
+			pod: &corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			}}},
+			want: false,
+		},
+		{
+			name: "no PodReady condition present",
+			pod: &corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+				{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},
+			}}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPodReady(tt.pod); got != tt.want {
+				t.Fatalf("isPodReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckCloudCorePermissions(t *testing.T) {
+	tests := []struct {
+		name      string
+		allow     bool
+		reactErr  error
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "all permissions granted",
+			allow:   true,
+			wantErr: false,
+		},
+		{
+			name:      "permission denied",
+			allow:     false,
+			wantErr:   true,
+			errSubstr: "insufficient permissions",
+		},
+		{
+			name:      "SAR API call fails",
+			reactErr:  errors.New("api server timeout"),
+			wantErr:   true,
+			errSubstr: "cannot verify permissions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset()
+			cli.PrependReactor("create", "selfsubjectaccessreviews",
+				func(action clienttesting.Action) (bool, runtime.Object, error) {
+					return true, &authv1.SelfSubjectAccessReview{
+						Status: authv1.SubjectAccessReviewStatus{Allowed: tt.allow},
+					}, tt.reactErr
+				})
+
+			err := checkCloudCorePermissions(cli)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("checkCloudCorePermissions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Fatalf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before this, `keadm init` would happily proceed through the entire helm installation even when the underlying Kubernetes cluster was broken, unhealthy nodes, missing CoreDNS, or insufficient RBAC permissions only surfaced as cryptic cloudcore failures later. This adds upfront checks for node readiness, CoreDNS availability, and required permissions, with a `--skip-preflight-checks` flag for cases where you knowingly want to bypass them. Fixes #6696.