### PR TITLE
tests: improve unit test coverage across multiple modules

### DIFF
--- a/cloud/pkg/csrapprovercontroller/csrapprover_test.go
+++ b/cloud/pkg/csrapprovercontroller/csrapprover_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csrapprovercontroller
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const metaServerServingMsg = "Auto approving MetaServer serving certificate."
+
+func TestGetCertApprovalCondition(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      *certificatesv1.CertificateSigningRequestStatus
+		wantApprove bool
+		wantDeny    bool
+	}{
+		{
+			name: "no conditions",
+			status: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{},
+			},
+			wantApprove: false,
+			wantDeny:    false,
+		},
+		{
+			name: "approved only",
+			status: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
+					{Type: certificatesv1.CertificateApproved},
+				},
+			},
+			wantApprove: true,
+			wantDeny:    false,
+		},
+		{
+			name: "denied only",
+			status: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
+					{Type: certificatesv1.CertificateDenied},
+				},
+			},
+			wantApprove: false,
+			wantDeny:    true,
+		},
+		{
+			name: "both approved and denied",
+			status: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
+					{Type: certificatesv1.CertificateApproved},
+					{Type: certificatesv1.CertificateDenied},
+				},
+			},
+			wantApprove: true,
+			wantDeny:    true,
+		},
+		{
+			name: "unrelated condition types",
+			status: &certificatesv1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1.CertificateSigningRequestCondition{
+					{Type: certificatesv1.CertificateFailed},
+				},
+			},
+			wantApprove: false,
+			wantDeny:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotApprove, gotDeny := GetCertApprovalCondition(tt.status)
+			assert.Equal(t, tt.wantApprove, gotApprove)
+			assert.Equal(t, tt.wantDeny, gotDeny)
+		})
+	}
+}
+
+func TestAppendApprovalCondition(t *testing.T) {
+	tests := []struct {
+		name    string
+		csr     *certificatesv1.CertificateSigningRequest
+		message string
+	}{
+		{
+			name: "empty status",
+			csr: &certificatesv1.CertificateSigningRequest{
+				Status: certificatesv1.CertificateSigningRequestStatus{},
+			},
+			message: metaServerServingMsg,
+		},
+		{
+			name: "existing conditions",
+			csr: &certificatesv1.CertificateSigningRequest{
+				Status: certificatesv1.CertificateSigningRequestStatus{
+					Conditions: []certificatesv1.CertificateSigningRequestCondition{
+						{Type: certificatesv1.CertificateFailed},
+					},
+				},
+			},
+			message: "Auto approving another certificate.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origLen := len(tt.csr.Status.Conditions)
+			appendApprovalCondition(tt.csr, tt.message)
+
+			assert.Equal(t, origLen+1, len(tt.csr.Status.Conditions))
+			lastCond := tt.csr.Status.Conditions[len(tt.csr.Status.Conditions)-1]
+			assert.Equal(t, certificatesv1.CertificateApproved, lastCond.Type)
+			assert.Equal(t, corev1.ConditionTrue, lastCond.Status)
+			assert.Equal(t, "AutoApproved", lastCond.Reason)
+			assert.Equal(t, tt.message, lastCond.Message)
+		})
+	}
+}
+
+func TestUsagesToSet(t *testing.T) {
+	tests := []struct {
+		name   string
+		usages []certificatesv1.KeyUsage
+		want   sets.String
+	}{
+		{
+			name:   "empty usages",
+			usages: []certificatesv1.KeyUsage{},
+			want:   sets.NewString(),
+		},
+		{
+			name:   "single usage",
+			usages: []certificatesv1.KeyUsage{certificatesv1.UsageDigitalSignature},
+			want:   sets.NewString(string(certificatesv1.UsageDigitalSignature)),
+		},
+		{
+			name:   "multiple usages",
+			usages: []certificatesv1.KeyUsage{certificatesv1.UsageDigitalSignature, certificatesv1.UsageKeyEncipherment},
+			want:   sets.NewString(string(certificatesv1.UsageDigitalSignature), string(certificatesv1.UsageKeyEncipherment)),
+		},
+		{
+			name:   "duplicate usages",
+			usages: []certificatesv1.KeyUsage{certificatesv1.UsageDigitalSignature, certificatesv1.UsageDigitalSignature},
+			want:   sets.NewString(string(certificatesv1.UsageDigitalSignature)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := usagesToSet(tt.usages)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsMetaServerServingCert(t *testing.T) {
+	tests := []struct {
+		name       string
+		signerName string
+		orgs       []string
+		dnsNames   []string
+		ipAddrs    []string
+		usages     []certificatesv1.KeyUsage
+		want       bool
+	}{
+		{
+			name:       "matching signer + valid kubelet serving CSR",
+			signerName: certificatesv1.KubeletServingSignerName,
+			orgs:       []string{"system:nodes"},
+			dnsNames:   []string{"node1"},
+			usages: []certificatesv1.KeyUsage{
+				certificatesv1.UsageDigitalSignature,
+				certificatesv1.UsageKeyEncipherment,
+				certificatesv1.UsageServerAuth,
+			},
+			want: true,
+		},
+		{
+			name:       "wrong signer name",
+			signerName: "wrong.signer.name",
+			orgs:       []string{"system:nodes"},
+			dnsNames:   []string{"node1"},
+			usages: []certificatesv1.KeyUsage{
+				certificatesv1.UsageDigitalSignature,
+				certificatesv1.UsageKeyEncipherment,
+				certificatesv1.UsageServerAuth,
+			},
+			want: false,
+		},
+		{
+			name:       "correct signer but non-kubelet CSR (missing server auth)",
+			signerName: certificatesv1.KubeletServingSignerName,
+			orgs:       []string{"system:nodes"},
+			dnsNames:   []string{"node1"},
+			usages: []certificatesv1.KeyUsage{
+				certificatesv1.UsageDigitalSignature,
+				certificatesv1.UsageKeyEncipherment,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+			template := x509.CertificateRequest{
+				Subject: pkix.Name{
+					CommonName:   "system:node:node1",
+					Organization: tt.orgs,
+				},
+				DNSNames: tt.dnsNames,
+			}
+			csrBytes, _ := x509.CreateCertificateRequest(rand.Reader, &template, privateKey)
+			x509cr, _ := x509.ParseCertificateRequest(csrBytes)
+
+			csr := &certificatesv1.CertificateSigningRequest{
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					SignerName: tt.signerName,
+					Usages:     tt.usages,
+				},
+			}
+
+			got := isMetaServerServingCert(csr, x509cr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRecognizers(t *testing.T) {
+	recs := recognizers()
+	assert.Equal(t, 1, len(recs))
+	assert.Equal(t, metaServerServingMsg, recs[0].successMessage)
+	assert.NotNil(t, recs[0].recognize)
+}

--- a/edge/pkg/edged/kubeclientbridge/typed/core/v1/bridge_test.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/core/v1/bridge_test.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+)
+
+type mockPodsInterface struct {
+	pod *corev1.Pod
+	err error
+}
+
+func (m *mockPodsInterface) Create(pod *corev1.Pod) (*corev1.Pod, error) {
+	return pod, m.err
+}
+
+func (m *mockPodsInterface) Update(pod *corev1.Pod) error {
+	return m.err
+}
+
+func (m *mockPodsInterface) Delete(name string, opts metav1.DeleteOptions) error {
+	return m.err
+}
+
+func (m *mockPodsInterface) Get(name string) (*corev1.Pod, error) {
+	return m.pod, m.err
+}
+
+func (m *mockPodsInterface) Patch(name string, ptData []byte) (*corev1.Pod, error) {
+	return m.pod, m.err
+}
+
+type mockNodesInterface struct {
+	node *corev1.Node
+	err  error
+}
+
+func (m *mockNodesInterface) Create(node *corev1.Node) (*corev1.Node, error) {
+	return node, m.err
+}
+
+func (m *mockNodesInterface) Update(node *corev1.Node) error {
+	return m.err
+}
+
+func (m *mockNodesInterface) Delete(name string) error {
+	return m.err
+}
+
+func (m *mockNodesInterface) Get(name string) (*corev1.Node, error) {
+	return m.node, m.err
+}
+
+func (m *mockNodesInterface) Patch(name string, ptData []byte) (*corev1.Node, error) {
+	return m.node, m.err
+}
+
+type mockConfigMapsInterface struct {
+	configMap *corev1.ConfigMap
+	err       error
+}
+
+func (m *mockConfigMapsInterface) Create(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return cm, m.err
+}
+
+func (m *mockConfigMapsInterface) Update(cm *corev1.ConfigMap) error {
+	return m.err
+}
+
+func (m *mockConfigMapsInterface) Delete(name string) error {
+	return m.err
+}
+
+func (m *mockConfigMapsInterface) Get(name string) (*corev1.ConfigMap, error) {
+	return m.configMap, m.err
+}
+
+type mockSecretsInterface struct {
+	secret *corev1.Secret
+	err    error
+}
+
+func (m *mockSecretsInterface) Create(s *corev1.Secret) (*corev1.Secret, error) {
+	return s, m.err
+}
+
+func (m *mockSecretsInterface) Update(s *corev1.Secret) error {
+	return m.err
+}
+
+func (m *mockSecretsInterface) Delete(name string) error {
+	return m.err
+}
+
+func (m *mockSecretsInterface) Get(name string) (*corev1.Secret, error) {
+	return m.secret, m.err
+}
+
+type mockPersistentVolumesInterface struct {
+	pv  *corev1.PersistentVolume
+	err error
+}
+
+func (m *mockPersistentVolumesInterface) Create(s *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+	return s, m.err
+}
+
+func (m *mockPersistentVolumesInterface) Update(s *corev1.PersistentVolume) error {
+	return m.err
+}
+
+func (m *mockPersistentVolumesInterface) Delete(name string) error {
+	return m.err
+}
+
+func (m *mockPersistentVolumesInterface) Get(name string, options metav1.GetOptions) (*corev1.PersistentVolume, error) {
+	return m.pv, m.err
+}
+
+type mockPersistentVolumeClaimsInterface struct {
+	pvc *corev1.PersistentVolumeClaim
+	err error
+}
+
+func (m *mockPersistentVolumeClaimsInterface) Create(s *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	return s, m.err
+}
+
+func (m *mockPersistentVolumeClaimsInterface) Update(s *corev1.PersistentVolumeClaim) error {
+	return m.err
+}
+
+func (m *mockPersistentVolumeClaimsInterface) Delete(name string) error {
+	return m.err
+}
+
+func (m *mockPersistentVolumeClaimsInterface) Get(name string, options metav1.GetOptions) (*corev1.PersistentVolumeClaim, error) {
+	return m.pvc, m.err
+}
+
+type mockServiceAccountInterface struct {
+	sa  *corev1.ServiceAccount
+	err error
+}
+
+func (m *mockServiceAccountInterface) Create(s *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+	return s, m.err
+}
+
+func (m *mockServiceAccountInterface) Update(s *corev1.ServiceAccount) error {
+	return m.err
+}
+
+func (m *mockServiceAccountInterface) Delete(name string) error {
+	return m.err
+}
+
+func (m *mockServiceAccountInterface) Get(name string) (*corev1.ServiceAccount, error) {
+	return m.sa, m.err
+}
+
+type mockEventsInterface struct {
+	event *corev1.Event
+	err   error
+}
+
+func (m *mockEventsInterface) Create(s *corev1.Event, opts metav1.CreateOptions) (*corev1.Event, error) {
+	return s, m.err
+}
+
+func (m *mockEventsInterface) Update(s *corev1.Event, opts metav1.UpdateOptions) (*corev1.Event, error) {
+	return s, m.err
+}
+
+func (m *mockEventsInterface) Delete(name string, opts metav1.DeleteOptions) error {
+	return m.err
+}
+
+func (m *mockEventsInterface) Get(name string, opts metav1.GetOptions) (*corev1.Event, error) {
+	return m.event, m.err
+}
+
+func (m *mockEventsInterface) Apply(event *corev1apply.EventApplyConfiguration, opts metav1.ApplyOptions) (*corev1.Event, error) {
+	return m.event, m.err
+}
+
+func (m *mockEventsInterface) Patch(name string, ptData types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*corev1.Event, error) {
+	return m.event, m.err
+}
+
+func (m *mockEventsInterface) CreateWithEventNamespace(event *corev1.Event) (*corev1.Event, error) {
+	return event, m.err
+}
+
+func (m *mockEventsInterface) UpdateWithEventNamespace(event *corev1.Event) (*corev1.Event, error) {
+	return event, m.err
+}
+
+func (m *mockEventsInterface) PatchWithEventNamespace(event *corev1.Event, data []byte) (*corev1.Event, error) {
+	return event, m.err
+}
+
+type mockCoreMetaClient struct {
+	pods                   client.PodsInterface
+	nodes                  client.NodesInterface
+	configMaps             client.ConfigMapsInterface
+	secrets                client.SecretsInterface
+	persistentVolumes      client.PersistentVolumesInterface
+	persistentVolumeClaims client.PersistentVolumeClaimsInterface
+	serviceAccounts        client.ServiceAccountInterface
+	events                 client.EventsInterface
+}
+
+func (m *mockCoreMetaClient) Pods(ns string) client.PodsInterface { return m.pods }
+func (m *mockCoreMetaClient) Nodes(ns string) client.NodesInterface { return m.nodes }
+func (m *mockCoreMetaClient) ConfigMaps(ns string) client.ConfigMapsInterface {
+	return m.configMaps
+}
+func (m *mockCoreMetaClient) Secrets(ns string) client.SecretsInterface { return m.secrets }
+func (m *mockCoreMetaClient) PersistentVolumes() client.PersistentVolumesInterface {
+	return m.persistentVolumes
+}
+func (m *mockCoreMetaClient) PersistentVolumeClaims(ns string) client.PersistentVolumeClaimsInterface {
+	return m.persistentVolumeClaims
+}
+func (m *mockCoreMetaClient) ServiceAccounts(ns string) client.ServiceAccountInterface {
+	return m.serviceAccounts
+}
+func (m *mockCoreMetaClient) Events(ns string) client.EventsInterface { return m.events }
+func (m *mockCoreMetaClient) NodeStatus(ns string) client.NodeStatusInterface  { return nil }
+func (m *mockCoreMetaClient) PodStatus(ns string) client.PodStatusInterface    { return nil }
+func (m *mockCoreMetaClient) VolumeAttachments(ns string) client.VolumeAttachmentsInterface {
+	return nil
+}
+func (m *mockCoreMetaClient) ServiceAccountToken() client.ServiceAccountTokenInterface { return nil }
+func (m *mockCoreMetaClient) Leases(ns string) client.LeasesInterface                 { return nil }
+func (m *mockCoreMetaClient) CertificateSigningRequests() client.CertificateSigningRequestInterface {
+	return nil
+}
+
+func TestPodsBridge(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod"}}
+	mockMetaClient := &mockCoreMetaClient{
+		pods: &mockPodsInterface{pod: pod},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &PodsBridge{
+		PodInterface: fake.Pods("default"),
+		ns:           "default",
+		MetaClient:   mockMetaClient,
+	}
+
+	got, err := bridge.Get(context.Background(), "test-pod", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, pod, got)
+
+	got, err = bridge.Create(context.Background(), pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, pod, got)
+
+	got, err = bridge.Patch(context.Background(), "test-pod", types.StrategicMergePatchType, []byte(""), metav1.PatchOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, pod, got)
+
+	err = bridge.Delete(context.Background(), "test-pod", metav1.DeleteOptions{})
+	assert.NoError(t, err)
+}
+
+func TestNodesBridge(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	mockMetaClient := &mockCoreMetaClient{
+		nodes: &mockNodesInterface{node: node},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &NodesBridge{
+		NodeInterface: fake.Nodes(),
+		MetaClient:    mockMetaClient,
+	}
+
+	got, err := bridge.Get(context.Background(), "test-node", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, node, got)
+
+	got, err = bridge.Create(context.Background(), node, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, node, got)
+
+	got, err = bridge.Update(context.Background(), node, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, node, got)
+
+	got, err = bridge.Patch(context.Background(), "test-node", types.StrategicMergePatchType, []byte(""), metav1.PatchOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, node, got)
+}
+
+func TestConfigMapBridge(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-cm"}}
+	mockMetaClient := &mockCoreMetaClient{
+		configMaps: &mockConfigMapsInterface{configMap: cm},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &ConfigMapBridge{
+		ConfigMapInterface: fake.ConfigMaps("default"),
+		ns:                 "default",
+		MetaClient:         mockMetaClient,
+	}
+
+	got, err := bridge.Get(context.Background(), "test-cm", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, cm, got)
+}
+
+func TestSecretBridge(t *testing.T) {
+	s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "test-s"}}
+	mockMetaClient := &mockCoreMetaClient{
+		secrets: &mockSecretsInterface{secret: s},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &SecretBridge{
+		SecretInterface: fake.Secrets("default"),
+		ns:              "default",
+		MetaClient:      mockMetaClient,
+	}
+
+	got, err := bridge.Get(context.Background(), "test-s", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, s, got)
+}
+
+func TestPersistentVolumeBridge(t *testing.T) {
+	pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "test-pv"}}
+	mockMetaClient := &mockCoreMetaClient{
+		persistentVolumes: &mockPersistentVolumesInterface{pv: pv},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &PersistentVolumesBridge{
+		PersistentVolumeInterface: fake.PersistentVolumes(),
+		MetaClient:                mockMetaClient,
+	}
+
+	got, err := bridge.Get(context.Background(), "test-pv", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, pv, got)
+}
+
+func TestPersistentVolumeClaimBridge(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "test-pvc"}}
+	mockMetaClient := &mockCoreMetaClient{
+		persistentVolumeClaims: &mockPersistentVolumeClaimsInterface{pvc: pvc},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &PersistentVolumeClaimsBridge{
+		PersistentVolumeClaimInterface: fake.PersistentVolumeClaims("default"),
+		ns:                             "default",
+		MetaClient:                     mockMetaClient,
+	}
+
+	got, err := bridge.Get(context.Background(), "test-pvc", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, pvc, got)
+}
+
+func TestServiceAccountBridge(t *testing.T) {
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-sa"}}
+	mockMetaClient := &mockCoreMetaClient{
+		serviceAccounts: &mockServiceAccountInterface{sa: sa},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &ServiceAccountsBridge{
+		ServiceAccountInterface: fake.ServiceAccounts("default"),
+		ns:                      "default",
+		MetaClient:              mockMetaClient,
+	}
+
+	got, err := bridge.Get(context.Background(), "test-sa", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, sa, got)
+}
+
+func TestEventBridge(t *testing.T) {
+	event := &corev1.Event{ObjectMeta: metav1.ObjectMeta{Name: "test-event"}}
+	mockMetaClient := &mockCoreMetaClient{
+		events: &mockEventsInterface{event: event},
+	}
+	fake := fakecorev1.FakeCoreV1{}
+	bridge := &EventsBridge{
+		EventInterface: fake.Events("default"),
+		ns:             "default",
+		MetaClient:     mockMetaClient,
+	}
+
+	got, err := bridge.CreateWithEventNamespace(event)
+	assert.NoError(t, err)
+	assert.Equal(t, event, got)
+
+	got, err = bridge.PatchWithEventNamespace(event, []byte(""))
+	assert.NoError(t, err)
+	assert.Equal(t, event, got)
+}

--- a/edge/pkg/edgestream/tunnel_test.go
+++ b/edge/pkg/edgestream/tunnel_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edgestream
+
+import (
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+type mockEdgedConnection struct {
+	cacheCalled    bool
+	cleanCalled    bool
+	closedReadChan bool
+}
+
+func (m *mockEdgedConnection) CacheTunnelMessage(msg *stream.Message) {
+	m.cacheCalled = true
+}
+
+func (m *mockEdgedConnection) CreateConnectMessage() (*stream.Message, error) {
+	return nil, nil
+}
+
+func (m *mockEdgedConnection) GetMessageID() uint64 {
+	return 0
+}
+
+func (m *mockEdgedConnection) String() string {
+	return "mockEdgedConnection"
+}
+
+func (m *mockEdgedConnection) CleanChannel() {
+	m.cleanCalled = true
+}
+
+func (m *mockEdgedConnection) CloseReadChannel() {
+	m.closedReadChan = true
+}
+
+func (m *mockEdgedConnection) Serve(tunnel stream.SafeWriteTunneler) error {
+	return nil
+}
+
+type mockTunnel struct {
+	closed bool
+}
+
+func (m *mockTunnel) WriteMessage(_ *stream.Message) error {
+	return nil
+}
+
+func (m *mockTunnel) WriteControl(_ int, _ []byte, _ time.Time) error {
+	return nil
+}
+
+func (m *mockTunnel) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockTunnel) NextReader() (messageType int, reader io.Reader, err error) {
+	return 0, nil, nil
+}
+
+func TestAddAndGetLocalConnection(t *testing.T) {
+	session := &TunnelSession{
+		localCons: make(map[uint64]stream.EdgedConnection),
+	}
+	mockConn := &mockEdgedConnection{}
+
+	session.AddLocalConnection(1, mockConn)
+
+	conn, ok := session.GetLocalConnection(1)
+	assert.True(t, ok)
+	assert.Equal(t, mockConn, conn)
+
+	_, ok = session.GetLocalConnection(999)
+	assert.False(t, ok)
+}
+
+func TestDeleteLocalConnection(t *testing.T) {
+	session := &TunnelSession{
+		localCons: make(map[uint64]stream.EdgedConnection),
+	}
+	mockConn := &mockEdgedConnection{}
+	session.AddLocalConnection(1, mockConn)
+
+	session.DeleteLocalConnection(1)
+
+	_, ok := session.GetLocalConnection(1)
+	assert.False(t, ok)
+	assert.True(t, mockConn.cleanCalled)
+	assert.True(t, mockConn.closedReadChan)
+
+	// delete nonexistent, should not panic
+	assert.NotPanics(t, func() {
+		session.DeleteLocalConnection(999)
+	})
+}
+
+func TestCloseTunnelSession(t *testing.T) {
+	mockTun := &mockTunnel{}
+	session := &TunnelSession{
+		Tunnel:    mockTun,
+	}
+
+	session.Close()
+	assert.True(t, mockTun.closed)
+	assert.True(t, session.closed)
+
+	// Idempotent close
+	assert.NotPanics(t, func() {
+		session.Close()
+	})
+}
+
+func TestWriteToLocalConnection(t *testing.T) {
+	session := &TunnelSession{
+		localCons: make(map[uint64]stream.EdgedConnection),
+	}
+	mockConn := &mockEdgedConnection{}
+	session.AddLocalConnection(1, mockConn)
+
+	msg := &stream.Message{
+		ConnectID: 1,
+	}
+	session.WriteToLocalConnection(msg)
+	assert.True(t, mockConn.cacheCalled)
+
+	// Write to nonexistent connection
+	msg2 := &stream.Message{
+		ConnectID: 999,
+	}
+	assert.NotPanics(t, func() {
+		session.WriteToLocalConnection(msg2)
+	})
+}
+
+func TestServeConnectionPanicsOnUnknownMessage(t *testing.T) {
+	session := &TunnelSession{
+		localCons: make(map[uint64]stream.EdgedConnection),
+	}
+	msg := &stream.Message{
+		MessageType: stream.MessageTypeData,
+	}
+
+	assert.Panics(t, func() {
+		session.ServeConnection(msg)
+	})
+}
+
+func TestConcurrentMapOperations(t *testing.T) {
+	session := &TunnelSession{
+		localCons: make(map[uint64]stream.EdgedConnection),
+	}
+
+	var wg sync.WaitGroup
+	workers := 10
+	wg.Add(workers * 2)
+
+	// Concurrent writes
+	for i := 0; i < workers; i++ {
+		go func(id uint64) {
+			defer wg.Done()
+			session.AddLocalConnection(id, &mockEdgedConnection{})
+		}(uint64(i))
+	}
+
+	// Concurrent reads/deletes
+	for i := 0; i < workers; i++ {
+		go func(id uint64) {
+			defer wg.Done()
+			session.GetLocalConnection(id)
+			session.DeleteLocalConnection(id)
+		}(uint64(i))
+	}
+
+	wg.Wait()
+}

--- a/edge/pkg/servicebus/servicebus_test.go
+++ b/edge/pkg/servicebus/servicebus_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicebus
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	commonType "github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+)
+
+func TestBuildErrorResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		parentID   string
+		content    string
+		statusCode int
+	}{
+		{
+			name:       "bad request",
+			parentID:   "msg-123",
+			content:    "invalid format",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "not found",
+			parentID:   "msg-456",
+			content:    "resource missing",
+			statusCode: http.StatusNotFound,
+		},
+		{
+			name:       "server error",
+			parentID:   "msg-789",
+			content:    "internal failure",
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			name:       "empty content",
+			parentID:   "msg-000",
+			content:    "",
+			statusCode: http.StatusBadRequest,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := buildErrorResponse(tt.parentID, tt.content, tt.statusCode)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.parentID, msg.GetParentID())
+
+			assert.Equal(t, modules.ServiceBusModuleName, msg.GetSource())
+			assert.Equal(t, modules.UserGroup, msg.GetGroup())
+
+			contentData, err := msg.GetContentData()
+			assert.NoError(t, err)
+
+			var resp commonType.HTTPResponse
+			err = json.Unmarshal(contentData, &resp)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.statusCode, resp.StatusCode)
+			assert.Equal(t, tt.content, string(resp.Body))
+		})
+	}
+}
+
+func TestMarshalResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		response *serverResponse
+	}{
+		{
+			name: "success response",
+			response: &serverResponse{
+				Code: http.StatusOK,
+				Msg:  "ok",
+				Body: "data",
+			},
+		},
+		{
+			name: "error response",
+			response: &serverResponse{
+				Code: http.StatusBadRequest,
+				Msg:  "error",
+				Body: "",
+			},
+		},
+		{
+			name: "empty response",
+			response: &serverResponse{
+				Code: 0,
+				Msg:  "",
+				Body: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := marshalResult(tt.response)
+
+			var decoded serverResponse
+			err := json.Unmarshal(data, &decoded)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.response.Code, decoded.Code)
+			assert.Equal(t, tt.response.Msg, decoded.Msg)
+			assert.Equal(t, tt.response.Body, decoded.Body)
+		})
+	}
+}

