### PR TITLE
fix(metaserver): replace panic with error log in KeyRootFunc

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/storage.go
@@ -174,7 +174,10 @@ func (r *REST) PassThrough(ctx context.Context, options *metav1.GetOptions) ([]b
 }
 
 func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
-	info, _ := apirequest.RequestInfoFrom(ctx)
+	info, ok := apirequest.RequestInfoFrom(ctx)
+	if !ok || info == nil {
+		return nil, fmt.Errorf("no request info in context, cannot list")
+	}
 	// First try to list the object from remote cloud
 	list, err := func() (runtime.Object, error) {
 		app, err := r.Agent.Generate(ctx, metaserver.List, *options, nil)
@@ -212,7 +215,10 @@ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOption
 }
 
 func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	info, _ := apirequest.RequestInfoFrom(ctx)
+	info, ok := apirequest.RequestInfoFrom(ctx)
+	if !ok || info == nil {
+		return nil, fmt.Errorf("no request info in context, cannot watch")
+	}
 
 	// First try watch from remote cloud
 	_, err := func() (runtime.Object, error) {

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/storage_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/storage_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	cri "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -702,4 +703,40 @@ func (f *fakeRuntimeService) RuntimeConfig(ctx context.Context) (*runtimeapi.Run
 
 func (f *fakeRuntimeService) ImageFsInfo(ctx context.Context) (*runtimeapi.ImageFsInfoResponse, error) {
 	return f.ImageFsInfoF(ctx)
+}
+
+func TestREST_List_NoRequestInfo(t *testing.T) {
+	patch := gomonkey.NewPatches()
+	defer patch.Reset()
+	patch.ApplyFunc(connect.IsConnected, func() bool { return false }).
+		ApplyFunc(beehiveContext.SendSync, func(string, model.Message, time.Duration) (model.Message, error) {
+			return model.Message{}, fmt.Errorf("cloud unavailable")
+		})
+
+	rest := &REST{
+		Agent: &agent.Agent{Applications: sync.Map{}},
+	}
+	opts := metainternalversion.ListOptions{}
+	_, err := rest.List(context.TODO(), &opts)
+	if err == nil {
+		t.Fatal("expected error when context has no RequestInfo, got nil")
+	}
+}
+
+func TestREST_Watch_NoRequestInfo(t *testing.T) {
+	patch := gomonkey.NewPatches()
+	defer patch.Reset()
+	patch.ApplyFunc(connect.IsConnected, func() bool { return false }).
+		ApplyFunc(beehiveContext.SendSync, func(string, model.Message, time.Duration) (model.Message, error) {
+			return model.Message{}, fmt.Errorf("cloud unavailable")
+		})
+
+	rest := &REST{
+		Agent: &agent.Agent{Applications: sync.Map{}},
+	}
+	opts := metainternalversion.ListOptions{}
+	_, err := rest.Watch(context.TODO(), &opts)
+	if err == nil {
+		t.Fatal("expected error when context has no RequestInfo, got nil")
+	}
 }

--- a/pkg/metaserver/key.go
+++ b/pkg/metaserver/key.go
@@ -96,9 +96,14 @@ func KeyFuncReq(ctx context.Context, _ string) (string, error) {
 }
 
 func KeyRootFunc(ctx context.Context) string {
+	if ctx == nil {
+		klog.Error("context is nil")
+		return ""
+	}
 	key, err := KeyFuncReq(ctx, "")
 	if err != nil {
-		panic("fail to get list key!")
+		klog.Errorf("failed to get list key: %v", err)
+		return ""
 	}
 	return key
 }

--- a/pkg/metaserver/key_test.go
+++ b/pkg/metaserver/key_test.go
@@ -293,3 +293,12 @@ func TestParseKey(t *testing.T) {
 		})
 	}
 }
+
+func TestKeyRootFuncNopanic(t *testing.T) {
+	assert := assert.New(t)
+	// nil context should not panic
+	assert.Empty(KeyRootFunc(nil))
+
+	// empty context has no request info, must return "" not panic
+	assert.Empty(KeyRootFunc(context.TODO()))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`KeyRootFunc` previously panicked if an invalid or unexpected key format was encountered. This caused the entire metaserver to crash.

This PR replaces the panic with a `klog.Errorf` and returns an empty string. It also adds a guard in the storage backend to prevent a nil `RequestInfo` from causing nil pointer dereferences.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This resolves the same panic bug that was attempted in #6879. However, this PR is focused solely on the panic fix, making it much safer to merge without side-effects.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```