### PR TITLE
feat(edged): InterLink integration for HPC/HTC offloading (PoC)

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -58,6 +59,7 @@ import (
 	commonmsg "github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	edgedconfig "github.com/kubeedge/kubeedge/edge/pkg/edged/config"
+	"github.com/kubeedge/kubeedge/edge/pkg/edged/interlink"
 	kubebridge "github.com/kubeedge/kubeedge/edge/pkg/edged/kubeclientbridge"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager"
 	metaclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
@@ -93,6 +95,13 @@ type edged struct {
 	nodeName       string
 	namespace      string
 	heldPodUpdates map[string][]kubelettypes.PodUpdate
+
+	// InterLink integration fields
+	interlinkClient     *interlink.Client                // HTTP client for InterLink API
+	interlinkEnabled    bool                             // whether InterLink integration is active
+	interlinkPollInterval time.Duration                  // status polling interval
+	interlinkPods       map[string]context.CancelFunc    // tracked offloaded pods (key: namespace/name)
+	interlinkMu         sync.Mutex                       // protects interlinkPods map
 }
 
 var _ core.Module = (*edged)(nil)
@@ -275,6 +284,23 @@ func newEdged(enable bool, nodeName, namespace string) (*edged, error) {
 		nodeName:       nodeName,
 		namespace:      namespace,
 		heldPodUpdates: make(map[string][]kubelettypes.PodUpdate),
+		interlinkPods:  make(map[string]context.CancelFunc),
+	}
+
+	// Initialize InterLink client if configured
+	if ilCfg := edgedconfig.Config.InterLink; ilCfg != nil && ilCfg.Enable {
+		if ilCfg.ServerURL == "" {
+			klog.Warning("InterLink is enabled but serverURL is empty, disabling InterLink integration")
+		} else {
+			pollInterval := 10 * time.Second
+			if ilCfg.StatusPollInterval.Duration > 0 {
+				pollInterval = ilCfg.StatusPollInterval.Duration
+			}
+			ed.interlinkClient = interlink.NewClient(ilCfg.ServerURL, 30*time.Second)
+			ed.interlinkEnabled = true
+			ed.interlinkPollInterval = pollInterval
+			klog.Infof("InterLink integration enabled: serverURL=%s, pollInterval=%s", ilCfg.ServerURL, pollInterval)
+		}
 	}
 
 	return ed, nil
@@ -402,6 +428,12 @@ func (e *edged) handlePod(op string, content []byte, updatesChan chan<- interfac
 	pods = append(pods, &pod)
 
 	if filterPodByNodeName(&pod, e.nodeName) {
+		// InterLink offloading: route annotated pods to the InterLink API
+		// instead of the local container runtime (CRI).
+		if e.interlinkEnabled && interlink.IsInterLinkPod(&pod) {
+			return e.handlePodViaInterLink(op, &pod)
+		}
+
 		var podOp kubelettypes.PodOperation
 		switch op {
 		case model.InsertOperation:
@@ -664,4 +696,124 @@ func kubeletHealthCheck(port int32, kubeletReadyChan chan struct{}) {
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+}
+
+// handlePodViaInterLink routes pod lifecycle operations to the InterLink API
+// server instead of the local container runtime. This enables offloading pods
+// to remote HPC/HTC backends (e.g., SLURM clusters) while maintaining
+// KubeEdge's offline autonomy and status reporting.
+func (e *edged) handlePodViaInterLink(op string, pod *v1.Pod) error {
+	podKey := pod.Namespace + "/" + pod.Name
+
+	switch op {
+	case model.InsertOperation:
+		klog.InfoS("InterLink: creating pod on remote backend", "pod", podKey)
+		if err := e.interlinkClient.Create(pod); err != nil {
+			klog.ErrorS(err, "InterLink: failed to create pod", "pod", podKey)
+			return fmt.Errorf("InterLink: failed to create pod %s: %w", podKey, err)
+		}
+
+		// Start status polling for this pod
+		ctx, cancel := context.WithCancel(e.context)
+		e.interlinkMu.Lock()
+		e.interlinkPods[podKey] = cancel
+		e.interlinkMu.Unlock()
+
+		go e.pollInterLinkStatus(ctx, pod)
+		klog.InfoS("InterLink: pod created and status polling started", "pod", podKey)
+
+	case model.UpdateOperation:
+		klog.V(4).InfoS("InterLink: update received for offloaded pod (no-op, status polling active)", "pod", podKey)
+
+	case model.DeleteOperation:
+		klog.InfoS("InterLink: deleting pod from remote backend", "pod", podKey)
+		if err := e.interlinkClient.Delete(pod); err != nil {
+			klog.ErrorS(err, "InterLink: failed to delete pod", "pod", podKey)
+			// Don't return error — still stop polling even if remote delete fails
+		}
+		e.stopInterLinkPolling(podKey)
+		klog.InfoS("InterLink: pod deleted and polling stopped", "pod", podKey)
+	}
+
+	return nil
+}
+
+// pollInterLinkStatus periodically queries the InterLink API for the status of
+// an offloaded pod and reports the status back through KubeEdge's MetaManager
+// → CloudHub pipeline. This ensures the cloud-side API server has accurate
+// status for pods running on remote HPC/HTC backends.
+func (e *edged) pollInterLinkStatus(ctx context.Context, pod *v1.Pod) {
+	podKey := pod.Namespace + "/" + pod.Name
+	ticker := time.NewTicker(e.interlinkPollInterval)
+	defer ticker.Stop()
+
+	klog.V(2).InfoS("InterLink: starting status poll loop", "pod", podKey, "interval", e.interlinkPollInterval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			klog.V(2).InfoS("InterLink: status polling stopped", "pod", podKey)
+			return
+		case <-ticker.C:
+			statuses, err := e.interlinkClient.Status([]*v1.Pod{pod})
+			if err != nil {
+				klog.ErrorS(err, "InterLink: failed to poll status", "pod", podKey)
+				continue
+			}
+
+			if len(statuses) == 0 {
+				klog.V(4).InfoS("InterLink: no status returned yet", "pod", podKey)
+				continue
+			}
+
+			podStatus := statuses[0]
+			patch := interlink.NewPodStatusPatch(podStatus)
+
+			if err := e.reportInterLinkStatus(pod, patch); err != nil {
+				klog.ErrorS(err, "InterLink: failed to report status", "pod", podKey)
+				continue
+			}
+
+			klog.V(4).InfoS("InterLink: reported pod status", "pod", podKey, "phase", patch.Status.Phase)
+
+			// Stop polling if the pod has reached a terminal state
+			if patch.Status.Phase == v1.PodSucceeded || patch.Status.Phase == v1.PodFailed {
+				klog.InfoS("InterLink: pod reached terminal state, stopping polling",
+					"pod", podKey, "phase", patch.Status.Phase)
+				e.stopInterLinkPolling(podKey)
+				return
+			}
+		}
+	}
+}
+
+// stopInterLinkPolling cancels the status polling goroutine for an offloaded pod
+// and removes it from the tracking map.
+func (e *edged) stopInterLinkPolling(podKey string) {
+	e.interlinkMu.Lock()
+	defer e.interlinkMu.Unlock()
+
+	if cancel, ok := e.interlinkPods[podKey]; ok {
+		cancel()
+		delete(e.interlinkPods, podKey)
+		klog.V(2).InfoS("InterLink: cancelled polling for pod", "pod", podKey)
+	}
+}
+
+// reportInterLinkStatus sends a pod status patch through KubeEdge's messaging
+// pipeline (EdgeD → MetaManager → CloudHub → API server) to update the cloud
+// with the current state of an InterLink-managed pod.
+func (e *edged) reportInterLinkStatus(pod *v1.Pod, patch interlink.PodStatusPatch) error {
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal status patch: %w", err)
+	}
+
+	resource := fmt.Sprintf("%s/%s/%s", pod.Namespace, model.ResourceTypePodPatch, pod.Name)
+	msg := model.NewMessage("").
+		BuildRouter(e.Name(), modules.MetaGroup, resource, model.PatchOperation).
+		FillBody(string(patchBytes))
+
+	beehiveContext.Send(modules.MetaManagerModuleName, *msg)
+	return nil
 }

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -714,8 +714,11 @@ func (e *edged) handlePodViaInterLink(op string, pod *v1.Pod) error {
 		}
 
 		// Start status polling for this pod
-		ctx, cancel := context.WithCancel(e.context)
+		ctx, cancel := context.WithCancel(beehiveContext.GetContext())
 		e.interlinkMu.Lock()
+		if oldCancel, exists := e.interlinkPods[podKey]; exists {
+			oldCancel()
+		}
 		e.interlinkPods[podKey] = cancel
 		e.interlinkMu.Unlock()
 
@@ -749,6 +752,8 @@ func (e *edged) pollInterLinkStatus(ctx context.Context, pod *v1.Pod) {
 
 	klog.V(2).InfoS("InterLink: starting status poll loop", "pod", podKey, "interval", e.interlinkPollInterval)
 
+	emptyCount := 0
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -762,9 +767,17 @@ func (e *edged) pollInterLinkStatus(ctx context.Context, pod *v1.Pod) {
 			}
 
 			if len(statuses) == 0 {
-				klog.V(4).InfoS("InterLink: no status returned yet", "pod", podKey)
+				emptyCount++
+				klog.V(4).InfoS("InterLink: no status returned yet", "pod", podKey, "emptyCount", emptyCount)
+				if emptyCount >= 5 {
+					klog.InfoS("InterLink: max empty status responses reached, stopping polling", "pod", podKey)
+					e.stopInterLinkPolling(podKey)
+					return
+				}
 				continue
 			}
+
+			emptyCount = 0 // reset counter
 
 			podStatus := statuses[0]
 			patch := interlink.NewPodStatusPatch(podStatus)

--- a/edge/pkg/edged/interlink/interlink_client.go
+++ b/edge/pkg/edged/interlink/interlink_client.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -116,7 +117,7 @@ type Client struct {
 // NewClient creates a new InterLink API client.
 func NewClient(serverURL string, timeout time.Duration) *Client {
 	return &Client{
-		serverURL: serverURL,
+		serverURL: strings.TrimSuffix(serverURL, "/"),
 		httpClient: &http.Client{
 			Timeout: timeout,
 		},
@@ -196,7 +197,7 @@ func (c *Client) Status(pods []*v1.Pod) ([]PodStatusResponse, error) {
 
 	klog.V(4).Infof("InterLink: querying status for %d pod(s)", len(pods))
 
-	httpReq, err := http.NewRequest(http.MethodGet, c.serverURL+statusPath, bytes.NewReader(body))
+	httpReq, err := http.NewRequest(http.MethodPost, c.serverURL+statusPath, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("InterLink: failed to build status request: %w", err)
 	}
@@ -237,7 +238,7 @@ func (c *Client) GetLogs(podNamespace, podName, containerName string, opts v1.Po
 
 	klog.V(4).Infof("InterLink: fetching logs for %s/%s/%s", podNamespace, podName, containerName)
 
-	httpReq, err := http.NewRequest(http.MethodGet, c.serverURL+getLogsPath, bytes.NewReader(body))
+	httpReq, err := http.NewRequest(http.MethodPost, c.serverURL+getLogsPath, bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("InterLink: failed to build logs request: %w", err)
 	}

--- a/edge/pkg/edged/interlink/interlink_client.go
+++ b/edge/pkg/edged/interlink/interlink_client.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package interlink provides an HTTP client for the InterLink API server,
+// enabling KubeEdge EdgeD to offload pod execution to remote HPC/HTC
+// backends (e.g., SLURM, HTCondor) via the InterLink plugin interface.
+//
+// InterLink API Spec: https://interlink-project.dev/docs/guides/api-reference
+package interlink
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// OffloadAnnotationKey is the annotation key used to mark pods for
+	// InterLink offloading. Pods with this annotation set to
+	// OffloadAnnotationValue will be routed to the InterLink API server
+	// instead of the local container runtime.
+	OffloadAnnotationKey = "kubeedge.io/offload-to"
+
+	// OffloadAnnotationValue is the expected value of the offload annotation.
+	OffloadAnnotationValue = "interlink"
+
+	createPath  = "/create"
+	deletePath  = "/delete"
+	statusPath  = "/status"
+	getLogsPath = "/getLogs"
+)
+
+// CreateRequest represents the request body for the InterLink /create endpoint.
+type CreateRequest struct {
+	// Pod is the Kubernetes Pod spec to be executed on the remote backend.
+	Pod *v1.Pod `json:"pod"`
+	// ConfigMaps associated with the pod.
+	ConfigMaps []v1.ConfigMap `json:"configmaps,omitempty"`
+	// Secrets associated with the pod.
+	Secrets []v1.Secret `json:"secrets,omitempty"`
+}
+
+// DeleteRequest represents the request body for the InterLink /delete endpoint.
+type DeleteRequest struct {
+	// Pod is the Kubernetes Pod to be deleted from the remote backend.
+	Pod *v1.Pod `json:"pod"`
+}
+
+// StatusRequest represents the request body for the InterLink /status endpoint.
+type StatusRequest struct {
+	// Pods is the list of pods to query status for.
+	Pods []*v1.Pod `json:"pods"`
+}
+
+// PodStatusResponse represents a single pod's status from the InterLink API.
+type PodStatusResponse struct {
+	// PodName is the name of the pod.
+	PodName string `json:"name"`
+	// PodNamespace is the namespace of the pod.
+	PodNamespace string `json:"namespace"`
+	// UID is the pod UID.
+	UID string `json:"UID"`
+	// Containers holds the status of each container in the pod.
+	Containers []ContainerStatusResponse `json:"containers"`
+}
+
+// ContainerStatusResponse represents a single container's status from InterLink.
+type ContainerStatusResponse struct {
+	// Name of the container.
+	Name string `json:"name"`
+	// State of the container.
+	State v1.ContainerState `json:"state"`
+	// ExitCode of the container, if terminated.
+	ExitCode int32 `json:"exitCode"`
+}
+
+// LogRequest represents the request body for the InterLink /getLogs endpoint.
+type LogRequest struct {
+	// PodName is the name of the pod.
+	PodName string `json:"podName"`
+	// PodNamespace is the namespace of the pod.
+	PodNamespace string `json:"podNamespace"`
+	// ContainerName is the name of the container.
+	ContainerName string `json:"containerName"`
+	// Opts contains the log options (tail lines, follow, etc).
+	Opts v1.PodLogOptions `json:"opts"`
+}
+
+// Client is an HTTP client for the InterLink API server.
+type Client struct {
+	// serverURL is the base URL of the InterLink API server (e.g., "http://localhost:3000").
+	serverURL string
+	// httpClient is the underlying HTTP client with configured timeout.
+	httpClient *http.Client
+}
+
+// NewClient creates a new InterLink API client.
+func NewClient(serverURL string, timeout time.Duration) *Client {
+	return &Client{
+		serverURL: serverURL,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+// Create submits a pod to the InterLink API server for execution on a remote backend.
+// This translates to a POST /create call which, for example, triggers an sbatch
+// command on a SLURM cluster.
+func (c *Client) Create(pod *v1.Pod) error {
+	req := CreateRequest{
+		Pod: pod,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal create request for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+
+	klog.V(4).Infof("InterLink: creating pod %s/%s on remote backend", pod.Namespace, pod.Name)
+
+	resp, err := c.httpClient.Post(c.serverURL+createPath, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("InterLink: failed to create pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("InterLink: create pod %s/%s returned status %d: %s", pod.Namespace, pod.Name, resp.StatusCode, string(respBody))
+	}
+
+	klog.V(2).Infof("InterLink: successfully created pod %s/%s on remote backend", pod.Namespace, pod.Name)
+	return nil
+}
+
+// Delete requests the InterLink API server to cancel/cleanup a remote job.
+// For SLURM backends, this triggers scancel.
+func (c *Client) Delete(pod *v1.Pod) error {
+	req := DeleteRequest{
+		Pod: pod,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal delete request for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+
+	klog.V(4).Infof("InterLink: deleting pod %s/%s from remote backend", pod.Namespace, pod.Name)
+
+	resp, err := c.httpClient.Post(c.serverURL+deletePath, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("InterLink: failed to delete pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("InterLink: delete pod %s/%s returned status %d: %s", pod.Namespace, pod.Name, resp.StatusCode, string(respBody))
+	}
+
+	klog.V(2).Infof("InterLink: successfully deleted pod %s/%s from remote backend", pod.Namespace, pod.Name)
+	return nil
+}
+
+// Status queries the InterLink API server for the current status of pods.
+// Returns a list of pod status responses that can be mapped to Kubernetes pod phases.
+func (c *Client) Status(pods []*v1.Pod) ([]PodStatusResponse, error) {
+	req := StatusRequest{
+		Pods: pods,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal status request: %w", err)
+	}
+
+	klog.V(4).Infof("InterLink: querying status for %d pod(s)", len(pods))
+
+	httpReq, err := http.NewRequest(http.MethodGet, c.serverURL+statusPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("InterLink: failed to build status request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("InterLink: failed to get status: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("InterLink: status returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var statuses []PodStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&statuses); err != nil {
+		return nil, fmt.Errorf("InterLink: failed to decode status response: %w", err)
+	}
+
+	return statuses, nil
+}
+
+// GetLogs fetches container logs from the remote backend via the InterLink API.
+func (c *Client) GetLogs(podNamespace, podName, containerName string, opts v1.PodLogOptions) (string, error) {
+	req := LogRequest{
+		PodName:       podName,
+		PodNamespace:  podNamespace,
+		ContainerName: containerName,
+		Opts:          opts,
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal log request: %w", err)
+	}
+
+	klog.V(4).Infof("InterLink: fetching logs for %s/%s/%s", podNamespace, podName, containerName)
+
+	httpReq, err := http.NewRequest(http.MethodGet, c.serverURL+getLogsPath, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("InterLink: failed to build logs request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("InterLink: failed to get logs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("InterLink: getLogs returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	logData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("InterLink: failed to read logs response: %w", err)
+	}
+
+	return string(logData), nil
+}
+
+// IsInterLinkPod checks whether a pod is annotated for InterLink offloading.
+func IsInterLinkPod(pod *v1.Pod) bool {
+	if pod == nil || pod.Annotations == nil {
+		return false
+	}
+	return pod.Annotations[OffloadAnnotationKey] == OffloadAnnotationValue
+}

--- a/edge/pkg/edged/interlink/interlink_client_test.go
+++ b/edge/pkg/edged/interlink/interlink_client_test.go
@@ -1,0 +1,378 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interlink
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestPod(name, namespace string, annotations map[string]string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image:latest",
+				},
+			},
+		},
+	}
+}
+
+func TestIsInterLinkPod(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *v1.Pod
+		expected bool
+	}{
+		{
+			name:     "nil pod",
+			pod:      nil,
+			expected: false,
+		},
+		{
+			name:     "pod without annotations",
+			pod:      newTestPod("test", "default", nil),
+			expected: false,
+		},
+		{
+			name:     "pod with unrelated annotation",
+			pod:      newTestPod("test", "default", map[string]string{"foo": "bar"}),
+			expected: false,
+		},
+		{
+			name:     "pod with wrong annotation value",
+			pod:      newTestPod("test", "default", map[string]string{OffloadAnnotationKey: "other"}),
+			expected: false,
+		},
+		{
+			name:     "pod with correct interlink annotation",
+			pod:      newTestPod("test", "default", map[string]string{OffloadAnnotationKey: OffloadAnnotationValue}),
+			expected: true,
+		},
+		{
+			name: "pod with interlink annotation and others",
+			pod: newTestPod("test", "default", map[string]string{
+				OffloadAnnotationKey:             OffloadAnnotationValue,
+				"slurm.interlink.io/partition":   "gpu",
+			}),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsInterLinkPod(tt.pod)
+			if result != tt.expected {
+				t.Errorf("IsInterLinkPod() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClientCreate(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		respBody   string
+		wantErr    bool
+	}{
+		{
+			name:       "successful create",
+			statusCode: http.StatusOK,
+			respBody:   `{"status": "ok"}`,
+			wantErr:    false,
+		},
+		{
+			name:       "server error",
+			statusCode: http.StatusInternalServerError,
+			respBody:   `{"error": "internal error"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "bad request",
+			statusCode: http.StatusBadRequest,
+			respBody:   `{"error": "bad request"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != createPath {
+					t.Errorf("expected path %s, got %s", createPath, r.URL.Path)
+				}
+				if r.Method != http.MethodPost {
+					t.Errorf("expected method POST, got %s", r.Method)
+				}
+
+				// Verify request body is valid
+				var req CreateRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+				if req.Pod.Name != "test-pod" {
+					t.Errorf("expected pod name test-pod, got %s", req.Pod.Name)
+				}
+
+				w.WriteHeader(tt.statusCode)
+				w.Write([]byte(tt.respBody))
+			}))
+			defer server.Close()
+
+			client := NewClient(server.URL, 5*time.Second)
+			pod := newTestPod("test-pod", "default", map[string]string{OffloadAnnotationKey: OffloadAnnotationValue})
+
+			err := client.Create(pod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestClientDelete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != deletePath {
+			t.Errorf("expected path %s, got %s", deletePath, r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected method POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, 5*time.Second)
+	pod := newTestPod("test-pod", "default", nil)
+
+	if err := client.Delete(pod); err != nil {
+		t.Errorf("Delete() unexpected error: %v", err)
+	}
+}
+
+func TestClientStatus(t *testing.T) {
+	expectedStatuses := []PodStatusResponse{
+		{
+			PodName:      "test-pod",
+			PodNamespace: "default",
+			Containers: []ContainerStatusResponse{
+				{
+					Name: "test-container",
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{
+							StartedAt: metav1.Now(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != statusPath {
+			t.Errorf("expected path %s, got %s", statusPath, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedStatuses)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, 5*time.Second)
+	pod := newTestPod("test-pod", "default", nil)
+
+	statuses, err := client.Status([]*v1.Pod{pod})
+	if err != nil {
+		t.Fatalf("Status() unexpected error: %v", err)
+	}
+
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	if statuses[0].PodName != "test-pod" {
+		t.Errorf("expected pod name test-pod, got %s", statuses[0].PodName)
+	}
+}
+
+func TestClientConnectionRefused(t *testing.T) {
+	// Use a URL that will definitely refuse connections
+	client := NewClient("http://127.0.0.1:1", 1*time.Second)
+	pod := newTestPod("test-pod", "default", nil)
+
+	if err := client.Create(pod); err == nil {
+		t.Error("Create() expected error for connection refused, got nil")
+	}
+
+	if err := client.Delete(pod); err == nil {
+		t.Error("Delete() expected error for connection refused, got nil")
+	}
+
+	if _, err := client.Status([]*v1.Pod{pod}); err == nil {
+		t.Error("Status() expected error for connection refused, got nil")
+	}
+}
+
+func TestMapInterLinkStatusToPodPhase(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []ContainerStatusResponse
+		expected   v1.PodPhase
+	}{
+		{
+			name:       "no containers - pending",
+			containers: nil,
+			expected:   v1.PodPending,
+		},
+		{
+			name: "container waiting - pending",
+			containers: []ContainerStatusResponse{
+				{
+					Name:  "c1",
+					State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "Queued"}},
+				},
+			},
+			expected: v1.PodPending,
+		},
+		{
+			name: "container running - running",
+			containers: []ContainerStatusResponse{
+				{
+					Name:  "c1",
+					State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				},
+			},
+			expected: v1.PodRunning,
+		},
+		{
+			name: "all terminated successfully - succeeded",
+			containers: []ContainerStatusResponse{
+				{
+					Name:     "c1",
+					State:    v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 0}},
+					ExitCode: 0,
+				},
+			},
+			expected: v1.PodSucceeded,
+		},
+		{
+			name: "terminated with error - failed",
+			containers: []ContainerStatusResponse{
+				{
+					Name:     "c1",
+					State:    v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 1}},
+					ExitCode: 1,
+				},
+			},
+			expected: v1.PodFailed,
+		},
+		{
+			name: "mixed running and terminated - running",
+			containers: []ContainerStatusResponse{
+				{
+					Name:  "c1",
+					State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				},
+				{
+					Name:  "c2",
+					State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 0}},
+				},
+			},
+			expected: v1.PodRunning,
+		},
+		{
+			name: "one waiting among multiple - pending",
+			containers: []ContainerStatusResponse{
+				{
+					Name:  "c1",
+					State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+				},
+				{
+					Name:  "c2",
+					State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{}},
+				},
+			},
+			expected: v1.PodPending,
+		},
+		{
+			name: "multiple terminated, one failed - failed",
+			containers: []ContainerStatusResponse{
+				{
+					Name:  "c1",
+					State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 0}},
+				},
+				{
+					Name:  "c2",
+					State: v1.ContainerState{Terminated: &v1.ContainerStateTerminated{ExitCode: 137}},
+				},
+			},
+			expected: v1.PodFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MapInterLinkStatusToPodPhase(tt.containers)
+			if result != tt.expected {
+				t.Errorf("MapInterLinkStatusToPodPhase() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewPodStatusPatch(t *testing.T) {
+	status := PodStatusResponse{
+		PodName:      "test-pod",
+		PodNamespace: "default",
+		Containers: []ContainerStatusResponse{
+			{
+				Name:  "c1",
+				State: v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+			},
+		},
+	}
+
+	patch := NewPodStatusPatch(status)
+
+	if patch.Status.Phase != v1.PodRunning {
+		t.Errorf("expected phase PodRunning, got %v", patch.Status.Phase)
+	}
+
+	if len(patch.Status.Conditions) != 1 {
+		t.Fatalf("expected 1 condition, got %d", len(patch.Status.Conditions))
+	}
+
+	if patch.Status.Conditions[0].Type != "InterLinkManaged" {
+		t.Errorf("expected condition type InterLinkManaged, got %s", patch.Status.Conditions[0].Type)
+	}
+
+	if patch.Status.Message == "" {
+		t.Error("expected non-empty status message")
+	}
+}

--- a/edge/pkg/edged/interlink/interlink_status.go
+++ b/edge/pkg/edged/interlink/interlink_status.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interlink
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MapInterLinkStatusToPodPhase determines the Kubernetes PodPhase from
+// the InterLink container status responses.
+//
+// Mapping rules:
+//   - If any container is Waiting → PodPending
+//   - If any container is Running → PodRunning
+//   - If all containers are Terminated with exit code 0 → PodSucceeded
+//   - If any container is Terminated with non-zero exit code → PodFailed
+//   - If no containers reported → PodPending (awaiting first status)
+func MapInterLinkStatusToPodPhase(containers []ContainerStatusResponse) v1.PodPhase {
+	if len(containers) == 0 {
+		return v1.PodPending
+	}
+
+	allTerminated := true
+	anyFailed := false
+	anyRunning := false
+	anyWaiting := false
+
+	for _, c := range containers {
+		if c.State.Waiting != nil {
+			anyWaiting = true
+			allTerminated = false
+		} else if c.State.Running != nil {
+			anyRunning = true
+			allTerminated = false
+		} else if c.State.Terminated != nil {
+			if c.State.Terminated.ExitCode != 0 {
+				anyFailed = true
+			}
+		} else {
+			// No state set, assume waiting
+			anyWaiting = true
+			allTerminated = false
+		}
+	}
+
+	if anyWaiting {
+		return v1.PodPending
+	}
+	if anyRunning {
+		return v1.PodRunning
+	}
+
+	if allTerminated {
+		if anyFailed {
+			return v1.PodFailed
+		}
+		return v1.PodSucceeded
+	}
+
+	return v1.PodPending
+}
+
+// BuildPodStatusPatch constructs a JSON merge patch for updating a pod's status
+// based on InterLink status responses. This patch is sent through KubeEdge's
+// MetaManager → CloudHub pipeline to report HPC job status back to the cloud.
+type PodStatusPatch struct {
+	Status PodStatusPatchBody `json:"status"`
+}
+
+// PodStatusPatchBody contains the status fields to patch.
+type PodStatusPatchBody struct {
+	Phase      v1.PodPhase      `json:"phase"`
+	Conditions []v1.PodCondition `json:"conditions,omitempty"`
+	Message    string            `json:"message,omitempty"`
+}
+
+// NewPodStatusPatch creates a status patch from InterLink status responses.
+func NewPodStatusPatch(podStatus PodStatusResponse) PodStatusPatch {
+	phase := MapInterLinkStatusToPodPhase(podStatus.Containers)
+
+	conditions := []v1.PodCondition{
+		{
+			Type:               "InterLinkManaged",
+			Status:             v1.ConditionTrue,
+			Reason:             "InterLinkOffloaded",
+			Message:            "Pod is managed by InterLink for remote HPC/HTC execution",
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+
+	var message string
+	switch phase {
+	case v1.PodPending:
+		message = "Pod is queued or initializing on the remote HPC/HTC backend"
+	case v1.PodRunning:
+		message = "Pod is running on the remote HPC/HTC backend"
+	case v1.PodSucceeded:
+		message = "Pod completed successfully on the remote HPC/HTC backend"
+	case v1.PodFailed:
+		message = "Pod failed on the remote HPC/HTC backend"
+	}
+
+	return PodStatusPatch{
+		Status: PodStatusPatchBody{
+			Phase:      phase,
+			Conditions: conditions,
+			Message:    message,
+		},
+	}
+}

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -119,6 +119,28 @@ type Edged struct {
 	// RegisterNodeNamespace indicates register node namespace
 	// default "default"
 	RegisterNodeNamespace string `json:"registerNodeNamespace,omitempty"`
+	// InterLink configures the InterLink integration for HPC/HTC workload offloading.
+	// When enabled, pods annotated with "kubeedge.io/offload-to: interlink" will be
+	// routed to the InterLink API server instead of the local container runtime,
+	// enabling execution on remote HPC (SLURM) or HTC (HTCondor) backends.
+	// +optional
+	InterLink *InterLinkConfig `json:"interlink,omitempty"`
+}
+
+// InterLinkConfig holds configuration for the InterLink integration.
+// InterLink (https://github.com/interTwin-eu/interLink) enables offloading
+// Kubernetes pods to external compute backends such as HPC clusters via SLURM.
+type InterLinkConfig struct {
+	// Enable indicates whether InterLink integration is enabled.
+	// default false
+	Enable bool `json:"enable"`
+	// ServerURL is the URL of the InterLink API server.
+	// Example: "http://localhost:3000"
+	ServerURL string `json:"serverURL"`
+	// StatusPollInterval is how often to poll the InterLink API for remote job status.
+	// default "10s"
+	// +optional
+	StatusPollInterval metav1.Duration `json:"statusPollInterval,omitempty"`
 }
 
 // TailoredKubeletConfiguration indicates the tailored kubelet configuration.


### PR DESCRIPTION
This PR adds a proof-of-concept integration of InterLink directly into EdgeD, addressing #6835.

When enabled via configuration, EdgeD will check pods for the `kubeedge.io/offload-to: interlink` annotation. If present, instead of managing the pod locally via CRI, EdgeD delegates the execution to an InterLink API server (which can be backed by plugins like SLURM or HTCondor).

**Changes:**
- Added `interlink_client.go`: HTTP client for InterLink API (`/create`, `/delete`, `/status`, `/getLogs`)
- Added `interlink_status.go`: Maps InterLink container statuses to K8s Pod phases and creates status patches
- Added `InterLinkConfig` to KubeEdge API `Edged` struct
- Modified `edged.go` to route annotated pods via the InterLink API and added status polling loop

**Status:** Tests pass, build successful. This is a PoC ready for review and feedback.