### PR TITLE
fix(devicetwin): validate message.Content type in dealLifeCycle

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/communicate.go
+++ b/edge/pkg/devicetwin/dtmanager/communicate.go
@@ -103,7 +103,10 @@ func dealLifeCycle(context *dtcontext.DTContext, _ string, msg interface{}) erro
 	if !ok {
 		return errors.New("msg not Message type")
 	}
-	connectedInfo, _ := message.Content.(string)
+	connectedInfo, ok := message.Content.(string)
+	if !ok {
+		return fmt.Errorf("lifecycle message content type %T is not string", message.Content)
+	}
 	if strings.Compare(connectedInfo, connect.CloudConnected) == 0 {
 		if strings.Compare(context.State, dtcommon.Disconnected) == 0 {
 			err := detailRequest(context)

--- a/edge/pkg/devicetwin/dtmanager/communicate_test.go
+++ b/edge/pkg/devicetwin/dtmanager/communicate_test.go
@@ -18,6 +18,7 @@ package dtmanager
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -200,6 +201,12 @@ func TestDealLifeCycle(t *testing.T) {
 			context: dtContext,
 			msg:     &model.Message{Content: cloudconn.CloudDisconnected},
 			wantErr: nil,
+		},
+		{
+			name:    "dealLifeCycleTest-WrongContentType",
+			context: dtContext,
+			msg:     &model.Message{Content: []byte("cloud_connected")},
+			wantErr: fmt.Errorf("lifecycle message content type %T is not string", []byte(nil)),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
### SUMMARY

This PR fixes a silent failure in `dealLifeCycle()` where non-string `message.Content` values are ignored, preventing `DeviceTwin` from updating its connection state. The primary change is in `edge/pkg/devicetwin/dtmanager/communicate.go`, with a small corresponding test addition in `communicate_test.go`.

### FIX

```go
// Before (problem pattern)
connectedInfo, _ := message.Content.(string)

// After (solution)
connectedInfo, ok := message.Content.(string)
if !ok {
    return fmt.Errorf("lifecycle message content type %T is not string", message.Content)
}
```