--- a/pkg/containers/container_runtime_test.go
+++ b/pkg/containers/container_runtime_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containers
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCopyResourcesCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		contains []string
+		wantLen  int
+	}{
+		{
+			name:     "single file",
+			files:    map[string]string{"/usr/bin/edgecore": "/usr/bin/edgecore"},
+			contains: []string{fmt.Sprintf("cp /usr/bin/edgecore %s", filepath.Join("/tmp", "/usr/bin/edgecore"))},
+			wantLen:  1,
+		},
+		{
+			name:     "multiple files",
+			files:    map[string]string{"/src1": "/dest1", "/src2": "/dest2"},
+			contains: []string{
+				fmt.Sprintf("cp /src1 %s", filepath.Join("/tmp", "/dest1")),
+				fmt.Sprintf("cp /src2 %s", filepath.Join("/tmp", "/dest2")),
+			},
+			wantLen:  2,
+		},
+		{
+			name:     "empty map",
+			files:    map[string]string{},
+			contains: []string{},
+			wantLen:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := copyResourcesCmd(tt.files)
+
+			if tt.wantLen == 0 {
+				if got != "" {
+					t.Errorf("copyResourcesCmd() = %v, want empty string", got)
+				}
+				return
+			}
+
+			parts := strings.Split(got, " && ")
+			if len(parts) != tt.wantLen {
+				t.Errorf("copyResourcesCmd() generated %d commands, want %d", len(parts), tt.wantLen)
+			}
+
+			for _, c := range tt.contains {
+				if !strings.Contains(got, c) {
+					t.Errorf("copyResourcesCmd() = %v, must contain %v", got, c)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for several previously untested modules in the KubeEdge codebase:

1. **CSR Approver Controller**: Added tests for certificate approval logic, including recognizers and MetaServer serving certificate validation.
2. **EdgeStream TunnelSession**: Added tests for connection management, thread-safety (concurrent map operations), and close idempotency.
3. **KubeClient Bridge (core/v1)**: Added unit tests for various core resource bridges (Pods, Nodes, ConfigMaps, etc.) using a mock MetaClient.
4. **Copy Resources Utility**: Added tests for shell command generation logic.
5. **ServiceBus Helpers**: Added tests for HTTP error response building and result marshalling.

All tests are table-driven and follow existing project patterns. Verified locally with \go test\.

/kind testing
/area test