### PR TITLE
cloudhub: queue resources on ObjectSync init failure

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -298,7 +298,21 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 	clusterObjectSync, err := md.clusterObjectSyncLister.Get(clusterObjectSyncName)
 
 	switch {
-	case err == nil && clusterObjectSync.Status.ObjectResourceVersion != "":
+	case err == nil:
+		if clusterObjectSync.Status.ObjectResourceVersion == "" {
+			clusterObjectSyncStatus := clusterObjectSync.DeepCopy()
+			clusterObjectSyncStatus.Status.ObjectResourceVersion = "0"
+			_, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ClusterObjectSyncs().
+				UpdateStatus(context.Background(), clusterObjectSyncStatus, metav1.UpdateOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Failed to update clusterObjectSync",
+					"clusterObjectSyncName", clusterObjectSyncName,
+					"resourceName", resourceName)
+			}
+			return true
+		}
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
@@ -325,7 +339,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			klog.ErrorS(err, "Failed to create clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
 				"resourceName", resourceName)
-			return false
+			return true
 		}
 
 		clusterObjectSync.Status.ObjectResourceVersion = "0"
@@ -337,7 +351,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			klog.ErrorS(err, "Failed to update clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
 				"resourceName", resourceName)
-			return false
+			return true
 		}
 
 		return true
@@ -362,7 +376,22 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 	objectSync, err := md.objectSyncLister.ObjectSyncs(resourceNamespace).Get(objectSyncName)
 
 	switch {
-	case err == nil && objectSync.Status.ObjectResourceVersion != "":
+	case err == nil:
+		if objectSync.Status.ObjectResourceVersion == "" {
+			objectSyncStatus := objectSync.DeepCopy()
+			objectSyncStatus.Status.ObjectResourceVersion = "0"
+			_, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ObjectSyncs(resourceNamespace).
+				UpdateStatus(context.Background(), objectSyncStatus, metav1.UpdateOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Failed to update objectSync",
+					"objectSyncName", objectSyncName,
+					"resourceNamespace", resourceNamespace,
+					"resourceName", resourceName)
+			}
+			return true
+		}
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
@@ -391,7 +420,7 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 				"objectSyncName", objectSyncName,
 				"resourceNamespace", resourceNamespace,
 				"resourceName", resourceName)
-			return false
+			return true
 		}
 
 		objectSyncStatus.Status.ObjectResourceVersion = "0"
@@ -404,7 +433,7 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 				"objectSyncName", objectSyncName,
 				"resourceNamespace", resourceNamespace,
 				"resourceName", resourceName)
-			return false
+			return true
 		}
 
 		return true

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -17,11 +17,17 @@ limitations under the License.
 package dispatcher
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	coretesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -33,6 +39,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common"
 	tf "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/testing"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/session"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
 	mockcon "github.com/kubeedge/kubeedge/pkg/viaduct/pkg/conn/testing"
 )
 
@@ -209,6 +216,28 @@ func TestEnqueueAckMessage(t *testing.T) {
 			ExpectedStoreMessage: normalMsg1,
 		},
 		{
+			Name:                 "new message is queued when objectSync create fails",
+			InitialObjectSyncs:   tf.NoObjectSyncs,
+			ReactorErrors:        []tf.ReactorError{{Verb: "create", Resource: "objectsyncs", Error: errors.New("create err")}},
+			InitialMessages:      []*beehivemodel.Message{},
+			CurrentArriveMessage: normalMsg1,
+			ExpectedObjectSyncs:  tf.NoObjectSyncs,
+			ExpectedStoreMessage: normalMsg1,
+		},
+		{
+			Name: "message with empty objectSync status is queued",
+			InitialObjectSyncs: []*v1alpha1.ObjectSync{
+				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, ""), "Pod"),
+			},
+			ReactorErrors:        tf.NoErrors,
+			InitialMessages:      []*beehivemodel.Message{},
+			CurrentArriveMessage: normalMsg1,
+			ExpectedObjectSyncs: []*v1alpha1.ObjectSync{
+				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "0"), "Pod"),
+			},
+			ExpectedStoreMessage: normalMsg1,
+		},
+		{
 			Name: "message with large resource version than already exist objectSync arrives, no message in store",
 			InitialObjectSyncs: []*v1alpha1.ObjectSync{
 				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
@@ -358,6 +387,48 @@ func TestEnqueueAckMessage(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			executeTest(t, test)
 		})
+	}
+}
+
+func TestEnqueueAckMessageClusterObjectSync(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.Fake.PrependReactor("create", "clusterobjectsyncs", func(coretesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("create err")
+	})
+
+	nmp := common.InitNodeMessagePool(tf.TestNodeID)
+	objectSyncIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	clusterObjectSyncIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          session.NewSessionManager(10),
+		objectSyncLister:        synclisters.NewObjectSyncLister(objectSyncIndexer),
+		clusterObjectSyncLister: synclisters.NewClusterObjectSyncLister(clusterObjectSyncIndexer),
+	}
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp)
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            tf.TestNodeID,
+			ResourceVersion: "1",
+			UID:             types.UID(tf.TestPodUID),
+		},
+	}
+	resource := fmt.Sprintf("node/%s/%s/node/%s", tf.TestNodeID, models.NullNamespace, node.Name)
+	msg := beehivemodel.NewMessage("").
+		SetResourceVersion(node.ResourceVersion).
+		FillBody(node).
+		BuildRouter("edgecontroller", "resource", resource, "update")
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	item, _, _ := nmp.AckMessageStore.Get(msg)
+	if item == nil {
+		t.Fatal("expected message to be queued")
+	}
+	if !reflect.DeepEqual(item.(*beehivemodel.Message), msg) {
+		t.Errorf("expected: %+v, got %+v", msg, item)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CloudHub dropped resource messages when it could not create or initialize the ObjectSync or ClusterObjectSync record before first delivery
Queue the message in that path so the edge ACK path can record the sync success point

**Which issue(s) this PR fixes**:
Refs #6672

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```