### PR TITLE
fix(stream): resolve goroutine leak in EdgedAttachConnection

### DIFF
--- a/pkg/stream/edgedattachconnection.go
+++ b/pkg/stream/edgedattachconnection.go
@@ -73,11 +73,21 @@ func (ah *EdgedAttachConnection) CleanChannel() {
 }
 
 func (ah *EdgedAttachConnection) receiveFromCloudStream(con net.Conn, stop chan struct{}) {
+	defer func() {
+		select {
+		case stop <- struct{}{}:
+		default:
+		}
+	}()
+
 	for message := range ah.ReadChan {
 		switch message.MessageType {
 		case MessageTypeRemoveConnect:
 			klog.V(6).Infof("%s receive remove client id %v", ah.String(), message.ConnectID)
-			stop <- struct{}{}
+			select {
+			case stop <- struct{}{}:
+			default:
+			}
 		case MessageTypeData:
 			_, err := con.Write(message.Data)
 			klog.V(6).Infof("%s receive attach %v data ", ah.String(), message.Data)
@@ -91,7 +101,10 @@ func (ah *EdgedAttachConnection) receiveFromCloudStream(con net.Conn, stop chan 
 
 func (ah *EdgedAttachConnection) write2CloudStream(tunnel SafeWriteTunneler, con net.Conn, stop chan struct{}) {
 	defer func() {
-		stop <- struct{}{}
+		select {
+		case stop <- struct{}{}:
+		default:
+		}
 	}()
 
 	var data [256]byte


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When the `EdgedAttachConnection` is closed, the underlying read go-routines were previously left hanging. This PR ensures proper closure and cleanup of the connection streams, resolving a goroutine leak in the stream package.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This consolidates the original 9 commits into a single clean, logical commit to fix the stream leak.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```