### PR TITLE
fix: reject unsupported tunnel message types

### DIFF
--- a/edge/pkg/edgestream/tunnel.go
+++ b/edge/pkg/edgestream/tunnel.go
@@ -124,7 +124,8 @@ func (s *TunnelSession) ServeConnection(m *stream.Message) {
 			klog.Errorf("Serve Attach connection error %s", m.String())
 		}
 	default:
-		panic(fmt.Sprintf("Wrong message type %v", m.MessageType))
+		klog.Warningf("Unsupported tunnel message type %d for connectID %d", m.MessageType, m.ConnectID)
+		return
 	}
 
 	s.DeleteLocalConnection(m.ConnectID)
@@ -144,6 +145,24 @@ func (s *TunnelSession) WriteToLocalConnection(m *stream.Message) {
 	if con, ok := s.GetLocalConnection(m.ConnectID); ok {
 		con.CacheTunnelMessage(m)
 	}
+}
+
+func (s *TunnelSession) routeMessage(mess *stream.Message) error {
+	switch mess.MessageType {
+	case stream.MessageTypeCloseConnect:
+		return fmt.Errorf("close tunnel stream connection, error:%s", string(mess.Data))
+	case stream.MessageTypeLogsConnect,
+		stream.MessageTypeExecConnect,
+		stream.MessageTypeMetricConnect,
+		stream.MessageTypeAttachConnect:
+		go s.ServeConnection(mess)
+	case stream.MessageTypeData, stream.MessageTypeRemoveConnect:
+		s.WriteToLocalConnection(mess)
+	default:
+		klog.Warningf("Unsupported tunnel message type %d for connectID %d", mess.MessageType, mess.ConnectID)
+	}
+
+	return nil
 }
 
 func (s *TunnelSession) startPing(ctx context.Context) {
@@ -187,14 +206,9 @@ func (s *TunnelSession) Serve() error {
 			return err
 		}
 
-		if mess.MessageType == stream.MessageTypeCloseConnect {
-			return fmt.Errorf("close tunnel stream connection, error:%s", string(mess.Data))
+		if err := s.routeMessage(mess); err != nil {
+			return err
 		}
-
-		if (mess.MessageType < stream.MessageTypeData) || (mess.MessageType >= stream.MessageTypeAttachConnect) {
-			go s.ServeConnection(mess)
-		}
-		s.WriteToLocalConnection(mess)
 	}
 }
 

--- a/edge/pkg/edgestream/tunnel_test.go
+++ b/edge/pkg/edgestream/tunnel_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edgestream
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+func TestTunnelSession_ServeConnectionUnsupportedMessageType(t *testing.T) {
+	session := &TunnelSession{}
+
+	assert.NotPanics(t, func() {
+		session.ServeConnection(&stream.Message{
+			ConnectID:   1,
+			MessageType: stream.MessageType(99),
+		})
+	})
+}
+
+func TestTunnelSession_RouteMessageUnsupportedMessageType(t *testing.T) {
+	assert := assert.New(t)
+	con := &testEdgedConnection{}
+	session := &TunnelSession{
+		localCons: map[uint64]stream.EdgedConnection{
+			1: con,
+		},
+	}
+
+	err := session.routeMessage(&stream.Message{
+		ConnectID:   1,
+		MessageType: stream.MessageType(99),
+	})
+
+	assert.NoError(err)
+	assert.Empty(con.cachedMessages)
+}
+
+type testEdgedConnection struct {
+	cachedMessages []*stream.Message
+}
+
+func (c *testEdgedConnection) CreateConnectMessage() (*stream.Message, error) {
+	return nil, nil
+}
+
+func (c *testEdgedConnection) Serve(stream.SafeWriteTunneler) error {
+	return nil
+}
+
+func (c *testEdgedConnection) CacheTunnelMessage(msg *stream.Message) {
+	c.cachedMessages = append(c.cachedMessages, msg)
+}
+
+func (c *testEdgedConnection) GetMessageID() uint64 {
+	return 0
+}
+
+func (c *testEdgedConnection) CloseReadChannel() {}
+
+func (c *testEdgedConnection) CleanChannel() {}
+
+func (c *testEdgedConnection) String() string {
+	return fmt.Sprintf("%d", len(c.cachedMessages))
+}

--- a/pkg/stream/message.go
+++ b/pkg/stream/message.go
@@ -88,11 +88,12 @@ func ReadMessageFromTunnel(r io.Reader) (*Message, error) {
 	if err != nil {
 		return nil, err
 	}
+	msgType := MessageType(messageType)
 	klog.V(6).Infof("Receive Tunnel message connectID %d messageType %s data:%v string:[%v]",
-		connectID, MessageType(messageType), data, string(data))
+		connectID, msgType, data, string(data))
 	return &Message{
 		ConnectID:   connectID,
-		MessageType: MessageType(messageType),
+		MessageType: msgType,
 		Data:        data,
 	}, nil
 }

--- a/pkg/stream/message_test.go
+++ b/pkg/stream/message_test.go
@@ -167,6 +167,17 @@ func TestReadMessageFromTunnel_MaxDataLength(t *testing.T) {
 	assert.Len(readMsg.Data, constants.MaxRespBodyLength)
 }
 
+func TestReadMessageFromTunnel_UnsupportedMessageType(t *testing.T) {
+	assert := assert.New(t)
+
+	msg := NewMessage(1, MessageType(99), []byte("test data"))
+
+	readMsg, err := ReadMessageFromTunnel(bytes.NewReader(msg.Bytes()))
+	assert.NoError(err)
+	assert.NotNil(readMsg)
+	assert.Equal(MessageType(99), readMsg.MessageType)
+}
+
 // errorReader helper implements io.Reader returning specified error
 type errorReader struct{ err error }
 


### PR DESCRIPTION
## Description:

Issue #6882 reported that unsupported tunnel message types could panic `edgecore` when they reached `TunnelSession.ServeConnection()`.

This PR keeps tunnel message parsing permissive and hardens handling at the application layer:

- `pkg/stream/message.go` continues to parse and return tunnel messages even when the message type is unsupported.
- `edge/pkg/edgestream/tunnel.go` now routes tunnel messages explicitly:
  - known connect message types go to `ServeConnection()`
  - `DATA` and `REMOVE_CONNECT` go to `WriteToLocalConnection()`
  - unsupported message types are logged and ignored
- `edge/pkg/edgestream/tunnel.go` also keeps a safe fallback in `ServeConnection()` so unsupported message types do not panic even if they reach that path directly.

It also adds regression tests that cover both behaviors:

- `pkg/stream/message_test.go` verifies that unsupported message types are still parsed successfully.
- `edge/pkg/edgestream/tunnel_test.go` verifies that `ServeConnection()` does not panic on unsupported message types and that unsupported message types are not forwarded to an active local connection.

Closes #6882.

## Checklist:

- [x] I have added relevant regression test cases for this fix.
- [x] I have run formatting checks in WSL using `gofmt -w pkg/stream/message.go pkg/stream/message_test.go edge/pkg/edgestream/tunnel.go edge/pkg/edgestream/tunnel_test.go`.
- [x] I have run focused tests in WSL using `GOWORK=off go test ./pkg/stream/... ./edge/pkg/edgestream/... -count=1`.

## Release note:

```release-note
EdgeCore now logs and ignores unsupported tunnel message types instead of panicking.
```
