### PR TITLE
test: improve test coverage to 100% for upgrade reporter

### DIFF
--- a/pkg/upgrade/edge/upgrade_reporter.go
+++ b/pkg/upgrade/edge/upgrade_reporter.go
@@ -40,6 +40,7 @@ const (
 )
 
 var upgradeReportJSONFile = filepath.Join(constants.KubeEdgePath, "upgrade_report.json")
+var jsonMarshal = json.Marshal
 
 // JSONReporterInfo defines the information to be reported.
 type JSONReporterInfo struct {
@@ -81,7 +82,7 @@ func (r JSONFileReporter) Report(inerr error) error {
 	if inerr != nil {
 		info.ErrorMessage = inerr.Error()
 	}
-	bff, err := json.Marshal(&info)
+	bff, err := jsonMarshal(&info)
 	if err != nil {
 		return fmt.Errorf("failed to marshal upgrade result, err: %v", err)
 	}

--- a/pkg/upgrade/edge/upgrade_reporter_test.go
+++ b/pkg/upgrade/edge/upgrade_reporter_test.go
@@ -18,6 +18,8 @@ package edge
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,10 +27,10 @@ import (
 
 func TestJSONFileReporter(t *testing.T) {
 	srcJSONFile := upgradeReportJSONFile
-	upgradeReportJSONFile = "test.json"
-	defer func() {
+	upgradeReportJSONFile = filepath.Join(t.TempDir(), "test.json")
+	t.Cleanup(func() {
 		upgradeReportJSONFile = srcJSONFile
-	}()
+	})
 
 	t.Run("report upgrade successful", func(t *testing.T) {
 		var err error
@@ -64,4 +66,98 @@ func TestJSONFileReporter(t *testing.T) {
 		assert.Equal(t, "v1.20.0", info.FromVersion)
 		assert.Equal(t, "v1.21.0", info.ToVersion)
 	})
+}
+
+// TestJSONReporterInfoExists covers the JSONReporterInfoExists() function
+func TestJSONReporterInfoExists(t *testing.T) {
+	srcJSONFile := upgradeReportJSONFile
+	upgradeReportJSONFile = filepath.Join(t.TempDir(), "test_exists.json")
+	t.Cleanup(func() {
+		upgradeReportJSONFile = srcJSONFile
+	})
+
+	// File does not exist yet
+	assert.False(t, JSONReporterInfoExists())
+
+	// Create the file
+	err := NewJSONFileReporter(EventTypeRollback, "v1.21.0", "v1.20.0").Report(nil)
+	assert.NoError(t, err)
+
+	// File now exists
+	assert.True(t, JSONReporterInfoExists())
+
+	// Cleanup
+	err = RemoveJSONReporterInfo()
+	assert.NoError(t, err)
+}
+
+// TestParseJSONReporterInfo_FileNotFound covers the os.ReadFile error branch
+func TestParseJSONReporterInfo_FileNotFound(t *testing.T) {
+	srcJSONFile := upgradeReportJSONFile
+	upgradeReportJSONFile = "/nonexistent/path/upgrade_report.json"
+	t.Cleanup(func() {
+		upgradeReportJSONFile = srcJSONFile
+	})
+
+	info, err := ParseJSONReporterInfo()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read upgrade result from file")
+	assert.Empty(t, info.EventType)
+}
+
+// TestParseJSONReporterInfo_InvalidJSON covers the json.Unmarshal error branch
+func TestParseJSONReporterInfo_InvalidJSON(t *testing.T) {
+	srcJSONFile := upgradeReportJSONFile
+	upgradeReportJSONFile = filepath.Join(t.TempDir(), "test_invalid.json")
+	t.Cleanup(func() {
+		os.Remove(upgradeReportJSONFile)
+		upgradeReportJSONFile = srcJSONFile
+	})
+
+	// Write invalid JSON to the file
+	err := os.WriteFile(upgradeReportJSONFile, []byte("not valid json {{{"), os.ModePerm)
+	assert.NoError(t, err)
+
+	info, err := ParseJSONReporterInfo()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal upgrade result")
+	assert.Empty(t, info.EventType)
+}
+
+// TestRemoveJSONReporterInfo_FileNotFound covers the os.Remove error branch
+func TestRemoveJSONReporterInfo_FileNotFound(t *testing.T) {
+	srcJSONFile := upgradeReportJSONFile
+	upgradeReportJSONFile = "nonexistent_file.json"
+	t.Cleanup(func() {
+		upgradeReportJSONFile = srcJSONFile
+	})
+
+	err := RemoveJSONReporterInfo()
+	assert.Error(t, err)
+}
+
+// TestReport_WriteFileError covers the os.WriteFile error branch in Report()
+func TestReport_WriteFileError(t *testing.T) {
+	srcJSONFile := upgradeReportJSONFile
+	// Use a path with a non-existent directory to force WriteFile to fail
+	upgradeReportJSONFile = "/nonexistent/directory/upgrade_report.json"
+	t.Cleanup(func() {
+		upgradeReportJSONFile = srcJSONFile
+	})
+
+	err := NewJSONFileReporter(EventTypeConfigUpdate, "v1.20.0", "v1.21.0").Report(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write upgrade result to file")
+}
+
+func TestReport_MarshalError(t *testing.T) {
+	origMarshal := jsonMarshal
+	jsonMarshal = func(v any) ([]byte, error) {
+		return nil, errors.New("forced marshal error")
+	}
+	t.Cleanup(func() { jsonMarshal = origMarshal })
+
+	err := NewJSONFileReporter(EventTypeUpgrade, "v1.20.0", "v1.21.0").Report(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal upgrade result")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Improves unit test coverage for the `pkg/upgrade/edge/upgrade_reporter` package from 70% to 100%.

The following changes were made:
- Added `jsonMarshal` as an injectable variable in `upgrade_reporter.go` to allow
  mocking of `json.Marshal` in tests
- Added missing test cases in `upgrade_reporter_test.go` to cover previously untested branches:
  - `TestJSONReporterInfoExists`: covers both true/false paths of `JSONReporterInfoExists()`
  - `TestParseJSONReporterInfo_FileNotFound`: covers `os.ReadFile` error branch
  - `TestParseJSONReporterInfo_InvalidJSON`: covers `json.Unmarshal` error branch
  - `TestRemoveJSONReporterInfo_FileNotFound`: covers `os.Remove` error branch
  - `TestReport_WriteFileError`: covers `os.WriteFile` error branch in `Report()`
  - `TestReport_MarshalError`: covers `json.Marshal` error branch in `Report()`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The only production code change is adding `var jsonMarshal = json.Marshal` in
`upgrade_reporter.go` and replacing `json.Marshal` with `jsonMarshal` in `Report()`.
This is a standard Go pattern for making marshal errors testable and does not
affect runtime behavior.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```