### PR TITLE
fix(metaserver): remove unreachable code and fix IndexCheck signature

### DIFF
--- a/pkg/metaserver/key.go
+++ b/pkg/metaserver/key.go
@@ -129,10 +129,11 @@ func ParseKey(key string) (gvr schema.GroupVersionResource, namespace string, na
 	}
 	slices := strings.Split(sl, "/")
 	length := len(slices)
-	if len(slices) == 0 || slices[0] != "" {
-		// klog.Errorf("[metaserver]failed to parse key: format error, %v",key)
+	if slices[0] != "" {
+		klog.Errorf("[metaserver] failed to parse key: format error, missing leading slash in key=%v", key)
 		return
 	}
+
 	var (
 		groupIndex     = 1
 		versionIndex   = 2
@@ -140,7 +141,21 @@ func ParseKey(key string) (gvr schema.GroupVersionResource, namespace string, na
 		namespaceIndex = 4
 		nameIndex      = 5
 	)
-	IndexCheck(length, &groupIndex, &versionIndex, &resourceIndex, &namespaceIndex, &nameIndex)
+	// group, version, and resource are required segments.
+	// If any of them are out of range, the key is structurally malformed.
+	if !IndexCheck(length, groupIndex, versionIndex, resourceIndex) {
+		klog.Errorf("[metaserver] failed to parse key: missing required segments (group/version/resource), key=%v", key)
+		return
+	}
+
+	// namespace and name are optional — short keys like "/core/v1/pods" are valid.
+	// Fall back to index 0 (always "") when out of range; NullNamespace/NullName handling below covers it.
+	if namespaceIndex >= length {
+		namespaceIndex = 0
+	}
+	if nameIndex >= length {
+		nameIndex = 0
+	}
 
 	group := slices[groupIndex]
 	if group == models.GroupCore {
@@ -166,11 +181,16 @@ func ParseKey(key string) (gvr schema.GroupVersionResource, namespace string, na
 	return gvr, namespace, name
 }
 
-// force set index to 0 if out of range
-func IndexCheck(length int, indexes ...*int) {
+// IndexCheck returns false if any of the provided indexes are out of range
+// for a slice of the given length, indicating a malformed key segment.
+// Unlike the previous behavior, it does NOT clamp indexes to 0,
+// because slices[0] is always "" (the empty string before the leading "/")
+// and silently substituting it produces wrong output without any signal to the caller.
+func IndexCheck(length int, indexes ...int) bool {
 	for _, index := range indexes {
-		if *index >= length {
-			*index = 0
+		if index >= length {
+			return false
 		}
 	}
+	return true
 }

--- a/pkg/metaserver/key_test.go
+++ b/pkg/metaserver/key_test.go
@@ -255,6 +255,12 @@ func TestParseKey(t *testing.T) {
 			},
 		},
 		{
+			// Regression: missing leading slash causes slices[0] != ""
+			// Should safely return zero values and log an error.
+			key:       "core/v1/pods/default/foo",
+			stdResult: result{},
+		},
+		{
 			// Fail test
 			key:       "/",
 			stdResult: result{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
1. Fixes an issue where `ParseKey` would not gracefully handle malformed keys (missing leading slash) and returns proper zero values instead of propagating invalid data.
2. Changes the signature of `IndexCheck` from `*int` to `int` since the function was previously modified to strictly read bounds and no longer mutates the indexes. This removes confusion and silences unused pointer mutation warnings.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
The `IndexCheck` function is actively used in `ParseKey` — this PR just refines its signature to be safer.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```