### PR TITLE
cloudstream: delete metrics connection on cancel

### DIFF
--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -209,10 +209,7 @@ func (s *StreamServer) getMetrics(r *restful.Request, w *restful.Response) {
 	}
 
 	defer func() {
-		if err != nil {
-			session.DeleteAPIServerConnection(metricsConnection)
-			klog.Infof("Delete %s from %s", metricsConnection.String(), session.String())
-		}
+		session.DeleteAPIServerConnection(metricsConnection)
 	}()
 
 	if err = metricsConnection.Serve(); err != nil {

--- a/cloud/pkg/cloudstream/streamserver_test.go
+++ b/cloud/pkg/cloudstream/streamserver_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudstream
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/emicklei/go-restful"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+func TestGetMetricsDeletesConnectionOnRequestCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil).WithContext(ctx)
+	req.Host = "edge-node"
+	resp := httptest.NewRecorder()
+
+	tunnel := &TunnelServer{
+		sessions: make(map[string]*Session),
+	}
+	mockTunneler := &MockTunneler{}
+	session := &Session{
+		sessionID:     "edge-node",
+		tunnel:        mockTunneler,
+		apiServerConn: make(map[uint64]APIServerConnection),
+		apiConnlock:   &sync.RWMutex{},
+	}
+	tunnel.addSession("edge-node", session)
+
+	streamServer := &StreamServer{
+		tunnel: tunnel,
+	}
+
+	streamServer.getMetrics(restful.NewRequest(req), restful.NewResponse(resp))
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	require.NotNil(t, mockTunneler.lastMessage)
+	assert.Equal(t, stream.MessageTypeRemoveConnect, mockTunneler.lastMessage.MessageType)
+	assert.Empty(t, session.apiServerConn)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
A canceled `/metrics` request could leave a metrics connection in the CloudStream session. Later data for that stale connection may write to a finished HTTP response.
This PR deletes the metrics connection when the request handler exits and adds a regression test.

**Which issue(s) this PR fixes**:
Fixes #5005

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
  NONE
```