### PR TITLE
fix(test): ensure dummy device test uses correct error type

### DIFF
--- a/pkg/util/dummy_device_linux_test.go
+++ b/pkg/util/dummy_device_linux_test.go
@@ -64,7 +64,7 @@ func TestEnsureDummyDevice(t *testing.T) {
 	t.Run("Device doesn't exist and creation fails", func(t *testing.T) {
 		patches := gomonkey.ApplyFunc((*netlink.Handle).LinkByName,
 			func(_ *netlink.Handle, name string) (netlink.Link, error) {
-				return nil, errors.New("not found")
+				return nil, netlink.LinkNotFoundError{}
 			})
 		patches.ApplyFunc((*netlink.Handle).LinkAdd,
 			func(_ *netlink.Handle, link netlink.Link) error {
@@ -75,6 +75,22 @@ func TestEnsureDummyDevice(t *testing.T) {
 		exists, err := manager.EnsureDummyDevice("dummy0")
 		assert.False(t, exists, "Expected device not to exist")
 		assert.Error(t, err, "Expected error on creation failure")
+	})
+
+	t.Run("Device doesn't exist and creation succeeds", func(t *testing.T) {
+		patches := gomonkey.ApplyFunc((*netlink.Handle).LinkByName,
+			func(_ *netlink.Handle, name string) (netlink.Link, error) {
+				return nil, netlink.LinkNotFoundError{}
+			})
+		patches.ApplyFunc((*netlink.Handle).LinkAdd,
+			func(_ *netlink.Handle, link netlink.Link) error {
+				return nil
+			})
+		defer patches.Reset()
+
+		exists, err := manager.EnsureDummyDevice("dummy0")
+		assert.False(t, exists, "Expected device to not initially exist")
+		assert.NoError(t, err, "Expected no error on successful creation")
 	})
 }
 


### PR DESCRIPTION
What type of PR is this?
/kind test

What this PR does / why we need it:
In pkg/util/dummy_device_linux_test.go, the TestEnsureDummyDevice function had two problems.

First, the "Device doesn't exist and creation fails" sub-test was patching LinkByName to return errors.New("not found") instead of netlink.LinkNotFoundError{}. The implementation type-checks for LinkNotFoundError to decide whether to call LinkAdd. With a plain errors.New, LinkAdd is never reached, meaning the creation code path was never exercised. The sub-test claimed to test "creation fails" but creation was never even attempted. This is directly inconsistent with TestDeleteDummyDevice in the same file, which correctly uses netlink.LinkNotFoundError{}.

Second, there was no sub-test covering the path where the device does not exist and LinkAdd succeeds, leaving the happy path of EnsureDummyDevice completely untested.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

errors.New("not found") replaced with netlink.LinkNotFoundError{} in the creation fails sub-test so the correct code branch is exercised. This matches the pattern already used correctly in TestDeleteDummyDevice in the same file.
New sub-test "Device doesn't exist and creation succeeds" added to cover the (false, nil) return path of EnsureDummyDevice.
Tests must be run with -gcflags=all=-l because gomonkey patches function memory at runtime and requires inlining to be disabled. Without this flag the real kernel call executes and fails with operation not permitted.
Does this PR introduce a user-facing change?:

NONE