### PR TITLE
Fix keadm debug command exit codes

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/check.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check.go
@@ -75,8 +75,8 @@ func NewSubEdgeCheck(object CheckObject) *cobra.Command {
 	cmd := &cobra.Command{
 		Short: object.Desc,
 		Use:   object.Use,
-		Run: func(cmd *cobra.Command, args []string) {
-			object.ExecuteCheck(object.Use, co)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return object.ExecuteCheck(object.Use, co)
 		},
 	}
 	switch object.Use {
@@ -109,7 +109,7 @@ func NewCheckOptions() *common.CheckOptions {
 }
 
 // ExecuteCheck starts to check data
-func (co *CheckObject) ExecuteCheck(use string, ob *common.CheckOptions) {
+func (co *CheckObject) ExecuteCheck(use string, ob *common.CheckOptions) error {
 	err := fmt.Errorf("")
 
 	if ob.Config == "" {
@@ -136,11 +136,12 @@ func (co *CheckObject) ExecuteCheck(use string, ob *common.CheckOptions) {
 	}
 
 	if err != nil {
-		fmt.Println(err)
 		util.PrintFail(use, common.StrCheck)
-	} else {
-		util.PrintSucceed(use, common.StrCheck)
+		return err
 	}
+
+	util.PrintSucceed(use, common.StrCheck)
+	return nil
 }
 
 func CheckAll(ob *common.CheckOptions) error {

--- a/keadm/cmd/keadm/app/cmd/debug/check_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check_test.go
@@ -17,13 +17,16 @@ limitations under the License.
 package debug
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kubeedge/api/apis/common/constants"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 )
 
 func TestNewCheck(t *testing.T) {
@@ -228,4 +231,43 @@ func TestNewCheckOptions(t *testing.T) {
 
 	assert.Equal("www.github.com", co.Domain)
 	assert.Equal(1, co.Timeout)
+}
+
+func TestExecuteCheckReturnsError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(CheckDNS, func(domain string) error {
+		assert.Equal(t, "bad.example", domain)
+		return errors.New("dns failed")
+	})
+	patches.ApplyFunc(util.PrintFail, func(cmd, s string) {
+		assert.Equal(t, common.ArgCheckDNS, cmd)
+		assert.Equal(t, common.StrCheck, s)
+	})
+
+	checkObj := CheckObject{Use: common.ArgCheckDNS}
+	err := checkObj.ExecuteCheck(common.ArgCheckDNS, &common.CheckOptions{Domain: "bad.example"})
+
+	assert.Error(t, err)
+	assert.Equal(t, "dns failed", err.Error())
+}
+
+func TestExecuteCheckReturnsNilOnSuccess(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(CheckDNS, func(domain string) error {
+		assert.Equal(t, "ok.example", domain)
+		return nil
+	})
+	patches.ApplyFunc(util.PrintSucceed, func(cmd, s string) {
+		assert.Equal(t, common.ArgCheckDNS, cmd)
+		assert.Equal(t, common.StrCheck, s)
+	})
+
+	checkObj := CheckObject{Use: common.ArgCheckDNS}
+	err := checkObj.ExecuteCheck(common.ArgCheckDNS, &common.CheckOptions{Domain: "ok.example"})
+
+	assert.NoError(t, err)
 }

--- a/keadm/cmd/keadm/app/cmd/debug/collect.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect.go
@@ -37,11 +37,8 @@ func NewCollect() *cobra.Command {
 		Short:   "Obtain all the data of the current node",
 		Long:    edgecollectLongDescription,
 		Example: edgecollectExample,
-		Run: func(cmd *cobra.Command, args []string) {
-			err := ExecuteCollect(collectOptions)
-			if err != nil {
-				fmt.Println(err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ExecuteCollect(collectOptions)
 		},
 	}
 	cmd.AddCommand()

--- a/keadm/cmd/keadm/app/cmd/debug/collect_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect_test.go
@@ -71,6 +71,26 @@ func setupCopyFilePatch(shouldSucceed bool) *gomonkey.Patches {
 	})
 }
 
+func TestNewCollectExecuteReturnsError(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(ExecuteCollect, func(collectOptions *common.CollectOptions) error {
+		assert.Equal(t, "/tmp/bad-edgecore.yaml", collectOptions.Config)
+		return errors.New("collect failed")
+	})
+
+	cmd := NewCollect()
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	assert.NoError(t, cmd.Flags().Set(common.EdgecoreConfig, "/tmp/bad-edgecore.yaml"))
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Equal(t, "collect failed", err.Error())
+	assert.Contains(t, stderr.String(), "collect failed")
+}
+
 func TestPrintDetail(t *testing.T) {
 	assert := assert.New(t)
 	oldStdout := os.Stdout

--- a/keadm/cmd/keadm/app/cmd/debug/diagnose.go
+++ b/keadm/cmd/keadm/app/cmd/debug/diagnose.go
@@ -57,8 +57,8 @@ func NewSubDiagnose(object Diagnose) *cobra.Command {
 	cmd := &cobra.Command{
 		Short: object.Desc,
 		Use:   object.Use,
-		Run: func(cmd *cobra.Command, args []string) {
-			object.ExecuteDiagnose(object.Use, do, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return object.ExecuteDiagnose(object.Use, do, args)
 		},
 	}
 	switch object.Use {
@@ -88,31 +88,32 @@ func NewDiagnoseOptions() *common.DiagnoseOptions {
 	return do
 }
 
-func (da Diagnose) ExecuteDiagnose(use string, ops *common.DiagnoseOptions, args []string) {
+func (da Diagnose) ExecuteDiagnose(use string, ops *common.DiagnoseOptions, args []string) error {
 	var err error
 	switch use {
 	case common.ArgDiagnoseNode:
 		err = DiagnoseNode(ops)
 	case common.ArgDiagnosePod:
 		if len(args) == 0 {
-			fmt.Println("error: You must specify a pod name")
-			return
-		}
-		// diagnose Pod, first diagnose node
-		err = DiagnoseNode(ops)
-		if err == nil {
-			err = DiagnosePod(ops, args[0])
+			err = fmt.Errorf("you must specify a pod name")
+		} else {
+			// diagnose Pod, first diagnose node
+			err = DiagnoseNode(ops)
+			if err == nil {
+				err = DiagnosePod(ops, args[0])
+			}
 		}
 	case common.ArgDiagnoseInstall:
 		err = DiagnoseInstall(ops.CheckOptions)
 	}
 
 	if err != nil {
-		fmt.Println(err.Error())
 		util.PrintFail(use, common.StrDiagnose)
-	} else {
-		util.PrintSucceed(use, common.StrDiagnose)
+		return err
 	}
+
+	util.PrintSucceed(use, common.StrDiagnose)
+	return nil
 }
 
 func DiagnoseNode(ops *common.DiagnoseOptions) error {

--- a/keadm/cmd/keadm/app/cmd/debug/diagnose_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/diagnose_test.go
@@ -171,7 +171,8 @@ func TestExecuteDiagnose(t *testing.T) {
 		})
 
 		var da Diagnose
-		da.ExecuteDiagnose(common.ArgDiagnoseNode, opts, nil)
+		err := da.ExecuteDiagnose(common.ArgDiagnoseNode, opts, nil)
+		assert.NoError(t, err)
 		assert.True(t, mustCallPrintSuccessed)
 	})
 
@@ -195,7 +196,8 @@ func TestExecuteDiagnose(t *testing.T) {
 		})
 
 		var da Diagnose
-		da.ExecuteDiagnose(common.ArgDiagnosePod, opts, []string{"test-pod"})
+		err := da.ExecuteDiagnose(common.ArgDiagnosePod, opts, []string{"test-pod"})
+		assert.NoError(t, err)
 		assert.True(t, mustCallPrintSuccessed)
 		assert.True(t, mustCallDiagnosePod)
 	})
@@ -220,12 +222,14 @@ func TestExecuteDiagnose(t *testing.T) {
 		})
 
 		var da Diagnose
-		da.ExecuteDiagnose(common.ArgDiagnosePod, opts, []string{"test-pod"})
+		err := da.ExecuteDiagnose(common.ArgDiagnosePod, opts, []string{"test-pod"})
+		assert.Error(t, err)
+		assert.Equal(t, "test error", err.Error())
 		assert.True(t, mustCallPrintFail)
 		assert.False(t, mustCallDiagnosePod)
 	})
 
-	t.Run("using the diagnose node", func(t *testing.T) {
+	t.Run("using the diagnose install", func(t *testing.T) {
 		var mustCallPrintSuccessed bool
 
 		patches := gomonkey.NewPatches()
@@ -241,8 +245,28 @@ func TestExecuteDiagnose(t *testing.T) {
 		})
 
 		var da Diagnose
-		da.ExecuteDiagnose(common.ArgDiagnoseInstall, opts, nil)
+		err := da.ExecuteDiagnose(common.ArgDiagnoseInstall, opts, nil)
+		assert.NoError(t, err)
 		assert.True(t, mustCallPrintSuccessed)
+	})
+
+	t.Run("using the diagnose pod without pod name", func(t *testing.T) {
+		var mustCallPrintFail bool
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFunc(util.PrintFail, func(cmd, s string) {
+			mustCallPrintFail = true
+			assert.Equal(t, common.ArgDiagnosePod, cmd)
+			assert.Equal(t, common.StrDiagnose, s)
+		})
+
+		var da Diagnose
+		err := da.ExecuteDiagnose(common.ArgDiagnosePod, opts, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "you must specify a pod name", err.Error())
+		assert.True(t, mustCallPrintFail)
 	})
 }
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`keadm debug` subcommands were printing errors but not returning them to cobra, so failed debug actions could still exit with status 0.

This updates `collect`, `check`, and `diagnose` to return errors through `RunE`, while keeping the existing success/fail output.

**Which issue(s) this PR fixes**:

Fixes #6869

**Special notes for your reviewer**:

Added tests for the error return paths.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed keadm debug subcommands to exit non-zero when the debug action fails.