### PR TITLE
edgehub: fix routeToCloud goroutine leak on reconnect

### DIFF
--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -1,6 +1,7 @@
 package edgehub
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -122,13 +123,21 @@ func (eh *EdgeHub) Start() {
 		}
 		// execute hook func after connect
 		eh.pubConnectInfo(true)
-		go eh.routeToEdge()
-		go eh.routeToCloud()
-		go eh.keepalive()
+		// Derive connCtx from the beehive global context so that both
+		// an explicit reconnect (connCancel) and process shutdown (beehive
+		// context cancel) both cause the goroutines below to exit.
+		connCtx, connCancel := context.WithCancel(beehiveContext.GetContext())
+		go eh.routeToEdge(connCtx)
+		go eh.routeToCloud(connCtx)
+		go eh.keepalive(connCtx)
 
 		// wait the stop signal
 		// stop authinfo manager/websocket connection
 		<-eh.reconnectChan
+		// Cancel the connection context before UnInit so that goroutines blocked
+		// inside ReceiveWithContext or the keepalive sleep exit immediately,
+		// preventing goroutine accumulation across reconnects.
+		connCancel()
 		eh.chClient.UnInit()
 
 		// execute hook fun after disconnect

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -39,11 +39,14 @@ func (eh *EdgeHub) dispatch(message model.Message) error {
 	return msghandler.ProcessHandler(message, eh.chClient)
 }
 
