### PR TITLE
Fix edge tests

### DIFF
--- a/edge/cmd/edgecore/app/options/options.go
+++ b/edge/cmd/edgecore/app/options/options.go
@@ -40,6 +40,7 @@ func GetEdgeCoreOptions() *EdgeCoreOptions {
 	return edgeCoreOptions
 }
 
+//go:noinline
 func GetEdgeCoreConfig() *v1alpha2.EdgeCoreConfig {
 	return edgeCoreConfig
 }

--- a/edge/pkg/taskmanager/actions/runner.go
+++ b/edge/pkg/taskmanager/actions/runner.go
@@ -48,6 +48,8 @@ func RegisterRunner(name string, runner *ActionRunner) {
 }
 
 // GetRunner returns the implementation of the job action runner.
+//
+//go:noinline
 func GetRunner(name string) *ActionRunner {
 	return runners[name]
 }


### PR DESCRIPTION
/kind test

edge tests fail (with go version go1.25.3 linux/amd64):

```
--- FAIL: TestConfirmUpgradeDoUpgrade (0.00s)
    extend_confirm_upgrade_test.go:177: 
        	Error Trace:	/home/max/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory/extend_confirm_upgrade_test.go:177
        	Error:      	Received unexpected error:
        	            	invalid resource type nodeupgradejob
        	Test:       	TestConfirmUpgradeDoUpgrade
--- FAIL: TestConfirmUpgradeDoV1alpha1Upgrade (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x2200bd3]

goroutine 120 [running]:
testing.tRunner.func1.2({0x26625e0, 0x4644060})
	/usr/lib/go-1.25/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
	/usr/lib/go-1.25/src/testing/testing.go:1875 +0x35b
panic({0x26625e0?, 0x4644060?})
	/usr/lib/go-1.25/src/runtime/panic.go:783 +0x132
github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory.doV1alpha1Upgrade(0xc000092a10)
	/home/max/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory/extend_confirm_upgrade.go:115 +0x213
github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory.TestConfirmUpgradeDoV1alpha1Upgrade(0xc000510c40)
	/home/max/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory/extend_confirm_upgrade_test.go:207 +0x425
testing.tRunner(0xc000510c40, 0x2c339d8)
	/usr/lib/go-1.25/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 1
	/usr/lib/go-1.25/src/testing/testing.go:1997 +0x465
FAIL	github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/handlerfactory	0.150s
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
