### PR TITLE
test(certs): check error from CreateCSR in TestSignX509Certs

### DIFF
--- a/pkg/security/certs/x509_ca_certs_test.go
+++ b/pkg/security/certs/x509_ca_certs_test.go
@@ -31,6 +31,9 @@ func TestSignX509Certs(t *testing.T) {
 		Province:     []string{"Zhejiang"},
 		CommonName:   "test-node",
 	}, certpkw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	opts := SignCertsOptionsWithCSR(csrblock.Bytes, cablock.Bytes, capkw.DER(),
 		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, 24*time.Hour)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Adds the missing `err != nil` check after `CreateCSR` in `TestSignX509Certs` to avoid nil pointer dereferences on failure and satisfy static analysis.

*(Note: The branch history was extremely polluted with 7 unrelated commits from other PRs due to cross-branch bleeding. I have completely rewritten this branch to isolate ONLY the certs test fix, making it a clean 1-commit PR).*

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Branch history is clean.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```