### PR TITLE
dynamiccontroller: fix concurrent map iteration and map write

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/listener_manager.go
+++ b/cloud/pkg/dynamiccontroller/application/listener_manager.go
@@ -92,7 +92,12 @@ func (lm *listenerManager) GetListenersForNode(nodeName string) map[string]*Sele
 		return nil
 	}
 
-	return listeners
+	// Return a shallow copy so callers can safely iterate without holding the lock.
+	copied := make(map[string]*SelectorListener, len(listeners))
+	for k, v := range listeners {
+		copied[k] = v
+	}
+	return copied
 }
 
 func (lm *listenerManager) GetListenersForGVR(gvr schema.GroupVersionResource) map[string]*SelectorListener {
@@ -104,5 +109,10 @@ func (lm *listenerManager) GetListenersForGVR(gvr schema.GroupVersionResource) m
 		return nil
 	}
 
-	return listeners
+	// Return a shallow copy so callers can safely iterate without holding the lock.
+	copied := make(map[string]*SelectorListener, len(listeners))
+	for k, v := range listeners {
+		copied[k] = v
+	}
+	return copied
 }

--- a/cloud/pkg/dynamiccontroller/application/listener_manager_test.go
+++ b/cloud/pkg/dynamiccontroller/application/listener_manager_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package application
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -154,4 +156,102 @@ func TestGetListenersForGVR(t *testing.T) {
 	nonExistentGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nonexistent"}
 	nonExistentGVRListeners := lm.GetListenersForGVR(nonExistentGVR)
 	assert.Nil(nonExistentGVRListeners)
+}
+
+// TestConcurrentGetListenersForGVR verifies that concurrent Add/Delete/Get
+// operations do not cause a data race.
+func TestConcurrentGetListenersForGVR(t *testing.T) {
+	lm := newListenerManager()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	const numListeners = 100
+	const numIterations = 200
+
+	for i := 0; i < numListeners; i++ {
+		listener := NewSelectorListener(
+			fmt.Sprintf("listener-%d", i),
+			fmt.Sprintf("node-%d", i%10),
+			gvr,
+			NewSelector("", ""),
+		)
+		lm.AddListener(listener)
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listener := NewSelectorListener(
+				fmt.Sprintf("dynamic-listener-%d", i),
+				fmt.Sprintf("node-%d", i%10),
+				gvr,
+				NewSelector("", ""),
+			)
+			lm.AddListener(listener)
+			lm.DeleteListener(listener)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listeners := lm.GetListenersForGVR(gvr)
+			for range listeners {
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestConcurrentGetListenersForNode verifies the same concurrent safety
+// for GetListenersForNode.
+func TestConcurrentGetListenersForNode(t *testing.T) {
+	lm := newListenerManager()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	nodeName := "test-node"
+
+	const numIterations = 200
+
+	for i := 0; i < 50; i++ {
+		listener := NewSelectorListener(
+			fmt.Sprintf("listener-%d", i),
+			nodeName,
+			gvr,
+			NewSelector("", ""),
+		)
+		lm.AddListener(listener)
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listener := NewSelectorListener(
+				fmt.Sprintf("dynamic-listener-%d", i),
+				nodeName,
+				gvr,
+				NewSelector("", ""),
+			)
+			lm.AddListener(listener)
+			lm.DeleteListener(listener)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listeners := lm.GetListenersForNode(nodeName)
+			for range listeners {
+			}
+		}
+	}()
+
+	wg.Wait()
 }

--- a/cloud/pkg/dynamiccontroller/application/listener_manager_test.go
+++ b/cloud/pkg/dynamiccontroller/application/listener_manager_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package application
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -154,4 +156,102 @@ func TestGetListenersForGVR(t *testing.T) {
 	nonExistentGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nonexistent"}
 	nonExistentGVRListeners := lm.GetListenersForGVR(nonExistentGVR)
 	assert.Nil(nonExistentGVRListeners)
+}
+
+// TestConcurrentGetListenersForGVR verifies that concurrent Add/Delete/Get
+// operations do not cause a data race.
+func TestConcurrentGetListenersForGVR(t *testing.T) {
+	lm := newListenerManager()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+
+	const numListeners = 100
+	const numIterations = 1000
+
+	for i := 0; i < numListeners; i++ {
+		listener := NewSelectorListener(
+			fmt.Sprintf("listener-%d", i),
+			fmt.Sprintf("node-%d", i%10),
+			gvr,
+			NewSelector("", ""),
+		)
+		lm.AddListener(listener)
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listener := NewSelectorListener(
+				fmt.Sprintf("dynamic-listener-%d", i),
+				fmt.Sprintf("node-%d", i%10),
+				gvr,
+				NewSelector("", ""),
+			)
+			lm.AddListener(listener)
+			lm.DeleteListener(listener)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listeners := lm.GetListenersForGVR(gvr)
+			for range listeners {
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// TestConcurrentGetListenersForNode verifies the same concurrent safety
+// for GetListenersForNode.
+func TestConcurrentGetListenersForNode(t *testing.T) {
+	lm := newListenerManager()
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	nodeName := "test-node"
+
+	const numIterations = 1000
+
+	for i := 0; i < 50; i++ {
+		listener := NewSelectorListener(
+			fmt.Sprintf("listener-%d", i),
+			nodeName,
+			gvr,
+			NewSelector("", ""),
+		)
+		lm.AddListener(listener)
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listener := NewSelectorListener(
+				fmt.Sprintf("dynamic-listener-%d", i),
+				nodeName,
+				gvr,
+				NewSelector("", ""),
+			)
+			lm.AddListener(listener)
+			lm.DeleteListener(listener)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations; i++ {
+			listeners := lm.GetListenersForNode(nodeName)
+			for range listeners {
+			}
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
`GetListenersForGVR` and `GetListenersForNode` in `listenerManager` returned direct references to internal maps. When `dispatchEvents()` iterates the returned map in its goroutine, concurrent calls to `AddListener`/`DeleteListener` mutate the same map, causing `fatal error: concurrent map iteration and map write`.

Changed both getters to return shallow copies instead of direct references, and added concurrency tests to prevent regression.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6053 

**Special notes for your reviewer**:
- `GetListenersForGVR()` now returns a shallow copy of the listener map for the given GVR, instead of a direct reference to the internal map
- `GetListenersForNode()` now returns a shallow copy of the listener map for the given node, instead of a direct reference to the internal map
- Added `TestConcurrentGetListenersForGVR` to verify concurrent Add/Delete/Get safety
- Added `TestConcurrentGetListenersForNode` to verify the same for node-based lookups

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a crash in dynamicController caused by concurrent map access when multiple edge nodes connect simultaneously.
```
