### PR TITLE
fix(metamanager): replace LIKE substring match with exact uid comparison

### DIFF
--- a/edge/pkg/metamanager/dao/dbclient/meta.go
+++ b/edge/pkg/metamanager/dao/dbclient/meta.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dbclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -62,7 +63,29 @@ func (s *MetaService) DeleteMetaByKey(key string) error {
 
 // DeleteMetaByKeyAndPodUID deletes meta by key and podUID from value field
 func (s *MetaService) DeleteMetaByKeyAndPodUID(key, podUID string) (int64, error) {
-	result := s.db.Where("key = ? AND value LIKE ?", key, "%"+podUID+"%").Delete(&models.Meta{})
+	var metas []models.Meta
+	if err := s.db.Where("key = ?", key).Find(&metas).Error; err != nil {
+		klog.Errorf("delete pod by key %s and podUID %s failed, err: %v", key, podUID, err)
+		return 0, err
+	}
+	if len(metas) == 0 {
+		return 0, nil
+	}
+
+	var pod struct {
+		Metadata struct {
+			UID string `json:"uid"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(metas[0].Value), &pod); err != nil {
+		klog.Errorf("delete pod by key %s and podUID %s failed, err: %v", key, podUID, err)
+		return 0, err
+	}
+	if pod.Metadata.UID != podUID {
+		return 0, nil
+	}
+
+	result := s.db.Where("key = ?", key).Delete(&models.Meta{})
 	if result.Error != nil {
 		klog.Errorf("delete pod by key %s and podUID %s failed, err: %v", key, podUID, result.Error)
 		return 0, result.Error


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a fragile database query in `MetaService.DeleteMetaByKeyAndPodUID` that previously used a SQL `LIKE` substring match (`value LIKE '%<podUID>%'`) to identify and delete pod metadata from the SQLite store.

Because the `value` column stores the full JSON-encoded pod spec, using a substring match on a UUID is risky. If a pod's UID happened to appear anywhere within a different row's JSON (e.g., inside an `ownerReference`, label, or annotation), that unrelated row would also be deleted, silently corrupting the edge node's local metadata store.

**Modifications**:
- Replaced the `LIKE` query with an exact primary key lookup (`Find()`).
- Added a lightweight, localized JSON unmarshal (via an anonymous struct) to safely extract `metadata.uid` from the stored value.
- The record is now only deleted if the unmarshaled UID is an exact, strict match to the requested `podUID`.
- Zero new package dependencies were introduced (avoids pulling `corev1.Pod` into the dbclient layer).

**Which issue(s) this PR fixes**:
Fixes #6854 

**Special notes for your reviewer**:
The fix is modeled exactly after the surrounding dbclient query patterns. It handles the `gorm` empty result safely without triggering `ErrRecordNotFound` panics, ensuring backwards-compatible behavior while fully closing the data-corruption risk.

**Does this PR introduce a user-facing change?**:
```release-note
Fix a potential edge database corruption issue where deleting a pod could inadvertently delete unrelated metadata if the pod's UID appeared as a substring in other records.
