### PR TITLE
keadm: improve help text for all keadm ctl subcommands

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/confirm/confirm.go
@@ -28,11 +28,39 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
+var (
+	edgeConfirmLongDescription = `
+Send a confirmation signal to the MetaService API to acknowledge
+that the current edge node upgrade has been verified and can proceed.
+
+This command is used as part of the KubeEdge upgrade workflow.
+When an edge node upgrade is held (paused at a checkpoint), the
+user must manually inspect the node and run 'keadm ctl confirm'
+to signal that the upgrade can continue.
+
+Typical workflow:
+  1. Cloud side triggers a node upgrade task.
+  2. EdgeCore pauses at the upgrade checkpoint (hold state).
+  3. User verifies node state, application health, and readiness.
+  4. User runs 'keadm ctl confirm' to release the hold.
+  5. EdgeCore continues and completes the upgrade.
+
+Note: This command must be run directly on the edge node where
+EdgeCore is running. It communicates with the local MetaService
+API (not the cloud).`
+
+	edgeConfirmExample = `
+  # Confirm the pending upgrade on this edge node
+  keadm ctl confirm`
+)
+
 // NewEdgeConfirm returns KubeEdge confirm command.
 func NewEdgeConfirm() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "confirm",
-		Short: "Send a confirmation signal to the MetaService API.",
+		Use:     "confirm",
+		Short:   "Confirm a held upgrade on this edge node.",
+		Long:    edgeConfirmLongDescription,
+		Example: edgeConfirmExample,
 		RunE: func(_cmd *cobra.Command, _args []string) error {
 			ctx := context.Background()
 			clientset, err := metaclient.KubeClient()

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/describe.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/describe.go
@@ -18,14 +18,52 @@ package describe
 
 import "github.com/spf13/cobra"
 
-var edgeDescribeShortDescription = `Show details of a specific resource`
+var (
+	edgeDescribeShortDescription = `Show details of a specific resource`
+
+	edgeDescribeLongDescription = `
+Show detailed information about resources stored in the edge node's
+local MetaManager database.
+
+This command provides detailed descriptions of edge resources (pods
+and devices) stored locally on the edge node. Unlike 'kubectl describe',
+which queries the cloud API server, this command reads from the edge
+node's local MetaManager database (SQLite-backed).
+
+Supported resource types:
+  pod      Show details of a pod running on this edge node.
+  device   Show details of a device managed by this edge node.
+
+The output includes resource metadata, status, and system annotations
+stored in the local MetaManager.
+
+Edge autonomy: This command works even when the cloud connection is
+temporarily lost, as it queries local metadata only.
+
+Note: This command must be run directly on the edge node where
+EdgeCore is running.`
+
+	edgeDescribeExample = `
+  # Describe a pod in the default namespace
+  keadm ctl describe pod <pod-name>
+
+  # Describe a pod in a specific namespace
+  keadm ctl describe pod <pod-name> -n <namespace>
+
+  # Describe a device in the default namespace
+  keadm ctl describe device <device-name>
+
+  # Describe a device in a specific namespace
+  keadm ctl describe device <device-name> -n <namespace>`
+)
 
 // NewEdgeDescribe returns KubeEdge edge resources describe command.
 func NewEdgeDescribe() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "describe",
-		Short: edgeDescribeShortDescription,
-		Long:  edgeDescribeShortDescription,
+		Use:     "describe",
+		Short:   edgeDescribeShortDescription,
+		Long:    edgeDescribeLongDescription,
+		Example: edgeDescribeExample,
 	}
 
 	cmd.AddCommand(NewEdgeDescribePod())

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/edit.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/edit.go
@@ -17,14 +17,56 @@ package edit
 
 import "github.com/spf13/cobra"
 
-var edgeEditShortDescription = `Edit a specific resource`
+var (
+	edgeEditShortDescription = `Edit a specific resource`
+
+	edgeEditLongDescription = `
+Edit a resource stored in the local edge node MetaManager database.
+
+This command opens the resource definition in your default terminal
+editor (controlled by the EDITOR or KUBE_EDITOR environment variable).
+After you save and close the editor, the updated definition is applied
+to the edge node via the MetaService API.
+
+Currently supported resources:
+  device   Edit a Device resource by name. Device properties such as
+           desired state and twin metadata can be modified.
+
+How edit works:
+  1. The current resource definition is fetched from the edge node's
+     local MetaManager (SQLite-backed, not from the cloud API server).
+  2. The definition is written to a temp file and opened in your editor.
+  3. After saving, the changed fields are validated and patched back
+     to the local MetaManager.
+  4. Changes are then synced to the cloud via EdgeHub when the
+     cloud-edge connection is available.
+
+WARNING: Editing resources directly on the edge node bypasses normal
+Kubernetes admission webhooks and validation. Only modify fields you
+understand. Malformed YAML will be rejected but some invalid values
+may not be caught until runtime.
+
+Note: This command must be run directly on the edge node where
+EdgeCore is running.`
+
+	edgeEditExample = `
+  # Edit a device by name in the default namespace
+  keadm ctl edit device <device-name>
+
+  # Edit a device in a specific namespace
+  keadm ctl edit device <device-name> -n <namespace>
+
+  # Use a specific editor (overrides EDITOR env variable)
+  KUBE_EDITOR=nano keadm ctl edit device <device-name>`
+)
 
 // NewEdgeEdit returns KubeEdge edit edge resources command.
 func NewEdgeEdit() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "edit",
