### PR TITLE
docs: fix Slack onboarding links and improve accessibility for new users

### DIFF
--- a/docs/community/slack.md
+++ b/docs/community/slack.md
@@ -1,0 +1,40 @@
+# Slack
+
+Slack is the primary communication channel for the KubeEdge community.
+
+## How to Join
+
+Follow these steps to join the KubeEdge Slack workspace:
+
+1. **Get an Invitation**: Visit [https://slack.cncf.io/](https://slack.cncf.io/) to get an invitation and create your account.
+2. **Sign In**: Complete the signup process and access the CNCF Slack workspace.
+3. **Find Channels**: Use the search bar or "Browse channels" to find channels prefixed with "kubeedge".
+
+## Channels
+
+KubeEdge channels are organized by topic and Special Interest Groups (SIGs):
+
+### General
+- **#kubeedge** — General discussions, questions, and community support.
+- **#kubeedge-announcement** — Official announcements and project updates.
+
+### Development
+- **#kubeedge-dev** — Core development and technical discussions.
+- **#kubeedge-dashboard** — Dashboard and user interface topics.
+- **#kubeedge-docs** — Documentation improvements and collaboration.
+
+### Special Interest Groups (SIGs)
+- **#kubeedge-sig-ai** — AI and machine learning at the edge.
+- **#kubeedge-sig-device-iot** — Device management and IoT protocols.
+- **#kubeedge-sig-robotics** — Robotics and KubeEdge integration.
+- **#kubeedge-sig-security** — Security practices and vulnerability reporting.
+- **#kubeedge-sig-mec** — Multi-access Edge Computing (MEC) discussions.
+
+## Community Guidelines
+
+- **Be Respectful**: Follow the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+- **Search First**: Search the channel history before asking new questions.
+- **Provide Context**: Include versions, logs, and environment details when asking for help.
+- **Use Topic Channels**: Post in the channel most relevant to your topic.
+
+For further support, reach out via the [mailing list](https://groups.google.com/forum/#!forum/kubeedge).


### PR DESCRIPTION
What this PR does

Fixes broken Slack links and improves onboarding experience for new contributors.

Changes

1. Removed Slack archive links that require authentication
2. Replaced with CNCF Slack onboarding flow: https://slack.cncf.io/
3. Added step-by-step guide to join Slack
4. Organized channels by category (General, Development, SIGs)
5. Added concise community participation guidelines


 Why this is needed

The previous documentation included links that required login and were not accessible to new users. This PR ensures all guidance is publicly accessible and improves onboarding clarity.

