### PR TITLE
Fix: cloud/edgecontroller: handle json.Marshal error for GPU status annotation

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -572,6 +572,24 @@ func (uc *UpstreamController) createNode(nodeID, name string, node *v1.Node) (*v
 	return node, err
 }
 
+// marshalGPUStatus marshals GPU status entries to JSON. It is a package-level
+// variable, rather than a direct call to json.Marshal, so tests can substitute
+// a failing implementation: []types.NvidiaGPUStatus only has string/bool
+// fields and can never actually fail to marshal.
+var marshalGPUStatus = json.Marshal
+
+// setGPUStatusAnnotation marshals gpuStatus and stores it under
+// constants.NvidiaGPUStatusAnnotationKey on node. If marshalling fails, it
+// logs a warning and leaves the existing annotation value untouched.
+func setGPUStatusAnnotation(node *v1.Node, msgID string, gpuStatus []types.NvidiaGPUStatus) {
+	data, err := marshalGPUStatus(gpuStatus)
+	if err != nil {
+		klog.Warningf("message: %s, marshal GPU status failed: %v", msgID, err)
+		return
+	}
+	node.Annotations[constants.NvidiaGPUStatusAnnotationKey] = string(data)
+}
+
 // updateNodeStatus update node status
 // Deprecated: updateNodeStatus will be deleted in subsequent versions, use patchNode instead.
 func (uc *UpstreamController) updateNodeStatus() {
@@ -676,8 +694,7 @@ func (uc *UpstreamController) updateNodeStatus() {
 							gpuStatus = append(gpuStatus, types.NvidiaGPUStatus{ID: er.Name, Healthy: true})
 						}
 						if len(gpuStatus) > 0 {
-							data, _ := json.Marshal(gpuStatus)
-							getNode.Annotations[constants.NvidiaGPUStatusAnnotationKey] = string(data)
+							setGPUStatusAnnotation(getNode, msg.GetID(), gpuStatus)
 						}
 					}
 					data, err := json.Marshal(v)

--- a/cloud/pkg/edgecontroller/controller/upstream_test.go
+++ b/cloud/pkg/edgecontroller/controller/upstream_test.go
@@ -37,10 +37,14 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
 	rulesv1 "github.com/kubeedge/api/apis/rules/v1"
 	"github.com/kubeedge/beehive/pkg/core/model"
 	messagelayer "github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
+	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/constants"
+	edgectypes "github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller/types"
 	edgeapi "github.com/kubeedge/kubeedge/common/types"
 )
 
