### PR TITLE
test: address keadm ctl tests and improve coverage

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package confirm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	fakerest "k8s.io/client-go/rest/fake"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+type mockCoreV1 struct {
+	corev1.CoreV1Interface
+	restClient rest.Interface
+}
+
+func (m *mockCoreV1) RESTClient() rest.Interface {
+	return m.restClient
+}
+
+type mockClientset struct {
+	*fake.Clientset
+	coreV1 *mockCoreV1
+}
+
+func (m *mockClientset) CoreV1() corev1.CoreV1Interface {
+	return m.coreV1
+}
+
+func TestNewEdgeConfirm(t *testing.T) {
+	cmd := NewEdgeConfirm()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "confirm", cmd.Use)
+}
+func TestConfirmNodeUpgrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		expectedErrMsg string
+		wantErr        bool
+		connErr        bool
+	}{
+		{
+			name:    "confirm success",
+			status:  http.StatusOK,
+			wantErr: false,
+		},
+		{
+			name:           "confirm failed with 500 status error",
+			status:         http.StatusInternalServerError,
+			wantErr:        true,
+			expectedErrMsg: "failed to confirm node upgrade, status code: 500",
+		},
+		{
+			name:           "confirm failed with connection error",
+			wantErr:        true,
+			expectedErrMsg: "failed to send confirm request to MetaService API",
+			connErr:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &fakerest.RESTClient{
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					if tt.connErr {
+						return nil, fmt.Errorf("connection refused")
+					}
+					return &http.Response{
+						StatusCode: tt.status,
+						Body:       http.NoBody,
+					}, nil
+				}),
+			}
+			mockClient := &mockClientset{
+				Clientset: fake.NewSimpleClientset(),
+				coreV1: &mockCoreV1{
+					restClient: client,
+				},
+			}
+			err := confirmNodeUpgrade(context.Background(), mockClient)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm_test.go
@@ -20,31 +20,12 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes/fake"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	fakerest "k8s.io/client-go/rest/fake"
 	"k8s.io/kubectl/pkg/scheme"
 )
-
-type mockCoreV1 struct {
-	corev1.CoreV1Interface
-	restClient rest.Interface
-}
-
-func (m *mockCoreV1) RESTClient() rest.Interface {
-	return m.restClient
-}
-
-type mockClientset struct {
-	*fake.Clientset
-	coreV1 *mockCoreV1
-}
-
-func (m *mockClientset) CoreV1() corev1.CoreV1Interface {
-	return m.coreV1
-}
 
 func TestNewEdgeConfirm(t *testing.T) {
 	cmd := NewEdgeConfirm()
@@ -91,16 +72,17 @@ func TestConfirmNodeUpgrade(t *testing.T) {
 					}, nil
 				}),
 			}
