### PR TITLE
Sanitize SQL identifiers in mapper-framework database templates

### DIFF
--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/mysql/client.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/mysql/client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -32,6 +33,24 @@ import (
 var (
 	DB *sql.DB
 )
+
+// identifierRegexp defines allowed characters in SQL identifiers to prevent
+// SQL injection when table names are derived from user-controlled data such
+// as device names, namespaces, and property names.
+var identifierRegexp = regexp.MustCompile(`^[a-zA-Z0-9_\-/.]+$`)
+
+// sanitizeIdentifier validates that a SQL identifier (table name, column name)
+// contains only safe characters. This prevents SQL injection when identifiers
+// are constructed from user-controlled input.
+func sanitizeIdentifier(name string) error {
+	if name == "" {
+		return fmt.Errorf("identifier must not be empty")
+	}
+	if !identifierRegexp.MatchString(name) {
+		return fmt.Errorf("identifier %q contains invalid characters, only alphanumeric characters, underscores, hyphens, dots, and slashes are allowed", name)
+	}
+	return nil
+}
 
 type DataBaseConfig struct {
 	MySQLClientConfig *MySQLClientConfig `json:"mysqlClientConfig"`
@@ -78,17 +97,20 @@ func (d *DataBaseConfig) CloseSession() {
 
 func (d *DataBaseConfig) AddData(data *common.DataModel) error {
 	tableName := data.Namespace + "/" + data.DeviceName + "/" + data.PropertyName
+	if err := sanitizeIdentifier(tableName); err != nil {
+		return fmt.Errorf("invalid table name: %v", err)
+	}
 	datatime := time.Unix(data.TimeStamp/1e3, 0).Format("2006-01-02 15:04:05")
 
 	createTable := fmt.Sprintf("CREATE TABLE IF NOT EXISTS `%s` (id INT AUTO_INCREMENT PRIMARY KEY, ts  DATETIME NOT NULL,field TEXT)", tableName)
 	_, err := DB.Exec(createTable)
 	if err != nil {
-		return fmt.Errorf("create table into mysql failed with err:%v", err)
+		return fmt.Errorf("create table in mysql failed with err:%v", err)
 	}
 
 	stmt, err := DB.Prepare(fmt.Sprintf("INSERT INTO `%s` (ts,field) VALUES (?,?)", tableName))
 	if err != nil {
-		return fmt.Errorf("prepare parament failed with err:%v", err)
+		return fmt.Errorf("prepare statement failed with err:%v", err)
 	}
 	defer func(stmt *sql.Stmt) {
 		err := stmt.Close()
@@ -98,7 +120,7 @@ func (d *DataBaseConfig) AddData(data *common.DataModel) error {
 	}(stmt)
 	_, err = stmt.Exec(datatime, data.Value)
 	if err != nil {
-		return fmt.Errorf("insert data into msyql failed with err:%v", err)
+		return fmt.Errorf("insert data into mysql failed with err:%v", err)
 	}
 
 	return nil

--- a/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/tdengine/client.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/_template/mapper/data/dbmethod/tdengine/client.go
@@ -1,4 +1,4 @@
-﻿package tdengine
+package tdengine
 
 import (
 	"database/sql"
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +19,24 @@ import (
 var (
 	DB *sql.DB
 )
+
+// identifierRegexp defines allowed characters in SQL identifiers to prevent
+// SQL injection when table names are derived from user-controlled data such
+// as device names, namespaces, and property names.
+var identifierRegexp = regexp.MustCompile(`^[a-zA-Z0-9_\-/.]+$`)
+
+// sanitizeIdentifier validates that a SQL identifier (table name, column name)
+// contains only safe characters. This prevents SQL injection when identifiers
+// are constructed from user-controlled input.
+func sanitizeIdentifier(name string) error {
+	if name == "" {
+		return fmt.Errorf("identifier must not be empty")
+	}
+	if !identifierRegexp.MatchString(name) {
+		return fmt.Errorf("identifier %q contains invalid characters, only alphanumeric characters, underscores, hyphens, dots, and slashes are allowed", name)
+	}
+	return nil
+}
 
 type DataBaseConfig struct {
 	TDEngineClientConfig *TDEngineClientConfig `json:"config,omitempty"`
@@ -63,6 +82,13 @@ func (d *DataBaseConfig) AddData(data *common.DataModel) error {
 	legalTable := strings.Replace(tableName, "-", "_", -1)
 	legalTag := strings.Replace(data.PropertyName, "-", "_", -1)
 
+	if err := sanitizeIdentifier(legalTable); err != nil {
+		return fmt.Errorf("invalid table name: %v", err)
+	}
+	if err := sanitizeIdentifier(legalTag); err != nil {
+		return fmt.Errorf("invalid tag name: %v", err)
+	}
+
 	stableName := fmt.Sprintf("SHOW STABLES LIKE '%s'", legalTable)
 	stable := fmt.Sprintf("CREATE STABLE %s (ts timestamp, deviceid binary(64), propertyname binary(64), data binary(64),type binary(64)) TAGS (location binary(64));", legalTable)
 
@@ -99,6 +125,9 @@ func (d *DataBaseConfig) AddData(data *common.DataModel) error {
 	return nil
 }
 func (d *DataBaseConfig) GetDataByDeviceID(deviceID string) ([]*common.DataModel, error) {
+	if err := sanitizeIdentifier(deviceID); err != nil {
+		return nil, fmt.Errorf("invalid device ID for table name: %v", err)
+	}
 	querySql := fmt.Sprintf("SELECT ts, deviceid, propertyname, data, type FROM %s", deviceID)
 	rows, err := DB.Query(querySql)
 	if err != nil {
@@ -127,11 +156,14 @@ func (d *DataBaseConfig) GetPropertyDataByDeviceID(deviceID string, propertyData
 func (d *DataBaseConfig) GetDataByTimeRange(deviceID string, start int64, end int64) ([]*common.DataModel, error) {
 
 	legalTable := strings.Replace(deviceID, "-", "_", -1)
+	if err := sanitizeIdentifier(legalTable); err != nil {
+		return nil, fmt.Errorf("invalid device ID for table name: %v", err)
+	}
 	startTime := time.Unix(start, 0).UTC().Format("2006-01-02 15:04:05")
 	endTime := time.Unix(end, 0).UTC().Format("2006-01-02 15:04:05")
 	//Query data within a specified time range
 	querySQL := fmt.Sprintf("SELECT ts, deviceid, propertyname, data, type FROM %s WHERE ts >= '%s' AND ts <= '%s'", legalTable, startTime, endTime)
-	fmt.Println(querySQL)
+	klog.V(4).Infof("query SQL: %s", querySQL)
 	rows, err := DB.Query(querySQL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
This PR adds input validation to the MySQL and TDEngine database clients in the mapper-framework templates. 

Previously, these templates constructed SQL table names and identifiers by directly interpolating device and property names using `fmt.Sprintf`. While these fields are generally populated via CRDs, leaving this pattern in template code could encourage downstream developers to build mappers susceptible to SQL injection.

A `sanitizeIdentifier` function is introduced to validate that any user-derived identifier contains only safe characters (alphanumeric, underscores, hyphens, dots, and slashes) before it is used in a SQL query.

This PR also corrects minor typos in error messages (`msyql`, `parament`) and replaces a debug `fmt.Println` with `klog.V(4).Infof` in the TDEngine client.

### Which issue(s) this PR fixes:
Fixes #6918

### Special notes for your reviewer:
This only touches the `staging/src/github.com/kubeedge/mapper-framework/_template` directory.

### Does this PR introduce a user-facing change?
```release-note
Sanitize SQL identifiers in mapper-framework database templates to prevent SQL injection patterns.
```
