### PR TITLE
test: fix swapped test case names in admission controller

### DIFF
--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
@@ -368,7 +368,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 		},
 		{
-			name: "Concurrency specified",
+			name: "TimeoutSeconds specified",
 			spec: v1alpha1.NodeUpgradeJobSpec{
 				Version:        "v1.0.0",
 				NodeNames:      []string{"node1"},
@@ -383,7 +383,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 		},
 		{
-			name: "TimeoutSeconds specified",
+			name: "Concurrency specified",
 			spec: v1alpha1.NodeUpgradeJobSpec{
 				Version:     "v1.0.0",
 				NodeNames:   []string{"node1"},


### PR DESCRIPTION
### **What type of PR is this?**

/kind test

### **What this PR does / why we need it**:

Fixes swapped test case names in `admit_nodeupgradejob_test.go`. The test block specifying `Concurrency` was accidentally labeled as "TimeoutSeconds specified" and vice versa. This fixes the labels so the test output is accurate.

### **Which issue(s) this PR fixes**:

Fixes #

### **Special notes for your reviewer**:

None, just a minor test label cleanup.

### **Does this PR introduce a user-facing change?**:

```release-note
NONE

```