### PR TITLE
Fix: delayed session shutdown and ackMessageCache leaks in sendMessageWithRetry

### DIFF
--- a/cloud/pkg/cloudhub/session/node_session.go
+++ b/cloud/pkg/cloudhub/session/node_session.go
@@ -345,6 +345,7 @@ func (ns *NodeSession) sendMessageWithRetry(copyMsg, msg *beehivemodel.Message) 
 
 	err := ns.connection.WriteMessageAsync(copyMsg)
 	if err != nil {
+		ns.ackMessageCache.Delete(copyMsg.GetID())
 		return err
 	}
 
@@ -354,13 +355,19 @@ func (ns *NodeSession) sendMessageWithRetry(copyMsg, msg *beehivemodel.Message) 
 			ns.saveSuccessPoint(msg)
 			return nil
 
+		case <-ns.ctx.Done():
+			ns.ackMessageCache.Delete(copyMsg.GetID())
+			return fmt.Errorf("session closed while waiting for ack of message %s", copyMsg.GetID())
+
 		case <-ticker.C:
 			if retryCount == 4 {
+				ns.ackMessageCache.Delete(copyMsg.GetID())
 				return ErrWaitTimeout
 			}
 
 			err := ns.connection.WriteMessageAsync(copyMsg)
 			if err != nil {
+				ns.ackMessageCache.Delete(copyMsg.GetID())
 				return err
 			}
 


### PR DESCRIPTION
# SUMMARY

This PR improves the reliability of CloudHub's ACK delivery path by ensuring `sendMessageWithRetry()` respects session cancellation and properly cleans up cached ACK tracking entries on all non-success exit paths. The changes primarily affect `cloud/pkg/cloudhub/session/node_session.go`, specifically the retry logic used by `NodeSession` when delivering ACK-required messages.

# FIX


**Before**

```go
//Before
select {
case <-ackChan:
    ns.saveSuccessPoint(msg)
    return nil

case <-ticker.C:
    if retryCount == 4 {
        return ErrWaitTimeout
    }
}



//After
select {
case <-ackChan:
    ns.saveSuccessPoint(msg)
    return nil

case <-ns.ctx.Done():
    ns.ackMessageCache.Delete(copyMsg.GetID())
    return fmt.Errorf("session closed while waiting for ack")

case <-ticker.C:
    if retryCount == 4 {
        ns.ackMessageCache.Delete(copyMsg.GetID())
        return ErrWaitTimeout
    }
}
```


