### PR TITLE
fix: improve cloudcore CrashLoopBackOff troubleshooting and logging

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -75,20 +75,27 @@ kubernetes controller which manages devices so that the device metadata/status d
 			flag.PrintDefaultConfigAndExitIfRequested(v1alpha1.NewDefaultCloudCoreConfig())
 			flag.PrintFlags(cmd.Flags())
 
+			klog.Info("Starting cloudcore...")
+			klog.Info("Validating command line options...")
 			if errs := opts.Validate(); len(errs) > 0 {
-				klog.Exit(util.SpliceErrors(errs))
+				klog.Exitf("Configuration-related error: command line options validation failed: %v", util.SpliceErrors(errs))
 			}
+
+			klog.Info("Loading configuration...")
 
 			config, err := opts.Config()
 			if err != nil {
-				klog.Exit(err)
+				klog.Exitf("Configuration-related error: failed to load configuration: %v", err)
 			}
+			klog.Info("Validating configuration...")
 			if errs := validation.ValidateCloudCoreConfiguration(config); len(errs) > 0 {
-				klog.Exit(util.SpliceErrors(errs.ToAggregate().Errors()))
+				klog.Exitf("Configuration-related error: configuration validation failed: %v", util.SpliceErrors(errs.ToAggregate().Errors()))
 			}
 
+			klog.Info("Setting feature gates...")
+
 			if err := features.DefaultMutableFeatureGate.SetFromMap(config.FeatureGates); err != nil {
-				klog.Exit(err)
+				klog.Exitf("Configuration-related error: failed to set feature gates: %v", err)
 			}
 
 			// start monitor server
@@ -101,12 +108,13 @@ kubernetes controller which manages devices so that the device metadata/status d
 				!config.Modules.CloudHub.Authorization.Debug
 			client.InitKubeEdgeClient(config.KubeAPIConfig, enableImpersonation)
 
+			klog.Info("Negotiating tunnel port...")
 			// Negotiate TunnelPort for multi cloudcore instances
 			waitTime := rand.Int31n(10)
 			time.Sleep(time.Duration(waitTime) * time.Second)
 			tunnelport, err := NegotiateTunnelPort()
 			if err != nil {
-				panic(err)
+				klog.Exitf("Kubernetes-related error: failed to negotiate tunnel port: %v", err)
 			}
 
 			config.CommonConfig.TunnelPort = *tunnelport

--- a/manifests/charts/cloudcore/README.md
+++ b/manifests/charts/cloudcore/README.md
@@ -55,6 +55,30 @@ helm upgrade --install cloudcore ./cloudcore --namespace kubeedge --create-names
 - `iptablesManager.affinity`, `iptablesManager.nodeSelector`, `iptablesManager.tolerations`, defines the node scheduling policies.
 - `iptablesManager.resources`, defines the resources limits and requests.
 
+## Troubleshooting CrashLoopBackOff
+
+If the `cloudcore` pod fails to start and enters a `CrashLoopBackOff` state, it is likely due to a configuration, network, or Kubernetes API connectivity issue during early startup. 
+
+To troubleshoot effectively:
+
+1. **View the previous container logs:**
+   Use the `--previous` flag to see the exact error that caused the pod to crash.
+   ```bash
+   kubectl logs -n kubeedge deployment/cloudcore --previous
+   ```
+   > Note: `kubectl describe pod` mainly shows Kubernetes-level events (like image pull errors), while `kubectl logs` will show application-level configuration and initialization errors.
+
+2. **Increase Log Verbosity:**
+   If the default logs do not provide enough context, you can increase the `klog` verbosity (e.g., to level 4 or higher). To do this, configure the `cloudCore.extraArgs` parameter in your `values.yaml` or during the helm upgrade:
+   ```yaml
+   cloudCore:
+     extraArgs:
+     - "-v=4"
+   ```
+   ```bash
+   helm upgrade cloudcore ./cloudcore --namespace kubeedge --set "cloudCore.extraArgs[0]=-v=4"
+   ```
+
 ## Uninstall
 
 ```

--- a/manifests/charts/cloudcore/templates/deployment_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/deployment_cloudcore.yaml
@@ -45,6 +45,10 @@ spec:
       - name: cloudcore
         image: {{ .Values.cloudCore.image.repository }}:{{ .Values.cloudCore.image.tag }}
         imagePullPolicy: {{ .Values.cloudCore.image.pullPolicy }}
+        {{- if .Values.cloudCore.extraArgs }}
+        args:
+{{ toYaml .Values.cloudCore.extraArgs | indent 8 }}
+        {{- end }}
         ports:
         - containerPort: 10000
           name: cloudhub

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -5,6 +5,7 @@ appVersion: "1.23.0"
 
 cloudCore:
   replicaCount: 1
+  extraArgs: []
   hostNetWork: true
   image:
     repository: "kubeedge/cloudcore"


### PR DESCRIPTION
This PR adds better startup logging context to cloudcore, adds extraArgs support to the helm chart, and adds a troubleshooting guide to the helm chart README to help users debug CrashLoopBackOff issues. Fixes #6695