### PR TITLE
policycontroller: optimize pod watch filtering and isEdgeNode lookup

### DIFF
--- a/cloud/pkg/policycontroller/manager/reconcile.go
+++ b/cloud/pkg/policycontroller/manager/reconcile.go
@@ -12,7 +12,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -20,6 +19,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -246,12 +246,6 @@ func (c *Controller) filterObject(ctx context.Context, object client.Object) boo
 
 // SetupWithManager creates a controller and register to controller manager.
 func (c *Controller) SetupWithManager(ctx context.Context, mgr controllerruntime.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Pod{}, "spec.serviceAccountName", func(o client.Object) []string {
-		pod := o.(*corev1.Pod)
-		return []string{pod.Spec.ServiceAccountName}
-	}); err != nil {
-		return fmt.Errorf("failed to set ServiceAccountName field selector for manager, %v", err)
-	}
 	return controllerruntime.NewControllerManagedBy(mgr).
 		For(&policyv1alpha1.ServiceAccountAccess{}).
 		Watches(&rbacv1.ClusterRoleBinding{}, handler.EnqueueRequestsFromMapFunc(c.mapRolesFunc), builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
@@ -269,26 +263,50 @@ func (c *Controller) SetupWithManager(ctx context.Context, mgr controllerruntime
 		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(c.mapObjectFunc), builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return c.filterObject(ctx, object)
 		}))).
-		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(c.mapObjectFunc), builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return c.filterObject(ctx, object)
-		}))).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(c.mapObjectFunc), builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				return c.filterObject(ctx, e.Object)
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				return c.podUpdateFilter(ctx, e)
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return c.filterObject(ctx, e.Object)
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		})).
 		Complete(c)
 }
 
-func isEdgeNode(ctx context.Context, reader client.Reader, name string) bool {
-	set := labels.Set{commonconstants.EdgeNodeRoleKey: commonconstants.EdgeNodeRoleValue}
-	selector := labels.SelectorFromSet(set)
-	var edgeNodeList = &corev1.NodeList{}
-	if err := reader.List(ctx, edgeNodeList, &client.ListOptions{LabelSelector: selector}); err != nil {
-		klog.Errorf("failed to list edge nodes, %v", err)
+// podUpdateFilter returns true for pod update events that may require an SAA
+// reconcile: NodeName first being assigned (DaemonSet scheduling) or deletion
+// beginning. Status-only updates are dropped to avoid high API-server churn.
+func (c *Controller) podUpdateFilter(ctx context.Context, e event.UpdateEvent) bool {
+	oldPod, ok := e.ObjectOld.(*corev1.Pod)
+	if !ok {
 		return false
 	}
-	for _, node := range edgeNodeList.Items {
-		if node.Name == name {
-			return true
-		}
+	newPod := e.ObjectNew.(*corev1.Pod)
+	if oldPod.Spec.NodeName == newPod.Spec.NodeName && newPod.DeletionTimestamp == nil {
+		return false
 	}
-	return false
+	return c.filterObject(ctx, e.ObjectNew)
+}
+
+func isEdgeNode(ctx context.Context, reader client.Reader, name string) bool {
+	node := &corev1.Node{}
+	if err := reader.Get(ctx, types.NamespacedName{Name: name}, node); err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("failed to get node %s: %v", name, err)
+		}
+		return false
+	}
+	// EdgeNodeRoleValue is "", so check key presence, not value equality —
+	// a missing key also returns "" from map lookup.
+	_, ok := node.Labels[commonconstants.EdgeNodeRoleKey]
+	return ok
 }
 
 func getNodeListOfServiceAccountAccess(ctx context.Context, reader client.Reader, acc *policyv1alpha1.ServiceAccountAccess) ([]string, error) {

--- a/cloud/pkg/policycontroller/manager/reconcile_test.go
+++ b/cloud/pkg/policycontroller/manager/reconcile_test.go
@@ -21,6 +21,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	policyv1alpha1 "github.com/kubeedge/api/apis/policy/v1alpha1"
 	"github.com/kubeedge/beehive/pkg/common"
@@ -1011,6 +1012,99 @@ func TestFilterResource(t *testing.T) {
 				t.Errorf("case %q want=%v, got=%v", tc.name, tc.objResult, got1)
 			}
 		}
+	}
+}
+
+func TestPodUpdateFilter(t *testing.T) {
+	var pod1 v1.Pod
+	if err := json.Unmarshal([]byte(podStr1), &pod1); err != nil {
+		t.Fatalf("unmarshal pod1: %v", err)
+	}
+	var podDel v1.Pod
+	if err := json.Unmarshal([]byte(podDelStr1), &podDel); err != nil {
+		t.Fatalf("unmarshal podDel: %v", err)
+	}
+	var podNoNodeName v1.Pod
+	if err := json.Unmarshal([]byte(podStrWithoutNodeName), &podNoNodeName); err != nil {
+		t.Fatalf("unmarshal podNoNodeName: %v", err)
+	}
+
+	edgeNode := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "my-node",
+			Labels: map[string]string{"node-role.kubernetes.io/edge": ""},
+		},
+	}
+	cloudNode := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "cloud-node",
+			Labels: map[string]string{},
+		},
+	}
+	podOnCloudNode := pod1.DeepCopy()
+	podOnCloudNode.Spec.NodeName = cloudNode.Name
+
+	tests := []struct {
+		name string
+		old  client.Object
+		new  client.Object
+		want bool
+	}{
+		{
+			name: "status-only update: NodeName unchanged, no DeletionTimestamp",
+			old:  pod1.DeepCopy(),
+			new:  pod1.DeepCopy(),
+			want: false,
+		},
+		{
+			name: "NodeName first assigned to edge node (DaemonSet scheduling)",
+			old:  podNoNodeName.DeepCopy(),
+			new:  pod1.DeepCopy(),
+			want: true,
+		},
+		{
+			name: "NodeName first assigned but not an edge node",
+			old:  podNoNodeName.DeepCopy(),
+			new:  podOnCloudNode,
+			want: false,
+		},
+		{
+			name: "deletion begins (DeletionTimestamp appears)",
+			old:  pod1.DeepCopy(),
+			new:  podDel.DeepCopy(),
+			want: true,
+		},
+		{
+			name: "ObjectOld is not a Pod",
+			old:  &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa1", Namespace: "my-namespace"}},
+			new:  pod1.DeepCopy(),
+			want: false,
+		},
+	}
+
+	var accessScheme = runtime.NewScheme()
+	if err := policyv1alpha1.AddToScheme(accessScheme); err != nil {
+		t.Fatalf("add policyv1alpha1 scheme: %v", err)
+	}
+	if err := v1.AddToScheme(accessScheme); err != nil {
+		t.Fatalf("add v1 scheme: %v", err)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(accessScheme).
+				WithObjects(&edgeNode, &cloudNode).
+				Build()
+			ctr := &Controller{Client: fakeClient, Reader: fakeClient}
+			got := ctr.podUpdateFilter(context.Background(), event.UpdateEvent{
+				ObjectOld: tc.old,
+				ObjectNew: tc.new,
+			})
+			if got != tc.want {
+				t.Errorf("podUpdateFilter() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Replace the broad pod update predicate with podUpdateFilter, which drops status-only pod updates (NodeName unchanged, no DeletionTimestamp) to reduce unnecessary reconcile churn.

Replace isEdgeNode's full node list scan with a targeted Get by name and key-presence check (EdgeNodeRoleValue is "", so value equality is insufficient).

Remove the spec.serviceAccountName field index that is no longer needed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
