### PR TITLE
Update keadm ctl command descriptions and help

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/ctl.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/ctl.go
@@ -30,13 +30,20 @@ import (
 )
 
 var ctlShortDescription = `Commands operating on the data plane at edge`
+var ctlLongDescription = `Commands operating on the data plane at the edge.
+
+The 'keadm ctl' commands are designed to be executed directly on edge nodes where EdgeCore is installed and running. They interact with the local MetaServer API to perform operations such as retrieving logs, executing commands, and querying resource statuses locally, even when disconnected from the cloud.
+
+Note:
+- Ensure the MetaServer module is enabled in your edgecore.yaml configuration.
+- To manage edge nodes and pods from the cloud side, please use standard 'kubectl' commands instead.`
 
 // NewCtl returns KubeEdge edge pod command.
 func NewCtl() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ctl",
 		Short: ctlShortDescription,
-		Long:  ctlShortDescription,
+		Long:  ctlLongDescription,
 	}
 
 	cmd.AddCommand(get.NewEdgeGet())

--- a/keadm/cmd/keadm/app/cmd/ctl/ctl.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/ctl.go
@@ -32,7 +32,7 @@ import (
 var ctlShortDescription = `Commands operating on the data plane at edge`
 var ctlLongDescription = `Commands operating on the data plane at the edge.
 
-The 'keadm ctl' commands are designed to be executed directly on edge nodes where EdgeCore is installed and running. They interact with the local MetaServer API to perform operations such as retrieving logs, executing commands, and querying resource statuses locally, even when disconnected from the cloud.
+The 'keadm ctl' commands are designed to be executed directly on edge nodes where EdgeCore is installed and running. They interact with the local MetaServer API to perform operations such as retrieving logs, executing commands, and querying resource statuses locally. This allows some operations to be performed even when the edge node is disconnected from the cloud.
 
 Note:
 - Ensure the MetaServer module is enabled in your edgecore.yaml configuration.

--- a/keadm/cmd/keadm/app/cmd/ctl/ctl.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/ctl.go
@@ -29,7 +29,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/unhold"
 )
 
-var ctlShortDescription = `Commands operating on the data plane at edge`
+var ctlShortDescription = `Commands operating on the data plane at the edge`
 var ctlLongDescription = `Commands operating on the data plane at the edge.
 
 The 'keadm ctl' commands are designed to be executed directly on edge nodes where EdgeCore is installed and running. They interact with the local MetaServer API to perform operations such as retrieving logs, executing commands, and querying resource statuses locally. This allows some operations to be performed even when the edge node is disconnected from the cloud.

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/describe.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/describe.go
@@ -20,12 +20,19 @@ import "github.com/spf13/cobra"
 
 var edgeDescribeShortDescription = `Show details of a specific resource`
 
+var edgeDescribeLongDescription = `Show details of a specific resource.
+
+This command is intended to be run on the edge node where EdgeCore is running. It queries the local MetaServer API to retrieve the details of a resource.
+Please ensure that the MetaServer module is enabled in your edgecore.yaml configuration.
+
+Currently, only 'pod' and 'device' resources are supported by this command.`
+
 // NewEdgeDescribe returns KubeEdge edge resources describe command.
 func NewEdgeDescribe() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: edgeDescribeShortDescription,
-		Long:  edgeDescribeShortDescription,
+		Long:  edgeDescribeLongDescription,
 	}
 
 	cmd.AddCommand(NewEdgeDescribePod())

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/device.go
@@ -36,7 +36,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
-var edgeDescribeDeviceShortDescription = `Describe device in edge node`
+var edgeDescribeDeviceShortDescription = `Describe device on an edge node`
 
 type DeviceDescribeOptions struct {
 	Namespace     string

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/pod.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/pod.go
@@ -36,7 +36,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
-var edgeDescribePodShortDescription = `Describe pod in edge node`
+var edgeDescribePodShortDescription = `Describe pod on an edge node`
 
 type PodDescribeOptions struct {
 	Namespace     string

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/device.go
@@ -40,7 +40,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 )
 
-var edgeEditDeviceShortDescription = `Edit a device in edge node`
+var edgeEditDeviceShortDescription = `Edit a device on an edge node`
 
 type DeviceEditOptions struct {
 	Namespace string

--- a/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
@@ -70,7 +70,7 @@ var edgePodExecExample = `  # Execute a command in a pod on the edge node
 func NewEdgePodExec() *cobra.Command {
 	execOpts := NewEdgePodExecOpts()
 	cmd := &cobra.Command{
-		Use:     "exec",
+		Use:     "exec <pod-name> -- <command> [args...]",
 		Short:   edgePodExecShortDescription,
 		Long:    edgePodExecLongDescription,
 		Example: edgePodExecExample,

--- a/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
@@ -53,13 +53,27 @@ type PodExecOptions struct {
 
 var edgePodExecShortDescription = `Execute command in edge pod`
 
+var edgePodExecLongDescription = `Execute command in edge pod.
+
+This command is intended to be run on the edge node where EdgeCore is running. It queries the local MetaServer API to execute a command in a pod.
+Please ensure that the MetaServer module is enabled in your edgecore.yaml configuration.
+
+If you want to execute commands in a pod from the cloud side, you should use 'kubectl exec' instead.`
+
+var edgePodExecExample = `  # Execute a command in a pod on the edge node
+  keadm ctl exec <pod-name> -n <namespace> -- <command>
+
+  # Execute an interactive bash shell in a pod
+  keadm ctl exec -it <pod-name> -n <namespace> -- /bin/bash`
+
 // NewEdgePodExec returns KubeEdge exec edge pod command.
 func NewEdgePodExec() *cobra.Command {
 	execOpts := NewEdgePodExecOpts()
 	cmd := &cobra.Command{
-		Use:   "exec",
-		Short: edgePodExecShortDescription,
-		Long:  edgePodExecShortDescription,
+		Use:     "exec",
+		Short:   edgePodExecShortDescription,
+		Long:    edgePodExecLongDescription,
+		Example: edgePodExecExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("no pod specified for exec")

--- a/keadm/cmd/keadm/app/cmd/ctl/get/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/get/device.go
@@ -35,7 +35,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 )
 
-var edgeDeviceGetShortDescription = `Get devices in edge node`
+var edgeDeviceGetShortDescription = `Get devices on an edge node`
 
 type DeviceGetOptions struct {
 	Namespace     string

--- a/keadm/cmd/keadm/app/cmd/ctl/get/get.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/get/get.go
@@ -19,7 +19,7 @@ package get
 import "github.com/spf13/cobra"
 
 var (
-	edgeGetShortDescription = `Get resources in edge node`
+	edgeGetShortDescription = `Get resources on an edge node`
 )
 
 // NewEdgeGet returns KubeEdge edge resources get command.

--- a/keadm/cmd/keadm/app/cmd/ctl/get/pod.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/get/pod.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	edgePodGetShortDescription = `Get pods in edge node`
+	edgePodGetShortDescription = `Get pods on an edge node`
 )
 
 type PodGetOptions struct {

--- a/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
@@ -34,7 +34,20 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
 )
 
-var edgePodLogsShortDescription = `Get pod logs in edge node`
+var edgePodLogsShortDescription = `Get pod logs on an edge node`
+
+var edgePodLogsLongDescription = `Get pod logs on an edge node.
+
+This command is intended to be run on the edge node where EdgeCore is running. It queries the local MetaServer API to retrieve the logs of a pod.
+Please ensure that the MetaServer module is enabled in your edgecore.yaml configuration.
+
+If you want to view pod logs from the cloud side, you should use 'kubectl logs' instead.`
+
+var edgePodLogsExample = `  # Get logs from a pod on the edge node
+  keadm ctl logs <pod-name> -n <namespace>
+
+  # Stream logs from a pod
+  keadm ctl logs -f <pod-name> -n <namespace>`
 
 // PodLogsOptions defines the options for getting logs of edge pod
 type PodLogsOptions struct {
@@ -61,9 +74,10 @@ type PodLogsOptions struct {
 func NewEdgePodLogs() *cobra.Command {
 	logsOpts := NewLogsPodOpts()
 	cmd := &cobra.Command{
-		Use:   "logs",
-		Short: edgePodLogsShortDescription,
-		Long:  edgePodLogsShortDescription,
+		Use:     "logs",
+		Short:   edgePodLogsShortDescription,
+		Long:    edgePodLogsLongDescription,
+		Example: edgePodLogsExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("no pod specified for logs")

--- a/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
@@ -74,7 +74,7 @@ type PodLogsOptions struct {
 func NewEdgePodLogs() *cobra.Command {
 	logsOpts := NewLogsPodOpts()
 	cmd := &cobra.Command{
-		Use:     "logs",
+		Use:     "logs <pod-name>",
 		Short:   edgePodLogsShortDescription,
 		Long:    edgePodLogsLongDescription,
 		Example: edgePodLogsExample,

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/pod.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/pod.go
@@ -35,7 +35,7 @@ type PodRestartOptions struct {
 }
 
 var (
-	edgePodRestartShortDescription = `Restart pods in edge node`
+	edgePodRestartShortDescription = `Restart pods on an edge node`
 )
 
 // NewEdgePodRestart returns KubeEdge delete edge pod command.

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/restart.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/restart.go
@@ -19,7 +19,7 @@ package restart
 import "github.com/spf13/cobra"
 
 var (
-	edgeRestartShortDescription = `Restart resources in edge node`
+	edgeRestartShortDescription = `Restart resources on an edge node`
 )
 
 // NewEdgeRestart returns KubeEdge restart edge resources command.


### PR DESCRIPTION

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Updates the CLI help documentation for `keadm ctl logs`, `exec`, `describe`, and the root `ctl` commands. Previously, the minimal `--help` text caused confusion about their expected behavior and environment (e.g., users trying to run them from the cloud side). 

This PR adds comprehensive `Long` descriptions and `Example` blocks to clarify that these commands are exclusively intended to be run on edge nodes and require the `MetaServer` module to be enabled in `edgecore.yaml`. It also points cloud-side users to the appropriate `kubectl` commands.

**Which issue(s) this PR fixes**:
Fixes #6708

**Special notes for your reviewer**:
The updates are purely text-based documentation enhancements to the cobra commands. No functional logic was changed.

**Does this PR introduce a user-facing change?**:
```release-note
Add detailed help descriptions to `keadm ctl` commands to clarify edge node usage and MetaServer prerequisites