### PR TITLE
Fix ServiceAccountAccess resync

### DIFF
--- a/cloud/pkg/policycontroller/constants/constants.go
+++ b/cloud/pkg/policycontroller/constants/constants.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	// KindTypeServiceAccountAccess is the Kind of the ServiceAccountAccess CRD.
+	// It is set on every ServiceAccountAccess sent to an edge node, because
+	// cloudHub derives ObjectSync's spec.objectAPIVersion/objectKind from the
+	// GVK carried by the message body.
+	KindTypeServiceAccountAccess = "ServiceAccountAccess"
+)

--- a/cloud/pkg/policycontroller/manager/reconcile.go
+++ b/cloud/pkg/policycontroller/manager/reconcile.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/constants"
+	pcconstants "github.com/kubeedge/kubeedge/cloud/pkg/policycontroller/constants"
 	commonconstants "github.com/kubeedge/kubeedge/common/constants"
 )
 
@@ -349,6 +350,23 @@ func (c *Controller) send2Edge(acc *policyv1alpha1.ServiceAccountAccess, targets
 	klog.V(4).Infof("send2Edge for serviceaccount %s/%s: %v (%s)",
 		acc.Namespace, acc.Spec.ServiceAccount.Name, targets, opr)
 	sendObj := acc.DeepCopy()
+	// A typed client strips apiVersion/kind from the object it decodes, but
+	// cloudHub reads the GVK off the message body to fill in ObjectSync's
+	// spec.objectAPIVersion/objectKind (util.GetMessageAPIVersion and
+	// util.GetMessageResourceType). Leaving it unset creates ObjectSyncs that no
+	// GVR can be built from, so syncController can neither resync this object nor
+	// build a delete event to collect it from the edge node.
+	// util.SetMetaType() is not usable here: it resolves kinds through
+	// client-go's scheme, which does not know CRDs.
+	//
+	// The edge needs it too: metaManager passes every message through
+	// imitator.Inject(), which decodes the body into an unstructured object to
+	// store it in meta_v2 and drive watches, and that decode fails without a
+	// Kind. The authn path is unaffected, since it reads the v1 meta table and
+	// unmarshals into a typed object, which is why a node that received one of
+	// these without a GVK still serves it.
+	sendObj.SetGroupVersionKind(policyv1alpha1.SchemeGroupVersion.
+		WithKind(pcconstants.KindTypeServiceAccountAccess))
 	for _, node := range targets {
 		resource, err := messagelayer.BuildResource(node, sendObj.Namespace, model.ResourceTypeSaAccess, sendObj.Name)
 		if err != nil {

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 
+	policyv1alpha1 "github.com/kubeedge/api/apis/policy/v1alpha1"
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
@@ -26,14 +27,21 @@ import (
 func (sctl *SyncController) reconcileObjectSync(sync *v1alpha1.ObjectSync) {
 	var object metav1.Object
 
-	gv, err := schema.ParseGroupVersion(sync.Spec.ObjectAPIVersion)
+	apiVersion := sync.Spec.ObjectAPIVersion
+	kind := sync.Spec.ObjectKind
+	if apiVersion == "" {
+		apiVersion = policyv1alpha1.SchemeGroupVersion.String()
+		kind = "ServiceAccountAccess"
+	}
+
+	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {
 		return
 	}
-	resource := util.UnsafeKindToResource(sync.Spec.ObjectKind)
+	resource := util.UnsafeKindToResource(kind)
 	gvr := gv.WithResource(resource)
 	nodeName := getNodeName(sync.Name)
-	resourceType := strings.ToLower(sync.Spec.ObjectKind)
+	resourceType := strings.ToLower(kind)
 
 	lister, err := sctl.informerManager.GetLister(gvr)
 	if err != nil {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

ServiceAccountAccess resync is broken: 

ObjectSync objects for SAA objects have empty ObjectAPIVersion/ObjectKind.

reconcileObjectSync() builds an empty GVR from those empty fields, causing an early return.
As the result, the SAA is never resynced regardless of how stale it is.

Example object state:

```
$ k -n observability get serviceaccountaccess kube-prom-stack-kube-prome-prometheus -o yaml
apiVersion: policy.kubeedge.io/v1alpha1
kind: ServiceAccountAccess
metadata:
  creationTimestamp: "2026-04-21T06:42:50Z"
  generation: 3
  name: kube-prom-stack-kube-prome-prometheus
  namespace: observability
  resourceVersion: "5259302"
  uid: 59a6b2ee-e3ef-4dde-9968-70c34af3bdf2
spec:
  accessClusterRoleBinding:
  - clusterRoleBinding:
      metadata:
        annotations:
          meta.helm.sh/release-name: kube-prom-stack
          meta.helm.sh/release-namespace: observability
        labels:
          app: kube-prometheus-stack-prometheus
          app.kubernetes.io/instance: kube-prom-stack
          app.kubernetes.io/managed-by: Helm
          app.kubernetes.io/part-of: kube-prometheus-stack
          app.kubernetes.io/version: 62.7.0
          chart: kube-prometheus-stack-62.7.0
          heritage: Helm
          release: kube-prom-stack
        name: kube-prom-stack-kube-prome-prometheus
      roleRef:
        apiGroup: rbac.authorization.k8s.io
        kind: ClusterRole
        name: kube-prom-stack-kube-prome-prometheus
      subjects:
      - kind: ServiceAccount
        name: kube-prom-stack-kube-prome-prometheus
        namespace: observability
    rules:
    - apiGroups:
      - ""
      resources:
      - nodes
      - nodes/metrics
      - services
      - endpoints
      - pods
      verbs:
      - get
      - list
      - watch
    - apiGroups:
      - discovery.k8s.io
      resources:
      - endpointslices
      verbs:
      - get
      - list
      - watch
    - apiGroups:
      - networking.k8s.io
      resources:
      - ingresses
      verbs:
      - get
      - list
      - watch
    - nonResourceURLs:
      - /metrics
      - /metrics/cadvisor
      verbs:
      - get
  - clusterRoleBinding:
      metadata:
        annotations:
          rbac.authorization.kubernetes.io/autoupdate: "true"
        labels:
          kubernetes.io/bootstrapping: rbac-defaults
        name: system:service-account-issuer-discovery
      roleRef:
        apiGroup: rbac.authorization.k8s.io
        kind: ClusterRole
        name: system:service-account-issuer-discovery
      subjects:
      - apiGroup: rbac.authorization.k8s.io
        kind: Group
        name: system:serviceaccounts
    rules:
    - nonResourceURLs:
      - /.well-known/openid-configuration
      - /.well-known/openid-configuration/
      - /openid/v1/jwks
      - /openid/v1/jwks/
      verbs:
      - get
  serviceAccount:
    automountServiceAccountToken: true
    metadata:
      annotations:
        meta.helm.sh/release-name: kube-prom-stack
        meta.helm.sh/release-namespace: observability
      labels:
        app: kube-prometheus-stack-prometheus
        app.kubernetes.io/component: prometheus
        app.kubernetes.io/instance: kube-prom-stack
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/name: kube-prometheus-stack-prometheus
        app.kubernetes.io/part-of: kube-prometheus-stack
        app.kubernetes.io/version: 62.7.0
        chart: kube-prometheus-stack-62.7.0
        heritage: Helm
        release: kube-prom-stack
      name: kube-prom-stack-kube-prome-prometheus
      namespace: observability
  serviceAccountUid: 0b666682-81cd-41d7-bf5c-dffa0ade30c7
status:
  nodeList:
  - edge-100-29-186-147
  - edge-3-91-99-124
$ k -n observability get objectsync | grep 59a6b2ee-e3ef-4dde-9968-70c34af3bdf2
edge-100-29-186-147.59a6b2ee-e3ef-4dde-9968-70c34af3bdf2   25d
edge-3-91-99-124.59a6b2ee-e3ef-4dde-9968-70c34af3bdf2      41d
$ k -n observability get objectsync edge-100-29-186-147.59a6b2ee-e3ef-4dde-9968-70c34af3bdf2 -o yaml
apiVersion: reliablesyncs.kubeedge.io/v1alpha1
kind: ObjectSync
metadata:
  creationTimestamp: "2026-05-07T05:01:13Z"
  generation: 1
  name: edge-100-29-186-147.59a6b2ee-e3ef-4dde-9968-70c34af3bdf2
  namespace: observability
  resourceVersion: "5259304"
  uid: 2adedcfa-148b-4b07-9b8e-ba9a5237106c
spec:
  objectName: kube-prom-stack-kube-prome-prometheus
status:
  objectResourceVersion: "0"
$ k -n observability get objectsync edge-3-91-99-124.59a6b2ee-e3ef-4dde-9968-70c34af3bdf2 -o yaml
apiVersion: reliablesyncs.kubeedge.io/v1alpha1
kind: ObjectSync
metadata:
  creationTimestamp: "2026-04-21T06:42:50Z"
  generation: 1
  name: edge-3-91-99-124.59a6b2ee-e3ef-4dde-9968-70c34af3bdf2
  namespace: observability
  resourceVersion: "2407970"
  uid: 53eff76f-6a47-4cfe-ac67-956e7905a465
spec:
  objectName: kube-prom-stack-kube-prome-prometheus
status:
  objectResourceVersion: "2407966"
$
```

If cloudcore/edgecore is restarted while the objectsync Ack from the edge node is not received yet, objectResourceVersion stays out of sync:
- “0” (never synced)
- “2307966” (out of sync)

while the original ServiceAccountAccess object is “5259302”

For "never synced" scenario this leads to the completely missing SAA in the edge Meta database:

```
Apr 21 15:54:34 c102-fra-prod edgecore[1409276]: E0421 15:54:34.771375 1409276 authentication.go:73] "Unable to authenticate the request" err="serviceaccount observability/kube-prom-stack-kube-prome-prometheus not found"
Apr 21 15:54:41 c102-fra-prod edgecore[1409276]: E0421 15:54:41.248030 1409276 authentication.go:73] "Unable to authenticate the request" err="serviceaccount observability/kube-prom-stack-kube-prome-prometheus not found"
Apr 21 15:54:46 c102-fra-prod edgecore[1409276]: I0421 15:54:46.174060 1409276 edgedlogconnection.go:141] receive stop signal, so stop logs scan ...
Apr 21 15:55:00 c102-fra-prod edgecore[1409276]: E0421 15:55:00.541239 1409276 authentication.go:73] "Unable to authenticate the request" err="serviceaccount observability/kube-prom-stack-kube-prome-prometheus not found"
Apr 21 15:55:04 c102-fra-prod edgecore[1409276]: I0421 15:55:04.371826 1409276 edgedlogconnection.go:141] receive stop signal, so stop logs scan ...
Apr 21 15:55:05 c102-fra-prod edgecore[1409276]: E0421 15:55:05.818764 1409276 authentication.go:73] "Unable to authenticate the request" err="serviceaccount observability/kube-prom-stack-kube-prome-prometheus not found"
Apr 21 15:55:07 c102-fra-prod edgecore[1409276]: E0421 15:55:07.994887 1409276 authentication.go:73] "Unable to authenticate the request" err="serviceaccount observability/kube-prom-stack-kube-prome-prometheus not found"
Apr 21 15:55:18 c102-fra-prod edgecore[1409276]: E0421 15:55:18.754825 1409276 authentication.go:73] "Unable to authenticate the request" err="serviceaccount observability/kube-prom-stack-kube-prome-prometheus not found"
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
