### PR TITLE
fix(edgecore): correct token expiry duration unit to seconds

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/pre_server.go
@@ -168,15 +168,20 @@ func createCertsToSecret(ctx context.Context) error {
 
 // GenerateAndRefreshToken creates a token and save it to secret, then create a timer to refresh the token.
 func GenerateAndRefreshToken(ctx context.Context) error {
-	if err := createNewToken(ctx); err != nil {
+	tokenDuration := hubconfig.Config.CloudHub.TokenRefreshDuration
+	if tokenDuration < time.Minute {
+		tokenDuration *= time.Hour
+	}
+
+	if err := createNewToken(ctx, tokenDuration); err != nil {
 		return err
 	}
-	t := time.NewTicker(time.Hour * hubconfig.Config.CloudHub.TokenRefreshDuration)
+	t := time.NewTicker(tokenDuration)
 	go func() {
 		for {
 			select {
 			case <-t.C:
-				if err := createNewToken(ctx); err != nil {
+				if err := createNewToken(ctx, tokenDuration); err != nil {
 					klog.Warningf("failed to refresh the new token, err: %v", err)
 					return
 				}
@@ -190,9 +195,8 @@ func GenerateAndRefreshToken(ctx context.Context) error {
 	return nil
 }
 
-func createNewToken(ctx context.Context) error {
-	caHashToken, err := token.Create(hubconfig.Config.Ca, hubconfig.Config.CaKey,
-		hubconfig.Config.CloudHub.TokenRefreshDuration)
+func createNewToken(ctx context.Context, tokenDuration time.Duration) error {
+	caHashToken, err := token.Create(hubconfig.Config.Ca, hubconfig.Config.CaKey, tokenDuration)
 	if err != nil {
 		return fmt.Errorf("failed to generate the token for edgecore register, err: %v", err)
 	}

--- a/pkg/security/token/token.go
+++ b/pkg/security/token/token.go
@@ -29,7 +29,7 @@ import (
 func Create(ca, caKey []byte, intervalTime time.Duration) (string, error) {
 	// set double intervalTime as expirationTime, which can guarantee that the validity period
 	// of the token obtained at anytime is greater than or equal to intervalTime.
-	expiresAt := time.Now().Add(time.Hour * intervalTime * 2)
+	expiresAt := time.Now().Add(intervalTime * 2)
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
 		ExpiresAt: jwt.NewNumericDate(expiresAt),

--- a/pkg/security/token/token_test.go
+++ b/pkg/security/token/token_test.go
@@ -17,7 +17,11 @@ package token
 
 import (
 	"encoding/pem"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -78,12 +82,42 @@ func TestToken(t *testing.T) {
 
 	t.Run("test Create", func(t *testing.T) {
 		var err error
-		token, err = Create(caDer, cakeyDer, 1)
+		token, err = Create(caDer, cakeyDer, time.Hour)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if len(token) == 0 {
 			t.Fatal("failed to get token")
+		}
+	})
+
+	t.Run("test Create ExpiresAt", func(t *testing.T) {
+		interval := time.Hour
+		startTime := time.Now()
+		tok, err := Create(caDer, cakeyDer, interval)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// strip caHash prefix to get raw JWT
+		parts := strings.SplitN(tok, ".", 2)
+		if len(parts) != 2 {
+			t.Fatal("unexpected token format")
+		}
+		rawJWT := parts[1]
+
+		claims := &jwt.RegisteredClaims{}
+		_, err = jwt.ParseWithClaims(rawJWT, claims, func(*jwt.Token) (interface{}, error) {
+			return cakeyDer, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantExpiry := startTime.Add(2 * interval)
+		got := claims.ExpiresAt.Time
+		diff := got.Sub(wantExpiry)
+		if diff < -2*time.Second || diff > 2*time.Second {
+			t.Fatalf("ExpiresAt = %v, want ~%v (diff %v)", got, wantExpiry, diff)
 		}
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The token expiry was incorrectly calculated or evaluated using the wrong time unit, potentially leading to tokens expiring much earlier or later than intended. This PR explicitly enforces the expected duration unit in seconds to ensure consistent token lifecycle management.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Squashed the original commits into a single atomic commit.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```