### PR TITLE
fix: prevent edgestream send on closed channel

### DIFF
--- a/edge/pkg/edgestream/tunnel.go
+++ b/edge/pkg/edgestream/tunnel.go
@@ -141,7 +141,9 @@ func (s *TunnelSession) Close() {
 }
 
 func (s *TunnelSession) WriteToLocalConnection(m *stream.Message) {
-	if con, ok := s.GetLocalConnection(m.ConnectID); ok {
+	s.localConsLock.RLock()
+	defer s.localConsLock.RUnlock()
+	if con, ok := s.localCons[m.ConnectID]; ok {
 		con.CacheTunnelMessage(m)
 	}
 }


### PR DESCRIPTION
Hold the local connection read lock while caching tunnel messages so connection cleanup cannot close the read channel between lookup and send.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

This PR fixes a race in edgestream tunnel message handling.

  `WriteToLocalConnection` previously fetched the local connection and released `localConsLock` before calling `CacheTunnelMessage`. In that gap, `DeleteLocalConnection` could close the
  connection's read channel, causing a panic when `CacheTunnelMessage` sent to the closed channel.

  This change keeps the local connection read lock held while looking up the connection and caching the tunnel message, preventing connection cleanup from closing the channel between lookup
  and send.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This is a minimal concurrency fix limited to `edge/pkg/edgestream/tunnel.go`.

Tested with:

  ```bash
  go test ./edge/pkg/edgestream

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
