### PR TITLE
edgecore: Fix SA token handling in MetaServer

### DIFF
--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -87,8 +87,10 @@ func requiresRefresh(tr *authenticationv1.TokenRequest) bool {
 	return false
 }
 
-// KeyFunc keys should be nonconfidential and safe to log
-func KeyFunc(name, namespace string, tr *authenticationv1.TokenRequest) string {
+// baseKey is the spec-derived key prefix that identifies the logical token
+// (independent of which generation). All generations of the same logical token
+// share this prefix. Used for prefix lookup in metaDB.
+func baseKey(name, namespace string, tr *authenticationv1.TokenRequest) string {
 	var exp int64
 	if tr.Spec.ExpirationSeconds != nil {
 		exp = *tr.Spec.ExpirationSeconds
@@ -102,34 +104,81 @@ func KeyFunc(name, namespace string, tr *authenticationv1.TokenRequest) string {
 	return fmt.Sprintf("%q/%q/%#v/%#v/%#v", name, namespace, tr.Spec.Audiences, exp, ref)
 }
 
+// KeyFunc returns the per-generation storage key for a TokenRequest. The key
+// is the base (spec-derived) key suffixed with the token's exp timestamp so
+// that successive refreshed tokens for the same logical token are stored as
+// separate rows. This is required to keep the previous (still un-expired)
+// token's row in metaDB during the propagation window between a refresh and
+// the moment the pod re-reads the new token from its projected volume; without
+// it, MetaServer (which authenticates by checking metaDB membership) rejects
+// requests bearing the previous token.
+//
+// Callers without a populated Status.ExpirationTimestamp (i.e., callers that
+// only have a TokenRequest spec, like an upstream kubelet refresh call) should
+// not use KeyFunc — they should use baseKey and a prefix query.
+//
+// Keys are nonconfidential and safe to log.
+func KeyFunc(name, namespace string, tr *authenticationv1.TokenRequest) string {
+	base := baseKey(name, namespace, tr)
+	if tr.Status.ExpirationTimestamp.IsZero() {
+		// Defensive: a write without exp is malformed. Return base so the
+		// behavior is at worst the pre-refactor behavior (one row per
+		// logical token, overwritten on refresh). The caller should ensure
+		// Status.ExpirationTimestamp is populated.
+		return base
+	}
+	return fmt.Sprintf("%s/%d", base, tr.Status.ExpirationTimestamp.UnixNano())
+}
+
 func getTokenLocally(name, namespace string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-	resKey := KeyFunc(name, namespace, tr)
+	prefix := baseKey(name, namespace, tr)
 	ms := dbclient.NewMetaService()
-	metas, err := ms.QueryMeta("key", resKey)
+	metas, err := ms.QueryMetaByKeyPrefix(prefix)
 	if err != nil {
-		klog.Errorf("query meta %s failed: %v", resKey, err)
+		klog.Errorf("query meta by prefix %s failed: %v", prefix, err)
 		return nil, err
 	}
-	if len(*metas) != 1 {
-		klog.Errorf("query meta %s length error", resKey)
-		return nil, fmt.Errorf("query meta %s length error", resKey)
+	if metas == nil || len(*metas) == 0 {
+		return nil, fmt.Errorf("no cached token for %s", prefix)
 	}
-	var tokenRequest authenticationv1.TokenRequest
-	err = json.Unmarshal([]byte((*metas)[0]), &tokenRequest)
-	if err != nil {
-		klog.Errorf("unmarshal resource %s token request failed: %v", resKey, err)
-		return nil, err
-	}
-	if requiresRefresh(&tokenRequest) {
-		err := ms.DeleteMetaByKey(resKey)
-		if err != nil {
-			klog.Errorf("delete meta %s failed: %v", resKey, err)
-			return nil, err
+
+	// Pick the newest un-expired generation. Older generations may still be
+	// present (kept intentionally to bridge the refresh-propagation window;
+	// the GC sweep removes them after their exp passes), but the freshest
+	// one is what we want to return to the caller.
+	now := time.Now()
+	var newest *authenticationv1.TokenRequest
+	for _, v := range *metas {
+		var cur authenticationv1.TokenRequest
+		if err := json.Unmarshal([]byte(v), &cur); err != nil {
+			klog.Errorf("unmarshal cached token under prefix %s failed: %v", prefix, err)
+			continue
 		}
-		klog.Errorf("resource %s token expired", resKey)
-		return nil, fmt.Errorf("resource %s token expired", resKey)
+		if cur.Status.ExpirationTimestamp.IsZero() || !cur.Status.ExpirationTimestamp.Time.After(now) {
+			continue
+		}
+		if newest == nil || cur.Status.ExpirationTimestamp.Time.After(newest.Status.ExpirationTimestamp.Time) {
+			snapshot := cur
+			newest = &snapshot
+		}
 	}
-	return &tokenRequest, nil
+	if newest == nil {
+		return nil, fmt.Errorf("no un-expired cached token for %s", prefix)
+	}
+
+	if requiresRefresh(newest) {
+		// The freshest cached generation is past the 80%-of-TTL threshold;
+		// trigger a remote refresh. Do NOT delete any cached rows here:
+		// MetaServer authenticates pod requests by checking presence of the
+		// token in metaDB (see CheckTokenExist). The previous patch removed
+		// the eviction of this row; this patch additionally arranges for
+		// the refreshed token to be stored under a *new* per-generation key
+		// (see KeyFunc), so both rows coexist for a brief window. GC
+		// (RunExpiredTokenGC) removes rows whose exp has passed.
+		klog.V(4).Infof("resource %s token requires refresh", prefix)
+		return nil, fmt.Errorf("resource %s token requires refresh", prefix)
+	}
+	return newest, nil
 }
 
 func getTokenRemotely(resource string, tr *authenticationv1.TokenRequest, c *serviceAccountToken) (*authenticationv1.TokenRequest, error) {
@@ -250,4 +299,61 @@ func CheckTokenExist(token string) bool {
 		}
 	}
 	return false
+}
+
+// RunExpiredTokenGC periodically scans all service-account token rows in
+// metaDB and deletes any whose Status.ExpirationTimestamp has passed.
+//
+// Because refreshed tokens are stored under per-generation keys (see KeyFunc)
+// rather than overwriting the previous generation, expired generations
+// accumulate until removed here. With a 10-minute token TTL and an 80%
+// refresh threshold, steady-state row count per logical token is bounded
+// by ~2; the GC interval below is generous.
+//
+// Stops when stopCh is closed.
+func RunExpiredTokenGC(stopCh <-chan struct{}, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			gcExpiredTokensOnce()
+		}
+	}
+}
+
+func gcExpiredTokensOnce() {
+	ms := dbclient.NewMetaService()
+	rows, err := ms.QueryAllMeta("type", model.ResourceTypeServiceAccountToken)
+	if err != nil {
+		klog.Errorf("GC: query SA tokens failed: %v", err)
+		return
+	}
+	if rows == nil {
+		return
+	}
+	now := time.Now()
+	for _, row := range *rows {
+		var tr authenticationv1.TokenRequest
+		if err := json.Unmarshal([]byte(row.Value), &tr); err != nil {
+			// Don't delete: an unparseable row is a separate bug; leave it
+			// for diagnosis rather than silently dropping it.
+			klog.Errorf("GC: unmarshal SA token row %s failed: %v", row.Key, err)
+			continue
+		}
+		if tr.Status.ExpirationTimestamp.IsZero() {
+			continue
+		}
+		if tr.Status.ExpirationTimestamp.Time.After(now) {
+			continue
+		}
+		if err := ms.DeleteMetaByKey(row.Key); err != nil {
+			klog.Errorf("GC: delete expired SA token row %s failed: %v", row.Key, err)
+		}
+	}
 }

--- a/edge/pkg/metamanager/client/serviceaccount_test.go
+++ b/edge/pkg/metamanager/client/serviceaccount_test.go
@@ -1,0 +1,926 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
+)
+
+type fakeSend struct {
+	syncHandler func(*model.Message) (*model.Message, error)
+	sendHandler func(*model.Message)
+}
+
+func (f *fakeSend) SendSync(message *model.Message) (*model.Message, error) {
+	if f.syncHandler != nil {
+		return f.syncHandler(message)
+	}
+	return &model.Message{}, nil
+}
+
+func (f *fakeSend) Send(message *model.Message) {
+	if f.sendHandler != nil {
+		f.sendHandler(message)
+	}
+}
+
+func newFakeSend() *fakeSend {
+	return &fakeSend{}
+}
+
+func TestNewServiceAccountToken(t *testing.T) {
+	assert := assert.New(t)
+
+	sendInterface := newFakeSend()
+
+	sat := newServiceAccountToken(sendInterface)
+	assert.NotNil(sat)
+	assert.NotNil(sat.send)
+	assert.Equal(sendInterface, sat.send)
+}
+
+func TestRequiresRefresh(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+	testcases := []struct {
+		name     string
+		tr       *authenticationv1.TokenRequest
+		expected bool
+	}{
+		{
+			name: "Not expired",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					ExpirationSeconds: func() *int64 { i := int64(3600); return &i }(),
+				},
+				Status: authenticationv1.TokenRequestStatus{
+					ExpirationTimestamp: metav1.NewTime(now.Add(time.Hour)),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Expired",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					ExpirationSeconds: func() *int64 { i := int64(3600); return &i }(),
+				},
+				Status: authenticationv1.TokenRequestStatus{
+					ExpirationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Near expiration (within 20% of TTL)",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					ExpirationSeconds: func() *int64 { i := int64(3600); return &i }(),
+				},
+				Status: authenticationv1.TokenRequestStatus{
+					ExpirationTimestamp: metav1.NewTime(now.Add(time.Minute * 10)),
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Beyond max TTL",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					ExpirationSeconds: func() *int64 { i := int64(24 * 3600 * 2); return &i }(),
+				},
+				Status: authenticationv1.TokenRequestStatus{
+					ExpirationTimestamp: metav1.NewTime(now.Add(time.Hour * 48)),
+					Token:               "test-token",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Nil ExpirationSeconds",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					ExpirationSeconds: nil,
+				},
+				Status: authenticationv1.TokenRequestStatus{
+					ExpirationTimestamp: metav1.NewTime(now.Add(time.Hour)),
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			result := requiresRefresh(test.tr)
+			assert.Equal(test.expected, result)
+		})
+	}
+}
+
+func TestKeyFunc(t *testing.T) {
+	assert := assert.New(t)
+
+	testcases := []struct {
+		name      string
+		saName    string
+		namespace string
+		tr        *authenticationv1.TokenRequest
+		expected  string
+	}{
+		{
+			// Zero ExpirationTimestamp: defensive fallback returns base key only.
+			name:      "Basic TokenRequest",
+			saName:    "test-sa",
+			namespace: "default",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					Audiences:         []string{"audience1", "audience2"},
+					ExpirationSeconds: func() *int64 { i := int64(3600); return &i }(),
+					BoundObjectRef: &authenticationv1.BoundObjectReference{
+						Kind: "Pod",
+						Name: "test-pod",
+						UID:  "12345",
+					},
+				},
+			},
+			expected: `"test-sa"/"default"/[]string{"audience1", "audience2"}/3600/v1.BoundObjectReference{Kind:"Pod", APIVersion:"", Name:"test-pod", UID:"12345"}`,
+		},
+		{
+			name:      "TokenRequest with nil ExpirationSeconds",
+			saName:    "test-sa",
+			namespace: "kube-system",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{
+					Audiences:         []string{"audience3"},
+					ExpirationSeconds: nil,
+					BoundObjectRef:    nil,
+				},
+			},
+			expected: `"test-sa"/"kube-system"/[]string{"audience3"}/0/v1.BoundObjectReference{Kind:"", APIVersion:"", Name:"", UID:""}`,
+		},
+		{
+			name:      "TokenRequest with empty fields",
+			saName:    "test-sa",
+			namespace: "default",
+			tr: &authenticationv1.TokenRequest{
+				Spec: authenticationv1.TokenRequestSpec{},
+			},
+			expected: `"test-sa"/"default"/[]string(nil)/0/v1.BoundObjectReference{Kind:"", APIVersion:"", Name:"", UID:""}`,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			result := KeyFunc(test.saName, test.namespace, test.tr)
+			assert.Equal(test.expected, result)
+		})
+	}
+
+	// Non-zero ExpirationTimestamp: key is suffixed with UnixNano of the expiry.
+	t.Run("per-generation key with ExpirationTimestamp", func(t *testing.T) {
+		fixedTime := time.Unix(1700000000, 0)
+		tr := &authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{
+				Audiences:         []string{"aud"},
+				ExpirationSeconds: func() *int64 { i := int64(600); return &i }(),
+			},
+			Status: authenticationv1.TokenRequestStatus{
+				ExpirationTimestamp: metav1.NewTime(fixedTime),
+			},
+		}
+		base := `"my-sa"/"ns"/[]string{"aud"}/600/v1.BoundObjectReference{Kind:"", APIVersion:"", Name:"", UID:""}`
+		expected := fmt.Sprintf("%s/%d", base, fixedTime.UnixNano())
+		assert.Equal(expected, KeyFunc("my-sa", "ns", tr))
+
+		// Two calls with the same timestamp must produce identical keys.
+		assert.Equal(KeyFunc("my-sa", "ns", tr), KeyFunc("my-sa", "ns", tr))
+
+		// A different expiry timestamp must produce a different key.
+		tr2 := tr.DeepCopy()
+		tr2.Status.ExpirationTimestamp = metav1.NewTime(fixedTime.Add(time.Hour))
+		assert.NotEqual(KeyFunc("my-sa", "ns", tr), KeyFunc("my-sa", "ns", tr2))
+	})
+}
+
+func TestHandleServiceAccountTokenFromMetaDB(t *testing.T) {
+	assert := assert.New(t)
+
+	validTokenRequest := &authenticationv1.TokenRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-token-request",
+		},
+		Spec: authenticationv1.TokenRequestSpec{
+			Audiences: []string{"audience1", "audience2"},
+		},
+		Status: authenticationv1.TokenRequestStatus{
+			Token: "test-token",
+		},
+	}
+	tokenRequestJSON, err := json.Marshal(validTokenRequest)
+	if err != nil {
+		t.Fatalf("Failed to marshal valid token request: %v", err)
+	}
+	validContent, err := json.Marshal([]string{string(tokenRequestJSON)})
+	if err != nil {
+		t.Fatalf("Failed to marshal valid content: %v", err)
+	}
+
+	tokenRequest, err := handleServiceAccountTokenFromMetaDB(validContent)
+	assert.NoError(err)
+	assert.NotNil(tokenRequest)
+	assert.Equal(validTokenRequest.Name, tokenRequest.Name)
+	assert.Equal(validTokenRequest.Spec.Audiences, tokenRequest.Spec.Audiences)
+	assert.Equal(validTokenRequest.Status.Token, tokenRequest.Status.Token)
+
+	invalidContent := []byte("invalid json")
+	tokenRequest, err = handleServiceAccountTokenFromMetaDB(invalidContent)
+	assert.Error(err)
+	assert.Nil(tokenRequest)
+	assert.Contains(err.Error(), "unmarshal message to serviceaccount list from db failed")
+
+	emptyContent, err := json.Marshal([]string{})
+	if err != nil {
+		t.Fatalf("Failed to marshal empty content: %v", err)
+	}
+	tokenRequest, err = handleServiceAccountTokenFromMetaDB(emptyContent)
+	assert.Error(err)
+	assert.Nil(tokenRequest)
+	assert.Contains(err.Error(), "serviceaccount length from meta db is 0")
+
+	multipleContent, err := json.Marshal([]string{"{}", "{}"})
+	if err != nil {
+		t.Fatalf("Failed to marshal multiple content: %v", err)
+	}
+	tokenRequest, err = handleServiceAccountTokenFromMetaDB(multipleContent)
+	assert.Error(err)
+	assert.Nil(tokenRequest)
+	assert.Contains(err.Error(), "serviceaccount length from meta db is 2")
+
+	invalidTokenRequestContent, err := json.Marshal([]string{"{invalid json}"})
+	if err != nil {
+		t.Fatalf("Failed to marshal invalid token request content: %v", err)
+	}
+	tokenRequest, err = handleServiceAccountTokenFromMetaDB(invalidTokenRequestContent)
+	assert.Error(err)
+	assert.Nil(tokenRequest)
+	assert.Contains(err.Error(), "unmarshal message to serviceaccount token from db failed")
+}
+
+func TestHandleServiceAccountTokenFromMetaManager(t *testing.T) {
+	assert := assert.New(t)
+
+	validTokenRequest := &authenticationv1.TokenRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-token-request",
+		},
+		Spec: authenticationv1.TokenRequestSpec{
+			Audiences: []string{"audience1", "audience2"},
+		},
+		Status: authenticationv1.TokenRequestStatus{
+			Token: "test-token",
+		},
+	}
+
+	validContent, err := json.Marshal(validTokenRequest)
+	if err != nil {
+		t.Fatalf("Failed to marshal valid token request: %v", err)
+	}
+
+	tokenRequest, err := handleServiceAccountTokenFromMetaManager(validContent)
+	assert.NoError(err)
+	assert.NotNil(tokenRequest)
+	assert.Equal(validTokenRequest.Name, tokenRequest.Name)
+	assert.Equal(validTokenRequest.Spec.Audiences, tokenRequest.Spec.Audiences)
+	assert.Equal(validTokenRequest.Status.Token, tokenRequest.Status.Token)
+
+	invalidContent := []byte("invalid json")
+	tokenRequest, err = handleServiceAccountTokenFromMetaManager(invalidContent)
+	assert.Error(err)
+	assert.Nil(tokenRequest)
+	assert.Contains(err.Error(), "unmarshal message to service account failed")
+
+	emptyContent := []byte("{}")
+	tokenRequest, err = handleServiceAccountTokenFromMetaManager(emptyContent)
+	assert.NoError(err)
+	assert.NotNil(tokenRequest)
+	assert.Empty(tokenRequest.Name)
+	assert.Empty(tokenRequest.Spec.Audiences)
+	assert.Empty(tokenRequest.Status.Token)
+}
+
+func TestNewServiceAccount(t *testing.T) {
+	namespace := testNamespace
+
+	sa := newServiceAccount(namespace)
+
+	assert.NotNil(t, sa)
+	assert.IsType(t, &serviceAccount{}, sa)
+	assert.Equal(t, namespace, sa.namespace)
+}
+
+func TestDeleteServiceAccountToken(t *testing.T) {
+	assert := assert.New(t)
+
+	podUID := types.UID("pod-123")
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	metaList := []models.Meta{
+		{
+			Key: "key1",
+			Value: func() string {
+				tr := authenticationv1.TokenRequest{
+					Spec: authenticationv1.TokenRequestSpec{
+						BoundObjectRef: &authenticationv1.BoundObjectReference{
+							UID: podUID,
+						},
+					},
+				}
+				data, err := json.Marshal(tr)
+				if err != nil {
+					t.Fatalf("Failed to marshal token request 1: %v", err)
+				}
+				return string(data)
+			}(),
+		},
+		{
+			Key: "key2",
+			Value: func() string {
+				tr := authenticationv1.TokenRequest{
+					Spec: authenticationv1.TokenRequestSpec{
+						BoundObjectRef: &authenticationv1.BoundObjectReference{
+							UID: "other-pod",
+						},
+					},
+				}
+				data, err := json.Marshal(tr)
+				if err != nil {
+					t.Fatalf("Failed to marshal token request 2: %v", err)
+				}
+				return string(data)
+			}(),
+		},
+	}
+
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(key, value string) (*[]models.Meta, error) {
+			assert.Equal("type", key)
+			assert.Equal(model.ResourceTypeServiceAccountToken, value)
+			return &metaList, nil
+		})
+
+	var deletedKey string
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "DeleteMetaByKey",
+		func(key string) error {
+			deletedKey = key
+			return nil
+		})
+
+	sat := &serviceAccountToken{}
+	sat.DeleteServiceAccountToken(podUID)
+	assert.Equal("key1", deletedKey)
+
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(key, value string) (*[]models.Meta, error) {
+			return nil, errors.New("query meta error")
+		})
+	sat.DeleteServiceAccountToken(podUID)
+
+	patches.Reset()
+	metaList = []models.Meta{{Key: "key1", Value: "invalid json"}}
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(key, value string) (*[]models.Meta, error) {
+			return &metaList, nil
+		})
+	sat.DeleteServiceAccountToken(podUID)
+
+	patches.Reset()
+	metaList = []models.Meta{
+		{
+			Key: "key1",
+			Value: func() string {
+				tr := authenticationv1.TokenRequest{
+					Spec: authenticationv1.TokenRequestSpec{
+						BoundObjectRef: &authenticationv1.BoundObjectReference{
+							UID: podUID,
+						},
+					},
+				}
+				data, err := json.Marshal(tr)
+				if err != nil {
+					t.Fatalf("Failed to marshal token request 3: %v", err)
+				}
+				return string(data)
+			}(),
+		},
+	}
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(key, value string) (*[]models.Meta, error) {
+			return &metaList, nil
+		})
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "DeleteMetaByKey",
+		func(key string) error {
+			return fmt.Errorf("failed to delete meta by key %s: delete operation failed", key)
+		})
+	sat.DeleteServiceAccountToken(podUID)
+}
+
+func TestGetTokenLocally(t *testing.T) {
+	assert := assert.New(t)
+
+	name := "sa-name"
+	namespace := "default"
+	tr := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: func() *int64 { i := int64(3600); return &i }(),
+		},
+	}
+
+	now := time.Now()
+	sec := func(i int64) *int64 { return &i }
+
+	freshTR := &authenticationv1.TokenRequest{
+		Spec:   authenticationv1.TokenRequestSpec{ExpirationSeconds: sec(3600)},
+		Status: authenticationv1.TokenRequestStatus{ExpirationTimestamp: metav1.NewTime(now.Add(time.Hour)), Token: "fresh-token"},
+	}
+	freshBytes, _ := json.Marshal(freshTR)
+
+	newerTR := &authenticationv1.TokenRequest{
+		Spec:   authenticationv1.TokenRequestSpec{ExpirationSeconds: sec(3600)},
+		Status: authenticationv1.TokenRequestStatus{ExpirationTimestamp: metav1.NewTime(now.Add(2 * time.Hour)), Token: "newer-token"},
+	}
+	newerBytes, _ := json.Marshal(newerTR)
+
+	expiredTR := &authenticationv1.TokenRequest{
+		Spec:   authenticationv1.TokenRequestSpec{ExpirationSeconds: sec(3600)},
+		Status: authenticationv1.TokenRequestStatus{ExpirationTimestamp: metav1.NewTime(now.Add(-time.Hour))},
+	}
+	expiredBytes, _ := json.Marshal(expiredTR)
+
+	// Within 20% of a 1h TTL → requiresRefresh returns true.
+	nearExpiryTR := &authenticationv1.TokenRequest{
+		Spec:   authenticationv1.TokenRequestSpec{ExpirationSeconds: sec(3600)},
+		Status: authenticationv1.TokenRequestStatus{ExpirationTimestamp: metav1.NewTime(now.Add(5 * time.Minute)), Token: "near-token"},
+	}
+	nearExpiryBytes, _ := json.Marshal(nearExpiryTR)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// DB error.
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return nil, errors.New("db error") })
+	result, err := getTokenLocally(name, namespace, tr)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "db error")
+
+	// nil result → no cached token.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return nil, nil })
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "no cached token")
+
+	// Empty slice → no cached token.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return &[]string{}, nil })
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "no cached token")
+
+	// Single valid unexpired generation.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return &[]string{string(freshBytes)}, nil })
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.Equal("fresh-token", result.Status.Token)
+
+	// Multiple generations → newest unexpired wins.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return &[]string{string(freshBytes), string(newerBytes)}, nil })
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.Equal("newer-token", result.Status.Token)
+
+	// All expired → no un-expired cached token.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return &[]string{string(expiredBytes)}, nil })
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "no un-expired cached token")
+
+	// All invalid JSON → no un-expired cached token.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return &[]string{"invalid-json"}, nil })
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "no un-expired cached token")
+
+	// Mixed: invalid + expired + valid → returns valid.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) {
+			return &[]string{"invalid-json", string(expiredBytes), string(freshBytes)}, nil
+		})
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.Equal("fresh-token", result.Status.Token)
+
+	// Newest requires refresh → error; no row must be deleted.
+	patches.Reset()
+	var deletedKey string
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) { return &[]string{string(nearExpiryBytes)}, nil })
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "DeleteMetaByKey",
+		func(k string) error { deletedKey = k; return nil })
+	result, err = getTokenLocally(name, namespace, tr)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "token requires refresh")
+	assert.Empty(deletedKey, "expired token rows must not be deleted during refresh trigger")
+}
+
+func TestGcExpiredTokensOnce(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+
+	expired := authenticationv1.TokenRequest{
+		Status: authenticationv1.TokenRequestStatus{
+			ExpirationTimestamp: metav1.NewTime(now.Add(-time.Hour)),
+		},
+	}
+	expiredBytes, _ := json.Marshal(expired)
+
+	fresh := authenticationv1.TokenRequest{
+		Status: authenticationv1.TokenRequestStatus{
+			ExpirationTimestamp: metav1.NewTime(now.Add(time.Hour)),
+		},
+	}
+	freshBytes, _ := json.Marshal(fresh)
+
+	zero := authenticationv1.TokenRequest{}
+	zeroBytes, _ := json.Marshal(zero)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// QueryAllMeta error → should not panic.
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(string, string) (*[]models.Meta, error) { return nil, errors.New("db error") })
+	gcExpiredTokensOnce()
+
+	// nil result → no-op.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(string, string) (*[]models.Meta, error) { return nil, nil })
+	gcExpiredTokensOnce()
+
+	// Expired row deleted; fresh and zero-timestamp rows untouched; invalid JSON skipped.
+	patches.Reset()
+	metas := []models.Meta{
+		{Key: "expired-key", Value: string(expiredBytes)},
+		{Key: "fresh-key", Value: string(freshBytes)},
+		{Key: "zero-key", Value: string(zeroBytes)},
+		{Key: "bad-key", Value: "invalid-json"},
+	}
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(string, string) (*[]models.Meta, error) { return &metas, nil })
+	var deletedKeys []string
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "DeleteMetaByKey",
+		func(k string) error { deletedKeys = append(deletedKeys, k); return nil })
+	gcExpiredTokensOnce()
+	assert.Equal([]string{"expired-key"}, deletedKeys)
+
+	// Delete error → continues without panic.
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(string, string) (*[]models.Meta, error) {
+			return &[]models.Meta{{Key: "exp-key", Value: string(expiredBytes)}}, nil
+		})
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "DeleteMetaByKey",
+		func(string) error { return errors.New("delete failed") })
+	gcExpiredTokensOnce()
+}
+
+// TestTokenCoexistenceDuringRefreshWindow is the end-to-end scenario the
+// per-generation key fix was designed to protect: a pod still holds the old
+// bearer token while the kubelet has already written a refreshed one. Both
+// rows must coexist in metaDB so MetaServer keeps accepting the old bearer
+// until GC removes it after its expiry.
+func TestTokenCoexistenceDuringRefreshWindow(t *testing.T) {
+	assert := assert.New(t)
+
+	now := time.Now()
+	sec := func(i int64) *int64 { return &i }
+
+	// Old generation: 5 min left — still un-expired but within the 20%-of-TTL
+	// refresh threshold (requiresRefresh = true for a 1 h token).
+	oldToken := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: sec(3600)},
+		Status: authenticationv1.TokenRequestStatus{
+			ExpirationTimestamp: metav1.NewTime(now.Add(5 * time.Minute)),
+			Token:               "old-bearer-token",
+		},
+	}
+	oldTokenBytes, _ := json.Marshal(oldToken)
+	oldKey := KeyFunc("sa", "ns", oldToken)
+
+	// New generation: freshly issued, 1 h remaining — requiresRefresh = false.
+	newToken := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: sec(3600)},
+		Status: authenticationv1.TokenRequestStatus{
+			ExpirationTimestamp: metav1.NewTime(now.Add(time.Hour)),
+			Token:               "new-bearer-token",
+		},
+	}
+	newTokenBytes, _ := json.Marshal(newToken)
+	newKey := KeyFunc("sa", "ns", newToken)
+
+	assert.NotEqual(oldKey, newKey, "each generation must get a distinct storage key")
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// --- Phase 1: propagation window — both rows coexist in metaDB ---
+
+	// getTokenLocally must return the newer generation, not the near-expiry old one.
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMetaByKeyPrefix",
+		func(string) (*[]string, error) {
+			return &[]string{string(oldTokenBytes), string(newTokenBytes)}, nil
+		})
+	tr := &authenticationv1.TokenRequest{Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: sec(3600)}}
+	got, err := getTokenLocally("sa", "ns", tr)
+	assert.NoError(err)
+	assert.Equal("new-bearer-token", got.Status.Token, "getTokenLocally must return the freshest generation")
+
+	// CheckTokenExist scans all SA token rows; both bearer strings must be recognised
+	// so MetaServer accepts pods still carrying the old token.
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(string, string) (*[]string, error) {
+			return &[]string{string(oldTokenBytes), string(newTokenBytes)}, nil
+		})
+	assert.True(CheckTokenExist("old-bearer-token"), "old token must pass MetaServer auth during propagation window")
+	assert.True(CheckTokenExist("new-bearer-token"), "new token must also be accepted")
+
+	// --- Phase 2: old token's expiry passes, GC runs ---
+
+	expiredOld := oldToken.DeepCopy()
+	expiredOld.Status.ExpirationTimestamp = metav1.NewTime(now.Add(-time.Minute))
+	expiredOldBytes, _ := json.Marshal(expiredOld)
+
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryAllMeta",
+		func(string, string) (*[]models.Meta, error) {
+			return &[]models.Meta{
+				{Key: oldKey, Value: string(expiredOldBytes)},
+				{Key: newKey, Value: string(newTokenBytes)},
+			}, nil
+		})
+	var deletedKeys []string
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "DeleteMetaByKey",
+		func(k string) error { deletedKeys = append(deletedKeys, k); return nil })
+	gcExpiredTokensOnce()
+	assert.Equal([]string{oldKey}, deletedKeys, "GC must remove exactly the expired old generation row")
+
+	// After GC: old bearer rejected, new bearer still accepted.
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(string, string) (*[]string, error) {
+			return &[]string{string(newTokenBytes)}, nil
+		})
+	assert.False(CheckTokenExist("old-bearer-token"), "old token must be rejected after GC removes its row")
+	assert.True(CheckTokenExist("new-bearer-token"), "new token must remain valid after GC")
+}
+
+func TestGetServiceAccountToken(t *testing.T) {
+	assert := assert.New(t)
+
+	name := "sa-name"
+	namespace := "default"
+	tr := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: func() *int64 { i := int64(3600); return &i }(),
+		},
+	}
+
+	fakeSender := newFakeSend()
+	sat := &serviceAccountToken{send: fakeSender}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	localToken := &authenticationv1.TokenRequest{
+		Status: authenticationv1.TokenRequestStatus{
+			Token: "local-token",
+		},
+	}
+
+	patches.ApplyFunc(getTokenLocally, func(n, ns string, t *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+		assert.Equal(name, n)
+		assert.Equal(namespace, ns)
+		assert.Equal(tr, t)
+		return localToken, nil
+	})
+
+	result, err := sat.GetServiceAccountToken(namespace, name, tr)
+	assert.NoError(err)
+	assert.Equal(localToken, result)
+
+	patches.Reset()
+	patches.ApplyFunc(getTokenLocally, func(n, ns string, t *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+		return nil, errors.New("local token not found")
+	})
+
+	responseMsg := model.NewMessage("")
+	remoteToken := &authenticationv1.TokenRequest{
+		Status: authenticationv1.TokenRequestStatus{
+			Token: "remote-token",
+		},
+	}
+	remoteTokenBytes, err := json.Marshal(remoteToken)
+	if err != nil {
+		t.Fatalf("Failed to marshal remote token: %v", err)
+	}
+
+	responseMsg.Content = remoteTokenBytes
+
+	var capturedMessage *model.Message
+	fakeSender.syncHandler = func(msg *model.Message) (*model.Message, error) {
+		capturedMessage = msg
+		return responseMsg, nil
+	}
+
+	result, err = sat.GetServiceAccountToken(namespace, name, tr)
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.NotNil(capturedMessage)
+	assert.Equal("remote-token", result.Status.Token)
+
+	patches.Reset()
+	patches.ApplyFunc(getTokenLocally, func(n, ns string, t *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+		return nil, errors.New("local token not found")
+	})
+
+	fakeSender.syncHandler = func(msg *model.Message) (*model.Message, error) {
+		return nil, errors.New("sender error")
+	}
+
+	result, err = sat.GetServiceAccountToken(namespace, name, tr)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "sender error")
+}
+
+func TestServiceAccountGet(t *testing.T) {
+	assert := assert.New(t)
+
+	namespace := testNamespace
+	name := "test-sa"
+	sa := newServiceAccount(namespace)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(key, value string) (*[]string, error) {
+			assert.Equal("type", key)
+			assert.Equal(model.ResourceTypeSaAccess, value)
+			mockData := `{"metadata":{"namespace":"default"},"spec":{"serviceAccount":{"metadata":{"name":"test-sa"}},"serviceAccountUID":"test-uid"}}`
+			return &[]string{mockData}, nil
+		})
+
+	result, err := sa.Get(name)
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.Equal(name, result.Name)
+	assert.Equal(types.UID("test-uid"), result.UID)
+
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(key, value string) (*[]string, error) {
+			return nil, errors.New("query metadata error")
+		})
+
+	result, err = sa.Get(name)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "query metadata error")
+
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(key, value string) (*[]string, error) {
+			return &[]string{`{"metadata":{"namespace":"other-namespace"},"spec":{"serviceAccount":{"metadata":{"name":"other-name"}}}}`}, nil
+		})
+
+	result, err = sa.Get(name)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "not found")
+
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(key, value string) (*[]string, error) {
+			return &[]string{"invalid-json"}, nil
+		})
+
+	result, err = sa.Get(name)
+	assert.Error(err)
+	assert.Nil(result)
+}
+
+func TestCheckTokenExist(t *testing.T) {
+	assert := assert.New(t)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	assert.False(CheckTokenExist(""))
+
+	tr1 := authenticationv1.TokenRequest{
+		Status: authenticationv1.TokenRequestStatus{Token: "test-token"},
+	}
+	tr1Bytes, err := json.Marshal(tr1)
+	if err != nil {
+		t.Fatalf("Failed to marshal token request 1: %v", err)
+	}
+
+	tr2 := authenticationv1.TokenRequest{
+		Status: authenticationv1.TokenRequestStatus{Token: "other-token"},
+	}
+	tr2Bytes, err := json.Marshal(tr2)
+	if err != nil {
+		t.Fatalf("Failed to marshal token request 2: %v", err)
+	}
+
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(key, value string) (*[]string, error) {
+			assert.Equal("type", key)
+			assert.Equal(model.ResourceTypeServiceAccountToken, value)
+			return &[]string{string(tr1Bytes), string(tr2Bytes)}, nil
+		})
+
+	assert.True(CheckTokenExist("test-token"))
+	assert.True(CheckTokenExist("other-token"))
+	assert.False(CheckTokenExist("non-existent-token"))
+
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(key, value string) (*[]string, error) {
+			return nil, errors.New("query metadata error")
+		})
+	assert.False(CheckTokenExist("test-token"))
+
+	patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf((*dbclient.MetaService)(nil)), "QueryMeta",
+		func(key, value string) (*[]string, error) {
+			return &[]string{"invalid-json"}, nil
+		})
+	assert.False(CheckTokenExist("test-token"))
+}

