### PR TITLE
Clean up keadm debug get filtering

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -114,11 +114,8 @@ func dealTwinSync(context *dtcontext.DTContext, resource string, msg interface{}
 	msgTwin, err := dttype.UnmarshalDeviceTwinUpdate(content)
 	if err != nil {
 		klog.Errorf("Unmarshal update request body failed, err: %#v", err)
-		if err := dealUpdateResult(context, "", "", dtcommon.BadRequestCode,
-			errors.New("unmarshal update request body failed, Please check the request"), result); err != nil {
-			// TODO: handle error
-			klog.Error(err)
-		}
+		sendTwinUpdateResult(context, "", "", dtcommon.BadRequestCode,
+			errors.New("unmarshal update request body failed, Please check the request"), result)
 		return err
 	}
 
@@ -177,10 +174,7 @@ func Updated(context *dtcontext.DTContext, deviceID string, payload []byte) {
 	msg, err := dttype.UnmarshalDeviceTwinUpdate(payload)
 	if err != nil {
 		klog.Errorf("Unmarshal update request body failed, err: %#v", err)
-		if err := dealUpdateResult(context, "", "", dtcommon.BadRequestCode, err, result); err != nil {
-			// TODO: handle error
-			klog.Error(err)
-		}
+		sendTwinUpdateResult(context, "", "", dtcommon.BadRequestCode, err, result)
 		return
 	}
 	klog.Infof("Begin to update twin of the device %s", deviceID)
@@ -199,11 +193,8 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 	device, isExist := context.GetDevice(deviceID)
 	if !isExist {
 		klog.Errorf("Update twin rejected due to the device %s is not existed", deviceID)
-		if err := dealUpdateResult(context, deviceID, eventID, dtcommon.NotFoundCode,
-			errors.New("update rejected due to the device is not existed"), result); err != nil {
-			// TODO: handle error
-			klog.Error(err)
-		}
+		sendTwinUpdateResult(context, deviceID, eventID, dtcommon.NotFoundCode,
+			errors.New("update rejected due to the device is not existed"), result)
 		return errors.New("update rejected due to the device is not existed")
 	}
 	content := msgTwin
@@ -211,10 +202,7 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 	if content == nil {
 		klog.Errorf("Update twin of device %s error, key:twin does not exist", deviceID)
 		err = dttype.ErrorUpdate
-		if err := dealUpdateResult(context, deviceID, eventID, dtcommon.BadRequestCode, err, result); err != nil {
-			// TODO: handle error
-			klog.Error(err)
-		}
+		sendTwinUpdateResult(context, deviceID, eventID, dtcommon.BadRequestCode, err, result)
 		return err
 	}
 	dealTwinResult := DealMsgTwin(context, deviceID, content, dealType)
@@ -227,20 +215,11 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 		}
 		err = dealTwinResult.Err
 		updateResult, _ := dttype.BuildDeviceTwinResult(dttype.BaseMessage{EventID: eventID, Timestamp: now}, dealTwinResult.Result, 0)
-		if err := dealUpdateResult(context, deviceID, eventID, dtcommon.BadRequestCode, err, updateResult); err != nil {
-			// TODO: handle error
-			klog.Error(err)
-		}
+		sendTwinUpdateResult(context, deviceID, eventID, dtcommon.BadRequestCode, err, updateResult)
 		return err
 	}
 	if len(add) != 0 || len(deletes) != 0 || len(update) != 0 {
-		for i := 1; i <= dtcommon.RetryTimes; i++ {
-			err = TwinServiceFactory().DeviceTwinTrans(add, deletes, update)
-			if err == nil {
-				break
-			}
-			time.Sleep(dtcommon.RetryInterval)
-		}
+		err = retryDeviceTwinTrans(add, deletes, update)
 		if err != nil {
 			if err := SyncDeviceFromSqlite(context, deviceID); err != nil {
 				// TODO: handle error
@@ -252,10 +231,7 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 
 	if dealType == RestDealType {
 		updateResult, _ := dttype.BuildDeviceTwinResult(dttype.BaseMessage{EventID: eventID, Timestamp: now}, dealTwinResult.Result, dealType)
-		if err := dealUpdateResult(context, deviceID, eventID, dtcommon.InternalErrorCode, err, updateResult); err != nil {
-			// TODO: handle error
-			klog.Error(err)
-		}
+		sendTwinUpdateResult(context, deviceID, eventID, dtcommon.InternalErrorCode, err, updateResult)
 		if err != nil { // The error returned by TwinServiceFactory().DeviceTwinTrans()
 			return err
 		}
@@ -282,6 +258,24 @@ func DealDeviceTwin(context *dtcontext.DTContext, deviceID string, eventID strin
 		}
 	}
 	return nil
+}
+
+func sendTwinUpdateResult(context *dtcontext.DTContext, deviceID string, eventID string, code int, err error, payload []byte) {
+	if err := dealUpdateResult(context, deviceID, eventID, code, err, payload); err != nil {
+		klog.Error(err)
+	}
+}
+
+func retryDeviceTwinTrans(adds []models.DeviceTwin, deletes []models.DeviceDelete, updates []models.DeviceTwinUpdate) error {
+	var err error
+	for i := 1; i <= dtcommon.RetryTimes; i++ {
+		err = TwinServiceFactory().DeviceTwinTrans(adds, deletes, updates)
+		if err == nil {
+			break
+		}
+		time.Sleep(dtcommon.RetryInterval)
+	}
+	return err
 }
 
 // dealUpdateResult build update result and send result, if success send the current state

--- a/keadm/cmd/keadm/app/cmd/debug/get.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get.go
@@ -303,15 +303,7 @@ func (g *GetOptions) getPodsFromDatabase(resNS string, resNames []string) ([]mod
 	if err != nil {
 		return nil, err
 	}
-	for _, v := range *podRecords {
-		namespaceParsed, _, _, _ := commonmsg.ParseResourceEdge(v.Key, model.QueryOperation)
-		if namespaceParsed != resNS && !g.AllNamespace {
-			continue
-		}
-		if len(resNames) > 0 && !isExistName(resNames, v.Key) {
-			continue
-		}
-
+	for _, v := range g.filterMetaRecords(*podRecords, resNS, resNames) {
 		podKey := strings.Replace(v.Key, constants.ResourceSep+model.ResourceTypePod+constants.ResourceSep,
 			constants.ResourceSep+model.ResourceTypePodStatus+constants.ResourceSep, 1)
 		podStatusRecords, err := ms.QueryMeta("key", podKey)
@@ -349,15 +341,7 @@ func (g *GetOptions) getNodeFromDatabase(resNS string, resNames []string) ([]mod
 	if err != nil {
 		return nil, err
 	}
-	for _, v := range *nodeRecords {
-		namespaceParsed, _, _, _ := commonmsg.ParseResourceEdge(v.Key, model.QueryOperation)
-		if namespaceParsed != resNS && !g.AllNamespace {
-			continue
-		}
-		if len(resNames) > 0 && !isExistName(resNames, v.Key) {
-			continue
-		}
-
+	for _, v := range g.filterMetaRecords(*nodeRecords, resNS, resNames) {
 		nodeKey := strings.Replace(v.Key, constants.ResourceSep+model.ResourceTypeNode+constants.ResourceSep,
 			constants.ResourceSep+model.ResourceTypeNodeStatus+constants.ResourceSep, 1)
 		nodeStatusRecords, err := ms.QueryMeta("key", nodeKey)
@@ -387,13 +371,17 @@ func (g *GetOptions) getNodeFromDatabase(resNS string, resNames []string) ([]mod
 }
 
 func (g *GetOptions) getResourceFromDatabase(resNS string, resNames []string, resType string) ([]models.Meta, error) {
-	var results []models.Meta
-
 	resRecords, err := ms.QueryAllMeta("type", resType)
 	if err != nil {
 		return nil, err
 	}
-	for _, v := range *resRecords {
+	return g.filterMetaRecords(*resRecords, resNS, resNames), nil
+}
+
+func (g *GetOptions) filterMetaRecords(records []models.Meta, resNS string, resNames []string) []models.Meta {
+	var results []models.Meta
+
+	for _, v := range records {
 		namespaceParsed, _, _, _ := commonmsg.ParseResourceEdge(v.Key, model.QueryOperation)
 		if namespaceParsed != resNS && !g.AllNamespace {
 			continue
@@ -404,24 +392,22 @@ func (g *GetOptions) getResourceFromDatabase(resNS string, resNames []string, re
 		results = append(results, v)
 	}
 
-	return results, nil
+	return results
 }
 
 // FilterSelector filter resource by selector
 func FilterSelector(data []models.Meta, selector string) ([]models.Meta, error) {
 	var results []models.Meta
-	var jsonValue = make(map[string]interface{})
 
 	selectors, err := SplitSelectorParameters(selector)
 	if err != nil {
 		return nil, err
 	}
 	for _, v := range data {
-		err := json.Unmarshal([]byte(v.Value), &jsonValue)
+		labels, err := getMetaLabels(v.Value)
 		if err != nil {
 			return nil, err
 		}
-		labels := jsonValue["metadata"].(map[string]interface{})["labels"]
 		if labels == nil {
 			results = append(results, v)
 			continue
@@ -429,10 +415,10 @@ func FilterSelector(data []models.Meta, selector string) ([]models.Meta, error) 
 		flag := true
 		for _, v := range selectors {
 			if !v.Exist {
-				flag = flag && labels.(map[string]interface{})[v.Key] != v.Value
+				flag = flag && labels[v.Key] != v.Value
 				continue
 			}
-			flag = flag && (labels.(map[string]interface{})[v.Key] == v.Value)
+			flag = flag && labels[v.Key] == v.Value
 		}
 		if flag {
 			results = append(results, v)
@@ -440,6 +426,20 @@ func FilterSelector(data []models.Meta, selector string) ([]models.Meta, error) 
 	}
 
 	return results, nil
+}
+
+type metaObject struct {
+	Metadata struct {
+		Labels map[string]string `json:"labels"`
+	} `json:"metadata"`
+}
+
+func getMetaLabels(value string) (map[string]string, error) {
+	var obj metaObject
+	if err := json.Unmarshal([]byte(value), &obj); err != nil {
+		return nil, err
+	}
+	return obj.Metadata.Labels, nil
 }
 
 // IsAvailableResources verification support resource type

--- a/keadm/cmd/keadm/app/cmd/debug/get_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"testing"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
+)
+
+func TestFilterMetaRecords(t *testing.T) {
+	records := []models.Meta{
+		{Key: "default/" + model.ResourceTypePod + "/pod-a"},
+		{Key: "default/" + model.ResourceTypePod + "/pod-b"},
+		{Key: "kube-system/" + model.ResourceTypePod + "/pod-c"},
+	}
+
+	opts := &GetOptions{}
+	got := opts.filterMetaRecords(records, "default", []string{"pod-a"})
+	if len(got) != 1 || got[0].Key != records[0].Key {
+		t.Fatalf("filterMetaRecords() = %#v, want only %q", got, records[0].Key)
+	}
+
+	opts.AllNamespace = true
+	got = opts.filterMetaRecords(records, "default", nil)
+	if len(got) != len(records) {
+		t.Fatalf("filterMetaRecords() with all namespaces returned %d records, want %d", len(got), len(records))
+	}
+}
+
+func TestFilterSelector(t *testing.T) {
+	data := []models.Meta{
+		{Key: "matched", Value: `{"metadata":{"labels":{"app":"edge","tier":"test"}}}`},
+		{Key: "unlabeled", Value: `{"metadata":{}}`},
+		{Key: "unmatched", Value: `{"metadata":{"labels":{"app":"cloud","tier":"test"}}}`},
+	}
+
+	got, err := FilterSelector(data, "app=edge,tier!=prod")
+	if err != nil {
+		t.Fatalf("FilterSelector() returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("FilterSelector() returned %d records, want 2", len(got))
+	}
+	if got[0].Key != "matched" || got[1].Key != "unlabeled" {
+		t.Fatalf("FilterSelector() = %#v, want matched and unlabeled records", got)
+	}
+}
+
+func TestFilterSelectorReturnsErrorForMalformedLabels(t *testing.T) {
+	data := []models.Meta{
+		{Key: "malformed", Value: `{"metadata":{"labels":["app=edge"]}}`},
+	}
+
+	if _, err := FilterSelector(data, "app=edge"); err == nil {
+		t.Fatal("FilterSelector() returned nil error for malformed labels")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR performs small behavior-preserving cleanups in `keadm debug get` and device twin update handling by:

- extracting repeated `keadm debug get` metadata namespace/name filtering into `filterMetaRecords`
- replacing unchecked selector metadata type assertions with typed label unmarshalling
- adding focused tests for metadata filtering and selector filtering behavior
- extracting repeated device twin update-result send/log handling into `sendTwinUpdateResult`
- extracting device twin DB transaction retry logic into `retryDeviceTwinTrans`

This keeps existing behavior for unlabeled resources while returning errors instead of panicking on malformed selector label data.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Focused tests passed:

```sh
GOCACHE=/Users/jagjeevankashid/Developer/lfx/kubeedge/.cache/go-build go test ./keadm/cmd/keadm/app/cmd/debug -run 'Test(FilterMetaRecords|FilterSelector|ToPrinter|NewGetPrintFlags|HumanPrintFlags|NewHumanPrintFlags|_EnsureWithNamespace)$'
GOCACHE=/Users/jagjeevankashid/Developer/lfx/kubeedge/.cache/go-build go test ./edge/pkg/devicetwin/dtmanager
```

The full `keadm/cmd/keadm/app/cmd/debug` package test currently fails in existing `collect_test.go::TestExecuteShell`, unrelated to this change.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
