### PR TITLE
fix: add devicestatuses permission to cloudcore rbac

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -22,7 +22,7 @@ rules:
   resources: ["leases"]
   verbs: ["get", "list", "watch", "create", "update"]
 - apiGroups: ["devices.kubeedge.io"]
-  resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
+  resources: ["devices", "devicemodels", "devicestatuses", "devices/status", "devicemodels/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["reliablesyncs.kubeedge.io"]
   resources: ["objectsyncs", "clusterobjectsyncs", "objectsyncs/status", "clusterobjectsyncs/status"]

--- a/build/cloud/ha/01-ha-prepare.yaml
+++ b/build/cloud/ha/01-ha-prepare.yaml
@@ -41,7 +41,7 @@ rules:
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update"]
   - apiGroups: ["devices.kubeedge.io"]
-    resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
+    resources: ["devices", "devicemodels", "devicestatuses", "devices/status", "devicemodels/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["reliablesyncs.kubeedge.io"]
     resources: ["objectsyncs", "clusterobjectsyncs", "objectsyncs/status", "clusterobjectsyncs/status"]

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update"]
   - apiGroups: ["devices.kubeedge.io"]
-    resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
+    resources: ["devices", "devicemodels", "devicestatuses", "devices/status", "devicemodels/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["reliablesyncs.kubeedge.io"]
     resources: ["objectsyncs", "clusterobjectsyncs", "objectsyncs/status", "clusterobjectsyncs/status"]


### PR DESCRIPTION
## Description:

Issue #6862 reported that `cloudcore` RBAC was missing permission for `devicestatuses.devices.kubeedge.io`, which caused repeated forbidden errors when the `DeviceStatus` informer started.

This PR updates the cloudcore RBAC manifests to include `devicestatuses` in all affected manifest variants:

- `build/cloud/03-clusterrole.yaml`
- `build/cloud/ha/01-ha-prepare.yaml`
- `manifests/charts/cloudcore/templates/rbac_cloudcore.yaml`

The fix is minimal and limited to the affected RBAC resource lists.

## Validation:

- `helm lint manifests/charts/cloudcore`
- rendered chart inspection to confirm `devicestatuses` is present in cloudcore RBAC
- fresh `kind` cluster deployment on latest `master`, where:
  - `kubectl auth can-i --as=system:serviceaccount:kubeedge:cloudcore list devicestatuses.devices.kubeedge.io` returned `yes`
  - `cloudcore` no longer logged `devicestatuses.devices.kubeedge.io is forbidden`
- `kubectl apply --dry-run=client -f build/cloud/03-clusterrole.yaml`
- `kubectl apply --dry-run=client -f build/cloud/ha/01-ha-prepare.yaml`

Closes #6862.

## Checklist:

- [x] I have run validation using `helm lint manifests/charts/cloudcore`.
- [x] I have validated the fix in a fresh `kind` cluster on latest `master`.

## Release note:

```release-note
CloudCore RBAC now includes permission for devicestatuses.devices.kubeedge.io to prevent informer forbidden errors.
```
