### PR TITLE
keadm: validate runtime in debug check

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/check.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/spf13/cobra"
+	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 
 	"github.com/kubeedge/api/apis/common/constants"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
@@ -48,12 +50,17 @@ and maintenance personnel to locate the problem`
         # Check whether the number of free processes on the node meets requirements.
         keadm debug check pid
 
-        # Check whether runtime(Docker) is installed on the node.
+        # Check whether the container runtime can work.
         keadm debug check runtime
 `
 )
 
 type CheckObject common.CheckObject
+
+type runtimeStatusChecker interface {
+	Connect() error
+	IsRunning() error
+}
 
 // NewCheck returns KubeEdge edge check command.
 func NewCheck() *cobra.Command {
@@ -95,6 +102,9 @@ func NewSubEdgeCheck(object CheckObject) *cobra.Command {
 		cmd.Flags().StringVarP(&co.CloudHubServer, "cloud-hub-server", "s", co.CloudHubServer, "specify cloudhub server")
 		cmd.Flags().StringVarP(&co.Config, common.EdgecoreConfig, "c", co.Config,
 			fmt.Sprintf("Specify configuration file, default is %s", constants.EdgecoreConfigPath))
+	case common.ArgCheckRuntime:
+		cmd.Flags().StringVarP(&co.Config, common.EdgecoreConfig, "c", co.Config,
+			fmt.Sprintf("Specify configuration file, default is %s", constants.EdgecoreConfigPath))
 	}
 
 	return cmd
@@ -130,7 +140,7 @@ func (co *CheckObject) ExecuteCheck(use string, ob *common.CheckOptions) {
 	case common.ArgCheckNetwork:
 		err = CheckNetWork(ob.IP, ob.Timeout, ob.CloudHubServer, ob.EdgecoreServer, ob.Config)
 	case common.ArgCheckRuntime:
-		err = CheckRuntime()
+		err = CheckRuntime(ob.Config)
 	case common.ArgCheckPID:
 		err = CheckPid()
 	}
@@ -174,7 +184,7 @@ func CheckAll(ob *common.CheckOptions) error {
 		return err
 	}
 
-	err = CheckRuntime()
+	err = CheckRuntime(ob.Config)
 	if err != nil {
 		return err
 	}
@@ -342,9 +352,53 @@ func CheckHTTP(url string) error {
 	return nil
 }
 
-func CheckRuntime() error {
-	// TODO: check runtime status
+func CheckRuntime(config string) error {
+	endpoint, err := getRuntimeEndpoint(config)
+	if err != nil {
+		return err
+	}
+	return checkRuntimeEndpoint(endpoint, utilruntime.NewContainerRuntime(endpoint))
+}
+
+func checkRuntimeEndpoint(endpoint string, containerRuntime runtimeStatusChecker) error {
+	if err := containerRuntime.Connect(); err != nil {
+		return fmt.Errorf("could not connect to the container runtime: %v", err)
+	}
+
+	if err := containerRuntime.IsRunning(); err != nil {
+		return err
+	}
+	fmt.Printf("check runtime endpoint %s success\n", endpoint)
 	return nil
+}
+
+func getRuntimeEndpoint(config string) (string, error) {
+	endpoint := constants.DefaultRemoteRuntimeEndpoint
+	if config == "" {
+		return endpoint, nil
+	}
+
+	if _, err := os.Stat(config); err != nil {
+		if os.IsNotExist(err) {
+			if config == constants.EdgecoreConfigPath {
+				return endpoint, nil
+			}
+			return "", fmt.Errorf("edgecore config %s does not exist", config)
+		}
+		return "", fmt.Errorf("stat edgecore config %s failed: %v", config, err)
+	}
+
+	edgeConfig, err := util.ParseEdgecoreConfig(config)
+	if err != nil {
+		return "", fmt.Errorf("parse Edgecore config failed: %w", err)
+	}
+	if edgeConfig.Modules == nil || edgeConfig.Modules.Edged == nil || edgeConfig.Modules.Edged.TailoredKubeletConfig == nil {
+		return endpoint, nil
+	}
+	if edgeConfig.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint != "" {
+		endpoint = edgeConfig.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint
+	}
+	return endpoint, nil
 }
 
 func CheckPid() error {

--- a/keadm/cmd/keadm/app/cmd/debug/check_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package debug
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kubeedge/api/apis/common/constants"
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 )
 
@@ -122,6 +127,14 @@ func TestNewCheck(t *testing.T) {
 			assert.Equal("c", flag.Shorthand)
 			expectedUsage := fmt.Sprintf("Specify configuration file, default is %s", constants.EdgecoreConfigPath)
 			assert.Equal(expectedUsage, flag.Usage)
+
+		case common.ArgCheckRuntime:
+			flag := flags.Lookup("config")
+			assert.NotNil(flag)
+			assert.Equal("", flag.DefValue)
+			assert.Equal("c", flag.Shorthand)
+			expectedUsage := fmt.Sprintf("Specify configuration file, default is %s", constants.EdgecoreConfigPath)
+			assert.Equal(expectedUsage, flag.Usage)
 		}
 	}
 }
