### PR TITLE
edgecontroller: delete untracked configmaps and secrets from location…

### DIFF
--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -60,7 +60,7 @@ func (dc *DownstreamController) syncPod() {
 			pod, ok := e.Object.(*v1.Pod)
 			if !ok {
 				klog.Warningf("object type: %T unsupported", e.Object)
-			continue
+				continue
 			}
 			if !dc.lc.IsEdgeNode(pod.Spec.NodeName) {
 				continue
@@ -356,40 +356,27 @@ func (dc *DownstreamController) removePodFromLocalCache(pod v1.Pod) {
 		}
 	}
 
-	for _, cm := range configMaps {
-		needed := false
-		for _, p := range otherPodsOnNode {
-			cms, _ := dc.lc.PodConfigMapsAndSecrets(*p)
-			for _, c := range cms {
-				if c == cm {
-					needed = true
-					break
-				}
-			}
-			if needed {
-				break
-			}
+	activeConfigMaps := make(map[string]struct{})
+	activeSecrets := make(map[string]struct{})
+
+	for _, p := range otherPodsOnNode {
+		otherConfig, otherSecret := dc.lc.PodConfigMapsAndSecrets(*p)
+		for _, c := range otherConfig {
+			activeConfigMaps[c] = struct{}{}
 		}
-		if !needed {
+		for _, s := range otherSecret {
+			activeSecrets[s] = struct{}{}
+		}
+	}
+
+	for _, cm := range configMaps {
+		if _, needed := activeConfigMaps[cm]; !needed {
 			dc.lc.RemoveNodeFromConfigMap(pod.Namespace, cm, pod.Spec.NodeName)
 		}
 	}
 
 	for _, secret := range secrets {
-		needed := false
-		for _, p := range otherPodsOnNode {
-			_, secs := dc.lc.PodConfigMapsAndSecrets(*p)
-			for _, s := range secs {
-				if s == secret {
-					needed = true
-					break
-				}
-			}
-			if needed {
-				break
-			}
-		}
-		if !needed {
+		if _, needed := activeSecrets[secret]; !needed {
 			dc.lc.RemoveNodeFromSecret(pod.Namespace, secret, pod.Spec.NodeName)
 		}
 	}

--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -60,7 +60,7 @@ func (dc *DownstreamController) syncPod() {
 			pod, ok := e.Object.(*v1.Pod)
 			if !ok {
 				klog.Warningf("object type: %T unsupported", e.Object)
-				continue
+			continue
 			}
 			if !dc.lc.IsEdgeNode(pod.Spec.NodeName) {
 				continue
@@ -79,6 +79,7 @@ func (dc *DownstreamController) syncPod() {
 				dc.lc.AddOrUpdatePod(*pod)
 			case watch.Deleted:
 				msg.BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, resource, model.DeleteOperation)
+				dc.removePodFromLocalCache(*pod)
 			case watch.Modified:
 				msg.BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, resource, model.UpdateOperation)
 				dc.lc.AddOrUpdatePod(*pod)
@@ -334,6 +335,62 @@ func (dc *DownstreamController) syncRuleEndpoint() {
 			} else {
 				klog.V(4).Infof("send message successfully, operation: %s, resource: %s", msg.GetOperation(), msg.GetResource())
 			}
+		}
+	}
+}
+
+// removePodFromLocalCache removes pod references from the LocationCache if no other pods require them.
+func (dc *DownstreamController) removePodFromLocalCache(pod v1.Pod) {
+	configMaps, secrets := dc.lc.PodConfigMapsAndSecrets(pod)
+
+	allPods, err := dc.podLister.Pods(pod.Namespace).List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list pods in namespace %s: %v", pod.Namespace, err)
+		return
+	}
+
+	var otherPodsOnNode []*v1.Pod
+	for _, p := range allPods {
+		if p.Name != pod.Name && p.Spec.NodeName == pod.Spec.NodeName {
+			otherPodsOnNode = append(otherPodsOnNode, p)
+		}
+	}
+
+	for _, cm := range configMaps {
+		needed := false
+		for _, p := range otherPodsOnNode {
+			cms, _ := dc.lc.PodConfigMapsAndSecrets(*p)
+			for _, c := range cms {
+				if c == cm {
+					needed = true
+					break
+				}
+			}
+			if needed {
+				break
+			}
+		}
+		if !needed {
+			dc.lc.RemoveNodeFromConfigMap(pod.Namespace, cm, pod.Spec.NodeName)
+		}
+	}
+
+	for _, secret := range secrets {
+		needed := false
+		for _, p := range otherPodsOnNode {
+			_, secs := dc.lc.PodConfigMapsAndSecrets(*p)
+			for _, s := range secs {
+				if s == secret {
+					needed = true
+					break
+				}
+			}
+			if needed {
+				break
+			}
+		}
+		if !needed {
+			dc.lc.RemoveNodeFromSecret(pod.Namespace, secret, pod.Spec.NodeName)
 		}
 	}
 }

--- a/cloud/pkg/edgecontroller/manager/location.go
+++ b/cloud/pkg/edgecontroller/manager/location.go
@@ -156,3 +156,59 @@ func (lc *LocationCache) DeleteSecret(namespace, name string) {
 func (lc *LocationCache) DeleteNode(nodeName string) {
 	lc.EdgeNodes.Delete(nodeName)
 }
+
+// RemoveNodeFromConfigMap removes a node from the ConfigMap synchronization list
+func (lc *LocationCache) RemoveNodeFromConfigMap(
+	namespace,
+	name,
+	node string, 
+){
+	configMapKey := fmt.Sprintf("%s/%s", namespace, name)
+	value, ok := lc.configMapNode.Load(configMapKey)
+	if !ok{
+		return
+	}
+
+	nodes, _ := value.([]string)
+	var newNodes []string
+
+	for _, n := range nodes {
+		if n!=node {
+			newNodes = append(newNodes, n)
+		}
+	}
+
+	if len(newNodes) == 0 {
+		lc.configMapNode.Delete(configMapKey)
+	} else {
+		lc.configMapNode.Store(configMapKey, newNodes)
+	}
+}
+
+// RemoveNodeFromSecret removes a node from the secret sync list
+func (lc *LocationCache) RemoveNodeFromSecret(
+	namespace,
+	name,
+	node string,
+){
+	secretKey := fmt.Sprintf("%s/%s", namespace, name)
+	value, ok := lc.secretNode.Load(secretKey)
+	if !ok{
+		return
+	}
+
+	nodes, _ := value.([]string)
+	var newNodes []string
+
+	for _, n := range nodes {
+		if n != node {
+			newNodes = append(newNodes, n)
+		}
+	}
+
+	if len(newNodes) == 0 {
+		lc.secretNode.Delete(secretKey)
+	} else {
+		lc.secretNode.Store(secretKey, newNodes)
+	}
+}

--- a/cloud/pkg/edgecontroller/manager/location.go
+++ b/cloud/pkg/edgecontroller/manager/location.go
@@ -15,6 +15,8 @@ type LocationCache struct {
 	configMapNode sync.Map
 	// secretNode is a map, key is namespace/secretName, value is nodeName
 	secretNode sync.Map
+	// mu protects configMapNode and secretNode updates
+	mu sync.Mutex
 }
 
 // PodConfigMapsAndSecrets return configmaps and secrets used by pod
@@ -77,6 +79,8 @@ func (lc *LocationCache) newNodes(oldNodes []string, node string) []string {
 
 // AddOrUpdatePod add pod to node, pod to configmap, configmap to pod, pod to secret, secret to pod relation
 func (lc *LocationCache) AddOrUpdatePod(pod v1.Pod) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
 	configMaps, secrets := lc.PodConfigMapsAndSecrets(pod)
 	for _, c := range configMaps {
 		configMapKey := fmt.Sprintf("%s/%s", pod.Namespace, c)
@@ -144,11 +148,15 @@ func (lc *LocationCache) UpdateEdgeNode(nodeName string) {
 
 // DeleteConfigMap from cache
 func (lc *LocationCache) DeleteConfigMap(namespace, name string) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
 	lc.configMapNode.Delete(fmt.Sprintf("%s/%s", namespace, name))
 }
 
 // DeleteSecret from cache
 func (lc *LocationCache) DeleteSecret(namespace, name string) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
 	lc.secretNode.Delete(fmt.Sprintf("%s/%s", namespace, name))
 }
 
@@ -161,11 +169,13 @@ func (lc *LocationCache) DeleteNode(nodeName string) {
 func (lc *LocationCache) RemoveNodeFromConfigMap(
 	namespace,
 	name,
-	node string, 
-){
+	node string,
+) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
 	configMapKey := fmt.Sprintf("%s/%s", namespace, name)
 	value, ok := lc.configMapNode.Load(configMapKey)
-	if !ok{
+	if !ok {
 		return
 	}
 
@@ -173,7 +183,7 @@ func (lc *LocationCache) RemoveNodeFromConfigMap(
 	var newNodes []string
 
 	for _, n := range nodes {
-		if n!=node {
+		if n != node {
 			newNodes = append(newNodes, n)
 		}
 	}
@@ -190,10 +200,12 @@ func (lc *LocationCache) RemoveNodeFromSecret(
 	namespace,
 	name,
 	node string,
-){
+) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
 	secretKey := fmt.Sprintf("%s/%s", namespace, name)
 	value, ok := lc.secretNode.Load(secretKey)
-	if !ok{
+	if !ok {
 		return
 	}
 

--- a/cloud/pkg/edgecontroller/manager/location_test.go
+++ b/cloud/pkg/edgecontroller/manager/location_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package manager
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -310,5 +311,49 @@ func TestDeleteNode(t *testing.T) {
 				t.Errorf("Manager.TestDeleteNode() case failed: exist = %v, want = %v.", exist, test.want)
 			}
 		})
+	}
+}
+
+func TestRemoveNodeFromConfigMapAndSecret(t *testing.T) {
+	lc := &LocationCache{}
+	namespace := "default"
+	cmName := "test-cm"
+	secretName := "test-secret"
+	node1 := "node-1"
+	node2 := "node-2"
+
+	lc.configMapNode.Store(fmt.Sprintf("%s/%s", namespace, cmName), []string{node1, node2})
+	lc.secretNode.Store(fmt.Sprintf("%s/%s", namespace, secretName), []string{node1, node2})
+
+	lc.RemoveNodeFromConfigMap(namespace, cmName, node1)
+	cmsNodesVal, ok := lc.configMapNode.Load(fmt.Sprintf("%s/%s", namespace, cmName))
+	if !ok {
+		t.Fatalf("Expected ConfigMap key to still exist")
+	}
+	cmsNodes := cmsNodesVal.([]string)
+	if len(cmsNodes) != 1 || cmsNodes[0] != node2 {
+		t.Errorf("Expected remaining node list to be [%s], got %v", node2, cmsNodes)
+	}
+
+	lc.RemoveNodeFromConfigMap(namespace, cmName, node2)
+	_, ok = lc.configMapNode.Load(fmt.Sprintf("%s/%s", namespace, cmName))
+	if ok {
+		t.Errorf("Expected ConfigMap key to be deleted when no nodes are left")
+	}
+
+	lc.RemoveNodeFromSecret(namespace, secretName, node1)
+	secretNodesVal, ok := lc.secretNode.Load(fmt.Sprintf("%s/%s", namespace, secretName))
+	if !ok {
+		t.Fatalf("Expected Secret key to still exist")
+	}
+	secNodes := secretNodesVal.([]string)
+	if len(secNodes) != 1 || secNodes[0] != node2 {
+		t.Errorf("Expected remaining node list to be [%s], got %v", node2, secNodes)
+	}
+
+	lc.RemoveNodeFromSecret(namespace, secretName, node2)
+	_, ok = lc.secretNode.Load(fmt.Sprintf("%s/%s", namespace, secretName))
+	if ok {
+		t.Errorf("Expected Secret key to be deleted when no nodes are left")
 	}
 }

--- a/cloud/pkg/edgecontroller/manager/location_test.go
+++ b/cloud/pkg/edgecontroller/manager/location_test.go
@@ -322,15 +322,38 @@ func TestRemoveNodeFromConfigMapAndSecret(t *testing.T) {
 	node1 := "node-1"
 	node2 := "node-2"
 
+	lc.RemoveNodeFromConfigMap(namespace, "non-existent-cm", node1)
+	lc.RemoveNodeFromSecret(namespace, "non-existent-secret", node1)
+
 	lc.configMapNode.Store(fmt.Sprintf("%s/%s", namespace, cmName), []string{node1, node2})
 	lc.secretNode.Store(fmt.Sprintf("%s/%s", namespace, secretName), []string{node1, node2})
 
-	lc.RemoveNodeFromConfigMap(namespace, cmName, node1)
+	lc.RemoveNodeFromConfigMap(namespace, cmName, "non-existent-node")
 	cmsNodesVal, ok := lc.configMapNode.Load(fmt.Sprintf("%s/%s", namespace, cmName))
 	if !ok {
 		t.Fatalf("Expected ConfigMap key to still exist")
 	}
 	cmsNodes := cmsNodesVal.([]string)
+	if len(cmsNodes) != 2 {
+		t.Errorf("Expected node list length to remain 2, got %d", len(cmsNodes))
+	}
+
+	lc.RemoveNodeFromSecret(namespace, secretName, "non-existent-node")
+	secretNodesVal, ok := lc.secretNode.Load(fmt.Sprintf("%s/%s", namespace, secretName))
+	if !ok {
+		t.Fatalf("Expected Secret key to still exist")
+	}
+	secNodes := secretNodesVal.([]string)
+	if len(secNodes) != 2 {
+		t.Errorf("Expected node list length to remain 2, got %d", len(secNodes))
+	}
+
+	lc.RemoveNodeFromConfigMap(namespace, cmName, node1)
+	cmsNodesVal, ok = lc.configMapNode.Load(fmt.Sprintf("%s/%s", namespace, cmName))
+	if !ok {
+		t.Fatalf("Expected ConfigMap key to still exist")
+	}
+	cmsNodes = cmsNodesVal.([]string)
 	if len(cmsNodes) != 1 || cmsNodes[0] != node2 {
 		t.Errorf("Expected remaining node list to be [%s], got %v", node2, cmsNodes)
 	}
@@ -342,11 +365,11 @@ func TestRemoveNodeFromConfigMapAndSecret(t *testing.T) {
 	}
 
 	lc.RemoveNodeFromSecret(namespace, secretName, node1)
-	secretNodesVal, ok := lc.secretNode.Load(fmt.Sprintf("%s/%s", namespace, secretName))
+	secretNodesVal, ok = lc.secretNode.Load(fmt.Sprintf("%s/%s", namespace, secretName))
 	if !ok {
 		t.Fatalf("Expected Secret key to still exist")
 	}
-	secNodes := secretNodesVal.([]string)
+	secNodes = secretNodesVal.([]string)
 	if len(secNodes) != 1 || secNodes[0] != node2 {
 		t.Errorf("Expected remaining node list to be [%s], got %v", node2, secNodes)
 	}


### PR DESCRIPTION
## **What type of PR is this?**

/kind bug

## **What this PR does / why we need it**:
This PR resolves a resource and credential leak in KubeEdge's cloud-side `LocationCache` by untracking node-resource mapping subscriptions when workloads are deleted.

## How it works:
We hooked a new helper `removePodFromLocalCache` into the `watch.Deleted` case inside `syncPod` (`downstream.go`). The cleanup behaves according to the following scenarios:

#### 1. Pod Deletion Loop (`syncPod`)
When a Pod is deleted, we scan all of its referenced ConfigMaps and Secrets, and check other active Pods running on the same node in that namespace using the local `podLister`:
* **Scenario A (Other Pods still use the resource):** If another Pod on the same node still references the ConfigMap or Secret, the node is kept in the subscription list (no-op).
* **Scenario B (Last Pod on the node using the resource):** If no other Pods on the node require the ConfigMap or Secret:
  * We remove the node name from that resource's subscriber slice inside `LocationCache`.
  * If no other nodes remain in the subscriber slice, the resource key itself is completely deleted from the cache map to prevent memory leaks.

#### 2. Node Deletion Loop (`syncEdgeNodes`)
When an entire edge node is deleted from the cluster, the `watch.Deleted` case in `syncEdgeNodes` calls `DeleteNode(nodeName)` to purge the node entirely from the Location Cache tracking.

## Verification & Test Coverage:
We added `TestRemoveNodeFromConfigMapAndSecret` in `location_test.go` covering all execution branches:
* **No-op / Safety cases:** Verifies that attempting to remove nodes for non-existent keys, or removing non-associated node names from existing keys, behaves safely and does not cause panics.
* **Partial subscription removal:** Verifies that removing a node from a resource shared by multiple nodes keeps the key and remaining nodes intact.
* **Complete key deletion:** Verifies that when the last subscribing node is removed, the resource key is entirely cleaned up from the cache.

**Which issue(s) this PR fixes**:
Fixes #6845 

**Special notes for your reviewer**:
* All workload checks are made against the local client-go informer cache (`podLister`), avoiding any network or API server database overhead.
* All unit tests and general controller tests compile and pass.

#### **Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
