### PR TITLE
taskmanager: handle downstream tombstone deletes

### DIFF
--- a/cloud/pkg/taskmanager/downstream/event_handler.go
+++ b/cloud/pkg/taskmanager/downstream/event_handler.go
@@ -79,10 +79,19 @@ func (h *NodeJobEventHandler) OnUpdate(_oldObj, newObj any) {
 // OnDelete gets the watched node job deletion event, and uses InterruptExecutor
 // method to interrupt the downstream executor.
 func (h *NodeJobEventHandler) OnDelete(obj any) {
+	obj = unwrapDeletedEventObj(obj)
 	downstreamHandler, err := MustGetHandlerWithObj(obj)
 	if err != nil {
 		h.logger.Error(err, "failed to get downstream handler")
 		return
 	}
 	downstreamHandler.InterruptExecutor(obj)
+}
+
+func unwrapDeletedEventObj(obj any) any {
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+	if !ok {
+		return obj
+	}
+	return tombstone.Obj
 }

--- a/cloud/pkg/taskmanager/downstream/event_handler.go
+++ b/cloud/pkg/taskmanager/downstream/event_handler.go
@@ -79,19 +79,13 @@ func (h *NodeJobEventHandler) OnUpdate(_oldObj, newObj any) {
 // OnDelete gets the watched node job deletion event, and uses InterruptExecutor
 // method to interrupt the downstream executor.
 func (h *NodeJobEventHandler) OnDelete(obj any) {
-	obj = unwrapDeletedEventObj(obj)
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
 	downstreamHandler, err := MustGetHandlerWithObj(obj)
 	if err != nil {
 		h.logger.Error(err, "failed to get downstream handler")
 		return
 	}
 	downstreamHandler.InterruptExecutor(obj)
-}
-
-func unwrapDeletedEventObj(obj any) any {
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-	if !ok {
-		return obj
-	}
-	return tombstone.Obj
 }

--- a/cloud/pkg/taskmanager/downstream/event_handler_test.go
+++ b/cloud/pkg/taskmanager/downstream/event_handler_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package downstream
+
+import (
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
+	"github.com/kubeedge/kubeedge/cloud/pkg/taskmanager/executor"
+	"github.com/kubeedge/kubeedge/cloud/pkg/taskmanager/wrap"
+)
+
+func TestNodeJobEventHandlerOnDeleteHandlesTombstone(t *testing.T) {
+	var interrupted, removed bool
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	job := &operationsv1alpha2.ImagePrePullJob{}
+	job.Name = "image-pre-pull-job"
+
+	patches.ApplyFunc(executor.GetExecutor, func(resourceType, jobName string,
+	) (*executor.NodeTaskExecutor, error) {
+		assert.Equal(t, operationsv1alpha2.ResourceImagePrePullJob, resourceType)
+		assert.Equal(t, job.Name, jobName)
+		return &executor.NodeTaskExecutor{}, nil
+	})
+	patches.ApplyMethodFunc(&executor.NodeTaskExecutor{}, "Interrupt", func() {
+		interrupted = true
+	})
+	patches.ApplyFunc(executor.RemoveExecutor, func(resourceType, jobName string) {
+		assert.Equal(t, operationsv1alpha2.ResourceImagePrePullJob, resourceType)
+		assert.Equal(t, job.Name, jobName)
+		removed = true
+	})
+
+	originDownstreamHandlers := downstreamHandlers
+	t.Cleanup(func() {
+		downstreamHandlers = originDownstreamHandlers
+	})
+	downstreamHandlers = map[string]DownstreamHandler{
+		operationsv1alpha2.ResourceImagePrePullJob: &ImagePrePullJobHandler{
+			logger: klog.Background(),
+		},
+	}
+
+	eventHandler := NewNodeJobEventHandler(klog.Background(), make(chan wrap.NodeJob))
+	eventHandler.OnDelete(cache.DeletedFinalStateUnknown{Obj: job})
+
+	assert.True(t, interrupted)
+	assert.True(t, removed)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Kubernetes informers may send a tombstone object on delete when the final object state is not available. 
Taskmanager now unwraps that object before looking up the downstream handler, so deleting a node job still stops its running executor.

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
