### PR TITLE
refactor(test): consolidate jsonpatch edge cases into table-driven suite

### DIFF
--- a/pkg/jsonpatch/jsonpatch_test.go
+++ b/pkg/jsonpatch/jsonpatch_test.go
@@ -68,6 +68,12 @@ func TestJosnPath(t *testing.T) {
 			value: beer{Number: 10, Str: "Hello"},
 			want:  `[{"op":"add","path":"/a/b/c","value":"{\"numb\":10,\"str\":\"Hello\"}"}]`,
 		},
+		{
+			op:    OpAdd,
+			path:  "/a/b/c",
+			value: make(chan int),
+			want:  `[]`,
+		},
 	}
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case_%d", i), func(t *testing.T) {
@@ -76,22 +82,4 @@ func TestJosnPath(t *testing.T) {
 			assert.Equal(t, c.want, string(bff))
 		})
 	}
-}
-
-func TestAdd_NilValue(t *testing.T) {
-	items := New().Add(OpAdd, "/a/b/c", nil)
-	bff, err := items.ToJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, `[{"op":"add","path":"/a/b/c"}]`, string(bff))
-}
-
-func TestAdd_UnsupportedMarshalType(t *testing.T) {
-	ch := make(chan int)
-
-	items := New().Add(OpAdd, "/a/b/c", ch)
-	assert.Len(t, items, 0)
-
-	bff, err := items.ToJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, `[]`, string(bff))
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind test
/kind cleanup

**What this PR does / why we need it**:
Cleaning up the jsonpatch tests by moving the edge cases into the main table-driven suite.

The standalone TestAdd_NilValue was redundant since nil paths are already covered by the OpRemove case and it was not contributing to the test coverage. I also moved the chan int error check into the table to hit 100% coverage without the extra boilerplate. This keeps the test file consistent and easier to read.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
The change focuses on code health. By moving the "unsupported type" logic into the table, we remove the need for extra boilerplate while ensuring the robustness of the `json.Marshal` error handling.
From a design standpoint `TestAdd_NilValue`  may be useful to keep. If so please let me know and I'll close the PR.

**Does this PR introduce a user-facing change?**:

```release-note
NONE

```