### PR TITLE
fix(keadm): add timeout handling for Kubernetes API operations during installation

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
+++ b/keadm/cmd/keadm/app/cmd/util/k8sinstaller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/blang/semver"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,8 @@ import (
 	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 )
+
+const DefaultK8sAPITimeout = 30 * time.Second
 
 // K8SInstTool embeds Common struct and contains the default K8S version and
 // a flag depicting if host is an edge or cloud node
@@ -91,13 +94,18 @@ func createKubeEdgeNs(kubeConfig, master string) error {
 		},
 	}
 
-	_, err = client.CoreV1().Namespaces().Get(context.Background(), ns.Name, metav1.GetOptions{})
+	ctxGet, cancelGet := context.WithTimeout(context.Background(), DefaultK8sAPITimeout)
+	defer cancelGet()
+
+	_, err = client.CoreV1().Namespaces().Get(ctxGet, ns.Name, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
+		ctxCreate, cancelCreate := context.WithTimeout(context.Background(), DefaultK8sAPITimeout)
+		defer cancelCreate()
 		if _, err = client.CoreV1().Namespaces().Create(
-			context.Background(), ns, metav1.CreateOptions{}); err != nil {
+			ctxCreate, ns, metav1.CreateOptions{}); err != nil {
 			return err
 		}
 	}
@@ -194,7 +202,10 @@ func createKubeEdgeV1CRD(dynamicClient dynamic.Interface, crdFile string) error 
 	gvk := kubeEdgeCRD.GetObjectKind().GroupVersionKind()
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
-	_, err = dynamicClient.Resource(gvr).Create(context.Background(), kubeEdgeCRD, metav1.CreateOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultK8sAPITimeout)
+	defer cancel()
+
+	_, err = dynamicClient.Resource(gvr).Create(ctx, kubeEdgeCRD, metav1.CreateOptions{})
 
 	return err
 }

--- a/keadm/cmd/keadm/app/cmd/util/kubeclient.go
+++ b/keadm/cmd/keadm/app/cmd/util/kubeclient.go
@@ -38,7 +38,11 @@ func (co *Common) CleanNameSpace(ns, kubeConfigPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create KubeClient, error: %s", err)
 	}
-	return cli.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultK8sAPITimeout)
+	defer cancel()
+
+	return cli.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
 }
 
 // IsCloudcoreContainerRunning judge whether cloudcore pod is running


### PR DESCRIPTION
## What this PR does / why we need it

`keadm` performs several Kubernetes API operations during installation and cleanup workflows, such as namespace creation, namespace deletion, and CRD creation.

These operations currently use untimed contexts. If the Kubernetes API server becomes temporarily unresponsive or the network stalls, the operation can appear stuck and wait much longer than expected.

This PR adds timeout handling to these API operations so they can fail cleanly instead of waiting indefinitely.

Changes included in this PR:

- Add timeout boundaries for Kubernetes API operations
- Use dedicated timeout contexts for independent API calls
- Preserve existing installation behavior
- Add tests covering timeout-related execution paths

## Special notes for reviewers

- This change is limited to Kubernetes API operation boundaries
- Helm behavior and installation flow remain unchanged
- Each API operation uses its own timeout budget

## Does this PR introduce a user-facing change?

Yes.

Operations that could previously appear stuck for an extended period may now fail cleanly when timeout limits are reached.

## What type of PR is this?

/kind bug

## Testing

```bash
go test ./keadm/...

