### PR TITLE
router: preserve REST timeout status

### DIFF
--- a/cloud/pkg/router/listener/http.go
+++ b/cloud/pkg/router/listener/http.go
@@ -3,7 +3,6 @@ package listener
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,6 +28,24 @@ const MaxMessageBytes = 12 * (1 << 20)
 var (
 	RestHandlerInstance = &RestHandler{}
 )
+
+type responseStatusError struct {
+	statusCode int
+	header     http.Header
+	body       []byte
+}
+
+func newResponseStatusError(statusCode int, header http.Header, body []byte) *responseStatusError {
+	return &responseStatusError{
+		statusCode: statusCode,
+		header:     header.Clone(),
+		body:       append([]byte(nil), body...),
+	}
+}
+
+func (e *responseStatusError) Error() string {
+	return string(e.body)
+}
 
 type RestHandler struct {
 	restTimeout time.Duration
@@ -124,8 +141,10 @@ func (rh *RestHandler) httpHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	edgeNodeName := uriSections[1]
+	var responseErr *responseStatusError
 	err = retry.Do(
 		func() error {
+			responseErr = nil
 			targetCloudCoreIP, err := GetEdgeToCloudCoreIP(r.Context(), edgeNodeName)
 			if err != nil {
 				return err
@@ -155,7 +174,11 @@ func (rh *RestHandler) httpHandler(w http.ResponseWriter, r *http.Request) {
 				for key, values := range r.Header {
 					forwardReq.Header[key] = values
 				}
-				return requestForward(targetCloudCoreIP, w, forwardReq)
+				err = requestForward(targetCloudCoreIP, w, forwardReq)
+				if respErr, ok := err.(*responseStatusError); ok {
+					responseErr = respErr
+				}
+				return err
 			}
 
 			matchPath, exist := rh.matchedPath(r.RequestURI)
@@ -201,19 +224,12 @@ func (rh *RestHandler) httpHandler(w http.ResponseWriter, r *http.Request) {
 					klog.Errorf("response body read error, msg id: %s, reason: %v", msgID, err)
 					return nil
 				}
-				for key, values := range response.Header {
-					for _, value := range values {
-						w.Header().Add(key, value)
-					}
-				}
-
 				if response.StatusCode != http.StatusOK {
-					errMsg := string(body)
-					return errors.New(errMsg)
+					responseErr = newResponseStatusError(response.StatusCode, response.Header, body)
+					return responseErr
 				}
 
-				w.WriteHeader(response.StatusCode)
-				if _, err = w.Write(body); err != nil {
+				if err = writeHTTPResponse(w, response.StatusCode, response.Header, body); err != nil {
 					klog.Errorf("response body write error, msg id: %s, reason: %v", msgID, err)
 					return nil
 				}
@@ -231,6 +247,12 @@ func (rh *RestHandler) httpHandler(w http.ResponseWriter, r *http.Request) {
 	)
 
 	if err != nil {
+		if responseErr != nil {
+			if err := writeHTTPResponse(w, responseErr.statusCode, responseErr.header, responseErr.body); err != nil {
+				klog.Errorf("response body write error: %v", err)
+			}
+			return
+		}
 		writeErr(w, r, http.StatusInternalServerError, err)
 		return
 	}
@@ -278,21 +300,15 @@ func requestForward(targetCloudCoreIP string, w http.ResponseWriter, forwardReq 
 		}
 	}(resp.Body)
 
-	for key, values := range resp.Header {
-		for _, value := range values {
-			w.Header().Add(key, value)
-		}
-	}
-
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("error reading body:%v", err)
 		}
-		errMsg := string(bodyBytes)
-		return errors.New(errMsg)
+		return newResponseStatusError(resp.StatusCode, resp.Header, bodyBytes)
 	}
 
+	copyHTTPHeader(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	_, err = io.Copy(w, resp.Body)
 	if err != nil {
@@ -301,6 +317,21 @@ func requestForward(targetCloudCoreIP string, w http.ResponseWriter, forwardReq 
 
 	klog.Infof("forwarded request to %s successfully", targetCloudCoreIP)
 	return nil
+}
+
+func writeHTTPResponse(w http.ResponseWriter, statusCode int, header http.Header, body []byte) error {
+	copyHTTPHeader(w.Header(), header)
+	w.WriteHeader(statusCode)
+	_, err := w.Write(body)
+	return err
+}
+
+func copyHTTPHeader(dst, src http.Header) {
+	for key, values := range src {
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
 }
 
 func writeErr(w http.ResponseWriter, r *http.Request, statusCode int, err error) {

--- a/cloud/pkg/router/listener/http_test.go
+++ b/cloud/pkg/router/listener/http_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package listener
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRequestForwardWritesOKResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Test-Header", "value")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("ok")); err != nil {
+			t.Fatalf("Write returned error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("NewRequest returned error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+
+	if err := requestForward("127.0.0.1", recorder, req); err != nil {
+		t.Fatalf("requestForward returned error: %v", err)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if got := recorder.Header().Get("X-Test-Header"); got != "value" {
+		t.Fatalf("X-Test-Header = %q, want %q", got, "value")
+	}
+	if got := recorder.Body.String(); got != "ok" {
+		t.Fatalf("body = %q, want %q", got, "ok")
+	}
+}
+
+func TestRequestForwardReturnsResponseStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Test-Header", "value")
+		w.WriteHeader(http.StatusGatewayTimeout)
+		if _, err := w.Write([]byte("upstream timeout")); err != nil {
+			t.Fatalf("Write returned error: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("NewRequest returned error: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+
+	err = requestForward("127.0.0.1", recorder, req)
+	if err == nil {
+		t.Fatal("requestForward returned nil, want error")
+	}
+	respErr, ok := err.(*responseStatusError)
+	if !ok {
+		t.Fatalf("requestForward returned %T, want *responseStatusError", err)
+	}
+	if respErr.statusCode != http.StatusGatewayTimeout {
+		t.Fatalf("statusCode = %d, want %d", respErr.statusCode, http.StatusGatewayTimeout)
+	}
+	if got := respErr.header.Get("X-Test-Header"); got != "value" {
+		t.Fatalf("X-Test-Header = %q, want %q", got, "value")
+	}
+	if got := string(respErr.body); got != "upstream timeout" {
+		t.Fatalf("body = %q, want %q", got, "upstream timeout")
+	}
+	if recorder.Body.Len() != 0 {
+		t.Fatalf("recorder body length = %d, want 0", recorder.Body.Len())
+	}
+}

--- a/cloud/pkg/router/provider/rest/rest.go
+++ b/cloud/pkg/router/provider/rest/rest.go
@@ -115,8 +115,8 @@ func (r *Rest) Forward(target provider.Target, data interface{}) (interface{}, e
 	res["header"] = request.Header
 	res["method"] = request.Method
 	stop := make(chan struct{})
-	respch := make(chan interface{})
-	errch := make(chan error)
+	respch := make(chan interface{}, 1)
+	errch := make(chan error, 1)
 	go func() {
 		resp, err := target.GoToTarget(res, stop)
 		if err != nil {
@@ -176,7 +176,7 @@ func (r *Rest) Forward(target provider.Target, data interface{}) (interface{}, e
 			return nil, errors.New("failed to get timer channel")
 		}
 		stop <- struct{}{}
-		httpResponse.StatusCode = http.StatusRequestTimeout
+		httpResponse.StatusCode = http.StatusGatewayTimeout
 		httpResponse.Body = io.NopCloser(strings.NewReader("wait to get response time out"))
 		klog.Warningf("operation timeout, msg id: %s, write result: get response timeout", messageID)
 	case _, ok := <-request.Context().Done():

--- a/cloud/pkg/router/provider/rest/rest_test.go
+++ b/cloud/pkg/router/provider/rest/rest_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type targetFunc func(map[string]interface{}, chan struct{}) (interface{}, error)
+
+func (f targetFunc) Name() string {
+	return "target"
+}
+
+func (f targetFunc) GoToTarget(data map[string]interface{}, stop chan struct{}) (interface{}, error) {
+	return f(data, stop)
+}
+
+func TestForwardReturnsGatewayTimeout(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/edge-node/default/api", nil)
+	req.RequestURI = "/edge-node/default/api"
+
+	target := targetFunc(func(_ map[string]interface{}, stop chan struct{}) (interface{}, error) {
+		<-stop
+		return nil, nil
+	})
+
+	got, err := (&Rest{Path: "api"}).Forward(target, map[string]interface{}{
+		"messageID": "timeout-message",
+		"request":   req,
+		"timeout":   time.Millisecond,
+		"data":      []byte("request body"),
+	})
+	if err != nil {
+		t.Fatalf("Forward returned error: %v", err)
+	}
+
+	response, ok := got.(*http.Response)
+	if !ok {
+		t.Fatalf("Forward returned %T, want *http.Response", got)
+	}
+	if response.StatusCode != http.StatusGatewayTimeout {
+		t.Fatalf("StatusCode = %d, want %d", response.StatusCode, http.StatusGatewayTimeout)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("ReadAll returned error: %v", err)
+	}
+	if string(body) != "wait to get response time out" {
+		t.Fatalf("body = %q, want %q", string(body), "wait to get response time out")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
REST router timeout responses now use `504 Gateway Timeout` instead of `408 Request Timeout`
The cloud router listener also preserves the final non 200 status, headers, and body after retry
  
**Which issue(s) this PR fixes**:

Fixes #5428 

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