-			mockClient := &mockClientset{
+			mockClient := &testutil.MockClientset{
 				Clientset: fake.NewSimpleClientset(),
-				coreV1: &mockCoreV1{
-					restClient: client,
+				Corev1: &testutil.MockCoreV1{
+					RestClient: client,
 				},
 			}
 			err := confirmNodeUpgrade(context.Background(), mockClient)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				}
 			} else {
 				assert.NoError(t, err)
 			}

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package edit
+
+import (
+	"context"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
+)
+
+func TestNewEditDeviceOpts(t *testing.T) {
+	opts := NewEditDeviceOpts()
+	assert.NotNil(t, opts)
+}
+func TestEditDevice(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		nodeName       string
+		device         *v1beta1.Device
+		wantErr        bool
+		expectedErrMsg string
+		cancelled      bool
+	}{
+		{
+			name:     "edit success",
+			args:     []string{"test-device"},
+			nodeName: "test-node",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-device",
+					Namespace: "default",
+				},
+				Spec: v1beta1.DeviceSpec{
+					NodeName: "test-node",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "too many args",
+			args:           []string{"device1", "device2"},
+			wantErr:        true,
+			expectedErrMsg: "too many args",
+		},
+		{
+			name:     "device node name mismatch",
+			args:     []string{"test-device"},
+			nodeName: "test-node",
+			device: &v1beta1.Device{
+				Spec: v1beta1.DeviceSpec{
+					NodeName: "other-node",
+				},
+			},
+			wantErr: false, // it just logs an error
+		},
+		{
+			name:     "edit cancelled",
+			args:     []string{"test-device"},
+			nodeName: "test-node",
+			device: &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-device",
+					Namespace: "default",
+				},
+				Spec: v1beta1.DeviceSpec{
+					NodeName: "test-node",
+				},
+			},
+			wantErr:        true,
+			expectedErrMsg: "no changes made",
+			cancelled:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(util.ParseEdgecoreConfig, func(path string) (*cfgv1alpha2.EdgeCoreConfig, error) {
+				return &cfgv1alpha2.EdgeCoreConfig{
+					Modules: &cfgv1alpha2.Modules{
+						Edged: &cfgv1alpha2.Edged{
+							TailoredKubeletFlag: cfgv1alpha2.TailoredKubeletFlag{
+								HostnameOverride: tt.nodeName,
+							},
+						},
+					},
+				}, nil
+			})
+			patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "GetDevice", func(_ *client.DeviceRequest, _ context.Context) (*v1beta1.Device, error) {
+				return tt.device, nil
+			})
+			patches.ApplyFunc(editor.NewDefaultEditor, func(envs []string) editor.Editor {
+				return editor.Editor{}
+			})
+			patches.ApplyMethod(reflect.TypeOf(editor.Editor{}), "LaunchTempFile", func(_ editor.Editor, prefix, suffix string, r io.Reader) ([]byte, string, error) {
+				if tt.cancelled {
+					data, _ := io.ReadAll(r)
+					return data, "fake-file", nil
+				}
+				// Return valid JSON that is different from the input YAML
+				return []byte("{\"metadata\":{\"name\":\"test-device\",\"namespace\":\"default\"},\"spec\":{\"nodeName\":\"test-node\"}}"), "fake-file", nil
+			})
+			patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "UpdateDevice", func(_ *client.DeviceRequest, _ context.Context, _ *v1beta1.Device) (*rest.Result, error) {
+				return nil, nil
+			})
+			o := NewEditDeviceOpts()
+			err := o.editDevice(tt.args)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
@@ -130,8 +130,9 @@ func TestEditDevice(t *testing.T) {
 			o := NewEditDeviceOpts()
 			err := o.editDevice(tt.args)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				}
 			} else {
 				assert.NoError(t, err)
 			}

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
@@ -1,11 +1,10 @@
 /*
 Copyright 2024 The KubeEdge Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,18 +12,130 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package restart
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	fakerest "k8s.io/client-go/rest/fake"
+	"k8s.io/kubectl/pkg/scheme"
 
+	"github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
+type mockCoreV1 struct {
+	corev1.CoreV1Interface
+	restClient rest.Interface
+}
+
+func (m *mockCoreV1) RESTClient() rest.Interface {
+	return m.restClient
+}
+
+type mockClientset struct {
+	*fake.Clientset
+	coreV1 *mockCoreV1
+}
+
+func (m *mockClientset) CoreV1() corev1.CoreV1Interface {
+	return m.coreV1
+}
+
+func TestPodRestart(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		resp           *types.RestartResponse
+		wantErr        bool
+		expectedErrMsg string
+	}{
+		{
+			name:   "restart success",
+			status: http.StatusOK,
+			resp: &types.RestartResponse{
+				LogMessages: []string{"pod1 restarted"},
+			},
+			wantErr: false,
+		},
+		{
+			name:           "restart failed - 500",
+			status:         http.StatusInternalServerError,
+			wantErr:        true,
+			expectedErrMsg: "error on the server",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			respBytes, _ := json.Marshal(tt.resp)
+			client := &fakerest.RESTClient{
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.status,
+						Body:       io.NopCloser(bytes.NewReader(respBytes)),
+					}, nil
+				}),
+			}
+			mockClient := &mockClientset{
+				Clientset: fake.NewSimpleClientset(),
+				coreV1: &mockCoreV1{
+					restClient: client,
+				},
+			}
+			resp, err := podRestart(context.Background(), mockClient, "default", []string{"pod1"})
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.resp, resp)
+			}
+		})
+	}
+}
+func TestRestartPod(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	client := &fakerest.RESTClient{
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			resp := &types.RestartResponse{
+				LogMessages: []string{"restarted"},
+			}
+			respBytes, _ := json.Marshal(resp)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(respBytes)),
+			}, nil
+		}),
+	}
+	mockClient := &mockClientset{
+		Clientset: fake.NewSimpleClientset(),
+		coreV1: &mockCoreV1{
+			restClient: client,
+		},
+	}
+	patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return mockClient, nil
+	})
+	opts := NewRestartPodOpts()
+	err := opts.restartPod([]string{"pod1"})
+	assert.NoError(t, err)
+}
 func TestNewEdgePodRestart(t *testing.T) {
 	assert := assert.New(t)
 	cmd := NewEdgePodRestart()

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
@@ -27,33 +27,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	fakerest "k8s.io/client-go/rest/fake"
 	"k8s.io/kubectl/pkg/scheme"
 
 	"github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
-
-type mockCoreV1 struct {
-	corev1.CoreV1Interface
-	restClient rest.Interface
-}
-
-func (m *mockCoreV1) RESTClient() rest.Interface {
-	return m.restClient
-}
-
-type mockClientset struct {
-	*fake.Clientset
-	coreV1 *mockCoreV1
-}
-
-func (m *mockClientset) CoreV1() corev1.CoreV1Interface {
-	return m.coreV1
-}
 
 func TestPodRestart(t *testing.T) {
 	tests := []struct {
@@ -80,7 +61,8 @@ func TestPodRestart(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			respBytes, _ := json.Marshal(tt.resp)
+			respBytes, err := json.Marshal(tt.resp)
+			assert.NoError(t, err)
 			client := &fakerest.RESTClient{
 				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 				Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
@@ -90,16 +72,17 @@ func TestPodRestart(t *testing.T) {
 					}, nil
 				}),
 			}
-			mockClient := &mockClientset{
+			mockClient := &testutil.MockClientset{
 				Clientset: fake.NewSimpleClientset(),
-				coreV1: &mockCoreV1{
-					restClient: client,
+				Corev1: &testutil.MockCoreV1{
+					RestClient: client,
 				},
 			}
 			resp, err := podRestart(context.Background(), mockClient, "default", []string{"pod1"})
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.resp, resp)
@@ -116,17 +99,18 @@ func TestRestartPod(t *testing.T) {
 			resp := &types.RestartResponse{
 				LogMessages: []string{"restarted"},
 			}
-			respBytes, _ := json.Marshal(resp)
+			respBytes, err := json.Marshal(resp)
+			assert.NoError(t, err)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader(respBytes)),
 			}, nil
 		}),
 	}
-	mockClient := &mockClientset{
+	mockClient := &testutil.MockClientset{
 		Clientset: fake.NewSimpleClientset(),
-		coreV1: &mockCoreV1{
-			restClient: client,
+		Corev1: &testutil.MockCoreV1{
+			RestClient: client,
 		},
 	}
 	patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {

--- a/keadm/cmd/keadm/app/cmd/ctl/testutil/mock.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/testutil/mock.go
@@ -1,0 +1,40 @@
+package testutil
+
+/*
+Copyright 2024 The KubeEdge Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+type MockCoreV1 struct {
+	corev1.CoreV1Interface
+	RestClient rest.Interface
+}
+
+func (m *MockCoreV1) RESTClient() rest.Interface {
+	return m.RestClient
+}
+
+type MockClientset struct {
+	*fake.Clientset
+	Corev1 *MockCoreV1
+}
+
+func (m *MockClientset) CoreV1() corev1.CoreV1Interface {
+	return m.Corev1
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
@@ -42,12 +42,13 @@ func NewEdgeUnholdUpgrade() *cobra.Command {
 				resourceName = args[1]
 			}
 			namespace, _ := cmd.Flags().GetString("namespace")
-			if resourceType == "pod" {
+			switch resourceType {
+			case "pod":
 				if resourceName == "" {
 					return fmt.Errorf("pod name is required")
 				}
 				return unholdPodUpgrade(fmt.Sprintf("%s/%s", namespace, resourceName))
-			} else if resourceType == "node" {
+			case "node":
 				if resourceName == "" {
 					var err error
 					resourceName, err = getCurrentNodeName()
@@ -56,7 +57,7 @@ func NewEdgeUnholdUpgrade() *cobra.Command {
 					}
 				}
 				return unholdNodeUpgrade(resourceName)
-			} else {
+			default:
 				return fmt.Errorf("error: unknown resource type: %s", resourceType)
 			}
 		},

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
@@ -58,7 +58,7 @@ func NewEdgeUnholdUpgrade() *cobra.Command {
 				}
 				return unholdNodeUpgrade(resourceName)
 			default:
-				return fmt.Errorf("error: unknown resource type: %s", resourceType)
+				return fmt.Errorf("unknown resource type: %s", resourceType)
 			}
 		},
 	}

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package unhold
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	fakerest "k8s.io/client-go/rest/fake"
+	"k8s.io/kubectl/pkg/scheme"
+
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
+)
+
+type mockCoreV1 struct {
+	corev1.CoreV1Interface
+	restClient rest.Interface
+}
+
+func (m *mockCoreV1) RESTClient() rest.Interface {
+	return m.restClient
+}
+
+type mockClientset struct {
+	*fake.Clientset
+	coreV1 *mockCoreV1
+}
+
+func (m *mockClientset) CoreV1() corev1.CoreV1Interface {
+	return m.coreV1
+}
+
+func TestNewEdgeUnholdUpgrade(t *testing.T) {
+	cmd := NewEdgeUnholdUpgrade()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "unhold-upgrade <resource-type> [<name>] [--namespace namespace]", cmd.Use)
+}
+
+func TestUnholdResourceUpgrade(t *testing.T) {
+	tests := []struct {
+		name           string
+		resource       string
+		target         string
+		status         int
+		expectedErrMsg string
+		wantErr        bool
+		kubeClientErr  bool
+	}{
+		{
+			name:     "unhold success",
+			resource: "pods",
+			target:   "default/test-pod",
+			status:   http.StatusOK,
+			wantErr:  false,
+		},
+		{
+			name:           "unhold failed - kube client error",
+			resource:       "pods",
+			target:         "default/test-pod",
+			wantErr:        true,
+			kubeClientErr:  true,
+			expectedErrMsg: "kube client error",
+		},
+		{
+			name:           "unhold failed - status error",
+			resource:       "nodes",
+			target:         "test-node",
+			status:         http.StatusInternalServerError,
+			wantErr:        true,
+			expectedErrMsg: "failed to unhold nodes upgrade, status code: 500",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			if tt.kubeClientErr {
+				patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+					return nil, fmt.Errorf("kube client error")
+				})
+			} else {
+				client := &fakerest.RESTClient{
+					NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+					Client: fakerest.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: tt.status,
+							Body:       http.NoBody,
+						}, nil
+					}),
+				}
+				mockClient := &mockClientset{
+					Clientset: fake.NewSimpleClientset(),
+					coreV1: &mockCoreV1{
+						restClient: client,
+					},
+				}
+				patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+					return mockClient, nil
+				})
+			}
+			err := unholdResourceUpgrade(tt.resource, tt.target)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetCurrentNodeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *cfgv1alpha2.EdgeCoreConfig
+		wantErr  bool
+		err      error
+		expected string
+	}{
+		{
+			name: "get node name success",
+			config: &cfgv1alpha2.EdgeCoreConfig{
+				Modules: &cfgv1alpha2.Modules{
+					Edged: &cfgv1alpha2.Edged{
+						TailoredKubeletFlag: cfgv1alpha2.TailoredKubeletFlag{
+							HostnameOverride: "test-node",
+						},
+					},
+				},
+			},
+			expected: "test-node",
+			wantErr:  false,
+		},
+		{
+			name:    "parse config error",
+			err:     fmt.Errorf("parse error"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(util.ParseEdgecoreConfig, func(path string) (*cfgv1alpha2.EdgeCoreConfig, error) {
+				return tt.config, tt.err
+			})
+			nodeName, err := getCurrentNodeName()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, nodeName)
+			}
+		})
+	}
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
@@ -23,33 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	fakerest "k8s.io/client-go/rest/fake"
 	"k8s.io/kubectl/pkg/scheme"
 
 	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/testutil"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
-
-type mockCoreV1 struct {
-	corev1.CoreV1Interface
-	restClient rest.Interface
-}
-
-func (m *mockCoreV1) RESTClient() rest.Interface {
-	return m.restClient
-}
-
-type mockClientset struct {
-	*fake.Clientset
-	coreV1 *mockCoreV1
-}
-
-func (m *mockClientset) CoreV1() corev1.CoreV1Interface {
-	return m.coreV1
-}
 
 func TestNewEdgeUnholdUpgrade(t *testing.T) {
 	cmd := NewEdgeUnholdUpgrade()
@@ -109,10 +90,10 @@ func TestUnholdResourceUpgrade(t *testing.T) {
 						}, nil
 					}),
 				}
-				mockClient := &mockClientset{
+				mockClient := &testutil.MockClientset{
 					Clientset: fake.NewSimpleClientset(),
-					coreV1: &mockCoreV1{
-						restClient: client,
+					Corev1: &testutil.MockCoreV1{
+						RestClient: client,
 					},
 				}
 				patches.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
@@ -121,8 +102,9 @@ func TestUnholdResourceUpgrade(t *testing.T) {
 			}
 			err := unholdResourceUpgrade(tt.resource, tt.target)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				}
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR addresses earlier review feedback from maintainers to improve the `keadm ctl` command tests:
- Removed the custom `testutil.MockClientset` implementation and replaced it with `fake.NewSimpleClientset()` from `client-go` for the `confirm`, `unhold`, and `restart` command tests to avoid unnecessary code duplication.
- Added a test case evaluating the `cancelled: true` path within the `edit device` tests, ensuring the full execution flow is covered.

**Which issue(s) this PR fixes**:
Fixes #6630

**Special notes for your reviewer**:
This addresses the feedback provided by @WillardHu concerning the use of existing `client-go` fakes instead of building unnecessary test utilities, and covers the missing logical path highlighted by the automated AI review.

**Does this PR introduce a user-facing change?**:
```release-note
NONE