### PR TITLE
fix(certs): correct HandlerType typo and add strong typing

### DIFF
--- a/pkg/security/certs/factory.go
+++ b/pkg/security/certs/factory.go
@@ -16,13 +16,16 @@ limitations under the License.
 package certs
 
 const (
-	CAHandlerTypeX509 CAHandlerType = "x509"
+	CAHandlerTypeX509 = "x509"
 
-	HandlerTypeX509 HandlerType = "x509"
+	HandlerTypeX509 = "x509"
 )
 
 type CAHandlerType string
 type HandlerType string
+
+// Deprecated: use HandlerType.
+type HanndlerType = HandlerType
 
 func GetCAHandler(t CAHandlerType) CAHandler {
 	switch t {

--- a/pkg/security/certs/factory.go
+++ b/pkg/security/certs/factory.go
@@ -16,13 +16,13 @@ limitations under the License.
 package certs
 
 const (
-	CAHandlerTypeX509 = "x509"
+	CAHandlerTypeX509 CAHandlerType = "x509"
 
-	HandlerTypeX509 = "x509"
+	HandlerTypeX509 HandlerType = "x509"
 )
 
 type CAHandlerType string
-type HanndlerType string
+type HandlerType string
 
 func GetCAHandler(t CAHandlerType) CAHandler {
 	switch t {
@@ -32,7 +32,7 @@ func GetCAHandler(t CAHandlerType) CAHandler {
 	return nil
 }
 
-func GetHandler(t HanndlerType) Handler {
+func GetHandler(t HandlerType) Handler {
 	switch t {
 	case HandlerTypeX509:
 		return &x509CertsHandler{}

--- a/pkg/security/certs/factory.go
+++ b/pkg/security/certs/factory.go
@@ -16,9 +16,9 @@ limitations under the License.
 package certs
 
 const (
-	CAHandlerTypeX509 = "x509"
+	CAHandlerTypeX509 CAHandlerType = "x509"
 
-	HandlerTypeX509 = "x509"
+	HandlerTypeX509 HandlerType = "x509"
 )
 
 type CAHandlerType string

--- a/pkg/security/certs/factory.go
+++ b/pkg/security/certs/factory.go
@@ -16,13 +16,22 @@ limitations under the License.
 package certs
 
 const (
+	// Untyped string constants preserve source compatibility for downstream users
+	// who pass these to functions accepting string or named string types.
 	CAHandlerTypeX509 = "x509"
 
 	HandlerTypeX509 = "x509"
 )
 
+// CAHandlerType is the type for CA certificate handler identifiers.
 type CAHandlerType string
-type HanndlerType string
+
+// HandlerType is the corrected type for certificate handler identifiers.
+type HandlerType string
+
+// Deprecated: HanndlerType is a typo alias for HandlerType kept for backward compatibility.
+// Use HandlerType instead.
+type HanndlerType = HandlerType
 
 func GetCAHandler(t CAHandlerType) CAHandler {
 	switch t {
@@ -32,7 +41,7 @@ func GetCAHandler(t CAHandlerType) CAHandler {
 	return nil
 }
 
-func GetHandler(t HanndlerType) Handler {
+func GetHandler(t HandlerType) Handler {
 	switch t {
 	case HandlerTypeX509:
 		return &x509CertsHandler{}

--- a/pkg/security/certs/factory_test.go
+++ b/pkg/security/certs/factory_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certs
+
+import (
+	"testing"
+)
+
+func TestGetCAHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerType CAHandlerType
+		wantNil     bool
+	}{
+		{
+			name:        "Valid x509 CA Handler",
+			handlerType: CAHandlerTypeX509,
+			wantNil:     false,
+		},
+		{
+			name:        "Invalid CA Handler",
+			handlerType: CAHandlerType("invalid-type"),
+			wantNil:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetCAHandler(tt.handlerType)
+			if (got == nil) != tt.wantNil {
+				t.Errorf("GetCAHandler() returned nil = %v, wantNil = %v", got == nil, tt.wantNil)
+			}
+		})
+	}
+}
+
+func TestGetHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerType HandlerType
+		wantNil     bool
+	}{
+		{
+			name:        "Valid x509 Handler",
+			handlerType: HandlerTypeX509,
+			wantNil:     false,
+		},
+		{
+			name:        "Invalid Handler",
+			handlerType: HandlerType("invalid-type"),
+			wantNil:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetHandler(tt.handlerType)
+			if (got == nil) != tt.wantNil {
+				t.Errorf("GetHandler() returned nil = %v, wantNil = %v", got == nil, tt.wantNil)
+			}
+		})
+	}
+}

--- a/pkg/security/certs/factory_test.go
+++ b/pkg/security/certs/factory_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCAHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerType CAHandlerType
+		wantNil     bool
+	}{
+		{
+			name:        "Valid x509 CA Handler",
+			handlerType: CAHandlerTypeX509,
+			wantNil:     false,
+		},
+		{
+			name:        "Invalid CA Handler",
+			handlerType: CAHandlerType("invalid-type"),
+			wantNil:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetCAHandler(tt.handlerType)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+func TestGetHandler(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerType HandlerType
+		wantNil     bool
+	}{
+		{
+			name:        "Valid x509 Handler",
+			handlerType: HandlerTypeX509,
+			wantNil:     false,
+		},
+		{
+			name:        "Invalid Handler",
+			handlerType: HandlerType("invalid-type"),
+			wantNil:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetHandler(tt.handlerType)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}

--- a/pkg/security/certs/factory_test.go
+++ b/pkg/security/certs/factory_test.go
@@ -18,6 +18,8 @@ package certs
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetCAHandler(t *testing.T) {
@@ -41,8 +43,10 @@ func TestGetCAHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetCAHandler(tt.handlerType)
-			if (got == nil) != tt.wantNil {
-				t.Errorf("GetCAHandler() returned nil = %v, wantNil = %v", got == nil, tt.wantNil)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
 			}
 		})
 	}
@@ -69,8 +73,10 @@ func TestGetHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := GetHandler(tt.handlerType)
-			if (got == nil) != tt.wantNil {
-				t.Errorf("GetHandler() returned nil = %v, wantNil = %v", got == nil, tt.wantNil)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind cleanup
/kind bug

**What this PR does / why we need it**:
This PR fixes a typo in `HandlerType` (`HanlderType` -> `HandlerType`) and introduces strong typing for certificate-related structures, improving code safety and readability across the certs package.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Clean, focused code quality improvement.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```