### PR TITLE
pkg/viaduct: add unit tests for filter

### DIFF
--- a/pkg/viaduct/pkg/filter/filter_test.go
+++ b/pkg/viaduct/pkg/filter/filter_test.go
@@ -79,6 +79,27 @@ func TestAddFilterFunc_AppendsMultipleFilters(t *testing.T) {
 	assert.Equal(t, []int{1, 2, 3}, order, "filters must be invoked in registration order")
 }
 
+// TestAddFilterFunc_PreservesExistingFilters verifies that AddFilterFunc
+// appends new filters without replacing previously registered filters.
+func TestAddFilterFunc_PreservesExistingFilters(t *testing.T) {
+	var order []int
+	mf := &MessageFilter{}
+
+	mf.AddFilterFunc(func(msg *model.Message) error {
+		order = append(order, 1)
+		return nil
+	})
+	mf.AddFilterFunc(func(msg *model.Message) error {
+		order = append(order, 2)
+		return nil
+	})
+
+	assert.Len(t, mf.Filters, 2)
+	assert.NoError(t, mf.Filters[0](newMsg("m3")))
+	assert.NoError(t, mf.Filters[1](newMsg("m4")))
+	assert.Equal(t, []int{1, 2}, order, "registered filters should remain addressable in append order")
+}
+
 // ---------------------------------------------------------------------------
 // ProcessFilter
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR adds unit tests for `pkg/viaduct/pkg/filter`.

The tests cover:
- adding filter functions
- processing messages without filters
- executing multiple filters in order
- stopping on the first filter error
- returning the original filter error

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
