### PR TITLE
fix(keadm): support embedded struct fields in config-update (Fix #6721)

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/set.go
+++ b/keadm/cmd/keadm/app/cmd/util/set.go
@@ -503,6 +503,14 @@ func findFieldByTag(obj interface{}, k int, tagName []string, fieldNames []strin
 			fieldNames[k] = field.Name
 			findFieldByTag(v.Field(i).Interface(), k+1, tagName, fieldNames)
 		}
+		// Support embedded/anonymous struct fields (Fix #6721)
+		if field.Anonymous {
+			f := v.Field(i)
+			if f.Kind() == reflect.Ptr && f.IsNil() {
+				continue
+			}
+			findFieldByTag(f.Interface(), k, tagName, fieldNames)
+		}
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Fixes #6721.

When using `keadm config-update` with nested fields (like `modules.edged.hostnameOverride`), the command fails with `No such field` error.

**Root Cause:**
The `findFieldByTag` function in `keadm/cmd/keadm/app/cmd/util/set.go` did not support Go's embedded/anonymous structs. The `hostnameOverride` field is defined inside `TailoredKubeletFlag`, which is an embedded struct within `Edged`.

**Fix:**
Added logic to recursively search embedded fields when the target tag is not found in the current struct level.

## Special notes for reviewers:
This allows users to successfully update config fields defined in embedded structs like `TailoredKubeletFlag` and `ContainerRuntimeOptions`.
