### PR TITLE
test: add unit tests for keadm ctl unhold command

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unhold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEdgeUnholdUpgrade(t *testing.T) {
+	cmd := NewEdgeUnholdUpgrade()
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "unhold-upgrade <resource-type> [<name>] [--namespace namespace]", cmd.Use)
+	assert.Equal(t, "Unhold an upgrade for a pod or node-wide", cmd.Short)
+	assert.NotNil(t, cmd.RunE)
+
+	namespaceFlag := cmd.Flags().Lookup("namespace")
+	assert.NotNil(t, namespaceFlag)
+	assert.Equal(t, "default", namespaceFlag.DefValue)
+}
+
+func TestUnholdUpgradeRequiresResourceType(t *testing.T) {
+	cmd := NewEdgeUnholdUpgrade()
+
+	err := cmd.Args(cmd, []string{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "requires at least 1 arg")
+}
+
+func TestUnholdPodUpgradeRequiresPodName(t *testing.T) {
+	cmd := NewEdgeUnholdUpgrade()
+
+	err := cmd.RunE(cmd, []string{"pod"})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "pod name is required")
+}
+
+func TestUnholdUpgradeUnknownResourceType(t *testing.T) {
+	cmd := NewEdgeUnholdUpgrade()
+
+	err := cmd.RunE(cmd, []string{"deployment", "test-deployment"})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown resource type: deployment")
+}
+
+func TestUnholdUpgradeNamespaceFlag(t *testing.T) {
+	cmd := NewEdgeUnholdUpgrade()
+
+	err := cmd.Flags().Set("namespace", "test-namespace")
+	assert.NoError(t, err)
+
+	namespace, err := cmd.Flags().GetString("namespace")
+	assert.NoError(t, err)
+	assert.Equal(t, "test-namespace", namespace)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind test

**What this PR does / why we need it**:

This PR adds unit tests for the `keadm ctl unhold-upgrade` command.

The tests cover basic command construction and argument validation, including:

* command metadata and namespace flag registration;
* missing resource type validation;
* missing pod name validation;
* unknown resource type validation;
* namespace flag parsing.

This improves test coverage for the `keadm ctl` package without changing command behavior.

**Which issue(s) this PR fixes**:

Part of #6630

**Special notes for your reviewer**:

This PR only adds unit tests for existing behavior. It does not change the implementation of `keadm ctl unhold-upgrade`.

Tested with:

```bash
go test ./keadm/cmd/keadm/app/cmd/ctl/unhold
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
