### PR TITLE
fix: prevent command injection via spec.image in NodeUpgradeJob

### DIFF
--- a/edge/pkg/taskmanager/actions/nodeupgradejob.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -241,15 +241,26 @@ func (h *nodeUpgradeJobActionHandler) upgrade(
 		resp.interrupt = true // No upgrade yet, no need to roll back.
 		return resp
 	}
-	var cmdline strings.Builder
-	cmdline.WriteString("keadm upgrade edge --force --toVersion " + spec.Version)
+	args := []string{"upgrade", "edge", "--force", "--toVersion", spec.Version}
 	if spec.Image != "" {
-		cmdline.WriteString(" --image " + spec.Image)
+		args = append(args, "--image", spec.Image)
 	}
-	cmdline.WriteString(" >> /tmp/keadm.log 2>&1")
-	cmd := execs.NewCommand(cmdline.String())
-	h.logger.V(2).Info("run upgrade cmd", "cmd", cmdline.String())
-	resp.err = cmd.Exec()
+	cmd := execs.NewCommandDirect("keadm", args...)
+	h.logger.V(2).Info("run upgrade cmd", "cmd", cmd.GetCommand())
+	// Write output to log file to avoid SIGPIPE when edgecore is killed during upgrade.
+	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		resp.err = fmt.Errorf("failed to open keadm log file: %v", err)
+		return resp
+	}
+	defer logFile.Close()
+	cmd.Cmd.Stdout = logFile
+	cmd.Cmd.Stderr = logFile
+	if err := cmd.Cmd.Start(); err != nil {
+		resp.err = fmt.Errorf("failed to start upgrade command: %v", err)
+		return resp
+	}
+	resp.err = cmd.Cmd.Wait()
 	return resp
 }
 

--- a/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
@@ -19,6 +19,8 @@ package actions
 import (
 	"context"
 	"errors"
+	"os"
+	"os/exec"
 	"reflect"
 	"testing"
 
@@ -275,9 +277,17 @@ func TestNodeUpgradeJobUpgrade(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		patches.ApplyMethod(reflect.TypeOf((*execs.Command)(nil)), "Exec",
-			func(cmd *execs.Command) error {
-				assert.Equal(t, "bash -c keadm upgrade edge --force --toVersion 1.21.0 >> /tmp/keadm.log 2>&1", cmd.GetCommand())
+		patches.ApplyFunc(os.OpenFile, func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			assert.Equal(t, "/tmp/keadm.log", name)
+			return os.NewFile(uintptr(0), name), nil
+		})
+		patches.ApplyMethod(reflect.TypeOf((*exec.Cmd)(nil)), "Start",
+			func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"keadm", "upgrade", "edge", "--force", "--toVersion", "1.21.0"}, cmd.Args)
+				return nil
+			})
+		patches.ApplyMethod(reflect.TypeOf((*exec.Cmd)(nil)), "Wait",
+			func(cmd *exec.Cmd) error {
 				return nil
 			})
 
