### PR TITLE
edgecontroller: keep assigned pod deletes after node cache removal

### DIFF
--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -62,7 +62,8 @@ func (dc *DownstreamController) syncPod() {
 				klog.Warningf("object type: %T unsupported", e.Object)
 				continue
 			}
-			if !dc.lc.IsEdgeNode(pod.Spec.NodeName) {
+			if !dc.lc.IsEdgeNode(pod.Spec.NodeName) &&
+				(e.Type != watch.Deleted || !dc.lc.IsPodOnNode(pod.UID, pod.Spec.NodeName)) {
 				continue
 			}
 			resource, err := messagelayer.BuildResource(pod.Spec.NodeName, pod.Namespace, model.ResourceTypePod, pod.Name)
@@ -79,6 +80,7 @@ func (dc *DownstreamController) syncPod() {
 				dc.lc.AddOrUpdatePod(*pod)
 			case watch.Deleted:
 				msg.BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, resource, model.DeleteOperation)
+				dc.lc.DeletePod(pod.UID)
 			case watch.Modified:
 				msg.BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, resource, model.UpdateOperation)
 				dc.lc.AddOrUpdatePod(*pod)

--- a/cloud/pkg/edgecontroller/controller/downstream_test.go
+++ b/cloud/pkg/edgecontroller/controller/downstream_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/manager"
+)
+
+type downstreamMessageLayer struct {
+	sendMessages chan model.Message
+}
+
+func (m *downstreamMessageLayer) Send(message model.Message) error {
+	m.sendMessages <- message
+	return nil
+}
+
+func (*downstreamMessageLayer) Receive() (model.Message, error) {
+	return model.Message{}, nil
+}
+
+func (*downstreamMessageLayer) Response(model.Message) error {
+	return nil
+}
+
+func TestSyncPodSendsDeleteAfterNodeCacheRemoval(t *testing.T) {
+	config := &v1alpha1.EdgeController{
+		Buffer: &v1alpha1.EdgeControllerBuffer{PodEvent: 4},
+	}
+	factory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
+	podManager, err := manager.NewPodManager(config, factory.Core().V1().Pods().Informer())
+	if err != nil {
+		t.Fatalf("failed to create pod manager: %v", err)
+	}
+
+	messageLayer := &downstreamMessageLayer{sendMessages: make(chan model.Message, 1)}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-pod",
+			Namespace:       "default",
+			ResourceVersion: "1",
+			UID:             types.UID("test-pod-uid"),
+		},
+		Spec: v1.PodSpec{
+			NodeName: "edge-node",
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+	lc := &manager.LocationCache{}
+	lc.UpdateEdgeNode("edge-node")
+	lc.AddOrUpdatePod(*pod)
+	lc.DeleteNode("edge-node")
+	if lc.IsEdgeNode("edge-node") {
+		t.Fatalf("edge node should be removed from location cache")
+	}
+
+	dc := &DownstreamController{
+		messageLayer: messageLayer,
+		podManager:   podManager,
+		lc:           lc,
+	}
+	go dc.syncPod()
+
+	podManager.Events() <- watch.Event{Type: watch.Modified, Object: pod}
+	expectNoPodMessage(t, messageLayer.sendMessages)
+
+	unassignedPod := pod.DeepCopy()
+	unassignedPod.UID = types.UID("unassigned-pod-uid")
+	unassignedPod.Spec.NodeName = ""
+	podManager.Events() <- watch.Event{Type: watch.Deleted, Object: unassignedPod}
+	expectNoPodMessage(t, messageLayer.sendMessages)
+
+	cloudPod := pod.DeepCopy()
+	cloudPod.UID = types.UID("cloud-pod-uid")
+	cloudPod.Spec.NodeName = "cloud-node"
+	podManager.Events() <- watch.Event{Type: watch.Deleted, Object: cloudPod}
+	expectNoPodMessage(t, messageLayer.sendMessages)
+
+	podManager.Events() <- watch.Event{Type: watch.Deleted, Object: pod}
+
+	select {
+	case msg := <-messageLayer.sendMessages:
+		if msg.GetOperation() != model.DeleteOperation {
+			t.Fatalf("expected operation %q, got %q", model.DeleteOperation, msg.GetOperation())
+		}
+		wantResource := "node/edge-node/default/" + model.ResourceTypePod + "/test-pod"
+		if msg.GetResource() != wantResource {
+			t.Fatalf("expected resource %q, got %q", wantResource, msg.GetResource())
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected pod delete message")
+	}
+
+	podManager.Events() <- watch.Event{Type: watch.Deleted, Object: pod}
+	expectNoPodMessage(t, messageLayer.sendMessages)
+}
+
+func expectNoPodMessage(t *testing.T, messages <-chan model.Message) {
+	t.Helper()
+	select {
+	case msg := <-messages:
+		t.Fatalf("expected no message, got operation %q for %q", msg.GetOperation(), msg.GetResource())
+	case <-time.After(100 * time.Millisecond):
+	}
+}

--- a/cloud/pkg/edgecontroller/manager/location.go
+++ b/cloud/pkg/edgecontroller/manager/location.go
@@ -5,12 +5,15 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // LocationCache cache the map of node, pod, configmap, secret
 type LocationCache struct {
 	// EdgeNodes is a set, key is nodeName
 	EdgeNodes sync.Map
+	// podNode is a map, key is pod UID, value is nodeName
+	podNode sync.Map
 	// configMapNode is a map, key is namespace/configMapName, value is nodeName
 	configMapNode sync.Map
 	// secretNode is a map, key is namespace/secretName, value is nodeName
@@ -77,6 +80,8 @@ func (lc *LocationCache) newNodes(oldNodes []string, node string) []string {
 
 // AddOrUpdatePod add pod to node, pod to configmap, configmap to pod, pod to secret, secret to pod relation
 func (lc *LocationCache) AddOrUpdatePod(pod v1.Pod) {
+	lc.podNode.Store(pod.UID, pod.Spec.NodeName)
+
 	configMaps, secrets := lc.PodConfigMapsAndSecrets(pod)
 	for _, c := range configMaps {
 		configMapKey := fmt.Sprintf("%s/%s", pod.Namespace, c)
@@ -137,9 +142,20 @@ func (lc *LocationCache) IsEdgeNode(nodeName string) bool {
 	return ok
 }
 
+// IsPodOnNode checks whether a pod was located on a node
+func (lc *LocationCache) IsPodOnNode(podUID types.UID, nodeName string) bool {
+	value, ok := lc.podNode.Load(podUID)
+	return ok && value == nodeName
+}
+
 // UpdateEdgeNode is to maintain edge nodes name upto-date by querying kubernetes client
 func (lc *LocationCache) UpdateEdgeNode(nodeName string) {
 	lc.EdgeNodes.Store(nodeName, struct{}{})
+}
+
+// DeletePod from cache
+func (lc *LocationCache) DeletePod(podUID types.UID) {
+	lc.podNode.Delete(podUID)
 }
 
 // DeleteConfigMap from cache

--- a/cloud/pkg/edgecontroller/manager/location_test.go
+++ b/cloud/pkg/edgecontroller/manager/location_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	commonconst "github.com/kubeedge/kubeedge/common/constants"
 )
@@ -241,6 +242,27 @@ func TestIsEdgeNode(t *testing.T) {
 				t.Errorf("Manager.TestIsEdgeNode() case failed: got = %v, want = %v", got, test.want)
 			}
 		})
+	}
+}
+
+func TestPodNode(t *testing.T) {
+	lc := &LocationCache{}
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("pod-uid")},
+		Spec:       v1.PodSpec{NodeName: nodes[0]},
+	}
+
+	lc.AddOrUpdatePod(pod)
+	if !lc.IsPodOnNode(pod.UID, pod.Spec.NodeName) {
+		t.Fatalf("expected pod to be located on %q", pod.Spec.NodeName)
+	}
+	if lc.IsPodOnNode(pod.UID, nodes[1]) {
+		t.Fatalf("expected pod not to be located on %q", nodes[1])
+	}
+
+	lc.DeletePod(pod.UID)
+	if lc.IsPodOnNode(pod.UID, pod.Spec.NodeName) {
+		t.Fatalf("expected pod to be removed from location cache")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Pod delete events can arrive after the edge node has already been removed from `LocationCache`. In this case `syncPod` should still send the delete to the node recorded in `Spec.NodeName`. This keeps the existing filter for add/update events and skips pod events without a node name.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
The test covers delete after node cache removal, plus the add/update and empty-node filters.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed edgecontroller pod delete delivery after edge node cache removal.
```