-		Short: edgeEditShortDescription,
-		Long:  edgeEditShortDescription,
+		Use:     "edit",
+		Short:   edgeEditShortDescription,
+		Long:    edgeEditLongDescription,
+		Example: edgeEditExample,
 	}
 	cmd.AddCommand(NewEdgeEditDevice())
 	return cmd

--- a/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
@@ -35,6 +35,51 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
+var (
+	edgePodExecShortDescription = `Execute command in edge pod`
+
+	edgePodExecLongDescription = `
+Execute a command inside a container running on an edge pod.
+
+This command communicates with the local MetaService API on the
+edge node to execute arbitrary commands inside containers. It works
+similarly to 'kubectl exec' but operates against the edge node's local
+MetaService API rather than the cloud API server.
+
+Interactive shells (-it flags):
+When both -i (stdin) and -t (tty) are specified, keadm ctl exec opens
+an interactive terminal session with the container. This is useful for
+debugging and interactive shell access.
+
+Command separation:
+If you need to pass flags to the command itself (not to keadm), use --
+to separate keadm flags from command flags:
+  keadm ctl exec <pod> -- command args
+
+Edge autonomy: This command works even when the cloud connection is
+temporarily lost, as it executes directly against the local Edged
+(edge-side kubelet).
+
+Note: This command must be run directly on the edge node where
+EdgeCore is running.`
+
+	edgePodExecExample = `
+  # Execute a command in a container
+  keadm ctl exec <pod-name> -- <command>
+
+  # Execute a command in a specific container of a pod
+  keadm ctl exec <pod-name> -c <container-name> -- <command>
+
+  # Open an interactive shell in a pod
+  keadm ctl exec <pod-name> -it -- /bin/sh
+
+  # Execute a command in a pod in a specific namespace
+  keadm ctl exec <pod-name> -n <namespace> -- <command>
+
+  # Pass command arguments with the -- separator
+  keadm ctl exec <pod-name> -- ls -la /tmp`
+)
+
 // PodExecOptions defines the options for executing command in edge pod
 type PodExecOptions struct {
 	Namespace string
@@ -51,15 +96,14 @@ type PodExecOptions struct {
 	TTY bool
 }
 
-var edgePodExecShortDescription = `Execute command in edge pod`
-
 // NewEdgePodExec returns KubeEdge exec edge pod command.
 func NewEdgePodExec() *cobra.Command {
 	execOpts := NewEdgePodExecOpts()
 	cmd := &cobra.Command{
-		Use:   "exec",
-		Short: edgePodExecShortDescription,
-		Long:  edgePodExecShortDescription,
+		Use:     "exec",
+		Short:   edgePodExecShortDescription,
+		Long:    edgePodExecLongDescription,
+		Example: edgePodExecExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("no pod specified for exec")

--- a/keadm/cmd/keadm/app/cmd/ctl/get/get.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/get/get.go
@@ -20,14 +20,55 @@ import "github.com/spf13/cobra"
 
 var (
 	edgeGetShortDescription = `Get resources in edge node`
+
+	edgeGetLongDescription = `
+List resources stored in the edge node's local MetaManager database.
+
+This command provides a list of resources (pods, devices) managed on
+the current edge node. Unlike 'kubectl get', which queries the cloud
+API server, this command reads from the edge node's local MetaManager
+database (SQLite-backed).
+
+Supported resource types and aliases:
+  pods, po         List all pods on this edge node.
+  devices          List all devices managed by this edge node.
+
+Resource filtering:
+The list is scoped to the current edge node only. If you specify a
+namespace with -n/--namespace, only resources in that namespace are
+shown. By default, resources in the 'default' namespace are displayed.
+
+Edge autonomy: This command works even when the cloud connection is
+temporarily lost, as it queries local metadata only.
+
+Note: This command must be run directly on the edge node where
+EdgeCore is running. The edge node name is read from the local
+EdgeCore configuration file automatically.`
+
+	edgeGetExample = `
+  # List all pods in the default namespace on this edge node
+  keadm ctl get pods
+
+  # List all pods in a specific namespace
+  keadm ctl get pods -n <namespace>
+
+  # List all devices in the default namespace
+  keadm ctl get devices
+
+  # List all devices in a specific namespace
+  keadm ctl get devices -n <namespace>
+
+  # Use the pod alias to list pods
+  keadm ctl get po`
 )
 
 // NewEdgeGet returns KubeEdge edge resources get command.
 func NewEdgeGet() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: edgeGetShortDescription,
-		Long:  edgeGetShortDescription,
+		Use:     "get",
+		Short:   edgeGetShortDescription,
+		Long:    edgeGetLongDescription,
+		Example: edgeGetExample,
 	}
 
 	cmd.AddCommand(NewEdgePodGet())

--- a/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
@@ -34,7 +34,56 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
-var edgePodLogsShortDescription = `Get pod logs in edge node`
+var (
+	edgePodLogsShortDescription = `Get pod logs in edge node`
+
+	edgePodLogsLongDescription = `
+Retrieve and stream logs from a pod running on an edge node.
+
+This command communicates with the local MetaService API on the
+edge node to fetch logs from containers. It works similarly to
+'kubectl logs' but operates against the edge node's local MetaManager
+rather than the cloud API server.
+
+Supported flags:
+  -f, --follow            Stream logs as they are produced by the container.
+  -p, --previous          Show logs from the previous instance of the container
+                          if it exists (useful after crashes/restarts).
+  -c, --container string  Print logs of a specific container in the pod.
+  --since string          Only return logs newer than a relative duration
+                          (e.g., 5s, 2m, 3h). Only one of --since or --since-time
+                          can be specified.
+  --since-time string     Only return logs after a specific RFC3339 date.
+  --tail int              Number of lines to display from the end of logs.
+                          Defaults to -1 (all lines) if no selector, otherwise 10.
+  --timestamps            Include timestamps on each line in the output.
+  --limit-bytes int       Maximum bytes of logs to return. Defaults to no limit.
+
+Edge autonomy: This command works even when the cloud connection is
+temporarily lost, as it queries the local MetaService API.
+
+Note: This command must be run directly on the edge node where
+EdgeCore is running.`
+
+	edgePodLogsExample = `
+  # Get logs from a pod in the default namespace
+  keadm ctl logs <pod-name>
+
+  # Get logs from a pod in a specific namespace
+  keadm ctl logs <pod-name> -n <namespace>
+
+  # Stream logs (follow mode)
+  keadm ctl logs <pod-name> -f
+
+  # Get logs from a specific container
+  keadm ctl logs <pod-name> -c <container-name>
+
+  # Get last 50 lines of logs
+  keadm ctl logs <pod-name> --tail 50
+
+  # Get logs from the previous instance of the container
+  keadm ctl logs <pod-name> -p`
+)
 
 // PodLogsOptions defines the options for getting logs of edge pod
 type PodLogsOptions struct {
@@ -61,9 +110,10 @@ type PodLogsOptions struct {
 func NewEdgePodLogs() *cobra.Command {
 	logsOpts := NewLogsPodOpts()
 	cmd := &cobra.Command{
-		Use:   "logs",
-		Short: edgePodLogsShortDescription,
-		Long:  edgePodLogsShortDescription,
+		Use:     "logs",
+		Short:   edgePodLogsShortDescription,
+		Long:    edgePodLogsLongDescription,
+		Example: edgePodLogsExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("no pod specified for logs")

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/restart.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/restart.go
@@ -20,14 +20,44 @@ import "github.com/spf13/cobra"
 
 var (
 	edgeRestartShortDescription = `Restart resources in edge node`
+
+	edgeRestartLongDescription = `
+Restart resources (such as pods) running on an edge node.
+
+This command communicates with the local MetaService API on the
+edge node to trigger a restart of the specified resource. It does
+NOT restart EdgeCore itself or affect the cloud-side state.
+
+Restart behaviour for pods:
+  - The pod is deleted and recreated by Edged (the edge-side kubelet).
+  - If the pod is managed by a Deployment or DaemonSet, a new pod
+    is scheduled automatically after deletion.
+  - Workloads continue running on the edge even if the cloud connection
+    is temporarily lost (edge autonomy is preserved).
+
+Subcommands:
+  pod    Restart one or more pods by name in the edge node.
+
+Note: This command must be run directly on the edge node.`
+
+	edgeRestartExample = `
+  # Restart a specific pod in the default namespace
+  keadm ctl restart pod <pod-name>
+
+  # Restart a pod in a specific namespace
+  keadm ctl restart pod <pod-name> -n <namespace>
+
+  # Restart multiple pods at once
+  keadm ctl restart pod <pod1> <pod2> <pod3>`
 )
 
 // NewEdgeRestart returns KubeEdge restart edge resources command.
 func NewEdgeRestart() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "restart",
-		Short: edgeRestartShortDescription,
-		Long:  edgeRestartShortDescription,
+		Use:     "restart",
+		Short:   edgeRestartShortDescription,
+		Long:    edgeRestartLongDescription,
+		Example: edgeRestartExample,
 	}
 	cmd.AddCommand(NewEdgePodRestart())
 	return cmd

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
@@ -29,12 +29,61 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
+var (
+	edgeUnholdLongDescription = `
+Release the upgrade hold on a pod or node, allowing a previously
+paused (held) upgrade to resume.
+
+KubeEdge supports a hold/unhold mechanism during upgrades. When an
+upgrade task is created with hold enabled, the upgrade process pauses
+at a checkpoint and waits for explicit user approval before continuing.
+
+This command sends an unhold signal via the local MetaService API to
+release that checkpoint for the specified resource.
+
+Resource types:
+  pod   Unhold the upgrade for a specific pod in a namespace.
+        Requires the pod name. Uses --namespace (default: "default").
+  node  Unhold the upgrade for the entire edge node.
+        If no node name is given, reads the node name from the local
+        EdgeCore configuration file automatically.
+
+Upgrade workflow with hold/unhold:
+  1. Cloud creates an upgrade task with hold=true.
+  2. EdgeCore upgrades but pauses at the checkpoint.
+  3. User inspects the node and confirms it is safe to proceed.
+  4. User runs 'keadm ctl unhold-upgrade node' (or 'pod') to release.
+  5. Upgrade resumes and completes.
+
+WARNING: Releasing a hold resumes the upgrade immediately. Ensure
+the node and its workloads are in a healthy state before running
+this command.
+
+Note: This command must be run directly on the edge node where
+EdgeCore is running. It communicates with the local MetaService API.`
+
+	edgeUnholdExample = `
+  # Unhold the upgrade for the current edge node (node name read from EdgeCore config)
+  keadm ctl unhold-upgrade node
+
+  # Unhold the upgrade for a specific edge node by name
+  keadm ctl unhold-upgrade node <node-name>
+
+  # Unhold the upgrade for a specific pod in the default namespace
+  keadm ctl unhold-upgrade pod <pod-name>
+
+  # Unhold the upgrade for a pod in a specific namespace
+  keadm ctl unhold-upgrade pod <pod-name> --namespace <namespace>`
+)
+
 // NewEdgeUnholdUpgrade returns KubeEdge unhold-upgrade command.
 func NewEdgeUnholdUpgrade() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unhold-upgrade <resource-type> [<name>] [--namespace namespace]",
-		Short: "Unhold an upgrade for a pod or node-wide",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "unhold-upgrade <resource-type> [<name>] [--namespace namespace]",
+		Short:   "Unhold an upgrade for a pod or node, allowing it to resume.",
+		Long:    edgeUnholdLongDescription,
+		Example: edgeUnholdExample,
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resourceType := args[0]
 			var resourceName string


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it:**

All eight `keadm ctl` subcommands — `get`, `logs`, `exec`, `describe`,
`confirm`, `restart`, `edit`, and `unhold-upgrade` — had either no
`Long` help description or a `Long` field that merely duplicated the
single-line `Short` description. No `Example` strings existed for any
command. This left users with no way to understand:

- What MetaService API endpoint each command calls
- Whether a command works when the cloud is disconnected
- Which flags to use for common scenarios
- Safety considerations (e.g. restart does not restart EdgeCore;
  edit bypasses cloud admission webhooks; unhold-upgrade resumes
  upgrade immediately)

This PR fixes all eight commands by adding accurate `Long` descriptions
and `Example` blocks derived directly from reading the source code —
no invented behaviour.

Changes are documentation-only. No logic, flags, or behaviour changes.

**Which issue(s) this PR fixes:**

Fixes #6707

**Special notes for your reviewer:**

Verify the improved help output with:
```
go run keadm/cmd/keadm/main.go ctl <subcommand> --help
```
for each of: get, logs, exec, describe, confirm, restart, edit, unhold-upgrade.

Each command should now show a descriptive Long section and an Examples
section with realistic usage patterns.

All descriptions were written from source code analysis — they
accurately reflect the actual MetaService endpoints, argument
handling, and runtime behaviour.

**Does this PR introduce a user-facing change?**:
```release-note
Improve help text for all keadm ctl subcommands: add detailed
descriptions and usage examples for get, logs, exec, describe,
confirm, restart, edit, and unhold-upgrade.
```
