### PR TITLE
fix(keadm): add retry handling for transient Kubernetes API failures during preflight checks

### DIFF
--- a/keadm/cmd/keadm/app/cmd/helm/preflight.go
+++ b/keadm/cmd/keadm/app/cmd/helm/preflight.go
@@ -57,7 +57,12 @@ func (c *CloudCoreHelmTool) runPreflightChecks(kubeConfig string, skip bool) err
 // checkNodeReadiness verifies at least one node in the cluster is Ready.
 // cloudcore depends on the node registry being functional before it can schedule edge workloads.
 func checkNodeReadiness(cli kubernetes.Interface) error {
-	nodes, err := cli.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	var nodes *corev1.NodeList
+	err := util.RetryWithBackoff(context.Background(), util.DefaultPreflightBackoff(), func() error {
+		var err error
+		nodes, err = cli.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("pre-flight check failed: cannot list nodes, err: %v", err)
 	}
@@ -80,8 +85,13 @@ func checkNodeReadiness(cli kubernetes.Interface) error {
 func checkCoreDNS(cli kubernetes.Interface) error {
 	selectors := []string{"app=coredns", "k8s-app=kube-dns"}
 	for _, sel := range selectors {
-		pods, err := cli.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{
-			LabelSelector: sel,
+		var pods *corev1.PodList
+		err := util.RetryWithBackoff(context.Background(), util.DefaultPreflightBackoff(), func() error {
+			var err error
+			pods, err = cli.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{
+				LabelSelector: sel,
+			})
+			return err
 		})
 		if err != nil {
 			return fmt.Errorf("pre-flight check failed: cannot list pods in kube-system, err: %v", err)

--- a/keadm/cmd/keadm/app/cmd/helm/preflight_test.go
+++ b/keadm/cmd/keadm/app/cmd/helm/preflight_test.go
@@ -17,16 +17,31 @@ package helm
 
 import (
 	"errors"
+	"net"
 	"strings"
 	"testing"
+	"time"
 
 	authv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 )
+
+func init() {
+	util.PreflightBackoff = wait.Backoff{
+		Steps:    3,
+		Duration: 1 * time.Microsecond,
+		Factor:   2.0,
+	}
+}
 
 func newNode(name string, ready corev1.ConditionStatus) *corev1.Node {
 	return &corev1.Node{
@@ -261,4 +276,73 @@ func TestCheckCloudCorePermissions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckNodeReadinessRetry(t *testing.T) {
+	t.Run("success after transient failure", func(t *testing.T) {
+		cli := fake.NewSimpleClientset()
+		calls := 0
+		cli.PrependReactor("list", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			calls++
+			if calls == 1 {
+				return true, nil, &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection timeout")} // transient
+			}
+			// return ready node on second call
+			nodes := &corev1.NodeList{
+				Items: []corev1.Node{
+					*newNode("node-1", corev1.ConditionTrue),
+				},
+			}
+			return true, nodes, nil
+		})
+
+		err := checkNodeReadiness(cli)
+		if err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("expected exactly 2 calls, got: %d", calls)
+		}
+	})
+
+	t.Run("max retries exceeded with transient failures", func(t *testing.T) {
+		cli := fake.NewSimpleClientset()
+		calls := 0
+		cli.PrependReactor("list", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			calls++
+			return true, nil, &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection timeout")} // transient
+		})
+
+		err := checkNodeReadiness(cli)
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "connection timeout") {
+			t.Fatalf("expected connection timeout error, got: %v", err)
+		}
+		if calls != 3 {
+			t.Fatalf("expected exactly 3 calls, got: %d", calls)
+		}
+	})
+
+	t.Run("immediate fail on permanent failure", func(t *testing.T) {
+		cli := fake.NewSimpleClientset()
+		calls := 0
+		cli.PrependReactor("list", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			calls++
+			// forbidden is a permanent error
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "", errors.New("denied"))
+		})
+
+		err := checkNodeReadiness(cli)
+		if err == nil {
+			t.Fatal("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "forbidden") {
+			t.Fatalf("expected forbidden error, got: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected exactly 1 call (no retry), got: %d", calls)
+		}
+	})
 }

--- a/keadm/cmd/keadm/app/cmd/util/retry.go
+++ b/keadm/cmd/keadm/app/cmd/util/retry.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+// IsTransientError determines whether a Kubernetes API or network error is transient.
+func IsTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Context cancellation should terminate immediately.
+	// These are not transient retryable errors.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// 2. Standard library network errors (TCP timeouts, refused connections, resets, DNS drops)
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// 3. Kubernetes API specific transient errors (timeouts, rate limits, temporary unavailability)
+	if apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsUnexpectedServerError(err) {
+		return true
+	}
+
+	return false
+}
+
+// PreflightBackoff is the overridable backoff config (1µs base during testing, 1s base in production).
+var PreflightBackoff = wait.Backoff{
+	Steps:    3,
+	Duration: 1 * time.Second,
+	Factor:   2.0,
+	Jitter:   0.0,
+}
+
+// DefaultPreflightBackoff returns the standard exponential backoff configuration.
+func DefaultPreflightBackoff() wait.Backoff {
+	return PreflightBackoff
+}
+
+// RetryWithBackoff executes f, retrying transient errors using wait.ExponentialBackoff while respecting context cancellation.
+func RetryWithBackoff(ctx context.Context, backoff wait.Backoff, f func() error) error {
+	var lastErr error
+	attempt := 0
+	currentDelay := backoff.Duration
+
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		// 1. Verify context is still active before performing the request
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return true, ctxErr
+		}
+
+		attempt++
+		err := f()
+		if err == nil {
+			if attempt > 1 {
+				klog.Infof("Preflight check recovered successfully after retry")
+			}
+			return true, nil
+		}
+
+		lastErr = err
+
+		// 2. Do not retry permanent errors (e.g. Forbidden, Unauthorized, Bad Request)
+		if !IsTransientError(err) {
+			return false, err
+		}
+
+		// 3. Log warning and continue retrying if steps remain
+		if attempt < backoff.Steps {
+			klog.Warningf("Preflight check attempt %d/%d failed: %v. Retrying in %v...", attempt, backoff.Steps, err, currentDelay)
+			currentDelay = time.Duration(float64(currentDelay) * backoff.Factor)
+			return false, nil
+		}
+
+		return false, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		return lastErr
+	}
+	return err
+}

