### PR TITLE
fix(devicetwin): make metadata unmarshal failures explicit

### DIFF
--- a/edge/pkg/devicetwin/dttype/types_helper.go
+++ b/edge/pkg/devicetwin/dttype/types_helper.go
@@ -74,10 +74,10 @@ func DeviceTwinToMsgTwin(deviceTwins []models.DeviceTwin) map[string]*MsgTwin {
 			expectedValue := &TwinValue{Value: &expected}
 			if twin.ExpectedMeta != "" {
 				if err := json.Unmarshal([]byte(twin.ExpectedMeta), &expectedMeta); err != nil {
-					// TODO: handle error
-					klog.Error(err)
+					klog.Warningf("skip invalid ExpectedMeta for twin %q: %v", twin.Name, err)
+				} else {
+					expectedValue.Metadata = &expectedMeta
 				}
-				expectedValue.Metadata = &expectedMeta
 			}
 			msgTwin.Expected = expectedValue
 		}
@@ -85,27 +85,27 @@ func DeviceTwinToMsgTwin(deviceTwins []models.DeviceTwin) map[string]*MsgTwin {
 			actualValue := &TwinValue{Value: &actual}
 			if twin.ActualMeta != "" {
 				if err := json.Unmarshal([]byte(twin.ActualMeta), &actualMeta); err != nil {
-					// TODO: handle error
-					klog.Error(err)
+					klog.Warningf("skip invalid ActualMeta for twin %q: %v", twin.Name, err)
+				} else {
+					actualValue.Metadata = &actualMeta
 				}
-				actualValue.Metadata = &actualMeta
 			}
 			msgTwin.Actual = actualValue
 		}
 
 		if twin.ExpectedVersion != "" {
 			if err := json.Unmarshal([]byte(twin.ExpectedVersion), &expectedVersion); err != nil {
-				// TODO: handle error
-				klog.Error(err)
+				klog.Warningf("skip invalid ExpectedVersion for twin %q: %v", twin.Name, err)
+			} else {
+				msgTwin.ExpectedVersion = &expectedVersion
 			}
-			msgTwin.ExpectedVersion = &expectedVersion
 		}
 		if twin.ActualVersion != "" {
 			if err := json.Unmarshal([]byte(twin.ActualVersion), &actualVersion); err != nil {
-				// TODO: handle error
-				klog.Error(err)
+				klog.Warningf("skip invalid ActualVersion for twin %q: %v", twin.Name, err)
+			} else {
+				msgTwin.ActualVersion = &actualVersion
 			}
-			msgTwin.ActualVersion = &actualVersion
 		}
 		msgTwins[twin.Name] = msgTwin
 	}

--- a/edge/pkg/devicetwin/dttype/types_helper_test.go
+++ b/edge/pkg/devicetwin/dttype/types_helper_test.go
@@ -277,6 +277,108 @@ func TestDeviceTwinToMsgTwin(t *testing.T) {
 	}
 }
 
