### PR TITLE
pkg/util/fsm: fix unsupported event error message

### DIFF
--- a/pkg/util/fsm/fsm.go
+++ b/pkg/util/fsm/fsm.go
@@ -96,7 +96,7 @@ func (F *FSM) transitCheck(event Event) (api.State, api.State, error) {
 	}
 	nextState, ok := F.guard[string(currentState)+"/"+event.UniqueName()]
 	if !ok {
-		return "", "", fmt.Errorf(string(currentState)+"/"+event.UniqueName(), " unsupported event")
+		return "", "", fmt.Errorf("%s/%s unsupported event", currentState, event.UniqueName())
 	}
 	return currentState, nextState, nil
 }

--- a/pkg/util/fsm/fsm_test.go
+++ b/pkg/util/fsm/fsm_test.go
@@ -120,6 +120,7 @@ func TestFSM_AllowTransit(t *testing.T) {
 		currentState api.State
 		event        Event
 		wantErr      bool
+		wantErrMsg   string
 	}{
 		{
 			name:         "Valid transition",
@@ -132,12 +133,14 @@ func TestFSM_AllowTransit(t *testing.T) {
 			currentState: StateRunning,
 			event:        eventStart,
 			wantErr:      true,
+			wantErrMsg:   "Running/Task/Start unsupported event",
 		},
 		{
 			name:         "Invalid event",
 			currentState: StateIdle,
 			event:        eventStop,
 			wantErr:      true,
+			wantErrMsg:   "Idle/Task/Stop unsupported event",
 		},
 	}
 
@@ -152,6 +155,9 @@ func TestFSM_AllowTransit(t *testing.T) {
 			err := fsm.AllowTransit(tt.event)
 			if tt.wantErr {
 				assert.Error(t, err)
+				if tt.wantErrMsg != "" {
+					assert.EqualError(t, err, tt.wantErrMsg)
+				}
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Invalid FSM transitions were returning a malformed unsupported-event message. 
Fixed the returned error text and adds a regression check in `TestFSM_AllowTransit`.

**Which issue(s) this PR fixes**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```