### PR TITLE
fix(containers): stop container before remove in CopyResources

### DIFF
--- a/pkg/containers/container_runtime.go
+++ b/pkg/containers/container_runtime.go
@@ -137,6 +137,9 @@ func (runtime *ContainerRuntimeImpl) CopyResources(
 		return fmt.Errorf("create container failed: %v", err)
 	}
 	defer func() {
+		if stopErr := runtime.ctrsvc.StopContainer(ctx, containerID, 0); stopErr != nil {
+			klog.V(3).ErrorS(stopErr, "Stop container failed", "containerID", containerID)
+		}
 		if err := runtime.ctrsvc.RemoveContainer(ctx, containerID); err != nil {
 			klog.V(3).ErrorS(err, "Remove container failed", "containerID", containerID)
 		}

--- a/pkg/containers/container_runtime_test.go
+++ b/pkg/containers/container_runtime_test.go
@@ -58,6 +58,7 @@ func TestCopyResources(t *testing.T) {
 						}
 					}).Return([]byte("stdout"), []byte(""), nil)
 
+				m.EXPECT().StopContainer(gomock.Any(), "cnt-123", int64(0)).Return(nil)
 				m.EXPECT().RemoveContainer(gomock.Any(), "cnt-123").Return(nil)
 				m.EXPECT().RemovePodSandbox(gomock.Any(), "sb-123").Return(nil)
 			},
@@ -80,6 +81,7 @@ func TestCopyResources(t *testing.T) {
 				m.EXPECT().CreateContainer(gomock.Any(), "sb-systemd", gomock.Any(), gomock.Any()).Return("cnt-systemd", nil)
 				m.EXPECT().StartContainer(gomock.Any(), "cnt-systemd").Return(nil)
 				m.EXPECT().ExecSync(gomock.Any(), "cnt-systemd", gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+				m.EXPECT().StopContainer(gomock.Any(), "cnt-systemd", int64(0)).Return(nil)
 				m.EXPECT().RemoveContainer(gomock.Any(), "cnt-systemd").Return(nil)
 				m.EXPECT().RemovePodSandbox(gomock.Any(), "sb-systemd").Return(nil)
 			},
@@ -101,6 +103,7 @@ func TestCopyResources(t *testing.T) {
 				m.EXPECT().RunPodSandbox(gomock.Any(), gomock.Any(), gomock.Any()).Return("sb-fail", nil)
 				m.EXPECT().CreateContainer(gomock.Any(), "sb-fail", gomock.Any(), gomock.Any()).Return("cnt-fail", nil)
 				m.EXPECT().StartContainer(gomock.Any(), "cnt-fail").Return(fmt.Errorf("internal error"))
+				m.EXPECT().StopContainer(gomock.Any(), "cnt-fail", int64(0)).Return(nil)
 				m.EXPECT().RemoveContainer(gomock.Any(), "cnt-fail").Return(nil)
 				m.EXPECT().RemovePodSandbox(gomock.Any(), "sb-fail").Return(nil)
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
RemoveContainer is called via defer immediately after CreateContainer succeeds, before StartContainer is invoked. When CopyResources completes normally the container is still in Running state. Calling RemoveContainer on a running container violates the CRI API contract; containerd returns an error which is only logged at V(3), leaving the container and its sandbox orphaned on the node.

This PR adds `StopContainer(gracePeriod=0)` before `RemoveContainer` in the defer to ensure proper cleanup, and tests to verify the CRI sequence.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
(Note: The git branch history was heavily contaminated with 33 unrelated file modifications from an accidental submodule pointer branch. This has been resolved and the PR is now atomic).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
