### PR TITLE
pkg/util: fix typo in GetLocalIP comment

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -38,7 +38,7 @@ func GetLocalIP(hostName string) (string, error) {
 
 	// fix https://github.com/kubeedge/kubeedge/issues/6023
 	// LookupIP maybe get docker0 ip's or other cni ip's
-	// maybe get default route interface ip's can be safter
+	// Using the IP of the default-route interface may be safer.
 	// if get default ip fails then should use LookupIP
 	// ignore when ChooseHostInterface fails
 	ipAddr, err = utilnet.ChooseHostInterface()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fixes a typo in the comment inside `GetLocalIP` function in `pkg/util/util.go`.

`safter` → `safer`

**Which issue(s) this PR fixes**:

Fixes #6930

**Special notes for your reviewer**:

One-line comment typo fix, no logic change.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
