### PR TITLE
fix: replace panic with error logging in CompareResourceVersion

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -141,13 +141,13 @@ func GetObjectResourceVersion(obj interface{}) string {
 func CompareResourceVersion(rva, rvb string) int {
 	a, err := strconv.ParseUint(rva, 10, 64)
 	if err != nil {
-		// coder error
-		panic(err)
+		klog.Errorf("failed to parse resource version %q: %v", rva, err)
+		return 0
 	}
 	b, err := strconv.ParseUint(rvb, 10, 64)
 	if err != nil {
-		// coder error
-		panic(err)
+		klog.Errorf("failed to parse resource version %q: %v", rvb, err)
+		return 0
 	}
 
 	if a > b {

--- a/cloud/pkg/synccontroller/objectsync_test.go
+++ b/cloud/pkg/synccontroller/objectsync_test.go
@@ -60,6 +60,26 @@ func TestCompareResourceVersion(t *testing.T) {
 			testNumber: []string{"123", "123"},
 			want:       0,
 		},
+		{
+			name:       "malformed first resource version",
+			testNumber: []string{"abc", "123"},
+			want:       0,
+		},
+		{
+			name:       "malformed second resource version",
+			testNumber: []string{"123", "xyz"},
+			want:       0,
+		},
+		{
+			name:       "empty first resource version",
+			testNumber: []string{"", "123"},
+			want:       0,
+		},
+		{
+			name:       "both resource versions malformed",
+			testNumber: []string{"foo", "bar"},
+			want:       0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #6782 

## What this PR does / why we need it:
This fixes a bug in the `SyncController` where a malformed resource version string could completely crash the `cloudcore` process. 

In `CompareResourceVersion`, `strconv.ParseUint` is used to compare resource versions. Previously, if parsing failed (for example, if a resource version was somehow empty or non-numeric), the code would explicitly call `panic(err)`. Because this happens inside the main sync reconciliation loop, a single bad piece of data shouldn't be allowed to crash the entire controller.

This PR:
- Replaces the `panic(err)` calls with `klog.Errorf` so we just log the issue instead of crashing.
- Returns `0` (treating the versions as equal) when a parse error occurs. This is a safe fallback: the callers (`sendEvents` and `sendClusterObjectSyncEvent`) only trigger a sync update when the result is `> 0`. Returning `0` ensures we safely skip the sync without taking down `cloudcore`.
- Adds unit tests to `objectsync_test.go` to explicitly cover empty and malformed string inputs.

## Which issue(s) this PR fixes:
Fixes #6782

## Special notes for your reviewer:
The unit tests in `objectsync_test.go` have been updated and all pass successfully.
