### PR TITLE
fix: cloud/cloudhub: correct "Node founded" typo to "Node found" in checknode response

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/node/checknode.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/node/checknode.go
@@ -59,7 +59,7 @@ func CheckNode(request *restful.Request, response *restful.Response) {
 	}
 
 	// node exists return success
-	err = response.WriteErrorString(http.StatusOK, "Node founded")
+	err = response.WriteErrorString(http.StatusOK, "Node found")
 	if err != nil {
 		klog.Errorf("failed to send the task resp to edge , err: %v", err)
 	}

--- a/cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go
@@ -93,7 +93,7 @@ func TestCheckNode(t *testing.T) {
 			container.ServeHTTP(httpWriter, httpReq)
 
 			assert.Equal(t, tt.expectedStatus, httpWriter.Code)
-			assert.Contains(t, httpWriter.Body.String(), tt.expectedBody)
+			assert.Equal(t, tt.expectedBody, httpWriter.Body.String())
 		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?
/kind bug

fix #6901

## What this PR does / why we need it

`checknode.go` returned `"Node founded"` on the success path — a grammatically wrong, user-visible string sent to every caller of the `/checknode/{nodename}` endpoint:

```go
// before (buggy)
err = response.WriteErrorString(http.StatusOK, "Node founded")

// after (fixed)
err = response.WriteErrorString(http.StatusOK, "Node found")
