### PR TITLE
fix(keadm): validate required RBAC resources and verbs during preflight checks

### DIFF
--- a/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
+++ b/keadm/cmd/keadm/app/cmd/helm/cloudcore.go
@@ -106,7 +106,7 @@ func (c *CloudCoreHelmTool) Install(opts *types.InitOptions) error {
 	if err := c.Common.OSTypeInstaller.IsK8SComponentInstalled(c.Common.KubeConfig, c.Common.Master); err != nil {
 		return fmt.Errorf("failed to verify k8s component installed, err: %v", err)
 	}
-	if err := c.runPreflightChecks(opts.KubeConfig, opts.SkipPreflightChecks); err != nil {
+	if err := c.runPreflightChecks(opts); err != nil {
 		return err
 	}
 

--- a/keadm/cmd/keadm/app/cmd/helm/preflight.go
+++ b/keadm/cmd/keadm/app/cmd/helm/preflight.go
@@ -24,18 +24,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 )
 
-func (c *CloudCoreHelmTool) runPreflightChecks(kubeConfig string, skip bool) error {
-	if skip {
+func (c *CloudCoreHelmTool) runPreflightChecks(opts *types.InitOptions) error {
+	if opts == nil {
+		return fmt.Errorf("pre-flight check failed: init options are nil")
+	}
+	if opts.SkipPreflightChecks {
 		fmt.Println("Skipping pre-flight checks.")
 		return nil
 	}
 
 	fmt.Println("Running pre-flight checks...")
 
-	cli, err := util.KubeClient(kubeConfig)
+	cli, err := util.KubeClient(opts.KubeConfig)
 	if err != nil {
 		return fmt.Errorf("pre-flight check failed: cannot create kube client, err: %v", err)
 	}
@@ -46,7 +50,9 @@ func (c *CloudCoreHelmTool) runPreflightChecks(kubeConfig string, skip bool) err
 	if err := checkCoreDNS(cli); err != nil {
 		return err
 	}
-	if err := checkCloudCorePermissions(cli); err != nil {
+
+	rbacChecks := util.RequiredPermissions(opts)
+	if err := util.CheckKubernetesPermissions(cli, rbacChecks); err != nil {
 		return err
 	}
 

--- a/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/kubeedge/kubeedge/common/constants"
+	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 )
 
@@ -58,6 +59,26 @@ func (ks *K8SInstTool) InstallTools() error {
 
 	err = ks.IsK8SComponentInstalled(ks.KubeConfig, ks.Master)
 	if err != nil {
+		return err
+	}
+
+	// Legacy path preflight RBAC permissions check
+	config, err := BuildConfig(ks.KubeConfig, ks.Master)
+	if err != nil {
+		return fmt.Errorf("failed to build config, err: %v", err)
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("failed to create client, err: %v", err)
+	}
+
+	opts := &types.InitOptions{
+		SkipCRDs: false, // Legacy path always installs CRDs
+	}
+	opts.Force = true // Legacy path wait behavior is disabled (pods list/watch not needed)
+
+	rbacChecks := RequiredPermissions(opts)
+	if err := CheckKubernetesPermissions(client, rbacChecks); err != nil {
 		return err
 	}
 

--- a/keadm/cmd/keadm/app/cmd/util/k8sinstaller_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/k8sinstaller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	"github.com/kubeedge/kubeedge/common/constants"
@@ -36,6 +37,13 @@ func TestK8SInstToolInstallTools(t *testing.T) {
 	defer globPatches.Reset()
 
 	globPatches.ApplyFuncReturn(GetOSInterface, &commfake.MockOSTypeInstaller{})
+	globPatches.ApplyFunc(BuildConfig, func(kubeConfig, master string) (*rest.Config, error) {
+		return &rest.Config{}, nil
+	})
+	globPatches.ApplyFunc(kubernetes.NewForConfig, func(c *rest.Config) (*kubernetes.Clientset, error) {
+		return nil, nil
+	})
+	globPatches.ApplyFuncReturn(CheckKubernetesPermissions, nil)
 	globPatches.ApplyFuncReturn(installCRDs, nil)
 	globPatches.ApplyFuncReturn(createKubeEdgeNs, nil)
 

--- a/keadm/cmd/keadm/app/cmd/util/rbac.go
+++ b/keadm/cmd/keadm/app/cmd/util/rbac.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	authv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubeedge/kubeedge/common/constants"
+	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+type rbacCheck struct {
+	Verb      string
+	Resource  string
+	Namespace string
+	Group     string
+}
+
+// RequiredPermissions determines installer-level permissions dynamically based on InitOptions
+func RequiredPermissions(opts *types.InitOptions) []rbacCheck {
+	var checks []rbacCheck
+
+	// Cluster-scoped permissions
+	clusterResources := []string{"namespaces", "clusterroles", "clusterrolebindings"}
+	for _, res := range clusterResources {
+		group := ""
+		if res == "clusterroles" || res == "clusterrolebindings" {
+			group = "rbac.authorization.k8s.io"
+		}
+		checks = append(checks, rbacCheck{Verb: "get", Resource: res, Group: group})
+		checks = append(checks, rbacCheck{Verb: "create", Resource: res, Group: group})
+	}
+
+	if opts == nil || !opts.SkipCRDs {
+		checks = append(checks, rbacCheck{Verb: "get", Resource: "customresourcedefinitions", Group: "apiextensions.k8s.io"})
+		checks = append(checks, rbacCheck{Verb: "create", Resource: "customresourcedefinitions", Group: "apiextensions.k8s.io"})
+	}
+
+	// Namespace-scoped permissions (defaults to constants.SystemNamespace / "kubeedge")
+	ns := constants.SystemNamespace
+	nsResources := []string{"serviceaccounts", "configmaps", "secrets", "services", "deployments"}
+	for _, res := range nsResources {
+		group := ""
+		if res == "deployments" {
+			group = "apps"
+		}
+		checks = append(checks, rbacCheck{Verb: "get", Resource: res, Namespace: ns, Group: group})
+		checks = append(checks, rbacCheck{Verb: "create", Resource: res, Namespace: ns, Group: group})
+	}
+
+	// Conditional namespace-scoped permissions (only if Helm wait behavior is enabled)
+	if opts == nil || !opts.Force {
+		checks = append(checks, rbacCheck{Verb: "list", Resource: "pods", Namespace: ns})
+		checks = append(checks, rbacCheck{Verb: "watch", Resource: "pods", Namespace: ns})
+	}
+
+	return checks
+}
+
+// CheckKubernetesPermissions executes SelfSubjectAccessReviews for all requested permissions
+func CheckKubernetesPermissions(client kubernetes.Interface, checks []rbacCheck) error {
+	var denied []rbacCheck
+
+	for _, check := range checks {
+		sar := &authv1.SelfSubjectAccessReview{
+			Spec: authv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authv1.ResourceAttributes{
+					Namespace: check.Namespace,
+					Verb:      check.Verb,
+					Group:     check.Group,
+					Resource:  check.Resource,
+				},
+			},
+		}
+
+		result, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(
+			context.Background(),
+			sar,
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return fmt.Errorf("rbac preflight check API call failed: %v", err)
+		}
+
+		if !result.Status.Allowed {
+			denied = append(denied, check)
+		}
+	}
+
+	if len(denied) > 0 {
+		return formatGroupedRBACError(denied)
+	}
+
+	return nil
+}
+
+type resourceKey struct {
+	Resource  string
+	Namespace string
+}
+
+func formatGroupedRBACError(denied []rbacCheck) error {
+	var orderedKeys []resourceKey
+	groupedMap := make(map[resourceKey][]string)
+
+	for _, check := range denied {
+		key := resourceKey{Resource: check.Resource, Namespace: check.Namespace}
+		if _, exists := groupedMap[key]; !exists {
+			orderedKeys = append(orderedKeys, key)
+		}
+		groupedMap[key] = append(groupedMap[key], check.Verb)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("RBAC preflight check failed.\n\nMissing Kubernetes permissions:\n")
+
+	for _, key := range orderedKeys {
+		sb.WriteString("\n")
+		if key.Namespace != "" {
+			sb.WriteString(fmt.Sprintf("%s (namespace: %s)\n", key.Resource, key.Namespace))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s\n", key.Resource))
+		}
+		for _, verb := range groupedMap[key] {
+			sb.WriteString(fmt.Sprintf("  - %s\n", verb))
+		}
+	}
+
+	sb.WriteString("\nPlease grant required permissions and retry.")
+	return errors.New(sb.String())
+}

--- a/keadm/cmd/keadm/app/cmd/util/rbac_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/rbac_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	authv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/kubeedge/kubeedge/common/constants"
+	types "github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+func TestRequiredPermissions(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          *types.InitOptions
+		wantResources map[string][]string // resource name -> expected verbs
+	}{
+		{
+			name: "default options (all permissions checked)",
+			opts: &types.InitOptions{
+				SkipCRDs:            false,
+				SkipPreflightChecks: false,
+			},
+			wantResources: map[string][]string{
+				"namespaces":                {"get", "create"},
+				"clusterroles":              {"get", "create"},
+				"clusterrolebindings":       {"get", "create"},
+				"customresourcedefinitions": {"get", "create"},
+				"serviceaccounts":           {"get", "create"},
+				"configmaps":                {"get", "create"},
+				"secrets":                   {"get", "create"},
+				"services":                  {"get", "create"},
+				"deployments":               {"get", "create"},
+				"pods":                      {"list", "watch"},
+			},
+		},
+		{
+			name: "skip CRDs enabled",
+			opts: &types.InitOptions{
+				SkipCRDs: true,
+			},
+			wantResources: map[string][]string{
+				"namespaces":          {"get", "create"},
+				"clusterroles":        {"get", "create"},
+				"clusterrolebindings": {"get", "create"},
+				"serviceaccounts":     {"get", "create"},
+				"configmaps":          {"get", "create"},
+				"secrets":             {"get", "create"},
+				"services":            {"get", "create"},
+				"deployments":         {"get", "create"},
+				"pods":                {"list", "watch"},
+			},
+		},
+		{
+			name: "force install / wait behavior disabled",
+			opts: &types.InitOptions{
+				CloudInitUpdateBase: types.CloudInitUpdateBase{
+					Force: true,
+				},
+			},
+			wantResources: map[string][]string{
+				"namespaces":                {"get", "create"},
+				"clusterroles":              {"get", "create"},
+				"clusterrolebindings":       {"get", "create"},
+				"customresourcedefinitions": {"get", "create"},
+				"serviceaccounts":           {"get", "create"},
+				"configmaps":                {"get", "create"},
+				"secrets":                   {"get", "create"},
+				"services":                  {"get", "create"},
+				"deployments":               {"get", "create"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checks := RequiredPermissions(tt.opts)
+			gotResources := make(map[string][]string)
+			for _, check := range checks {
+				gotResources[check.Resource] = append(gotResources[check.Resource], check.Verb)
+				// Ensure correct namespace-scoped resource checks
+				if check.Resource == "pods" || check.Resource == "deployments" || check.Resource == "secrets" {
+					if check.Namespace != constants.SystemNamespace {
+						t.Errorf("expected namespace %q, got %q for resource %s", constants.SystemNamespace, check.Namespace, check.Resource)
+					}
+				}
+			}
+
+			if len(gotResources) != len(tt.wantResources) {
+				t.Errorf("expected %d resources checked, got %d", len(tt.wantResources), len(gotResources))
+			}
+
+			for res, expectedVerbs := range tt.wantResources {
+				verbs, ok := gotResources[res]
+				if !ok {
+					t.Fatalf("missing expected resource check: %s", res)
+				}
+				// verify verbs match
+				for _, ev := range expectedVerbs {
+					found := false
+					for _, v := range verbs {
+						if v == ev {
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Errorf("resource %s: expected verb %s not checked", res, ev)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCheckKubernetesPermissions(t *testing.T) {
+	tests := []struct {
+		name       string
+		allowRules func(verb, resource, namespace, group string) bool
+		reactErr   error
+		wantErr    bool
+		errSubstrs []string
+	}{
+		{
+			name: "all permissions allowed",
+			allowRules: func(verb, resource, namespace, group string) bool {
+				return true
+			},
+			wantErr: false,
+		},
+		{
+			name: "single permission denied",
+			allowRules: func(verb, resource, namespace, group string) bool {
+				return !(resource == "secrets" && verb == "create")
+			},
+			wantErr: true,
+			errSubstrs: []string{
+				"RBAC preflight check failed.",
+				"secrets (namespace: kubeedge)",
+				"  - create",
+			},
+		},
+		{
+			name: "multiple permissions denied",
+			allowRules: func(verb, resource, namespace, group string) bool {
+				if resource == "secrets" && verb == "create" {
+					return false
+				}
+				if resource == "clusterroles" && verb == "create" {
+					return false
+				}
+				return true
+			},
+			wantErr: true,
+			errSubstrs: []string{
+				"RBAC preflight check failed.",
+				"secrets (namespace: kubeedge)",
+				"  - create",
+				"clusterroles",
+				"  - create",
+			},
+		},
+		{
+			name: "API call failure",
+			allowRules: func(verb, resource, namespace, group string) bool {
+				return true
+			},
+			reactErr:   errors.New("connection timeout to API server"),
+			wantErr:    true,
+			errSubstrs: []string{"rbac preflight check API call failed", "connection timeout to API server"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := fake.NewSimpleClientset()
+			cli.PrependReactor("create", "selfsubjectaccessreviews",
+				func(action clienttesting.Action) (bool, runtime.Object, error) {
+					if tt.reactErr != nil {
+						return true, nil, tt.reactErr
+					}
+					createAction := action.(clienttesting.CreateAction)
+					sar := createAction.GetObject().(*authv1.SelfSubjectAccessReview)
+					allowed := tt.allowRules(
+						sar.Spec.ResourceAttributes.Verb,
+						sar.Spec.ResourceAttributes.Resource,
+						sar.Spec.ResourceAttributes.Namespace,
+						sar.Spec.ResourceAttributes.Group,
+					)
+					return true, &authv1.SelfSubjectAccessReview{
+						Status: authv1.SubjectAccessReviewStatus{Allowed: allowed},
+					}, nil
+				})
+
+			opts := &types.InitOptions{}
+			checks := RequiredPermissions(opts)
+			err := CheckKubernetesPermissions(cli, checks)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CheckKubernetesPermissions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				for _, sub := range tt.errSubstrs {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("expected error to contain %q, got: %v", sub, err)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

keadm currently verifies Kubernetes connectivity during preflight checks, but missing RBAC permissions may not be detected early in the installation flow. As a result, installation can proceed and later fail during deployment or resource creation, requiring users to troubleshoot permission issues after partial setup has already started.

This PR adds RBAC validation during the preflight stage so that required permissions are checked before installation begins.

Changes included in this PR:

- Validate required resources and verbs before installation
- Run `SelfSubjectAccessReview` checks during preflight
- Return grouped and actionable error messages for missing permissions
- Respect existing installer execution paths and existing configuration behavior
- Add regression tests covering permission validation scenarios

## Special notes for reviewers

- The implementation follows existing `keadm` installer behavior and remains aligned with the current namespace handling approach in KubeEdge.
- Modern and legacy installer paths were verified independently to ensure permission validation executes correctly for each installation flow.
- The change is intended to fail early with clear feedback while avoiding changes to existing installation behavior.

## Does this PR introduce a user-facing change?

Yes.

Users with missing RBAC permissions will now receive earlier and more actionable validation errors during preflight checks instead of encountering failures later in the installation process.

## Testing

```bash
go test ./keadm/...
```

## What type of PR is this?

/kind bug
