### PR TITLE
controllermanager: fix missing node-task job handling

### DIFF
--- a/cloud/pkg/controllermanager/nodetask/configupdatejob_handler.go
+++ b/cloud/pkg/controllermanager/nodetask/configupdatejob_handler.go
@@ -166,6 +166,11 @@ func (h *ConfigUpdateJobReconcileHandler) CheckTimeout(ctx context.Context, jobN
 	if err != nil {
 		return err
 	}
+	if job == nil {
+		logger.V(2).Info("the node job is not found")
+		ReleaseTimeoutJob[operationsv1alpha2.ConfigUpdateJob](ctx, jobName, h.GetResource())
+		return nil
+	}
 	if job.Status.Phase != operationsv1alpha2.JobPhaseInProgress {
 		logger.V(2).Info("job is not in InProgress phase, no need to check timeout")
 		return nil

--- a/cloud/pkg/controllermanager/nodetask/configupdatejob_handler_test.go
+++ b/cloud/pkg/controllermanager/nodetask/configupdatejob_handler_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetask
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
+)
+
+func TestConfigUpdateJobCheckTimeout(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("job not found", func(t *testing.T) {
+		handler := NewConfigUpdateJobReconcileHandler(fakeConfigUpdateJobClient(), nil)
+		err := handler.CheckTimeout(ctx, "test-job")
+		require.NoError(t, err)
+	})
+}
+
+func fakeConfigUpdateJobClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(operationsv1alpha2.SchemeGroupVersion,
+		&operationsv1alpha2.ConfigUpdateJob{},
+		&operationsv1alpha2.ConfigUpdateJobList{},
+	)
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(objs...).
+		Build()
+}

