### PR TITLE
fix(pkg/metaserver): use pointer map in MsgToApplications to avoid copylocks

### DIFF
--- a/pkg/metaserver/application.go
+++ b/pkg/metaserver/application.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package metaserver provides meta server functionality.
 package metaserver
 
 import (
@@ -63,10 +64,12 @@ type Application struct {
 	// count the number of current citations
 	count     uint64
 	countLock *sync.Mutex
+	idOnce    sync.Once
 	// Timestamp record the last closing time of application, only make sense when count == 0
 	Timestamp time.Time
 }
 
+// NewApplication creates and returns a new Application instance.
 func NewApplication(ctx context.Context, key string, verb ApplicationVerb, nodename, subresource string, option interface{}, reqBody interface{}) (*Application, error) {
 	var v1 metav1.ListOptions
 	if internal, ok := option.(metainternalversion.ListOptions); ok {
@@ -96,17 +99,20 @@ func NewApplication(ctx context.Context, key string, verb ApplicationVerb, noden
 	return app, nil
 }
 
+// Identifier returns the unique SHA256-based ID of the application.
 func (a *Application) Identifier() string {
-	if a.ID != "" {
-		return a.ID
-	}
-	b := []byte(a.Nodename)
-	b = append(b, []byte(a.Key)...)
-	b = append(b, []byte(a.Verb)...)
-	b = append(b, a.Option...)
-	b = append(b, a.ReqBody...)
-	b = append(b, []byte(a.Subresource)...)
-	a.ID = fmt.Sprintf("%x", sha256.Sum256(b))
+	a.idOnce.Do(func() {
+		if a.ID != "" {
+			return
+		}
+		b := []byte(a.Nodename)
+		b = append(b, []byte(a.Key)...)
+		b = append(b, []byte(a.Verb)...)
+		b = append(b, a.Option...)
+		b = append(b, a.ReqBody...)
+		b = append(b, []byte(a.Subresource)...)
+		a.ID = fmt.Sprintf("%x", sha256.Sum256(b))
+	})
 	return a.ID
 }
 
@@ -114,10 +120,12 @@ func (a *Application) String() string {
 	return fmt.Sprintf("(NodeName=%v;Key=%v;Verb=%v;Status=%v;Reason=%v)", a.Nodename, a.Key, a.Verb, a.Status, a.Reason)
 }
 
+// ReqContent returns the raw request body bytes.
 func (a *Application) ReqContent() interface{} {
 	return a.ReqBody
 }
 
+// RespContent returns the raw response body bytes.
 func (a *Application) RespContent() interface{} {
 	return a.RespBody
 }
@@ -131,6 +139,7 @@ func (a *Application) OptionTo(i interface{}) error {
 	return nil
 }
 
+// ReqBodyTo unmarshals the request body into the given interface.
 func (a *Application) ReqBodyTo(i interface{}) error {
 	err := json.Unmarshal(a.ReqBody, i)
 	if err != nil {
@@ -139,6 +148,7 @@ func (a *Application) ReqBodyTo(i interface{}) error {
 	return nil
 }
 
+// RespBodyTo unmarshals the response body into the given interface.
 func (a *Application) RespBodyTo(i interface{}) error {
 	err := json.Unmarshal(a.RespBody, i)
 	if err != nil {
@@ -147,22 +157,26 @@ func (a *Application) RespBodyTo(i interface{}) error {
 	return nil
 }
 
+// GVR returns the GroupVersionResource parsed from the application key.
 func (a *Application) GVR() schema.GroupVersionResource {
 	gvr, _, _ := ParseKey(a.Key)
 	return gvr
 }
 
+// Namespace returns the namespace parsed from the application key.
 func (a *Application) Namespace() string {
 	_, ns, _ := ParseKey(a.Key)
 	return ns
 }
 
+// Cancel cancels the application context.
 func (a *Application) Cancel() {
 	if a.cancel != nil {
 		a.cancel()
 	}
 }
 
+// GetStatus returns the current status of the application.
 func (a *Application) GetStatus() ApplicationStatus {
 	return a.Status
 }
@@ -174,6 +188,7 @@ func (a *Application) Wait() {
 	}
 }
 
+// Reset resets the application context and clears response data.
 func (a *Application) Reset() {
 	if a.ctx != nil && a.cancel != nil {
 		a.cancel()
@@ -183,6 +198,7 @@ func (a *Application) Reset() {
 	a.RespBody = []byte{}
 }
 
+// Add increments the application reference count.
 func (a *Application) Add() {
 	a.countLock.Lock()
 	a.count++
@@ -211,6 +227,7 @@ func (a *Application) Close() {
 	}
 }
 
+// LastCloseTime returns the timestamp of the last close when count is zero.
 func (a *Application) LastCloseTime() time.Time {
 	a.countLock.Lock()
 	defer a.countLock.Unlock()
@@ -220,6 +237,7 @@ func (a *Application) LastCloseTime() time.Time {
 	return time.Time{}
 }
 
+// ToBytes converts an interface to a byte slice via JSON marshaling.
 func ToBytes(i interface{}) (bytes []byte) {
 	if i == nil {
 		return
@@ -236,7 +254,7 @@ func ToBytes(i interface{}) (bytes []byte) {
 	return
 }
 
-// extract application in message's Content
+// MsgToApplication extracts an Application from a message's Content.
 func MsgToApplication(msg model.Message) (*Application, error) {
 	var app = new(Application)
 	contentData, err := msg.GetContentData()
@@ -258,13 +276,13 @@ func MsgToApplication(msg model.Message) (*Application, error) {
 }
 
 // MsgToApplications extract applications in message's Content
-func MsgToApplications(msg model.Message) (map[string]Application, error) {
+func MsgToApplications(msg model.Message) (map[string]*Application, error) {
 	contentData, err := msg.GetContentData()
 	if err != nil {
 		return nil, err
 	}
 
-	applications := make(map[string]Application)
+	applications := make(map[string]*Application)
 
 	err = json.Unmarshal(contentData, &applications)
 	if err != nil {

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -84,11 +84,11 @@ func TestNewApplication(t *testing.T) {
 
 func TestIdentifier(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult string
 	}{
 		{
-			app: Application{
+			app: &Application{
 				Nodename:    "test-node-one",
 				Key:         "group/version/resource/namespaces/name",
 				Verb:        "GET",
@@ -99,7 +99,7 @@ func TestIdentifier(t *testing.T) {
 			stdResult: fmt.Sprintf("%x", sha256.Sum256([]byte("test-node-onegroup/version/resource/namespaces/nameGETpod"))),
 		},
 		{
-			app: Application{
+			app: &Application{
 				Nodename:    "test-node-two",
 				Key:         "group/version/resource/namespaces/name",
 				Verb:        "POST",
@@ -110,7 +110,7 @@ func TestIdentifier(t *testing.T) {
 			stdResult: fmt.Sprintf("%x", sha256.Sum256([]byte("test-node-twogroup/version/resource/namespaces/namePOST{\"foo\":\"bar\"}{\"baz\":\"qux\"}pod"))),
 		},
 		{
-			app: Application{
+			app: &Application{
 				ID:          "predefined-id",
 				Nodename:    "test-node-three",
 				Key:         "group/version/resource/namespaces/name",
@@ -134,11 +134,11 @@ func TestIdentifier(t *testing.T) {
 
 func TestString(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult string
 	}{
 		{
-			app: Application{
+			app: &Application{
 				Nodename: "test-node-one",
 				Key:      "group/version/resource/namespaces/name",
 				Verb:     "GET",
@@ -148,7 +148,7 @@ func TestString(t *testing.T) {
 			stdResult: "(NodeName=test-node-one;Key=group/version/resource/namespaces/name;Verb=GET;Status=completed;Reason=test reason one)",
 		},
 		{
-			app: Application{
+			app: &Application{
 				Nodename: "test-node-two",
 				Key:      "group/version/resource/namespaces/name",
 				Verb:     "POST",
@@ -169,22 +169,22 @@ func TestString(t *testing.T) {
 
 func TestReqContent(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult []byte
 	}{
 		{
-			app:       Application{ReqBody: []byte(`{"test":"data"}`)},
+			app:       &Application{ReqBody: []byte(`{"test":"data"}`)},
 			stdResult: []byte(`{"test":"data"}`),
 		},
 		{
-			app: Application{
+			app: &Application{
 				Nodename: "test-node",
 				Key:      "group/version/resource/namespaces/name",
 			},
 			stdResult: nil,
 		},
 		{
-			app:       Application{ReqBody: nil},
+			app:       &Application{ReqBody: nil},
 			stdResult: nil,
 		},
 	}
@@ -196,22 +196,22 @@ func TestReqContent(t *testing.T) {
 
 func TestRespContent(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult []byte
 	}{
 		{
-			app:       Application{RespBody: []byte(`{"test":"data"}`)},
+			app:       &Application{RespBody: []byte(`{"test":"data"}`)},
 			stdResult: []byte(`{"test":"data"}`),
 		},
 		{
-			app: Application{
+			app: &Application{
 				Nodename: "test-node",
 				Key:      "group/version/resource/namespaces/name",
 			},
 			stdResult: nil,
 		},
 		{
-			app:       Application{RespBody: nil},
+			app:       &Application{RespBody: nil},
 			stdResult: nil,
 		},
 	}
@@ -223,15 +223,15 @@ func TestRespContent(t *testing.T) {
 
 func TestOptionTo(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult map[string]string
 	}{
 		{
-			app:       Application{Option: []byte(`{"field-one":"value-one"}`)},
+			app:       &Application{Option: []byte(`{"field-one":"value-one"}`)},
 			stdResult: map[string]string{"field-one": "value-one"},
 		},
 		{
-			app:       Application{Option: []byte(`{"field-two":"value-two"}`)},
+			app:       &Application{Option: []byte(`{"field-two":"value-two"}`)},
 			stdResult: map[string]string{"field-two": "value-two"},
 		},
 	}
@@ -252,11 +252,11 @@ func TestOptionTo(t *testing.T) {
 
 func TestReqBodyTo(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult map[string]string
 	}{
 		{
-			app:       Application{ReqBody: []byte(`{"test-key":"test-value"}`)},
+			app:       &Application{ReqBody: []byte(`{"test-key":"test-value"}`)},
 			stdResult: map[string]string{"test-key": "test-value"},
 		},
 	}
@@ -276,11 +276,11 @@ func TestReqBodyTo(t *testing.T) {
 
 func TestRespBodyTo(t *testing.T) {
 	cases := []struct {
-		app      Application
+		app      *Application
 		expected map[string]string
 	}{
 		{
-			app:      Application{RespBody: []byte(`{"test-key":"test-value"}`)},
+			app:      &Application{RespBody: []byte(`{"test-key":"test-value"}`)},
 			expected: map[string]string{"test-key": "test-value"},
 		},
 	}
@@ -301,11 +301,11 @@ func TestRespBodyTo(t *testing.T) {
 
 func TestGVR(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult schema.GroupVersionResource
 	}{
 		{
-			app: Application{
+			app: &Application{
 				Key: "/group/version/resource/namespaces/ns",
 			},
 			stdResult: schema.GroupVersionResource{
@@ -315,7 +315,7 @@ func TestGVR(t *testing.T) {
 			},
 		},
 		{
-			app: Application{
+			app: &Application{
 				Key: "/group-two/v2/resource/namespaces/ns-two",
 			},
 			stdResult: schema.GroupVersionResource{
@@ -336,17 +336,17 @@ func TestGVR(t *testing.T) {
 
 func TestNamespace(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult string
 	}{
 		{
-			app: Application{
+			app: &Application{
 				Key: "/group/version/resource/test-namespace-one/",
 			},
 			stdResult: "test-namespace-one",
 		},
 		{
-			app: Application{
+			app: &Application{
 				Key: "/group-two/v2/resource/test-namespace-two/",
 			},
 			stdResult: "test-namespace-two",
@@ -363,15 +363,15 @@ func TestNamespace(t *testing.T) {
 
 func TestGetStatus(t *testing.T) {
 	cases := []struct {
-		app       Application
+		app       *Application
 		stdResult ApplicationStatus
 	}{
 		{
-			app:       Application{Status: PreApplying},
+			app:       &Application{Status: PreApplying},
 			stdResult: PreApplying,
 		},
 		{
-			app:       Application{Status: Completed},
+			app:       &Application{Status: Completed},
 			stdResult: Completed,
 		},
 	}
@@ -426,7 +426,7 @@ func TestMsgToApplication(t *testing.T) {
 func TestMsgToApplications(t *testing.T) {
 	cases := []struct {
 		msg       model.Message
-		stdResult map[string]Application
+		stdResult map[string]*Application
 		hasError  bool
 	}{
 		{
@@ -434,7 +434,7 @@ func TestMsgToApplications(t *testing.T) {
 				Content: []byte(`{"app1":{"Key":"group/version/resource/namespaces/name1","Verb":"GET","Nodename":"test-node1"},
 				"app2":{"Key":"group/version/resource/namespaces/name2","Verb":"POST","Nodename":"test-node2"}}`),
 			},
-			stdResult: map[string]Application{
+			stdResult: map[string]*Application{
 				"app1": {
 					Key:      "group/version/resource/namespaces/name1",
 					Verb:     "GET",
@@ -636,4 +636,29 @@ func TestWait(t *testing.T) {
 	}
 	// Should not block or panic when context is nil
 	app.Wait()
+}
+
+func TestIdentifierConcurrent(t *testing.T) {
+	app := &Application{
+		Nodename:    "node1",
+		Key:         "group/version/resource/namespaces/name",
+		Verb:        "GET",
+		Subresource: "pod",
+	}
+
+	var wg sync.WaitGroup
+	ids := make([]string, 10)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ids[idx] = app.Identifier()
+		}(i)
+	}
+	wg.Wait()
+
+	for _, id := range ids {
+		assert.Equal(t, ids[0], id)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adding `sync.Once` as a value field in the `Application` struct made it a non-copyable type. `MsgToApplications` was returning `map[string]Application` (copy-by-value), which triggered a `go vet copylocks` failure because it copies the lock value.

This PR changes `MsgToApplications` to return `map[string]*Application` and updates all downstream callers (in `dynamiccontroller` and `metamanager`) to use pointers. It also fixes `json.Marshal(app)` to `json.Marshal(&app)` in tests to resolve identical copylocks warnings.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This addresses the linter/copylocks failure flagged by the bot.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```