### PR TITLE
keadm: fix segmentation fault in init/install commands

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -124,6 +124,30 @@ func GetPackageManager() string {
 	}
 }
 
+// unsupportedOSType implements OSTypeInstaller for unsupported operating systems.
+// All methods return errors instead of panicking or causing segfaults.
+type unsupportedOSType struct{}
+
+func (u *unsupportedOSType) InstallMQTT() error {
+	return fmt.Errorf("unsupported operating system")
+}
+func (u *unsupportedOSType) IsK8SComponentInstalled(string, string) error {
+	return fmt.Errorf("unsupported operating system")
+}
+func (u *unsupportedOSType) SetKubeEdgeVersion(version semver.Version) {}
+func (u *unsupportedOSType) InstallKubeEdge(types.InstallOptions) error {
+	return fmt.Errorf("unsupported operating system")
+}
+func (u *unsupportedOSType) RunEdgeCore() error {
+	return fmt.Errorf("unsupported operating system")
+}
+func (u *unsupportedOSType) KillKubeEdgeBinary(string) error {
+	return fmt.Errorf("unsupported operating system")
+}
+func (u *unsupportedOSType) IsKubeEdgeProcessRunning(string) (bool, error) {
+	return false, fmt.Errorf("unsupported operating system")
+}
+
 // GetOSInterface helps in returning OS specific object which implements OSTypeInstaller interface.
 func GetOSInterface() types.OSTypeInstaller {
 	switch GetPackageManager() {
@@ -135,7 +159,7 @@ func GetOSInterface() types.OSTypeInstaller {
 		return &PacmanOS{}
 	default:
 		fmt.Println("Failed to detect supported package manager command(apt, yum, pacman), exit")
-		panic("Failed to detect supported package manager command(apt, yum, pacman), exit")
+		return &unsupportedOSType{}
 	}
 }
 
@@ -474,7 +498,6 @@ func isK8SComponentInstalled(kubeConfig, master string) error {
 		return fmt.Errorf("failed to init discovery client, err: %v", err)
 	}
 
-	discoveryClient.RESTClient().Post()
 	serverVersion, err := discoveryClient.ServerVersion()
 	if err != nil {
 		return fmt.Errorf("failed to get the version of K8s master, please check whether K8s was successfully installed, err: %v", err)


### PR DESCRIPTION

 **What type of PR is this?**
/kind bug
Fixes #5003

**What this PR does / why we need it:**
Fixes two crash causes in `keadm init` that produce a segmentation fault (Issue #5003):

1. **Removed** `discoveryClient.RESTClient().Post()` — a no-op call that can nil-dereference if the REST client is nil, causing SIGSEGV.

2. **Replaced** `panic()` in `GetOSInterface()` with a graceful `unsupportedOSType{}` struct. On unsupported OS (non-apt/yum/pacman), the old code panicked, which manifests as a segfault. The new implementation returns descriptive errors from all methods instead.

The e2e test at `tests/scripts/keadm_e2e.sh:60` was already updated to use `--kubeedge-version` instead of `--profile version=`, removing that trigger, but the underlying code bugs remained.

**Which issue(s) this PR fixes:**
Fixes #5003

**Special notes for your reviewer:**
The `unsupportedOSType` struct implements all 7 methods of the `OSTypeInstaller` interface, each returning an appropriate error. This ensures no nil interface dereferences can occur on unsupported platforms.

**Does this PR introduce a user-facing change?**
```release-note
Fixed segmentation fault in keadm init/install on unsupported OS or when K8s REST client is unavailable
```