### PR TITLE
fix(cloudhub): fix typo "Node founded" and improve consistency in CheckNode handler

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/node/checknode.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/node/checknode.go
@@ -33,7 +33,7 @@ func CheckNode(request *restful.Request, response *restful.Response) {
 	if nodeName == "" {
 		err := response.WriteErrorString(http.StatusBadRequest, "nodename parameter is required")
 		if err != nil {
-			klog.Errorf("failed to send the task resp to edge , err: %v", err)
+			klog.Errorf("failed to write response to edge, err: %v", err)
 		}
 		return
 	}
@@ -44,7 +44,7 @@ func CheckNode(request *restful.Request, response *restful.Response) {
 			// node not found or query error
 			err = response.WriteErrorString(http.StatusNotFound, "Node not found")
 			if err != nil {
-				klog.Errorf("failed to send the task resp to edge , err: %v", err)
+				klog.Errorf("failed to write response to edge, err: %v", err)
 			}
 			return
 		}
@@ -53,14 +53,14 @@ func CheckNode(request *restful.Request, response *restful.Response) {
 		klog.Errorf("failed to query the node, err: %v", err)
 		err = response.WriteErrorString(http.StatusInternalServerError, "Failed to query node information")
 		if err != nil {
-			klog.Errorf("failed to send the response to edge, err: %v", err)
+			klog.Errorf("failed to write response to edge, err: %v", err)
 		}
 		return
 	}
 
 	// node exists return success
-	err = response.WriteErrorString(http.StatusOK, "Node founded")
+		err = response.WriteErrorString(http.StatusOK, "Node found")
 	if err != nil {
-		klog.Errorf("failed to send the task resp to edge , err: %v", err)
+		klog.Errorf("failed to write response to edge, err: %v", err)
 	}
 }

--- a/cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go
@@ -93,7 +93,7 @@ func TestCheckNode(t *testing.T) {
 			container.ServeHTTP(httpWriter, httpReq)
 
 			assert.Equal(t, tt.expectedStatus, httpWriter.Code)
-			assert.Contains(t, httpWriter.Body.String(), tt.expectedBody)
+			assert.Equal(t, tt.expectedBody, httpWriter.Body.String())
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it:**

Fixes grammatical error in CheckNode HTTP handler response message ("Node founded" → "Node found").
Improves consistency in error logging by standardizing message format ("failed to send the task resp to edge" → "failed to write response to edge").
Tightens test assertion from substring matching to exact string comparison for improved test precision.

The typo was introduced in the initial implementation and affects user-facing error responses. Log message inconsistency makes debugging harder as different call sites use different terminology. Tests now use assert.Equal for exact matching where the expected response is known.

**Which issue(s) this PR fixes:**
Fixes #

**Special notes for your reviewer:**

- All three changes are minimal and focused on the CheckNode handler
- Tests already use gomonkey correctly and cover all code paths (400, 404, 500, 200 responses)
- No signature changes; all call sites already compatible
- Test assertion improvement from assert.Contains to assert.Equal increases precision
- Run tests with: `go test -gcflags=all=-l ./cloud/pkg/cloudhub/servers/httpserver/node/...`

**Does this PR introduce a user-facing change?**:
```release-note
Fixed grammatical error in CheckNode response: "Node founded" → "Node found"