@@ -192,6 +205,18 @@ func TestNewSubEdgeCheck(t *testing.T) {
 				"config":           fmt.Sprintf("Specify configuration file, default is %s", constants.EdgecoreConfigPath),
 			},
 		},
+		{
+			use: "runtime",
+			expectedDefValue: map[string]string{
+				"config": "",
+			},
+			expectedShorthand: map[string]string{
+				"config": "c",
+			},
+			expectedUsage: map[string]string{
+				"config": fmt.Sprintf("Specify configuration file, default is %s", constants.EdgecoreConfigPath),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -228,4 +253,111 @@ func TestNewCheckOptions(t *testing.T) {
 
 	assert.Equal("www.github.com", co.Domain)
 	assert.Equal(1, co.Timeout)
+}
+
+type fakeContainerRuntime struct {
+	connectErr error
+	runningErr error
+}
+
+func (f *fakeContainerRuntime) Connect() error {
+	return f.connectErr
+}
+
+func (f *fakeContainerRuntime) IsRunning() error {
+	return f.runningErr
+}
+
+func writeEdgeCoreConfig(t *testing.T, data string) string {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "edgecore.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(data), 0644))
+	return configPath
+}
+
+func TestGetRuntimeEndpoint(t *testing.T) {
+	customEndpoint := "unix:///tmp/kubeedge-test-containerd.sock"
+	configPath := filepath.Join(t.TempDir(), "edgecore.yaml")
+	cfg := cfgv1alpha2.NewDefaultEdgeCoreConfig()
+	cfg.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint = customEndpoint
+	require.NoError(t, cfg.WriteTo(configPath))
+
+	tests := []struct {
+		name         string
+		config       string
+		wantEndpoint string
+		wantErr      string
+	}{
+		{
+			name:         "empty config uses default endpoint",
+			config:       "",
+			wantEndpoint: constants.DefaultRemoteRuntimeEndpoint,
+		},
+		{
+			name:         "uses endpoint from edgecore config",
+			config:       configPath,
+			wantEndpoint: customEndpoint,
+		},
+		{
+			name:    "missing custom config returns error",
+			config:  filepath.Join(t.TempDir(), "missing-edgecore.yaml"),
+			wantErr: "does not exist",
+		},
+		{
+			name:    "invalid config returns parse error",
+			config:  writeEdgeCoreConfig(t, "modules: [\n"),
+			wantErr: "parse Edgecore config failed",
+		},
+		{
+			name:         "nil modules use default endpoint",
+			config:       writeEdgeCoreConfig(t, "modules: null\n"),
+			wantEndpoint: constants.DefaultRemoteRuntimeEndpoint,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, err := getRuntimeEndpoint(tt.config)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEndpoint, endpoint)
+		})
+	}
+}
+
+func TestCheckRuntimeEndpoint(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime *fakeContainerRuntime
+		wantErr string
+	}{
+		{
+			name:    "runtime is ready",
+			runtime: &fakeContainerRuntime{},
+		},
+		{
+			name:    "returns connect error",
+			runtime: &fakeContainerRuntime{connectErr: errors.New("connect failed")},
+			wantErr: "could not connect to the container runtime",
+		},
+		{
+			name:    "returns runtime status error",
+			runtime: &fakeContainerRuntime{runningErr: errors.New("runtime is not ready")},
+			wantErr: "runtime is not ready",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkRuntimeEndpoint(constants.DefaultRemoteRuntimeEndpoint, tt.runtime)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`keadm debug check runtime` returned success without checking the runtime. It now checks the CRI
endpoint from `edgecore.yaml`, or the default endpoint when no config is present.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
`go test -count=1 ./keadm/cmd/keadm/app/cmd/debug` also fails on current `origin/master` in
existing `collect_test.go` cases.

**Does this PR introduce a user-facing change?**:
```release-note
  NONE
```