### PR TITLE
hack: redirect git tag warnings to stderr

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -59,10 +59,10 @@ kubeedge::version::get_version_info() {
 
   GIT_VERSION=$(git describe --tags --abbrev=14 "${GIT_COMMIT}^{commit}" 2>/dev/null)
   if [[ -z "${GIT_VERSION}" ]]; then
-    echo 
-    echo "⚠️  No git tags found."
-    echo "⚠️  Falling back to default version: v0.0.0"
-    echo "⚠️  To avoid this, consider running: git fetch --tags"
+    echo >&2
+    echo "⚠️  No git tags found." >&2
+    echo "⚠️  Falling back to default version: v0.0.0" >&2
+    echo "⚠️  To avoid this, consider running: git fetch --tags" >&2
 
     GIT_VERSION="v0.0.0"
   fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


****What this PR does / why we need it**:**

When building KubeEdge locally (e.g., using `make all`) in a repository without local git tags (such as a shallow clone), the build script (`hack/lib/golang.sh`) outputs a warning message `"⚠️ No git tags found."` to `stdout`. 

Because it is sent to `stdout`, this warning gets captured by the `$(kubeedge::version::ldflags)` execution and injected directly into the `GOLDFLAGS` variable. This causes the Go compiler to crash with malformed linker arguments. 
This PR redirects these git tag warning messages to `stderr` (`>&2`), ensuring they do not get captured by the linker flags variable and allowing the build to gracefully fall back to `v0.0.0` without crashing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6924 

**Special notes for your reviewer**:

This is a straightforward bash redirection fix that ensures warning outputs don't pollute the variable captures.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

NONE