-func (eh *EdgeHub) routeToEdge() {
+func (eh *EdgeHub) routeToEdge(connCtx context.Context) {
 	for {
 		select {
 		case <-beehiveContext.Done():
 			klog.Warning("EdgeHub RouteToEdge stop")
+			return
+		case <-connCtx.Done():
+			klog.Warning("EdgeHub RouteToEdge stop due to connection reset")
 			return
 		default:
 		}
@@ -72,16 +75,19 @@ func (eh *EdgeHub) sendToCloud(message model.Message) error {
 	return nil
 }
 
-func (eh *EdgeHub) routeToCloud() {
+func (eh *EdgeHub) routeToCloud(connCtx context.Context) {
 	for {
-		select {
-		case <-beehiveContext.Done():
-			klog.Warning("EdgeHub RouteToCloud stop")
-			return
-		default:
-		}
-		message, err := beehiveContext.Receive(modules.EdgeHubModuleName)
+		// ReceiveWithContext unblocks immediately when connCtx is cancelled
+		// (either by connCancel on reconnect, or by the beehive global context
+		// on process shutdown), preventing this goroutine from outliving its
+		// connection and accumulating across reconnect cycles.
+		message, err := beehiveContext.ReceiveWithContext(connCtx, modules.EdgeHubModuleName)
 		if err != nil {
+			if connCtx.Err() != nil {
+				// connCtx was cancelled: reconnect in progress or process shutting down.
+				klog.Warning("EdgeHub RouteToCloud stop")
+				return
+			}
 			klog.Errorf("failed to receive message from edge: %v", err)
 			time.Sleep(time.Second)
 			continue
@@ -103,11 +109,14 @@ func (eh *EdgeHub) routeToCloud() {
 	}
 }
 
-func (eh *EdgeHub) keepalive() {
+func (eh *EdgeHub) keepalive(connCtx context.Context) {
 	for {
 		select {
 		case <-beehiveContext.Done():
 			klog.Warning("EdgeHub KeepAlive stop")
+			return
+		case <-connCtx.Done():
+			klog.Warning("EdgeHub KeepAlive stop due to connection reset")
 			return
 		default:
 		}
@@ -123,7 +132,17 @@ func (eh *EdgeHub) keepalive() {
 			return
 		}
 
-		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second)
+		// Use select so that the keepalive goroutine exits immediately when
+		// connCtx is cancelled rather than sleeping through a reconnect cycle.
+		select {
+		case <-connCtx.Done():
+			klog.Warning("EdgeHub KeepAlive stop due to connection reset")
+			return
+		case <-beehiveContext.Done():
+			klog.Warning("EdgeHub KeepAlive stop")
+			return
+		case <-time.After(time.Duration(config.Config.Heartbeat) * time.Second):
+		}
 	}
 }
 

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/channel/context_channel.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	gocontext "context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -86,6 +87,22 @@ func (ctx *Context) Receive(module string) (model.Message, error) {
 
 	klog.Warningf("Failed to get channel for module:%s when receive message", module)
 	return model.Message{}, fmt.Errorf("failed to get channel for module(%s)", module)
+}
+
+// ReceiveWithContext receives a message from the module's channel, returning
+// immediately with ctx.Err() if ctx is cancelled before a message is available.
+func (ctx *Context) ReceiveWithContext(goCtx gocontext.Context, module string) (model.Message, error) {
+	channel := ctx.getChannel(module)
+	if channel == nil {
+		klog.Warningf("Failed to get channel for module:%s when receive message", module)
+		return model.Message{}, fmt.Errorf("failed to get channel for module(%s)", module)
+	}
+	select {
+	case <-goCtx.Done():
+		return model.Message{}, goCtx.Err()
+	case content := <-channel:
+		return content, nil
+	}
 }
 
 func getAnonChannelName(msgID string) string {

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/context/context.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/context/context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	gocontext "context"
 	"time"
 
 	"github.com/kubeedge/beehive/pkg/common"
@@ -19,6 +20,9 @@ type MessageContext interface {
 	// async mode
 	Send(module string, message model.Message)
 	Receive(module string) (model.Message, error)
+	// ReceiveWithContext receives a message like Receive, but returns immediately
+	// with ctx.Err() when ctx is cancelled instead of blocking forever.
+	ReceiveWithContext(ctx gocontext.Context, module string) (model.Message, error)
 	// sync mode
 	SendSync(module string, message model.Message, timeout time.Duration) (model.Message, error)
 	SendResp(message model.Message)

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/context/context_factory.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/context/context_factory.go
@@ -139,6 +139,17 @@ func Receive(module string) (model.Message, error) {
 	return messageContext.Receive(module)
 }
 
+// ReceiveWithContext receives a message like Receive, but returns immediately
+// with ctx.Err() when ctx is cancelled instead of blocking forever.
+func ReceiveWithContext(ctx gocontext.Context, module string) (model.Message, error) {
+	messageContext, err := getMessageContext(module)
+	if err != nil {
+		return model.Message{}, err
+	}
+
+	return messageContext.ReceiveWithContext(ctx, module)
+}
+
 // SendSync sends message in sync mode
 // module: the destination of the message
 // timeout: if <= 0 using default value(30s)

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/socket/context_socket.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/socket/context_socket.go
@@ -1,6 +1,7 @@
 package socket
 
 import (
+	gocontext "context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -70,6 +71,30 @@ func (s *Context) Send(module string, message model.Message) {
 // Receive receive
 func (s *Context) Receive(module string) (model.Message, error) {
 	return s.getContext(module).Receive(module)
+}
+
+// ReceiveWithContext receives a message, returning when ctx is cancelled.
+// The underlying socket read is not directly cancellable; the goroutine that
+// drives it will exit on its own once the connection is closed or a message arrives.
+func (s *Context) ReceiveWithContext(ctx gocontext.Context, module string) (model.Message, error) {
+	type result struct {
+		msg model.Message
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		msg, err := s.Receive(module)
+		select {
+		case ch <- result{msg, err}:
+		default:
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return model.Message{}, ctx.Err()
+	case r := <-ch:
+		return r.msg, r.err
+	}
 }
 
 // SendSync send sync


### PR DESCRIPTION
## Summary

- `routeToCloud` in `edge/pkg/edgehub/process.go` called the blocking `beehiveContext.Receive()` with no cancellation path — when a connection broke and `Start()` launched a new connection, the old goroutine stayed alive blocking on the same beehive channel indefinitely; `keepalive` had the same issue via an uncancellable `time.Sleep`
- Each reconnect on an idle edge node (no outbound messages queued) leaked one additional goroutine that outlived the connection, consumed messages non-deterministically from the EdgeHub channel, and could trigger spurious reconnects by writing to `reconnectChan` on stale connections — goroutine count grew linearly with the number of network flaps
- Fixed by adding `ReceiveWithContext(ctx, module)` to the beehive `MessageContext` interface (channel implementation uses a proper `select` on the module channel and `ctx.Done()`; socket implementation falls back gracefully), adding a top-level factory function, and wiring a per-connection `connCtx` — derived from the beehive global context so process shutdown also propagates — into all three goroutines in `Start()`; `connCtx` is cancelled before `UnInit()` on every disconnect so goroutines exit immediately without waiting for the next message or heartbeat tick

## Test plan

- [ ] Verify `routeToCloud` exits immediately on reconnect when no messages are pending in the EdgeHub module channel
- [ ] Verify `keepalive` exits immediately on reconnect without sleeping through the full heartbeat interval
- [ ] Confirm goroutine count stays stable after multiple rapid reconnect cycles
- [ ] CI passes: `make lint`, `make build`, unit tests under `edge/pkg/edgehub`