--- a/keadm/cmd/keadm/app/cmd/util/retry_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/retry_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type mockNetError struct {
+	timeout bool
+}
+
+func (m mockNetError) Error() string   { return "mock net error" }
+func (m mockNetError) Timeout() bool   { return m.timeout }
+func (m mockNetError) Temporary() bool { return true }
+
+func TestIsTransientError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is not transient",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "context deadline exceeded is not transient",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "context canceled is not transient",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "net timeout error is transient",
+			err:  mockNetError{timeout: true},
+			want: true,
+		},
+		{
+			name: "net non-timeout error is transient (all net.Error are transient)",
+			err:  mockNetError{timeout: false},
+			want: true,
+		},
+		{
+			name: "real net OpError is transient",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")},
+			want: true,
+		},
+		{
+			name: "real net DNSError is transient",
+			err:  &net.DNSError{Err: "no such host", Name: "kubernetes.default"},
+			want: true,
+		},
+		{
+			name: "k8s too many requests is transient",
+			err:  apierrors.NewTooManyRequests("too many requests", 10),
+			want: true,
+		},
+		{
+			name: "k8s service unavailable is transient",
+			err:  apierrors.NewServiceUnavailable("service unavailable"),
+			want: true,
+		},
+		{
+			name: "k8s internal error is transient",
+			err:  apierrors.NewInternalError(errors.New("internal error")),
+			want: true,
+		},
+		{
+			name: "k8s server timeout is transient",
+			err:  apierrors.NewServerTimeout(schema.GroupResource{}, "list", 10),
+			want: true,
+		},
+		{
+			name: "k8s timeout is transient",
+			err:  apierrors.NewTimeoutError("timeout", 10),
+			want: true,
+		},
+		{
+			name: "k8s unexpected server error is transient",
+			err: &apierrors.StatusError{
+				ErrStatus: metav1.Status{
+					Status:  metav1.StatusFailure,
+					Code:    500,
+					Message: "unexpected server error",
+					Details: &metav1.StatusDetails{
+						Causes: []metav1.StatusCause{
+							{
+								Type:    metav1.CauseTypeUnexpectedServerResponse,
+								Message: "unexpected server error",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "k8s forbidden is permanent",
+			err:  apierrors.NewForbidden(schema.GroupResource{}, "secret", errors.New("denied")),
+			want: false,
+		},
+		{
+			name: "k8s unauthorized is permanent",
+			err:  apierrors.NewUnauthorized("unauthorized"),
+			want: false,
+		},
+		{
+			name: "k8s bad request is permanent",
+			err:  apierrors.NewBadRequest("bad request"),
+			want: false,
+		},
+		{
+			name: "k8s not found is permanent",
+			err:  apierrors.NewNotFound(schema.GroupResource{}, "crd"),
+			want: false,
+		},
+		{
+			name: "generic random error is not transient",
+			err:  errors.New("some random failure"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransientError(tt.err); got != tt.want {
+				t.Errorf("IsTransientError() = %v, want %v for err: %v", got, tt.want, tt.err)
+			}
+		})
+	}
+}
+
+func TestRetryWithBackoff_SuccessFirstAttempt(t *testing.T) {
+	calls := 0
+	f := func() error {
+		calls++
+		return nil
+	}
+
+	backoff := wait.Backoff{
+		Steps:    3,
+		Duration: 1 * time.Microsecond,
+		Factor:   2.0,
+	}
+
+	err := RetryWithBackoff(context.Background(), backoff, f)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call, got: %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_SuccessAfterRetries(t *testing.T) {
+	calls := 0
+	f := func() error {
+		calls++
+		if calls < 3 {
+			return mockNetError{timeout: true} // transient net error
+		}
+		return nil
+	}
+
+	backoff := wait.Backoff{
+		Steps:    3,
+		Duration: 1 * time.Microsecond,
+		Factor:   2.0,
+	}
+
+	err := RetryWithBackoff(context.Background(), backoff, f)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected exactly 3 calls, got: %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_MaxRetriesExceeded(t *testing.T) {
+	calls := 0
+	transientErr := mockNetError{timeout: true}
+	f := func() error {
+		calls++
+		return fmt.Errorf("error number %d: %w", calls, transientErr)
+	}
+
+	backoff := wait.Backoff{
+		Steps:    3,
+		Duration: 1 * time.Microsecond,
+		Factor:   2.0,
+	}
+
+	err := RetryWithBackoff(context.Background(), backoff, f)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !errors.Is(err, transientErr) {
+		t.Fatalf("expected error to wrap transientErr, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "error number 3") {
+		t.Fatalf("expected error from the 3rd attempt, got: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected exactly 3 calls, got: %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_PermanentErrorNotRetried(t *testing.T) {
+	calls := 0
+	permErr := apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "pod-1", errors.New("denied"))
+	f := func() error {
+		calls++
+		return permErr
+	}
+
+	backoff := wait.Backoff{
+		Steps:    3,
+		Duration: 1 * time.Microsecond,
+		Factor:   2.0,
+	}
+
+	err := RetryWithBackoff(context.Background(), backoff, f)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	var statusErr *apierrors.StatusError
+	if !errors.As(err, &statusErr) || statusErr.ErrStatus.Code != 403 {
+		t.Fatalf("expected 403 Forbidden error, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call (no retries), got: %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	calls := 0
+	f := func() error {
+		calls++
+		return mockNetError{timeout: true}
+	}
+
+	backoff := wait.Backoff{
+		Steps:    3,
+		Duration: 1 * time.Microsecond,
+		Factor:   2.0,
+	}
+
+	err := RetryWithBackoff(ctx, backoff, f)
+	if err == nil {
+		t.Fatal("expected context canceled error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected 0 calls due to immediate cancel, got: %d", calls)
+	}
+}
+
+func TestDefaultPreflightBackoff(t *testing.T) {
+	backoff := DefaultPreflightBackoff()
+	if backoff.Steps != 3 {
+		t.Errorf("expected 3 steps, got: %d", backoff.Steps)
+	}
+	if backoff.Duration != 1*time.Second {
+		t.Errorf("expected 1s duration, got: %v", backoff.Duration)
+	}
+	if backoff.Factor != 2.0 {
+		t.Errorf("expected 2.0 factor, got: %v", backoff.Factor)
+	}
+	if backoff.Jitter != 0.0 {
+		t.Errorf("expected 0.0 jitter, got: %v", backoff.Jitter)
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

`keadm` performs several Kubernetes API checks during the preflight stage, including node readiness and CoreDNS validation.

Currently, these checks use one-shot API requests. If a temporary issue occurs (for example, a short network interruption, API timeout, or brief connection issue), the installation can fail immediately even though the cluster may become available again a few moments later.

This PR adds targeted retry handling with exponential backoff for transient failures during preflight discovery checks, allowing short-lived issues to recover without requiring the user to restart the installation.

Changes included in this PR:

- Add retry handling for transient network/API failures
- Apply retries only to read-only preflight discovery checks
- Keep authorization and permission validation behavior unchanged
- Respect context cancellation during retry execution
- Add regression tests for retry and recovery scenarios

## Special notes for reviewers

- Retry handling is intentionally limited to `checkNodeReadiness()` and `checkCoreDNS()`
- RBAC and authorization checks continue to fail immediately
- The change is scoped only to preflight discovery paths and does not alter installation behavior outside of those checks

## Does this PR introduce a user-facing change?

Yes.

Temporary API or network issues during preflight checks may now recover automatically instead of immediately terminating the installation process during preflight checks instead of causing the installation process to stop immediately.

## Testing

```bash
go test ./keadm/...
```

## What type of PR is this?

/kind bug