### PR TITLE
synccontroller: guard nil message on object sync update path

### DIFF
--- a/cloud/pkg/synccontroller/clusterobjectsync.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync.go
@@ -126,6 +126,10 @@ func sendClusterObjectSyncEvent(nodeName string, sync *v1alpha1.ClusterObjectSyn
 		// trigger the update event
 		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
 		msg := buildEdgeControllerMessageFunc(nodeName, models.NullNamespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
+		if msg == nil {
+			klog.Warningf("failed to build update message for %s %s, skip sending update event", resourceType, sync.Spec.ObjectName)
+			return
+		}
 		sendToEdge(commonconst.DefaultContextSendModuleName, *msg)
 	}
 }

--- a/cloud/pkg/synccontroller/clusterobjectsync_test.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync_test.go
@@ -429,6 +429,37 @@ func TestSendClusterObjectSyncEventDirect(t *testing.T) {
 	assert.True(t, sendCalled, "Send should have been called")
 }
 
+func TestSendClusterObjectSyncEventNilMessage(t *testing.T) {
+	backup := setupTest()
+	defer backup.restore()
+
+	compareResourceVersionFunc = func(rv1, rv2 string) int {
+		if rv1 == "1000" && rv2 == "500" {
+			return 1
+		}
+		return 0
+	}
+
+	sendCalled := false
+	sendToEdge = func(module string, msg model.Message) {
+		sendCalled = true
+	}
+
+	// buildEdgeControllerMessageFunc returns nil when BuildResource fails;
+	// the update path must skip sending instead of dereferencing nil.
+	buildEdgeControllerMessageFunc = func(nodeID, namespace, resource, resourceID string, operation string, content interface{}) *model.Message {
+		return nil
+	}
+
+	obj := createTestPod("test-pod", "12345", "1000")
+	sync := createTestSync("node1-pod-12345", "test-pod", "Pod", "v1", "500")
+
+	assert.NotPanics(t, func() {
+		sendClusterObjectSyncEvent("node1", sync, "pod", "1000", obj)
+	}, "sendClusterObjectSyncEvent should not panic when message build returns nil")
+	assert.False(t, sendCalled, "Send should not be called when message build returns nil")
+}
+
 func TestDeleteClusterObjectSyncFunc(t *testing.T) {
 	backup := setupTest()
 	defer backup.restore()

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -97,7 +97,11 @@ func sendEvents(nodeName string, sync *v1alpha1.ObjectSync, resourceType string,
 	if CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
 		// trigger the update event
 		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
-		msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
+		msg := buildEdgeControllerMessageFunc(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
+		if msg == nil {
+			klog.Warningf("failed to build update message for %s %s/%s, skip sending update event", resourceType, sync.Namespace, sync.Spec.ObjectName)
+			return
+		}
 		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
 	}
 }

--- a/cloud/pkg/synccontroller/objectsync_test.go
+++ b/cloud/pkg/synccontroller/objectsync_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,6 +176,32 @@ func TestSendEvents(t *testing.T) {
 		})
 	}
 }
+
+// sendEvents must not panic when the message builder returns nil, and it
+// must skip sending in that case. buildEdgeControllerMessageFunc returns nil
+// when messagelayer.BuildResource fails; mock it directly so the test
+// deterministically exercises the nil-guard branch instead of relying on the
+// internal validation behavior of BuildResource.
+func TestSendEventsNilMessage(t *testing.T) {
+	originalBuild := buildEdgeControllerMessageFunc
+	defer func() { buildEdgeControllerMessageFunc = originalBuild }()
+
+	buildEdgeControllerMessageFunc = func(nodeName, namespace, resourceType, resourceName, operationType string, obj interface{}) *model.Message {
+		return nil
+	}
+
+	// status resourceVersion "1" < object resourceVersion "2" drives the
+	// update branch, where the builder is invoked and returns nil here.
+	sync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod")
+	tmp := sync.DeepCopy()
+
+	// The nil-guard returns before reaching beehiveContext.Send, so reaching
+	// this point without a panic proves the message was not dereferenced or sent.
+	assert.NotPanics(t, func() {
+		sendEvents(tf.TestNodeID, sync, "pod", "2", tmp)
+	}, "sendEvents should not panic when message build returns nil")
+}
+
 func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`buildEdgeControllerMessage` returns `nil` when `messagelayer.BuildResource` fails. The update path in `sendEvents` (`objectsync.go`) and `sendClusterObjectSyncEvent` (`clusterobjectsync.go`) dereferenced the returned message without a nil check, so a failed `BuildResource` panics the syncController goroutine in cloudcore.

The delete path in both files already guards this with `if msg != nil`. This PR mirrors that guard on the update path: log and skip sending when the message is nil, matching the existing pattern.

Adds unit tests asserting neither function panics when message build returns nil.

**Which issue(s) this PR fixes**:

Fixes #6895

**Special notes for your reviewer**:

`TestSendEventsNilMessage` triggers the nil return naturally by passing an empty node name (`BuildResource` errors on empty `nodeID`/`namespace`/`resourceType`). `TestSendClusterObjectSyncEventNilMessage` uses the existing `buildEdgeControllerMessageFunc` test seam to return nil. Verified the tests fail (panic) without the fix and pass with it.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
