### PR TITLE
improved test coverage of jsonpatch.go in pkg

### DIFF
--- a/pkg/jsonpatch/jsonpatch_test.go
+++ b/pkg/jsonpatch/jsonpatch_test.go
@@ -1,11 +1,10 @@
 /*
 Copyright 2025 The KubeEdge Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package jsonpatch
 
 import (
@@ -77,4 +75,22 @@ func TestJosnPath(t *testing.T) {
 			assert.Equal(t, c.want, string(bff))
 		})
 	}
+}
+
+func TestAdd_NilValue(t *testing.T) {
+	items := New().Add(OpAdd, "/a/b/c", nil)
+	bff, err := items.ToJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `[{"op":"add","path":"/a/b/c"}]`, string(bff))
+}
+
+func TestAdd_UnmarshalableValue(t *testing.T) {
+	ch := make(chan int)
+
+	items := New().Add(OpAdd, "/a/b/c", ch)
+	assert.Len(t, items, 0)
+
+	bff, err := items.ToJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `[]`, string(bff))
 }

--- a/pkg/jsonpatch/jsonpatch_test.go
+++ b/pkg/jsonpatch/jsonpatch_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package jsonpatch
 
 import (
@@ -77,4 +76,22 @@ func TestJosnPath(t *testing.T) {
 			assert.Equal(t, c.want, string(bff))
 		})
 	}
+}
+
+func TestAdd_NilValue(t *testing.T) {
+	items := New().Add(OpAdd, "/a/b/c", nil)
+	bff, err := items.ToJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `[{"op":"add","path":"/a/b/c"}]`, string(bff))
+}
+
+func TestAdd_UnsupportedMarshalType(t *testing.T) {
+	ch := make(chan int)
+
+	items := New().Add(OpAdd, "/a/b/c", ch)
+	assert.Len(t, items, 0)
+
+	bff, err := items.ToJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `[]`, string(bff))
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Improves unit test coverage for the `pkg/jsonpatch` package from 82% to 100%.

Two test cases were added to cover previously untested branches:
- `TestAdd_NilValue`: covers the `value == nil` early return in `setValue()`
- `TestAdd_UnmarshalableValue`: covers the `klog.Warningf` + early return in `Add()` when `json.Marshal` fails on an unmarshallable type (e.g. `chan int`)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
No logic changes were made. Only test coverage improvements.
The `chan int` type is used intentionally to trigger a `json.Marshal` error,
as channels have no JSON representation in Go.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```