@@ -856,6 +860,131 @@ func TestUpdateNodeStatus(t *testing.T) {
 
 	UC.nodeStatusChan <- msg
 	time.Sleep(1000 * time.Millisecond)
+}
+
+// TestUpdateNodeStatusWithGPUAnnotation is a happy-path regression test that verifies
+// the NvidiaGPUStatusAnnotationKey annotation is correctly written to the Node when
+// updateNodeStatus processes a NodeStatusRequest carrying nvidia.com/gpu ExtendResources.
+// It does not exercise the marshal-error branch (json.Marshal on []types.NvidiaGPUStatus
+// cannot realistically fail with the current schema).
+func TestUpdateNodeStatusWithGPUAnnotation(t *testing.T) {
+	setupTest(t)
+
+	nodeName := "test-gpu-node"
+	nodeID := "node-gpu-id"
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}
+
+	_, err := UC.kubeClient.CoreV1().Nodes().Create(context.Background(), node, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test node: %v", err)
+	}
+
+	nodeStatusReq := &edgeapi.NodeStatusRequest{
+		Status: corev1.NodeStatus{},
+		ExtendResources: map[corev1.ResourceName][]edgeapi.ExtendResource{
+			"nvidia.com/gpu": {
+				{Name: "GPU-aaa111"},
+				{Name: "GPU-bbb222"},
+			},
+		},
+	}
+
+	nodeStatusData, err := json.Marshal(nodeStatusReq)
+	if err != nil {
+		t.Fatalf("Failed to marshal node status request: %v", err)
+	}
+
+	resource := fmt.Sprintf("node/%s/%s/%s/%s", nodeID, "default", model.ResourceTypeNodeStatus, nodeName)
+
+	msg := model.Message{
+		Header: model.MessageHeader{ID: "test-update-gpu-node-status"},
+		Router: model.MessageRoute{
+			Resource:  resource,
+			Operation: model.UpdateOperation,
+		},
+		Content: string(nodeStatusData),
+	}
+
+	UC.nodeStatusChan <- msg
+
+	// Poll until the annotation appears rather than using a fixed sleep,
+	// so the test is faster when the update is quick and reliable when it is slow.
+	var annotation string
+	require.Eventually(t, func() bool {
+		updatedNode, err := UC.kubeClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		val, ok := updatedNode.Annotations[constants.NvidiaGPUStatusAnnotationKey]
+		if !ok || val == "" {
+			return false
+		}
+		annotation = val
+		return true
+	}, 3*time.Second, 50*time.Millisecond,
+		"annotation %q was not set on Node within timeout", constants.NvidiaGPUStatusAnnotationKey)
+
+	var gpuStatuses []struct {
+		ID      string `json:"id"`
+		Healthy bool   `json:"healthy"`
+	}
+	if err := json.Unmarshal([]byte(annotation), &gpuStatuses); err != nil {
+		t.Fatalf("annotation %q is not valid JSON: %v", constants.NvidiaGPUStatusAnnotationKey, err)
+	}
+	if len(gpuStatuses) != 2 {
+		t.Errorf("Expected 2 GPU entries in annotation, got %d", len(gpuStatuses))
+	}
+	for _, gs := range gpuStatuses {
+		if !gs.Healthy {
+			t.Errorf("Expected GPU %q to be marked Healthy=true, got false", gs.ID)
+		}
+	}
+}
+
+// TestSetGPUStatusAnnotation unit-tests setGPUStatusAnnotation directly, covering
+// both the successful-marshal branch and the marshal-failure branch. The latter
+// is unreachable through updateNodeStatus with real input, since
+// []types.NvidiaGPUStatus (string/bool fields only) can never fail to marshal,
+// so the failure is injected via the marshalGPUStatus seam.
+func TestSetGPUStatusAnnotation(t *testing.T) {
+	gpuStatus := []edgectypes.NvidiaGPUStatus{
+		{ID: "GPU-aaa111", Healthy: true},
+	}
+
+	t.Run("marshal succeeds", func(t *testing.T) {
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+
+		setGPUStatusAnnotation(node, "test-msg-ok", gpuStatus)
+
+		val, ok := node.Annotations[constants.NvidiaGPUStatusAnnotationKey]
+		require.True(t, ok, "expected annotation to be set")
+
+		var got []edgectypes.NvidiaGPUStatus
+		require.NoError(t, json.Unmarshal([]byte(val), &got))
+		require.Equal(t, gpuStatus, got)
+	})
+
+	t.Run("marshal fails", func(t *testing.T) {
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			constants.NvidiaGPUStatusAnnotationKey: "pre-existing-value",
+		}}}
+
+		orig := marshalGPUStatus
+		marshalGPUStatus = func(any) ([]byte, error) {
+			return nil, errors.New("injected marshal failure")
+		}
+		defer func() { marshalGPUStatus = orig }()
+
+		setGPUStatusAnnotation(node, "test-msg-fail", gpuStatus)
+
+		require.Equal(t, "pre-existing-value", node.Annotations[constants.NvidiaGPUStatusAnnotationKey],
+			"annotation must be left untouched when marshal fails")
+	})
 }
 
 func TestProcessCSR(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

In `updateNodeStatus` (`cloud/pkg/edgecontroller/controller/upstream.go`), the error return from `json.Marshal(gpuStatus)` was silently discarded with the blank identifier `_`. If marshalling were to fail, `data` would be `nil` and `string(nil)` evaluates to `""`, causing the existing `huawei.com/gpu-status` Node annotation to be silently overwritten with an empty string - erasing all GPU health information with no log output.

This PR fixes the discarded error by:

1. Capturing the `err` return value.
2. Emitting a `klog.Warningf` with the message ID so operators can trace the
   event.
3. Skipping the annotation write via `continue` so the pre-existing value is
   preserved.

The change also makes the first `json.Marshal` call consistent with the immediately following `json.Marshal(v)` call at line 687, which already checks and logs its error. A unit test covering the happy-path annotation
write is added in `upstream_test.go`.

## Which issue(s) this PR fixes

Fixes #6890 

## Special notes for your reviewer

`json.Marshal` on `[]types.NvidiaGPUStatus` (a slice of a struct with only `string` and `bool` fields) cannot realistically fail in the current code.

The fix is a defensive hardening change for consistency and correctness against future schema changes, not a regression fix.

## Does this PR introduce a user-facing change?

```release-note
NONE
```