--- a/cloud/pkg/controllermanager/nodetask/imageprepulljob_handler.go
+++ b/cloud/pkg/controllermanager/nodetask/imageprepulljob_handler.go
@@ -167,6 +167,11 @@ func (h *ImagePrePullJobReconcileHandler) CheckTimeout(ctx context.Context, jobN
 	if err != nil {
 		return err
 	}
+	if job == nil {
+		logger.V(2).Info("the node job is not found")
+		ReleaseTimeoutJob[operationsv1alpha2.ImagePrePullJob](ctx, jobName, h.GetResource())
+		return nil
+	}
 	if job.Status.Phase != operationsv1alpha2.JobPhaseInProgress {
 		logger.V(2).Info("job is not in InProgress phase, no need to check timeout")
 		return nil

--- a/cloud/pkg/controllermanager/nodetask/imageprepulljob_handler_test.go
+++ b/cloud/pkg/controllermanager/nodetask/imageprepulljob_handler_test.go
@@ -367,6 +367,12 @@ func TestImagePrePullJobUpdateJobStatus(t *testing.T) {
 func TestImagePrePullJobCheckTimeout(t *testing.T) {
 	ctx := context.TODO()
 
+	t.Run("job not found", func(t *testing.T) {
+		handler := NewImagePrePullJobReconcileHandler(fakeImagePrePullJobClient(), nil)
+		err := handler.CheckTimeout(ctx, "test-job")
+		require.NoError(t, err)
+	})
+
 	t.Run("job is not in progress", func(t *testing.T) {
 		var updateJobStatusCalled bool
 		patches := gomonkey.NewPatches()

--- a/cloud/pkg/controllermanager/nodetask/nodeupgradejob_handler.go
+++ b/cloud/pkg/controllermanager/nodetask/nodeupgradejob_handler.go
@@ -166,6 +166,11 @@ func (h *NodeUpgradeJobReconcileHandler) CheckTimeout(ctx context.Context, jobNa
 	if err != nil {
 		return err
 	}
+	if job == nil {
+		logger.V(3).Info("the node job is not found")
+		ReleaseTimeoutJob[operationsv1alpha2.NodeUpgradeJob](ctx, jobName, h.GetResource())
+		return nil
+	}
 	if job.Status.Phase != operationsv1alpha2.JobPhaseInProgress {
 		logger.V(3).Info("job is not in InProgress phase, no need to check timeout")
 		return nil

--- a/cloud/pkg/controllermanager/nodetask/nodeupgradejob_handler_test.go
+++ b/cloud/pkg/controllermanager/nodetask/nodeupgradejob_handler_test.go
@@ -363,6 +363,12 @@ func TestNodeUpgradeJobUpdateJobStatus(t *testing.T) {
 func TestNodeUpgradeJobCheckTimeout(t *testing.T) {
 	ctx := context.TODO()
 
+	t.Run("job not found", func(t *testing.T) {
+		handler := NewNodeUpgradeJobReconcileHandler(fakeNodeUpgradeJobClient(), nil)
+		err := handler.CheckTimeout(ctx, "test-job")
+		require.NoError(t, err)
+	})
+
 	t.Run("job is not in progress", func(t *testing.T) {
 		var updateJobStatusCalled bool
 		patches := gomonkey.NewPatches()

--- a/cloud/pkg/controllermanager/nodetask/reconcile_runner.go
+++ b/cloud/pkg/controllermanager/nodetask/reconcile_runner.go
@@ -135,6 +135,11 @@ func RunReconcile[T NodeJobType](
 			if err != nil {
 				return err
 			}
+			if job == nil {
+				logger.V(2).Info("the node job is not found")
+				ReleaseTimeoutJob[T](ctx, req.Name, handler.GetResource())
+				return nil
+			}
 			changed := handler.CalculateStatus(ctx, job)
 			if changed {
 				return handler.UpdateJobStatus(ctx, job)

--- a/cloud/pkg/controllermanager/nodetask/reconcile_runner_test.go
+++ b/cloud/pkg/controllermanager/nodetask/reconcile_runner_test.go
@@ -86,6 +86,37 @@ func TestRunReconcile(t *testing.T) {
 		assert.Equal(t, 1, handler.called["UpdateJobStatus"])
 	})
 
+	t.Run("job not found during status retry", func(t *testing.T) {
+		jobName := "retry-not-found-job"
+		retryReq := controllerruntime.Request{
+			NamespacedName: types.NamespacedName{
+				Name: jobName,
+			},
+		}
+		retryObj := &operationsv1alpha2.ImagePrePullJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       jobName,
+				Finalizers: []string{operationsv1alpha2.FinalizerImagePrePullJob},
+			},
+			Status: operationsv1alpha2.ImagePrePullJobStatus{
+				Phase: operationsv1alpha2.JobPhaseInProgress,
+			},
+		}
+		handler := &fakeReconcileHandler{
+			getJobs: []*operationsv1alpha2.ImagePrePullJob{retryObj, nil},
+		}
+
+		defer ReleaseTimeoutJob[operationsv1alpha2.ImagePrePullJob](ctx, jobName, operationsv1alpha2.ResourceImagePrePullJob)
+
+		err := RunReconcile(ctx, retryReq, handler)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, handler.called["GetJob"])
+		assert.Equal(t, 0, handler.called["CalculateStatus"])
+		assert.Equal(t, 0, handler.called["UpdateJobStatus"])
+		_, ok := timeoutJobs.Load(timeoutJobsKey(jobName, operationsv1alpha2.ResourceImagePrePullJob))
+		assert.False(t, ok)
+	})
+
 	t.Run("job is final phase", func(t *testing.T) {
 		obj.Status.Phase = operationsv1alpha2.JobPhaseCompleted
 		handler := &fakeReconcileHandler{
@@ -110,6 +141,8 @@ func TestRunReconcile(t *testing.T) {
 type fakeReconcileHandler struct {
 	// obj is the job object
 	obj *operationsv1alpha2.ImagePrePullJob
+	// getJobs is the sequence of jobs returned by GetJob.
+	getJobs []*operationsv1alpha2.ImagePrePullJob
 	// called records the function call times
 	called map[string]int
 }
@@ -121,6 +154,11 @@ func (fakeReconcileHandler) GetResource() string {
 func (h *fakeReconcileHandler) GetJob(_ctx context.Context, _req controllerruntime.Request,
 ) (*operationsv1alpha2.ImagePrePullJob, error) {
 	h.recordCalledFunc("GetJob")
+	if len(h.getJobs) > 0 {
+		job := h.getJobs[0]
+		h.getJobs = h.getJobs[1:]
+		return job, nil
+	}
 	return h.obj, nil
 }
 

--- a/cloud/pkg/controllermanager/nodetask/timeout_job.go
+++ b/cloud/pkg/controllermanager/nodetask/timeout_job.go
@@ -93,6 +93,9 @@ func (job *TimeoutJob[T]) Run(ctx context.Context) {
 				job.ticker.Stop()
 				return
 			}
+			if job.IsStopped() {
+				return
+			}
 		case <-ctx.Done():
 			logger.V(2).Info("timeout job is stopped by context")
 			job.ticker.Stop()


### PR DESCRIPTION
  **What type of PR is this?**
/kind bug

  **What this PR does / why we need it**:
`GetJob` returns nil when a node task resource is not found, but timeout and status retry paths read the job status without checking for nil. 
This treats missing jobs as a no-op before timeout and status processing

  **Which issue(s) this PR fixes**:

  **Does this PR introduce a user-facing change?**:
  ```release-note
  NONE