### PR TITLE
Fix/keyrootfunc panic

### DIFF
--- a/pkg/metaserver/key.go
+++ b/pkg/metaserver/key.go
@@ -98,7 +98,8 @@ func KeyFuncReq(ctx context.Context, _ string) (string, error) {
 func KeyRootFunc(ctx context.Context) string {
 	key, err := KeyFuncReq(ctx, "")
 	if err != nil {
-		panic("fail to get list key!")
+		klog.Errorf("failed to get list key: %v", err)
+		return ""
 	}
 	return key
 }

--- a/pkg/metaserver/key_test.go
+++ b/pkg/metaserver/key_test.go
@@ -293,3 +293,11 @@ func TestParseKey(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyRootFuncNopanic(t *testing.T) {
+	// empty context has no request info, must return "" not panic
+	result := KeyRootFunc(context.TODO())
+	if result != "" {
+		t.Errorf("expected empty string, got %v", result)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
KeyRootFunc called panic on any context missing request info.
This path is reachable at runtime when middleware is absent or
request is malformed. panic crashes the handler goroutine.
Replace panic with klog.Errorf and return empty string.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
KeyRootFunc is assigned as KeyRootFunc field in storage.go:62.
It is called by vendor store during GetList and Watch (store.go:423, 1447).
Both are hot paths. Test added: TestKeyRootFuncNopanic verifies
empty context returns "" without panic.

**Does this PR introduce a user-facing change?**:
```release-note
Fix panic in metaserver KeyRootFunc when request context is missing info.
Edge node no longer crashes during list/watch on malformed requests.
```
