### PR TITLE
fix(metamanager): keep token when expired offline

### DIFF
--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -120,15 +120,6 @@ func getTokenLocally(name, namespace string, tr *authenticationv1.TokenRequest) 
 		klog.Errorf("unmarshal resource %s token request failed: %v", resKey, err)
 		return nil, err
 	}
-	if requiresRefresh(&tokenRequest) {
-		err := ms.DeleteMetaByKey(resKey)
-		if err != nil {
-			klog.Errorf("delete meta %s failed: %v", resKey, err)
-			return nil, err
-		}
-		klog.Errorf("resource %s token expired", resKey)
-		return nil, fmt.Errorf("resource %s token expired", resKey)
-	}
 	return &tokenRequest, nil
 }
 
@@ -153,12 +144,24 @@ func getTokenRemotely(resource string, tr *authenticationv1.TokenRequest, c *ser
 }
 
 func (c *serviceAccountToken) GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-	tokenReq, err := getTokenLocally(name, namespace, tr)
+	localTokenReq, err := getTokenLocally(name, namespace, tr)
 	if err != nil {
 		resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypeServiceAccountToken, name)
 		return getTokenRemotely(resource, tr, c)
 	}
-	return tokenReq, nil
+
+	if !requiresRefresh(localTokenReq) {
+		return localTokenReq, nil
+	}
+
+	resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypeServiceAccountToken, name)
+	remoteTokenReq, err := getTokenRemotely(resource, tr, c)
+	if err != nil {
+		klog.Warningf("get remote service account token failed, returning expired local token: %v", err)
+		return localTokenReq, nil
+	}
+
+	return remoteTokenReq, nil
 }
 
 func handleServiceAccountTokenFromMetaDB(content []byte) (*authenticationv1.TokenRequest, error) {


### PR DESCRIPTION
Fixes #4441

This PR fixes the issue where an expired local token is deleted when a node goes offline, causing all pods to fail to authenticate or restart. We now fall back to returning the expired local token if the remote token fetch fails.