### PR TITLE
fix: edge/metaserver: replace Count panic with sentinel error in sqlite store

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -138,8 +138,8 @@ func (s *store) GuaranteedUpdate(context.Context, string, runtime.Object, bool, 
 	panic("Do not call this function")
 }
 
-func (s *store) Count(string) (int64, error) {
-	panic("implement me")
+func (s *store) Count(key string) (int64, error) {
+	return 0, fmt.Errorf("Count is not supported by the edge SQLite store")
 }
 
 func (s *store) RequestWatchProgress(context.Context) error {

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -24,6 +25,11 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/metaserver"
 	"github.com/kubeedge/kubeedge/pkg/metaserver/util"
 )
+
+// ErrCountUnsupported is returned by Count to signal that the operation is
+// not implemented by this SQLite-backed store. Callers can test for it with
+// errors.Is.
+var ErrCountUnsupported = errors.New("Count is not supported by the edge SQLite store")
 
 /*
 This file is designed to encapsulate the Imitator as Store.Interface,
@@ -138,8 +144,8 @@ func (s *store) GuaranteedUpdate(context.Context, string, runtime.Object, bool, 
 	panic("Do not call this function")
 }
 
-func (s *store) Count(key string) (int64, error) {
-	return 0, fmt.Errorf("Count is not supported by the edge SQLite store")
+func (s *store) Count(_ string) (int64, error) {
+	return 0, ErrCountUnsupported
 }
 
 func (s *store) RequestWatchProgress(context.Context) error {

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlite
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestCountReturnsErrorAndDoesNotPanic verifies that Count:
+//  1. does not panic (regression guard against the original panic("implement me"))
+//  2. returns exactly 0 as the count
+//  3. returns a non-nil error
+//  4. returns ErrCountUnsupported so callers can use errors.Is
+func TestCountReturnsErrorAndDoesNotPanic(t *testing.T) {
+	s := &store{}
+
+	// Ensure Count does not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Count panicked: %v", r)
+		}
+	}()
+
+	count, err := s.Count("any/key")
+
+	if count != 0 {
+		t.Errorf("Count() count = %d, want 0", count)
+	}
+
+	if err == nil {
+		t.Error("Count() error = nil, want non-nil error")
+	}
+
+	if !errors.Is(err, ErrCountUnsupported) {
+		t.Errorf("Count() error = %v, want errors.Is(err, ErrCountUnsupported) == true", err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

The `Count` method in the SQLite-backed `storage.Interface` implementation was left as an unfinished stub with `panic("implement me")` — unlike sibling methods (`Create`, `Delete`, `GuaranteedUpdate`, `RequestWatchProgress`) which intentionally refuse with `panic("Do not call this function")`.

This makes `Count` a crash hazard: any code path in the upstream `k8s.io/apiserver` machinery that calls it, or a future `k8s.io/apiserver` bump that adds a new caller, would crash the entire edgecore process.

fix #6887 
This PR:
- Replaces the panic with a package-level **sentinel error** `ErrCountUnsupported` so callers can degrade gracefully and use `errors.Is` to detect the unsupported operation
- Makes the unused `key` parameter anonymous (`_`) to avoid implying the value affects the result
- Adds a focused unit test that verifies `Count()` returns `0`, a non-nil error matching
  `ErrCountUnsupported`, and never panics

```go
// ErrCountUnsupported is returned by Count to signal that the operation is
// not implemented by this SQLite-backed store. Callers can test for it with
// errors.Is.
var ErrCountUnsupported = errors.New("Count is not supported by the edge SQLite store")

func (s *store) Count(_ string) (int64, error) {
    return 0, ErrCountUnsupported
}
