### PR TITLE
test: add unit tests for extsystem_unix

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/extsystem/extsystem_unix.go
+++ b/keadm/cmd/keadm/app/cmd/util/extsystem/extsystem_unix.go
@@ -56,7 +56,7 @@ type SystemdExtSystem struct {
 	initsystem.SystemdInitSystem
 }
 
-const (
+var (
 	systemdDir = "/etc/systemd/system"
 )
 

--- a/keadm/cmd/keadm/app/cmd/util/extsystem/extsystem_unix_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/extsystem/extsystem_unix_test.go
@@ -1,0 +1,107 @@
+//go:build !windows
+
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extsystem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSystemdExtSystem_ServiceCreateAndRemove(t *testing.T) {
+	// Create a temporary directory to act as systemdDir
+	tmpDir := t.TempDir()
+	
+	// Backup the original systemdDir and restore after test
+	originalSystemdDir := systemdDir
+	systemdDir = tmpDir
+	defer func() {
+		systemdDir = originalSystemdDir
+	}()
+
+	sysd := SystemdExtSystem{}
+	serviceName := "testservice"
+	binPath := "/usr/local/bin/testbin"
+	args := []string{"--arg1", "val1"}
+	envs := map[string]string{
+		"ENV_VAR_1": "value1",
+		"ENV_VAR_2": "value2",
+	}
+
+	// Test ServiceCreate
+	err := sysd.ServiceCreate(serviceName, binPath, args, envs)
+	if err != nil {
+		t.Fatalf("failed to create systemd service: %v", err)
+	}
+
+	expectedFilePath := filepath.Join(tmpDir, serviceName+".service")
+	if _, err := os.Stat(expectedFilePath); os.IsNotExist(err) {
+		t.Fatalf("expected service file to be created at %s, but it does not exist", expectedFilePath)
+	}
+
+	// Read and verify file contents
+	contentBytes, err := os.ReadFile(expectedFilePath)
+	if err != nil {
+		t.Fatalf("failed to read service file: %v", err)
+	}
+	content := string(contentBytes)
+
+	// Verify content contains expected binary path and arguments
+	if !strings.Contains(content, "ExecStart=/usr/local/bin/testbin --arg1 val1") {
+		t.Errorf("service file content does not contain expected ExecStart: %s", content)
+	}
+
+	// Verify content contains environment variables
+	if !strings.Contains(content, "Environment=") {
+		t.Errorf("service file content does not contain Environment section: %s", content)
+	}
+	if !strings.Contains(content, "ENV_VAR_1=value1") {
+		t.Errorf("service file content does not contain ENV_VAR_1: %s", content)
+	}
+	if !strings.Contains(content, "ENV_VAR_2=value2") {
+		t.Errorf("service file content does not contain ENV_VAR_2: %s", content)
+	}
+
+	// Test ServiceRemove
+	err = sysd.ServiceRemove(serviceName)
+	if err != nil {
+		t.Fatalf("failed to remove systemd service: %v", err)
+	}
+
+	if _, err := os.Stat(expectedFilePath); !os.IsNotExist(err) {
+		t.Errorf("expected service file to be removed at %s, but it still exists", expectedFilePath)
+	}
+}
+
+func TestOpenRCExtSystem_ServiceCreateAndRemove(t *testing.T) {
+	openrc := OpenRCExtSystem{}
+	
+	// ServiceCreate and ServiceRemove are currently stubs for OpenRC,
+	// verifying that calling them doesn't panic and returns nil.
+	err := openrc.ServiceCreate("testservice", "/usr/local/bin/testbin", nil, nil)
+	if err != nil {
+		t.Errorf("expected ServiceCreate to return nil, got: %v", err)
+	}
+
+	err = openrc.ServiceRemove("testservice")
+	if err != nil {
+		t.Errorf("expected ServiceRemove to return nil, got: %v", err)
+	}
+}


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup
/kind testing

### What this PR does / why we need it:
This PR improves the unit test coverage for the `keadm` utility. Currently, the `extsystem` package, which is responsible for managing system service files, lacks test coverage. To make the code testable, I changed the `systemdDir` constant in `extsystem_unix.go` to a package-level variable. This refactor enables unit tests to point the path to a temporary directory using `t.TempDir()`, preventing permission-denied errors when running tests locally or in CI since we no longer write to the root `/etc/systemd/system` folder. I then added unit tests in `extsystem_unix_test.go` to verify that creating and removing service files works correctly.

### Which issue(s) this PR fixes:
This is a proactive improvement to test coverage, so there is no pre-existing issue associated with it.

### Fixes #
None.

### Special notes for your reviewer:
The tests have been written to run in isolation using mock directories so they do not impact any host configuration files during execution.

### Does this PR introduce a user-facing change?:
No, this change only affects internal testing infrastructure and does not modify any user-facing APIs or command-line behavior.