### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'build/docker/build-tools/build-tools.dockerfile'
 
+permissions:
+  contents: read
+
 jobs:
   publish-image-to-dockerhub:
     name: publish to DockerHub

--- a/.github/workflows/cifuzz-doc.yaml
+++ b/.github/workflows/cifuzz-doc.yaml
@@ -15,6 +15,10 @@ on:
       - 'docs/**'
       - '**/OWNERS'
       - '**/MAINTAINERS'
+
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-22.04

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,6 +15,10 @@ on:
       - 'docs/**'
       - '**/OWNERS'
       - '**/MAINTAINERS'
+
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-22.04

--- a/.github/workflows/cilium-e2e.yml
+++ b/.github/workflows/cilium-e2e.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   image-prepare:
     runs-on: ubuntu-22.04

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,6 +2,9 @@ name: codespell
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-22.04

--- a/.github/workflows/fossa-doc.yaml
+++ b/.github/workflows/fossa-doc.yaml
@@ -14,6 +14,9 @@ on:
       - '**/OWNERS'
       - '**/MAINTAINERS'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -14,6 +14,9 @@ on:
       - '**/OWNERS'
       - '**/MAINTAINERS'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main-arm64.yaml
+++ b/.github/workflows/main-arm64.yaml
@@ -21,6 +21,9 @@ env:
   CONTAINER_RUN_OPTIONS: " "
   GINKGO_VERSION: "v2.21.0"
 
+permissions:
+  contents: read
+
 jobs:
   image-prepare:
     runs-on: openeuler-linux-arm64

--- a/.github/workflows/main-doc.yaml
+++ b/.github/workflows/main-doc.yaml
@@ -17,6 +17,9 @@ on:
       - '**/OWNERS'
       - '**/MAINTAINERS'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,9 @@ env:
   CONTAINER_RUN_OPTIONS: " "
   GINKGO_VERSION: "v2.21.0"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ env:
   CONTAINER_RUN_OPTIONS: " "
   IMAGE_REPOSITORY: kubeedge
 
+permissions:
+  contents: read
+
 jobs:
   release-assests:
     name: release kubeedge components

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -10,6 +10,9 @@ env:
   CONTAINER_RUN_OPTIONS: " "
   GINKGO_VERSION: "v2.21.0"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

**Which issue(s) this PR fixes**:
Fixes #6742

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
