### PR TITLE
cloudstream: add updateNodeCloudCoreAddress to support direct apiserv…

### DIFF
--- a/cloud/pkg/cloudstream/tunnelserver.go
+++ b/cloud/pkg/cloudstream/tunnelserver.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"net/http"
 	"strings"
 	"sync"
@@ -237,5 +238,38 @@ func (s *TunnelServer) updateNodeKubeletEndpoint(nodeName string) error {
 		return fmt.Errorf("failed to Update KubeletEndpoint Port")
 	}
 	klog.V(4).Infof("Update node KubeletEndpoint Port successfully, node: %s, tunnelPort: %d", nodeName, s.tunnelPort)
+	return nil
+}
+
+func (s *TunnelServer) updateNodeCloudCoreAddress(nodeName, cloudCoreIP string) error {
+	if s.kubeClient == nil {
+		return fmt.Errorf("kubeclient is nil, cannot update node address")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), s.updateTimeout)
+	defer cancel()
+	if err := wait.PollUntilContextTimeout(ctx, s.retrySleep, s.updateTimeout, true, func(ctx context.Context) (bool, error) {
+		node, err := s.kubeClient.Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to get node %s for address update, err: %v", nodeName, err)
+			return false, nil
+		}
+
+		for i, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				node.Status.Addresses[i].Address = cloudCoreIP
+				_, err = s.kubeClient.Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
+				if err != nil {
+					klog.Errorf("Failed to update node %s address to CloudCore IP %s, err: %v", nodeName, cloudCoreIP, err)
+					return false, nil
+				}
+				klog.V(4).Infof("Updated node %s InternalIP to CloudCore IP %s", nodeName, cloudCoreIP)
+				return true, nil
+			}
+		}
+		klog.Warningf("Node %s has no InternalIP address to update", nodeName)
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("failed to update node %s address to CloudCore IP: %w", nodeName, err)
+	}
 	return nil
 }

--- a/cloud/pkg/cloudstream/tunnelserver_test.go
+++ b/cloud/pkg/cloudstream/tunnelserver_test.go
@@ -369,3 +369,60 @@ func TestTLSSetup(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateNodeCloudCoreAddress(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset(
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeInternalIP, Address: "192.168.1.1"},
+					},
+				},
+			},
+		)
+		ts := newTunnelServerWithClient(testTunnelPort, fakeClient.CoreV1(), time.Millisecond*10, time.Millisecond*300)
+
+		err := ts.updateNodeCloudCoreAddress(testNodeName, "10.0.0.1")
+		assert.NoError(t, err)
+
+		node, err := fakeClient.CoreV1().Nodes().Get(context.Background(), testNodeName, metav1.GetOptions{})
+		assert.NoError(t, err)
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				assert.Equal(t, "10.0.0.1", addr.Address)
+			}
+		}
+	})
+
+	t.Run("NilKubeClient", func(t *testing.T) {
+		ts := newTunnelServerWithClient(testTunnelPort, nil, time.Millisecond*10, time.Millisecond*100)
+		err := ts.updateNodeCloudCoreAddress(testNodeName, "10.0.0.1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "kubeclient is nil")
+	})
+
+	t.Run("NodeNotFound", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		ts := newTunnelServerWithClient(testTunnelPort, fakeClient.CoreV1(), time.Millisecond*10, time.Millisecond*100)
+		err := ts.updateNodeCloudCoreAddress("non-existent-node", "10.0.0.1")
+		assert.Error(t, err)
+	})
+
+	t.Run("NoInternalIP", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset(
+			&corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: testNodeName},
+				Status: corev1.NodeStatus{
+					Addresses: []corev1.NodeAddress{
+						{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+					},
+				},
+			},
+		)
+		ts := newTunnelServerWithClient(testTunnelPort, fakeClient.CoreV1(), time.Millisecond*10, time.Millisecond*300)
+		err := ts.updateNodeCloudCoreAddress(testNodeName, "10.0.0.1")
+		assert.NoError(t, err)
+	})
+}

--- a/cloud/pkg/cloudstream/tunnelserver_test.go
+++ b/cloud/pkg/cloudstream/tunnelserver_test.go
@@ -40,6 +40,7 @@ import (
 const (
 	testNodeName   = "test-node"
 	testTunnelPort = 10350
+	testSessionKey = "test-session"
 )
 
 func setupTest(_ *testing.T) (*TunnelServer, *fake.Clientset) {
@@ -67,7 +68,7 @@ func TestSessionManagement(t *testing.T) {
 	t.Run("AddAndGetSession", func(t *testing.T) {
 		ts := newTunnelServer(testTunnelPort)
 		session := &Session{
-			sessionID: "test-session",
+			sessionID: testSessionKey,
 		}
 
 		ts.addSession("test-key", session)
@@ -98,8 +99,8 @@ func TestSessionManagement(t *testing.T) {
 	t.Run("SessionConcurrency", func(t *testing.T) {
 		ts, _ := setupTest(t)
 
-		session1 := &Session{sessionID: "session1"}
-		session2 := &Session{sessionID: "session2"}
+		session1 := &Session{sessionID: testSessionKey + "1"}
+		session2 := &Session{sessionID: testSessionKey + "2"}
 
 		ts.addSession("key1", session1)
 		ts.addSession("key2", session2)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds updateNodeCloudCoreAddress to TunnelServer as groundwork for replacing the iptableManager with direct apiserver-to-cloudcore routing. Currently the iptableManager intercepts apiserver requests via iptables DNAT rules every 10 seconds and redirects them to cloudcore. This new method enables updating the node InternalIP address to point directly to CloudCore so the apiserver can route requests without iptables interception. This is the first step toward the design proposed in the iptableManager replacement issue.

**Which issue(s) this PR fixes**:
Fixes #6754 

**Special notes for your reviewer**:
This is purely additive and does not change any existing behavior. The method is not yet called in the connect flow, that integration will follow after the design proposal is reviewed and approved.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```