### PR TITLE
fix(pkg/metaserver): close data race in Application Wait and Cancel methods

### DIFF
--- a/pkg/metaserver/application.go
+++ b/pkg/metaserver/application.go
@@ -62,7 +62,7 @@ type Application struct {
 
 	// count the number of current citations
 	count     uint64
-	countLock *sync.Mutex
+	countLock sync.Mutex
 	// Timestamp record the last closing time of application, only make sense when count == 0
 	Timestamp time.Time
 }
@@ -89,7 +89,6 @@ func NewApplication(ctx context.Context, key string, verb ApplicationVerb, noden
 		ctx:         ctx2,
 		cancel:      cancel,
 		count:       0,
-		countLock:   &sync.Mutex{},
 		Timestamp:   time.Time{},
 	}
 	app.Add()
@@ -158,8 +157,12 @@ func (a *Application) Namespace() string {
 }
 
 func (a *Application) Cancel() {
-	if a.cancel != nil {
-		a.cancel()
+	a.countLock.Lock()
+	cancel := a.cancel
+	a.countLock.Unlock()
+
+	if cancel != nil {
+		cancel()
 	}
 }
 
@@ -169,8 +172,12 @@ func (a *Application) GetStatus() ApplicationStatus {
 
 // Wait the result of application after it is applied by application agent
 func (a *Application) Wait() {
-	if a.ctx != nil {
-		<-a.ctx.Done()
+	a.countLock.Lock()
+	ctx := a.ctx
+	a.countLock.Unlock()
+
+	if ctx != nil {
+		<-ctx.Done()
 	}
 }
 

--- a/pkg/metaserver/application.go
+++ b/pkg/metaserver/application.go
@@ -182,12 +182,16 @@ func (a *Application) Wait() {
 }
 
 func (a *Application) Reset() {
-	if a.ctx != nil && a.cancel != nil {
-		a.cancel()
-	}
+	a.countLock.Lock()
+	oldCancel := a.cancel
 	a.ctx, a.cancel = context.WithCancel(beehiveContext.GetContext())
 	a.Reason = ""
 	a.RespBody = []byte{}
+	a.countLock.Unlock()
+
+	if oldCancel != nil {
+		oldCancel()
+	}
 }
 
 func (a *Application) Add() {

--- a/pkg/metaserver/application.go
+++ b/pkg/metaserver/application.go
@@ -62,7 +62,7 @@ type Application struct {
 
 	// count the number of current citations
 	count     uint64
-	countLock *sync.Mutex
+	countLock sync.Mutex
 	// Timestamp record the last closing time of application, only make sense when count == 0
 	Timestamp time.Time
 }
@@ -89,7 +89,6 @@ func NewApplication(ctx context.Context, key string, verb ApplicationVerb, noden
 		ctx:         ctx2,
 		cancel:      cancel,
 		count:       0,
-		countLock:   &sync.Mutex{},
 		Timestamp:   time.Time{},
 	}
 	app.Add()
@@ -158,8 +157,12 @@ func (a *Application) Namespace() string {
 }
 
 func (a *Application) Cancel() {
-	if a.cancel != nil {
-		a.cancel()
+	a.countLock.Lock()
+	cancel := a.cancel
+	a.countLock.Unlock()
+
+	if cancel != nil {
+		cancel()
 	}
 }
 
@@ -169,18 +172,26 @@ func (a *Application) GetStatus() ApplicationStatus {
 
 // Wait the result of application after it is applied by application agent
 func (a *Application) Wait() {
-	if a.ctx != nil {
-		<-a.ctx.Done()
+	a.countLock.Lock()
+	ctx := a.ctx
+	a.countLock.Unlock()
+
+	if ctx != nil {
+		<-ctx.Done()
 	}
 }
 
 func (a *Application) Reset() {
-	if a.ctx != nil && a.cancel != nil {
-		a.cancel()
-	}
+	a.countLock.Lock()
+	oldCancel := a.cancel
 	a.ctx, a.cancel = context.WithCancel(beehiveContext.GetContext())
 	a.Reason = ""
 	a.RespBody = []byte{}
+	a.countLock.Unlock()
+
+	if oldCancel != nil {
+		oldCancel()
+	}
 }
 
 func (a *Application) Add() {

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -556,7 +555,6 @@ func TestReset(t *testing.T) {
 
 func TestAddAndClose(t *testing.T) {
 	app := Application{
-		countLock: &sync.Mutex{},
 		count:     1, // Initial count
 	}
 
@@ -581,7 +579,6 @@ func TestAddAndClose(t *testing.T) {
 
 func TestLastCloseTime(t *testing.T) {
 	app1 := Application{
-		countLock: &sync.Mutex{},
 		count:     1,
 		Timestamp: time.Now(),
 	}
@@ -589,7 +586,6 @@ func TestLastCloseTime(t *testing.T) {
 	assert.True(t, result1.IsZero())
 
 	app2 := Application{
-		countLock: &sync.Mutex{},
 		count:     0,
 		Timestamp: time.Time{}, // Zero timestamp
 	}
@@ -598,7 +594,6 @@ func TestLastCloseTime(t *testing.T) {
 
 	expectedTime := time.Now()
 	app3 := Application{
-		countLock: &sync.Mutex{},
 		count:     0,
 		Timestamp: expectedTime,
 	}

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -556,8 +556,7 @@ func TestReset(t *testing.T) {
 
 func TestAddAndClose(t *testing.T) {
 	app := Application{
-		countLock: &sync.Mutex{},
-		count:     1, // Initial count
+		count: 1, // Initial count
 	}
 
 	app.Add()
@@ -581,7 +580,6 @@ func TestAddAndClose(t *testing.T) {
 
 func TestLastCloseTime(t *testing.T) {
 	app1 := Application{
-		countLock: &sync.Mutex{},
 		count:     1,
 		Timestamp: time.Now(),
 	}
@@ -589,7 +587,6 @@ func TestLastCloseTime(t *testing.T) {
 	assert.True(t, result1.IsZero())
 
 	app2 := Application{
-		countLock: &sync.Mutex{},
 		count:     0,
 		Timestamp: time.Time{}, // Zero timestamp
 	}
@@ -598,7 +595,6 @@ func TestLastCloseTime(t *testing.T) {
 
 	expectedTime := time.Now()
 	app3 := Application{
-		countLock: &sync.Mutex{},
 		count:     0,
 		Timestamp: expectedTime,
 	}
@@ -636,4 +632,40 @@ func TestWait(t *testing.T) {
 	}
 	// Should not block or panic when context is nil
 	app.Wait()
+}
+
+func TestConcurrentResetWaitCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	app := Application{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			app.Reset()
+		}
+		// Ensure the final context is cancelled so Wait does not hang
+		app.Cancel()
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			app.Wait()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			app.Cancel()
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
-	"sync"
 
 	"github.com/stretchr/testify/assert"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -556,7 +556,7 @@ func TestReset(t *testing.T) {
 
 func TestAddAndClose(t *testing.T) {
 	app := Application{
-		count:     1, // Initial count
+		count: 1, // Initial count
 	}
 
 	app.Add()
@@ -649,6 +649,8 @@ func TestConcurrentResetWaitCancel(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			app.Reset()
 		}
+		// Ensure the final context is cancelled so Wait does not hang
+		app.Cancel()
 	}()
 
 	go func() {

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"sync"
 
 	"github.com/stretchr/testify/assert"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -631,4 +632,38 @@ func TestWait(t *testing.T) {
 	}
 	// Should not block or panic when context is nil
 	app.Wait()
+}
+
+func TestConcurrentResetWaitCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	app := Application{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			app.Reset()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			app.Wait()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			app.Cancel()
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR resolves data races in `pkg/metaserver/application.go` when `Wait()`, `Cancel()`, and `Reset()` are invoked concurrently on an `Application`:

1. **Mutex Value Type**: Changes `countLock` from `*sync.Mutex` to `sync.Mutex` value type to eliminate nil pointer risks.
2. **Synchronized Field Access**: Acquires `countLock` in `Wait()` and `Cancel()` when reading `a.ctx` and `a.cancel`.
3. **Deadlock-Free Reset**: Acquires `countLock` in `Reset()` when re-assigning `a.ctx` and `a.cancel`, and executes the previous context cancel function *after* releasing the lock to avoid lock-holding during callbacks.
4. **Deterministic Regression Test**: Adds `TestConcurrentResetWaitCancel` running heavy concurrent invocations under `go test -race` with a guaranteed final cancel so `Wait()` never blocks indefinitely.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
- Formatted with `gofmt -s`.
- Exactly 1 squashed commit with DCO sign-off.
- Verified with `go test -race ./pkg/metaserver/...`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```