### PR TITLE
metaserver: surface missing container log errors

### DIFF
--- a/edge/pkg/metamanager/metaserver/handlerfactory/extend_logs_pod.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/extend_logs_pod.go
@@ -58,7 +58,18 @@ func (f *Factory) Logs(request *request.RequestInfo) http.Handler {
 
 		logsResponse, res := f.storage.Logs(req.Context(), logsInfo)
 		if res == nil {
-			http.Error(w, "Failed to get logs from edged", http.StatusInternalServerError)
+			logsResBytes, err := json.Marshal(logsResponse)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(logsResBytes)
+			if err != nil {
+				klog.Warningf("[metaserver/logs] failed to write logs response with err:%v", err)
+				return
+			}
 			return
 		}
 

--- a/edge/pkg/metamanager/metaserver/handlerfactory/extend_logs_pod_test.go
+++ b/edge/pkg/metamanager/metaserver/handlerfactory/extend_logs_pod_test.go
@@ -127,8 +127,8 @@ func TestLogs(t *testing.T) {
 				queryParams:   "",
 				isGetLogsFail: true,
 			},
-			expectedStatus: http.StatusInternalServerError,
-			expectedBody:   "Failed to get logs from edged\n",
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"errMessages":["failed to get logs for container"]}`,
 		},
 		{
 			name: "Logs with unexpected status code",

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go
@@ -459,6 +459,12 @@ func (r *REST) Logs(ctx context.Context, logsInfo common.LogsInfo) (*types.LogsR
 				break
 			}
 		}
+		if container == "" {
+			errMessage := fmt.Sprintf("not found container %s in pod:\"/%s/%s\"", logsInfo.ContainerName, nameSpace, podName)
+			klog.Warningf("[metaserver/logs] %v", errMessage)
+			logsResponse.ErrMessages = append(logsResponse.ErrMessages, errMessage)
+			return logsResponse, nil
+		}
 	} else {
 		container = containers[0].Metadata.Name
 	}

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/storage_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/storage_test.go
@@ -500,6 +500,24 @@ func TestREST_Logs(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "test requested container not found",
+			cases: testCase{
+				logsInfo: common.LogsInfo{
+					Namespace:     "default",
+					PodName:       "pod-name",
+					ContainerName: "missing-container",
+				},
+				isEdgedEnabled:         true,
+				isRemoteRuntimeService: true,
+				expectedLogsResponse: &types.LogsResponse{
+					ErrMessages: []string{"not found container missing-container in pod:\"/default/pod-name\""},
+					LogMessages: []string{},
+				},
+				expectedHTTPResponseNil: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "test restful request failed",
 			cases: testCase{
 				logsInfo: common.LogsInfo{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When pod logs are requested for a specific container, MetaServer now returns a clear "not found" error if that container is not in the pod's runtime containers. 
This will avoid sending an edged logs request with an empty container name.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
None
```