@@ -292,9 +302,16 @@ func TestNodeUpgradeJobUpgrade(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		patches.ApplyMethod(reflect.TypeOf((*execs.Command)(nil)), "Exec",
-			func(cmd *execs.Command) error {
-				assert.Equal(t, "bash -c keadm upgrade edge --force --toVersion 1.21.0 --image custom.com/kubeedge/installation-package >> /tmp/keadm.log 2>&1", cmd.GetCommand())
+		patches.ApplyFunc(os.OpenFile, func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			return os.NewFile(uintptr(0), name), nil
+		})
+		patches.ApplyMethod(reflect.TypeOf((*exec.Cmd)(nil)), "Start",
+			func(cmd *exec.Cmd) error {
+				assert.Equal(t, []string{"keadm", "upgrade", "edge", "--force", "--toVersion", "1.21.0", "--image", "custom.com/kubeedge/installation-package"}, cmd.Args)
+				return nil
+			})
+		patches.ApplyMethod(reflect.TypeOf((*exec.Cmd)(nil)), "Wait",
+			func(cmd *exec.Cmd) error {
 				return nil
 			})
 

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -191,16 +192,25 @@ func upgrade(taskReq types.NodeTaskRequest) (event fsm.Event) {
 
 func keadmUpgrade(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) error {
 	klog.Infof("Begin to run upgrade command")
-	upgradeCmd := fmt.Sprintf("keadm upgrade edge --upgradeID %s --historyID %s --fromVersion %s --toVersion %s --config %s --image %s > /tmp/keadm.log 2>&1",
-		upgradeReq.UpgradeID, upgradeReq.HistoryID, version.Get(), upgradeReq.Version, opts.ConfigFile, upgradeReq.Image)
-
-	// run upgrade cmd to upgrade edge node
-	// use nohup command to start a child progress
-	command := fmt.Sprintf("nohup %s &", upgradeCmd)
-	cmd := exec.Command("bash", "-c", command)
-	s, err := cmd.CombinedOutput()
+	args := []string{
+		"upgrade", "edge",
+		"--upgradeID", upgradeReq.UpgradeID,
+		"--historyID", upgradeReq.HistoryID,
+		"--fromVersion", version.Get().String(),
+		"--toVersion", upgradeReq.Version,
+		"--config", opts.ConfigFile,
+		"--image", upgradeReq.Image,
+	}
+	cmd := exec.Command("keadm", args...)
+	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		return fmt.Errorf("run upgrade command %s failed: %v, %s", command, err, s)
+		return fmt.Errorf("failed to open keadm log file: %v", err)
+	}
+	defer logFile.Close()
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("run upgrade command failed: %v", err)
 	}
 	klog.Infof("!!! Finish upgrade from Version %s to %s ...", version.Get(), upgradeReq.Version)
 	return nil

--- a/pkg/util/execs/exec.go
+++ b/pkg/util/execs/exec.go
@@ -16,6 +16,14 @@ type Command struct {
 	ExitCode int
 }
 
+// NewCommandDirect creates a Command that executes the given binary directly
+// without wrapping in a shell.
+func NewCommandDirect(name string, args ...string) *Command {
+	return &Command{
+		Cmd: exec.Command(name, args...),
+	}
+}
+
 // Exec run command and exit formatted error, callers can print err directly
 // Any running error or non-zero exitcode is consider as error
 func (cmd *Command) Exec() error {

--- a/pkg/util/execs/exec_test.go
+++ b/pkg/util/execs/exec_test.go
@@ -165,6 +165,23 @@ func TestGetCommand(t *testing.T) {
 	}
 }
 
+func TestNewCommandDirect(t *testing.T) {
+	cmd := NewCommandDirect("echo", "hello", "world")
+	got := cmd.GetCommand()
+	want := "echo hello world"
+	if got != want {
+		t.Errorf("GetCommand() = %q, want %q", got, want)
+	}
+
+	err := cmd.Exec()
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if string(cmd.StdOut) != "hello world\n" {
+		t.Errorf("unexpected output: %q", string(cmd.StdOut))
+	}
+}
+
 // TestExec_ExitError_StderrNonEmpty covers the *exec.ExitError branch where
 // StdErr is non-empty and is used as the error message (not StdOut).
 func TestExec_ExitError_StderrNonEmpty(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Fixes command injection in `NodeUpgradeJob` where `spec.image` was concatenated directly into a `bash -c` command string on edge nodes.

Both the v1alpha2 (`nodeupgradejob.go`) and v1alpha1 (`node_upgrade.go`) upgrade handlers built a shell command by string concatenation and passed it to `exec.Command("bash", "-c", ...)`. Since `spec.image` has no validation in the admission webhook or CRD schema, shell metacharacters in the image field would be interpreted.

## Changes

- Added `NewCommandDirect(name, args...)` to the `execs` package (creates commands without shell wrapping).
- **v1alpha2**: `upgrade()` now uses `NewCommandDirect("keadm", args...)` with direct arg passing. Stdout/stderr redirect to `/tmp/keadm.log` via `os.OpenFile` (needed to avoid SIGPIPE when edgecore is killed during upgrade).
- **v1alpha1**: `keadmUpgrade()` now uses `exec.Command("keadm", args...)` with `cmd.Start()` instead of `nohup bash -c`.
- Updated tests accordingly.

## Which issue this PR fixes

Fixes #6909 