--- a/edge/pkg/metamanager/dao/dbclient/meta.go
+++ b/edge/pkg/metamanager/dao/dbclient/meta.go
@@ -106,6 +106,20 @@ func (s *MetaService) QueryMeta(key string, condition string) (*[]string, error)
 	return &result, nil
 }
 
+// QueryMetaByKeyPrefix returns meta values whose Key starts with prefix.
+func (s *MetaService) QueryMetaByKeyPrefix(prefix string) (*[]string, error) {
+	var metas []models.Meta
+	err := s.db.Where("key LIKE ?", prefix+"%").Find(&metas).Error
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, v := range metas {
+		result = append(result, v.Value)
+	}
+	return &result, nil
+}
+
 // QueryAllMeta returns all metas for given key and condition
 func (s *MetaService) QueryAllMeta(key string, condition string) (*[]models.Meta, error) {
 	var metas []models.Meta

--- a/edge/pkg/metamanager/metamanager.go
+++ b/edge/pkg/metamanager/metamanager.go
@@ -6,6 +6,7 @@ import (
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
 	metamanagerconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver"
@@ -62,6 +63,8 @@ func (m *metaManager) Start() {
 		imitator.StorageInit()
 		go metaserver.NewMetaServer().Start(beehiveContext.Done())
 	}
+
+	go client.RunExpiredTokenGC(beehiveContext.Done(), 0)
 
 	m.runMetaManager()
 }


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

MetaServer keeps a copy of last SA token. However, when the tokens expire (and re-mounted to the container, for example), the application may have a copy of preivous SA token which is still valid because tokens are rotated at 80% expiration, but since MetaServer keeps only the latest copy, previous (still valid) SA tokens are not found and application receives Unauthorized.

Sample app log (prometheus):

```
ts=2026-05-27T04:51:33.174Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/
mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Endpoints: Unauthorized"        
ts=2026-05-27T04:51:33.174Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T04:51:35.078Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T04:51:35.078Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T04:51:38.564Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T04:51:38.564Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:15.445Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:15.445Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:18.253Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:18.253Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="p
kg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v
1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:22.194Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/
mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:22.194Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="p
kg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v
1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:31.864Z caller=klog.go:108 level=warn component=k8s_client_runtime func=Warningf msg="pkg/
mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: failed to list *v1.Endpoints: Unauthorized"
ts=2026-05-27T12:57:31.864Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="p
kg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: Failed to watch *v1.Endpoints: failed to list *v
1.Endpoints: Unauthorized"
```

Sample edgecore log:
```
May 27 04:51:31 ip-10-100-121-202 edgecore[2399364]: E0527 04:51:31.602825 2399364 authentication.go:73] "Unab
le to authenticate the request" err="tokenData not found when authenticating"                                 
May 27 04:51:33 ip-10-100-121-202 edgecore[2399364]: E0527 04:51:33.173704 2399364 authentication.go:73] "Unab
le to authenticate the request" err="tokenData not found when authenticating"                                 
May 27 04:51:35 ip-10-100-121-202 edgecore[2399364]: E0527 04:51:35.077079 2399364 authentication.go:73] "Unab
le to authenticate the request" err="tokenData not found when authenticating"                                 
May 27 04:51:38 ip-10-100-121-202 edgecore[2399364]: E0527 04:51:38.563202 2399364 authentication.go:73] "Unab
le to authenticate the request" err="tokenData not found when authenticating"  
May 27 12:57:14 ip-10-100-121-202 edgecore[2399364]: E0527 12:57:14.138065 2399364 authentication.go:73] "Unable to authenticate the request" err="tokenData not found when authenticating"
May 27 12:57:15 ip-10-100-121-202 edgecore[2399364]: E0527 12:57:15.444101 2399364 authentication.go:73] "Unable to authenticate the request" err="tokenData not found when authenticating"
May 27 12:57:18 ip-10-100-121-202 edgecore[2399364]: E0527 12:57:18.252789 2399364 authentication.go:73] "Unable to authenticate the request" err="tokenData not found when authenticating"
May 27 12:57:22 ip-10-100-121-202 edgecore[2399364]: E0527 12:57:22.193603 2399364 authentication.go:73] "Unable to authenticate the request" err="tokenData not found when authenticating"
May 27 12:57:31 ip-10-100-121-202 edgecore[2399364]: E0527 12:57:31.863779 2399364 authentication.go:73] "Unable to authenticate the request" err="tokenData not found when authenticating"
```

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
