### PR TITLE
docs: clarify Flannel behavior on KubeEdge edge nodes

### DIFF
--- a/build/edge/kubernetes/README.md
+++ b/build/edge/kubernetes/README.md
@@ -4,6 +4,15 @@ This method will guide you to deploy the edge part into a k8s cluster,
 so you need to login to the k8s master node (or where else if you can
 operate the cluster with `kubectl`).
 
+### Flannel on edge nodes
+
+Flannel is a standard CNI plugin, but KubeEdge does not bundle or manage Flannel on edge nodes. Flannel can be healthy on cloud Kubernetes nodes while edge pods still lack networking because edge nodes:
+
+- do not automatically run the Flannel DaemonSet (it only runs on nodes that can schedule it; edge nodes may be tainted or isolated);
+- may be in different network planes or behind NAT, so Flannel overlay traffic (e.g., VXLAN/UDP port 8472) can be blocked.
+
+If you want Flannel on edge nodes, install the CNI binaries and config on each edge node, ensure the Flannel agent runs there (DaemonSet with proper tolerations/selectors or a host-level service), and verify the required overlay ports are reachable between edge nodes.
+
 The manifests and scripts in `github.com/kubeedge/kubeedge/build/edge/kubernetes`
 will be used, so place these files to somewhere you can kubectl with.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

This PR adds documentation explaining why Flannel may appear to work correctly on standard Kubernetes nodes while Pod networking on KubeEdge edge nodes may still fail or behave unexpectedly.
This helps users better understand expected behavior and reduces confusion during deployment and troubleshooting.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6684

**Special notes for your reviewer**:

This is a documentation-only change. No functional or behavioral changes were introduced.

**Does this PR introduce a user-facing change?**:

Added documentation explaining Flannel networking behavior differences between Kubernetes nodes and KubeEdge edge nodes, including common causes and required edge-side configuration.
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
