### PR TITLE
fix(viaduct/chat): use RootCAs instead of ClientCAs in client TLS config

### DIFF
--- a/pkg/viaduct/examples/chat/common.go
+++ b/pkg/viaduct/examples/chat/common.go
@@ -47,8 +47,7 @@ func GetTlsConfig(cfg *config.Config) (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		ClientCAs:    pool,
+		RootCAs:      pool,
 		Certificates: []tls.Certificate{cert},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
 	}, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`GetTlsConfig()`  was using `ClientCAs` and `ClientAuth: RequireAndVerifyClientCert`
in the TLS config, which are server-side only fields. For a client TLS config
the correct field to verify the server's certificate is RootCAs. Using the
wrong fields would cause TLS handshake failures in production.

**Special notes for your reviewer**:
Only ClientCAs ->  RootCAs and removal of ClientAuth. No other logic changed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```