+func TestDeviceTwinToMsgTwinMetadataUnmarshal(t *testing.T) {
+	validTwin := models.DeviceTwin{
+		Name:            "SensorTag",
+		Expected:        "ON",
+		Actual:          "ON",
+		ExpectedVersion: `{"cloud": 10, "edge": 11}`,
+		ActualVersion:   `{"cloud": 12, "edge": 13}`,
+		Optional:        true,
+		ExpectedMeta:    `{"timestamp": 100}`,
+		ActualMeta:      `{"timestamp": 200}`,
+		AttrType:        "Temperature",
+	}
+
+	tests := []struct {
+		name  string
+		twin  models.DeviceTwin
+		check func(*testing.T, *MsgTwin)
+	}{
+		{
+			name: "valid metadata still works",
+			twin: validTwin,
+			check: func(t *testing.T, twin *MsgTwin) {
+				assert.Equal(t, int64(100), twin.Expected.Metadata.Timestamp)
+				assert.Equal(t, int64(200), twin.Actual.Metadata.Timestamp)
+				assert.Equal(t, TwinVersion{CloudVersion: 10, EdgeVersion: 11}, *twin.ExpectedVersion)
+				assert.Equal(t, TwinVersion{CloudVersion: 12, EdgeVersion: 13}, *twin.ActualVersion)
+			},
+		},
+		{
+			name: "invalid ExpectedMeta remains nil",
+			twin: func() models.DeviceTwin {
+				twin := validTwin
+				twin.ExpectedMeta = "{"
+				return twin
+			}(),
+			check: func(t *testing.T, twin *MsgTwin) {
+				assert.Nil(t, twin.Expected.Metadata)
+				assert.NotNil(t, twin.Actual.Metadata)
+				assert.NotNil(t, twin.ExpectedVersion)
+				assert.NotNil(t, twin.ActualVersion)
+			},
+		},
+		{
+			name: "invalid ActualMeta remains nil",
+			twin: func() models.DeviceTwin {
+				twin := validTwin
+				twin.ActualMeta = "{"
+				return twin
+			}(),
+			check: func(t *testing.T, twin *MsgTwin) {
+				assert.NotNil(t, twin.Expected.Metadata)
+				assert.Nil(t, twin.Actual.Metadata)
+				assert.NotNil(t, twin.ExpectedVersion)
+				assert.NotNil(t, twin.ActualVersion)
+			},
+		},
+		{
+			name: "invalid ExpectedVersion remains nil",
+			twin: func() models.DeviceTwin {
+				twin := validTwin
+				twin.ExpectedVersion = "{"
+				return twin
+			}(),
+			check: func(t *testing.T, twin *MsgTwin) {
+				assert.NotNil(t, twin.Expected.Metadata)
+				assert.NotNil(t, twin.Actual.Metadata)
+				assert.Nil(t, twin.ExpectedVersion)
+				assert.NotNil(t, twin.ActualVersion)
+			},
+		},
+		{
+			name: "invalid ActualVersion remains nil",
+			twin: func() models.DeviceTwin {
+				twin := validTwin
+				twin.ActualVersion = "{"
+				return twin
+			}(),
+			check: func(t *testing.T, twin *MsgTwin) {
+				assert.NotNil(t, twin.Expected.Metadata)
+				assert.NotNil(t, twin.Actual.Metadata)
+				assert.NotNil(t, twin.ExpectedVersion)
+				assert.Nil(t, twin.ActualVersion)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got map[string]*MsgTwin
+			assert.NotPanics(t, func() {
+				got = DeviceTwinToMsgTwin([]models.DeviceTwin{tt.twin})
+			})
+
+			twin := got[tt.twin.Name]
+			if !assert.NotNil(t, twin) || !assert.NotNil(t, twin.Expected) || !assert.NotNil(t, twin.Actual) {
+				return
+			}
+			tt.check(t, twin)
+		})
+	}
+}
+
 // TestMsgAttrToDeviceAttr is function to test MsgAttrToDeviceAttr().
 func TestMsgAttrToDeviceAttr(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

---

**What this PR does / why we need it**:

`DeviceTwinToMsgTwin` currently logs JSON unmarshal failures for metadata/version fields but still assigns zero-value metadata structures implicitly.

This PR makes the behavior explicit and more reliable by:

* logging metadata/version unmarshal failures with warnings
* skipping assignment of invalid metadata/version values
* preserving existing graceful degradation behavior
* adding unit tests covering invalid metadata/version scenarios

Valid metadata behavior remains unchanged.

---

**Which issue(s) this PR fixes**:

Fixes #6923 

---

**Special notes for your reviewer**:

* This change intentionally avoids returning errors to prevent interrupting device synchronization flows.
* Invalid metadata/version JSON is treated as non-fatal and skipped.
* Added tests for:

  * valid metadata
  * invalid ExpectedMeta
  * invalid ActualMeta
  * invalid ExpectedVersion
  * invalid ActualVersion

Verification:

```bash
go test ./edge/pkg/devicetwin/dttype -v
```

---

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
