### PR TITLE
fix: return CLOSE_CONNECT for MessageTypeCloseConnect

### DIFF
--- a/pkg/stream/message.go
+++ b/pkg/stream/message.go
@@ -43,6 +43,8 @@ func (m MessageType) String() string {
 		return "DATA"
 	case MessageTypeRemoveConnect:
 		return "REMOVE_CONNECT"
+	case MessageTypeCloseConnect:
+		return "CLOSE_CONNECT"
 	}
 	return "UNKNOWN"
 }

--- a/pkg/stream/message_test.go
+++ b/pkg/stream/message_test.go
@@ -59,6 +59,10 @@ func TestMessageType_String(t *testing.T) {
 			stdResult: "REMOVE_CONNECT",
 		},
 		{
+			msg:       MessageTypeCloseConnect,
+			stdResult: "CLOSE_CONNECT",
+		},
+		{
 			msg:       100,
 			stdResult: "UNKNOWN",
 		},


### PR DESCRIPTION
## Description:

Issue #6883 reported that `MessageTypeCloseConnect` stringified as `UNKNOWN` because it was missing from `MessageType.String()`.

This PR updates `pkg/stream/message.go` to return `CLOSE_CONNECT` for `MessageTypeCloseConnect`.

It also adds a regression test case in `pkg/stream/message_test.go` to cover the missing string mapping.

Closes #6883.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run formatting checks using `gofmt -w pkg/stream/message.go pkg/stream/message_test.go`.
- [x] I have run focused tests using `GOWORK=off go test ./pkg/stream/... -count=1`.

## Release note:

```release-note
`MessageTypeCloseConnect` now stringifies as `CLOSE_CONNECT` instead of `UNKNOWN`.
```
