### PR TITLE
fix(nodetask): prevent nil panics in actionflow.Find

### DIFF
--- a/pkg/nodetask/actionflow/action_flow.go
+++ b/pkg/nodetask/actionflow/action_flow.go
@@ -40,26 +40,27 @@ type Flow struct {
 
 // Find returns the found action by name.
 func (sf *Flow) Find(name string) *Action {
-	if sf.First.Name == name {
-		return sf.First
+	// Guard against nil receiver
+	if sf == nil {
+		return nil
 	}
+	
 	return doFind(name, sf.First)
 }
 
-// Using recursion to find a action by name.
+// doFind recursively searches for an action by name across both
+// NextSuccessful and NextFailure branches.
 func doFind(name string, act *Action) *Action {
+	if act == nil {
+		return nil
+	}
 	if act.Name == name {
 		return act
 	}
-	if act.NextSuccessful != nil {
-		if next := doFind(name, act.NextSuccessful); next != nil {
-			return next
-		}
+	if next := doFind(name, act.NextSuccessful); next != nil {
+		return next
 	}
-	if act.NextFailure != nil {
-		return doFind(name, act.NextFailure)
-	}
-	return nil
+	return doFind(name, act.NextFailure)
 }
 
 var (

--- a/pkg/nodetask/actionflow/action_flow.go
+++ b/pkg/nodetask/actionflow/action_flow.go
@@ -44,7 +44,7 @@ func (sf *Flow) Find(name string) *Action {
 	if sf == nil {
 		return nil
 	}
-	
+
 	return doFind(name, sf.First)
 }
 

--- a/pkg/nodetask/actionflow/action_flow_test.go
+++ b/pkg/nodetask/actionflow/action_flow_test.go
@@ -49,3 +49,41 @@ func TestFound(t *testing.T) {
 	require.NotNil(t, FlowNodeUpgradeJob.Find(string(v1alpha2.NodeUpgradeJobActionRollBack)))
 	require.Nil(t, FlowNodeUpgradeJob.Find("unknown"))
 }
+
+func TestImagePrePullActionFlow(t *testing.T) {
+	check := FlowImagePrePullJob.First
+	require.Equal(t, string(v1alpha2.ImagePrePullJobActionCheck), check.Name)
+	require.Nil(t, check.Next(false))
+	pulls := check.Next(true)
+	require.Equal(t, string(v1alpha2.ImagePrePullJobActionPull), pulls.Name)
+	require.Nil(t, pulls.Next(true))
+	require.Nil(t, pulls.Next(false))
+}
+
+func TestConfigUpdateActionFlow(t *testing.T) {
+	check := FlowConfigUpdateJob.First
+	require.Equal(t, string(v1alpha2.ConfigUpdateJobActionCheck), check.Name)
+	require.Nil(t, check.Next(false))
+	backUp := check.Next(true)
+	require.Equal(t, string(v1alpha2.ConfigUpdateJobActionBackUp), backUp.Name)
+	require.Nil(t, backUp.Next(false))
+	update := backUp.Next(true)
+	require.Equal(t, string(v1alpha2.ConfigUpdateJobActionUpdate), update.Name)
+	require.Nil(t, update.Next(true))
+	rollback := update.Next(false)
+	require.Equal(t, string(v1alpha2.ConfigUpdateJobActionRollBack), rollback.Name)
+}
+
+func TestFoundAllFlows(t *testing.T) {
+	// ImagePrePullJob
+	require.NotNil(t, FlowImagePrePullJob.Find(string(v1alpha2.ImagePrePullJobActionCheck)))
+	require.NotNil(t, FlowImagePrePullJob.Find(string(v1alpha2.ImagePrePullJobActionPull)))
+	require.Nil(t, FlowImagePrePullJob.Find("unknown"))
+
+	// ConfigUpdateJob -- RollBack hangs off NextFailure; this was the broken case
+	require.NotNil(t, FlowConfigUpdateJob.Find(string(v1alpha2.ConfigUpdateJobActionCheck)))
+	require.NotNil(t, FlowConfigUpdateJob.Find(string(v1alpha2.ConfigUpdateJobActionBackUp)))
+	require.NotNil(t, FlowConfigUpdateJob.Find(string(v1alpha2.ConfigUpdateJobActionUpdate)))
+	require.NotNil(t, FlowConfigUpdateJob.Find(string(v1alpha2.ConfigUpdateJobActionRollBack)))
+	require.Nil(t, FlowConfigUpdateJob.Find("unknown"))
+}

--- a/pkg/nodetask/actionflow/action_flow_test.go
+++ b/pkg/nodetask/actionflow/action_flow_test.go
@@ -87,3 +87,13 @@ func TestFoundAllFlows(t *testing.T) {
 	require.NotNil(t, FlowConfigUpdateJob.Find(string(v1alpha2.ConfigUpdateJobActionRollBack)))
 	require.Nil(t, FlowConfigUpdateJob.Find("unknown"))
 }
+
+func TestFindWithNilFlow(t *testing.T) {
+	var f *Flow
+	require.Nil(t, f.Find("anything"))
+}
+
+func TestFindWithEmptyFlow(t *testing.T) {
+	f := &Flow{}
+	require.Nil(t, f.Find("anything"))
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds a `nil` receiver guard for `sf *Flow` and a `nil` action guard in `doFind()` to prevent panics if an empty or nil flow is searched.

(Note: An accidental submodule pointer commit in the root `kubeedge` directory has been successfully rebased out of this branch).

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Bot concerns regarding the `nil` receiver have been addressed, and tests verifying the behavior of `Find` on a nil/empty flow have been added.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
