### PR TITLE
devicecontroller: handle informer tombstone deletes

### DIFF
--- a/cloud/pkg/devicecontroller/manager/common.go
+++ b/cloud/pkg/devicecontroller/manager/common.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -37,6 +38,9 @@ func (c *CommonResourceEventHandler) OnUpdate(_, newObj interface{}) {
 
 // OnDelete handle Delete event
 func (c *CommonResourceEventHandler) OnDelete(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
 	c.obj2Event(watch.Deleted, obj)
 }
 

--- a/cloud/pkg/devicecontroller/manager/device_test.go
+++ b/cloud/pkg/devicecontroller/manager/device_test.go
@@ -159,6 +159,30 @@ func TestDeviceManagerWithRealEvents(t *testing.T) {
 	assert.True(t, received)
 }
 
+func TestDeviceManagerDeleteHandlesTombstone(t *testing.T) {
+	mockInformer := newMockInformer(false)
+	dm, err := NewDeviceManager(mockInformer)
+	assert.NoError(t, err)
+	assert.NotNil(t, dm)
+
+	testDevice := &v1beta1.Device{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-device",
+			Namespace: "default",
+		},
+	}
+
+	mockInformer.handler.OnDelete(cache.DeletedFinalStateUnknown{Obj: testDevice})
+
+	select {
+	case event := <-dm.Events():
+		assert.Equal(t, watch.Deleted, event.Type)
+		assert.Equal(t, testDevice, event.Object)
+	default:
+		t.Fatal("expected delete event")
+	}
+}
+
 func TestDeviceManagerDeviceMap(t *testing.T) {
 	dm := &DeviceManager{
 		Device: sync.Map{},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
DeviceController delete events should still be handled when the informer sends a tombstone object.
This unwraps the deleted object before passing it into the existing watch event path

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```