### PR TITLE
Reject invalid keadm image part

### DIFF
--- a/keadm/cmd/keadm/app/cmd/config.go
+++ b/keadm/cmd/keadm/app/cmd/config.go
@@ -83,6 +83,10 @@ func newCmdConfigImagesList() *cobra.Command {
 		Use:   "list",
 		Short: "Print a list of images keadm will use.",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := validateImagePart(cfg.Part); err != nil {
+				return err
+			}
+
 			ver, err := util.GetCurrentVersion(cfg.KubeEdgeVersion)
 			if err != nil {
 				return err
@@ -111,6 +115,10 @@ func newCmdConfigImagesPull() *cobra.Command {
 		Use:   "pull",
 		Short: "Pull images used by keadm",
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := validateImagePart(cfg.Part); err != nil {
+				return err
+			}
+
 			ctx := context.Background()
 			ver, err := util.GetCurrentVersion(cfg.KubeEdgeVersion)
 			if err != nil {
@@ -144,6 +152,15 @@ func AddImagesCommonConfigFlags(cmd *cobra.Command, cfg *Configuration) {
 
 	cmd.Flags().StringVar(&cfg.RemoteRuntimeEndpoint, cmdcommon.FlagNameRemoteRuntimeEndpoint, cfg.RemoteRuntimeEndpoint,
 		"The endpoint of remote runtime service in edge node")
+}
+
+func validateImagePart(part string) error {
+	switch strings.ToLower(part) {
+	case "", "cloud", "edge":
+		return nil
+	default:
+		return fmt.Errorf("invalid --part: %s, must be cloud or edge", part)
+	}
 }
 
 // GetKubeEdgeImages returns a list of container images that related part expects to use

--- a/keadm/cmd/keadm/app/cmd/config_test.go
+++ b/keadm/cmd/keadm/app/cmd/config_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateImagePart(t *testing.T) {
+	tests := []struct {
+		name    string
+		part    string
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			part: "",
+		},
+		{
+			name: "cloud",
+			part: "cloud",
+		},
+		{
+			name: "cloud mixed case",
+			part: "Cloud",
+		},
+		{
+			name: "edge",
+			part: "edge",
+		},
+		{
+			name: "edge uppercase",
+			part: "EDGE",
+		},
+		{
+			name:    "invalid",
+			part:    "clodu",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateImagePart(tt.part)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid --part")
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestConfigImagesListRejectsInvalidPart(t *testing.T) {
+	cmd := newCmdConfigImagesList()
+	assert.NoError(t, cmd.Flags().Set("part", "clodu"))
+
+	err := cmd.RunE(cmd, nil)
+
+	assert.Error(t, err)
+	assert.Equal(t, "invalid --part: clodu, must be cloud or edge", err.Error())
+}
+
+func TestConfigImagesPullRejectsInvalidPart(t *testing.T) {
+	cmd := newCmdConfigImagesPull()
+	assert.NoError(t, cmd.Flags().Set("part", "clodu"))
+
+	err := cmd.RunE(cmd, nil)
+
+	assert.Error(t, err)
+	assert.Equal(t, "invalid --part: clodu, must be cloud or edge", err.Error())
+}


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:

`keadm config images` accepted any value for `--part`. A typo would silently fall back to the default behavior and list or pull images for both cloud and edge.

This rejects unknown `--part` values while keeping empty `--part` as the current “all images” behavior.

**Which issue(s) this PR fixes**:

Fixes #6871

**Special notes for your reviewer**:

Added tests for valid and invalid `--part` values.


**Does this PR introduce a user-facing change?**:

```release-note
keadm config images now rejects invalid --part values.
```