### PR TITLE
Fix metaserver readyz authentication for discovery paths

### DIFF
--- a/edge/pkg/metamanager/metaserver/server.go
+++ b/edge/pkg/metamanager/metaserver/server.go
@@ -84,6 +84,21 @@ func (a *AlwaysAllowDiscoveryAuthorizer) Authorize(ctx context.Context, attrs au
 	return authorizer.DecisionNoOpinion, "", nil
 }
 
+// NewDiscoverySafeAuthenticator creates a custom authenticator that ignores errors for discovery paths
+// so they can fall back to the anonymous authenticator instead of failing immediately.
+func NewDiscoverySafeAuthenticator(delegate authenticator.Request) authenticator.Request {
+	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		if req == nil || req.URL == nil {
+			return nil, false, nil
+		}
+		resp, ok, err := delegate.AuthenticateRequest(req)
+		if err != nil && passthrough.IsPassThroughPath(req.URL.Path, strings.ToLower(req.Method)) {
+			return nil, false, nil
+		}
+		return resp, ok, err
+	})
+}
+
 func buildAuth() *metaServerAuth {
 	newAuthorizer := rbac.New(
 		&client.RoleGetter{},
@@ -105,18 +120,7 @@ func buildAuth() *metaServerAuth {
 		auth.NewValidator(client.NewGetterFromClient(kubeclientbridge.NewSimpleClientset(client.New()))))
 	bearerTokenAuthenticator := bearertoken.New(tokenAuthenticator)
 
-	// Create a custom authenticator that ignores errors for discovery paths
-	// so they can fall back to the anonymous authenticator instead of failing immediately.
-	discoverySafeAuthenticator := authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
-		if req == nil || req.URL == nil {
-			return nil, false, nil
-		}
-		resp, ok, err := bearerTokenAuthenticator.AuthenticateRequest(req)
-		if err != nil && passthrough.IsPassThroughPath(req.URL.Path, strings.ToLower(req.Method)) {
-			return nil, false, nil
-		}
-		return resp, ok, err
-	})
+	discoverySafeAuthenticator := NewDiscoverySafeAuthenticator(bearerTokenAuthenticator)
 
 	// Use union authenticator with anonymous fallback for discovery paths
 	// This follows Kubernetes API Server's standard approach for anonymous access

--- a/edge/pkg/metamanager/metaserver/server.go
+++ b/edge/pkg/metamanager/metaserver/server.go
@@ -108,6 +108,9 @@ func buildAuth() *metaServerAuth {
 	// Create a custom authenticator that ignores errors for discovery paths
 	// so they can fall back to the anonymous authenticator instead of failing immediately.
 	discoverySafeAuthenticator := authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		if req == nil || req.URL == nil {
+			return nil, false, nil
+		}
 		resp, ok, err := bearerTokenAuthenticator.AuthenticateRequest(req)
 		if err != nil && passthrough.IsPassThroughPath(req.URL.Path, strings.ToLower(req.Method)) {
 			return nil, false, nil

--- a/edge/pkg/metamanager/metaserver/server.go
+++ b/edge/pkg/metamanager/metaserver/server.go
@@ -84,9 +84,9 @@ func (a *AlwaysAllowDiscoveryAuthorizer) Authorize(ctx context.Context, attrs au
 	return authorizer.DecisionNoOpinion, "", nil
 }
 
-// NewDiscoverySafeAuthenticator creates a custom authenticator that ignores errors for discovery paths
+// newDiscoverySafeAuthenticator creates a custom authenticator that ignores errors for discovery paths
 // so they can fall back to the anonymous authenticator instead of failing immediately.
-func NewDiscoverySafeAuthenticator(delegate authenticator.Request) authenticator.Request {
+func newDiscoverySafeAuthenticator(delegate authenticator.Request) authenticator.Request {
 	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
 		if req == nil || req.URL == nil {
 			return nil, false, nil
@@ -120,7 +120,7 @@ func buildAuth() *metaServerAuth {
 		auth.NewValidator(client.NewGetterFromClient(kubeclientbridge.NewSimpleClientset(client.New()))))
 	bearerTokenAuthenticator := bearertoken.New(tokenAuthenticator)
 
-	discoverySafeAuthenticator := NewDiscoverySafeAuthenticator(bearerTokenAuthenticator)
+	discoverySafeAuthenticator := newDiscoverySafeAuthenticator(bearerTokenAuthenticator)
 
 	// Use union authenticator with anonymous fallback for discovery paths
 	// This follows Kubernetes API Server's standard approach for anonymous access

--- a/edge/pkg/metamanager/metaserver/server.go
+++ b/edge/pkg/metamanager/metaserver/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -104,10 +105,20 @@ func buildAuth() *metaServerAuth {
 		auth.NewValidator(client.NewGetterFromClient(kubeclientbridge.NewSimpleClientset(client.New()))))
 	bearerTokenAuthenticator := bearertoken.New(tokenAuthenticator)
 
+	// Create a custom authenticator that ignores errors for discovery paths
+	// so they can fall back to the anonymous authenticator instead of failing immediately.
+	discoverySafeAuthenticator := authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		resp, ok, err := bearerTokenAuthenticator.AuthenticateRequest(req)
+		if err != nil && passthrough.IsPassThroughPath(req.URL.Path, strings.ToLower(req.Method)) {
+			return nil, false, nil
+		}
+		return resp, ok, err
+	})
+
 	// Use union authenticator with anonymous fallback for discovery paths
 	// This follows Kubernetes API Server's standard approach for anonymous access
 	anonymousAuthenticator := anonymous.NewAuthenticator(nil)
-	newAuthenticator := authnunion.NewFailOnError(bearerTokenAuthenticator, anonymousAuthenticator)
+	newAuthenticator := authnunion.NewFailOnError(discoverySafeAuthenticator, anonymousAuthenticator)
 
 	// Use union authorizer with discovery paths allowed first, then RBAC
 	discoveryAuthorizer := &AlwaysAllowDiscoveryAuthorizer{}

--- a/edge/pkg/metamanager/metaserver/server_test.go
+++ b/edge/pkg/metamanager/metaserver/server_test.go
@@ -1,0 +1,78 @@
+package metaserver
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+// mockAuthenticator always returns the configured response and error.
+type mockAuthenticator struct {
+	resp *authenticator.Response
+	ok   bool
+	err  error
+}
+
+func (m *mockAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return m.resp, m.ok, m.err
+}
+
+func TestDiscoverySafeAuthenticator(t *testing.T) {
+	authErr := errors.New("token validation error")
+	delegate := &mockAuthenticator{
+		resp: nil,
+		ok:   false,
+		err:  authErr,
+	}
+
+	safeAuth := NewDiscoverySafeAuthenticator(delegate)
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantErr    bool
+	}{
+		{
+			name:       "a token validation error on GET /readyz falling back to anonymous authentication (error ignored)",
+			method:     http.MethodGet,
+			path:       "/readyz",
+			wantErr:    false,
+		},
+		{
+			name:       "the same error on a protected resource path still being returned",
+			method:     http.MethodGet,
+			path:       "/api/v1/pods",
+			wantErr:    true,
+		},
+		{
+			name:       "a non-GET request to a discovery path not bypassing the authentication error",
+			method:     http.MethodPost,
+			path:       "/readyz",
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &http.Request{
+				Method: tc.method,
+				URL: &url.URL{
+					Path: tc.path,
+				},
+			}
+
+			_, _, err := safeAuth.AuthenticateRequest(req)
+
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error %v, got nil", authErr)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected nil error, got %v", err)
+			}
+		})
+	}
+}

--- a/edge/pkg/metamanager/metaserver/server_test.go
+++ b/edge/pkg/metamanager/metaserver/server_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package metaserver
 
 import (
@@ -7,6 +23,7 @@ import (
 	"testing"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // mockAuthenticator always returns the configured response and error.
@@ -22,42 +39,72 @@ func (m *mockAuthenticator) AuthenticateRequest(req *http.Request) (*authenticat
 
 func TestDiscoverySafeAuthenticator(t *testing.T) {
 	authErr := errors.New("token validation error")
-	delegate := &mockAuthenticator{
-		resp: nil,
-		ok:   false,
-		err:  authErr,
-	}
 
-	safeAuth := NewDiscoverySafeAuthenticator(delegate)
+	successResp := &authenticator.Response{
+		User: &user.DefaultInfo{Name: "test-user"},
+	}
 
 	tests := []struct {
 		name       string
 		method     string
 		path       string
-		wantErr    bool
+		delegateOk bool
+		delegateErr error
+		wantResp   *authenticator.Response
+		wantOk     bool
+		wantErr    error
 	}{
 		{
-			name:       "a token validation error on GET /readyz falling back to anonymous authentication (error ignored)",
-			method:     http.MethodGet,
-			path:       "/readyz",
-			wantErr:    false,
+			name:        "a token validation error on GET /readyz falling back to anonymous authentication (error ignored)",
+			method:      http.MethodGet,
+			path:        "/readyz",
+			delegateOk:  false,
+			delegateErr: authErr,
+			wantResp:    nil,
+			wantOk:      false,
+			wantErr:     nil, // Error is bypassed
 		},
 		{
-			name:       "the same error on a protected resource path still being returned",
-			method:     http.MethodGet,
-			path:       "/api/v1/pods",
-			wantErr:    true,
+			name:        "the same error on a protected resource path still being returned",
+			method:      http.MethodGet,
+			path:        "/api/v1/pods",
+			delegateOk:  false,
+			delegateErr: authErr,
+			wantResp:    nil,
+			wantOk:      false,
+			wantErr:     authErr,
 		},
 		{
-			name:       "a non-GET request to a discovery path not bypassing the authentication error",
-			method:     http.MethodPost,
-			path:       "/readyz",
-			wantErr:    true,
+			name:        "a non-GET request to a discovery path not bypassing the authentication error",
+			method:      http.MethodPost,
+			path:        "/readyz",
+			delegateOk:  false,
+			delegateErr: authErr,
+			wantResp:    nil,
+			wantOk:      false,
+			wantErr:     authErr,
+		},
+		{
+			name:        "delegate success case confirms that resp, ok, and err are returned unchanged",
+			method:      http.MethodGet,
+			path:        "/readyz",
+			delegateOk:  true,
+			delegateErr: nil,
+			wantResp:    successResp,
+			wantOk:      true,
+			wantErr:     nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			delegate := &mockAuthenticator{
+				resp: tc.wantResp, // Only populated in the success case
+				ok:   tc.delegateOk,
+				err:  tc.delegateErr,
+			}
+			safeAuth := newDiscoverySafeAuthenticator(delegate)
+
 			req := &http.Request{
 				Method: tc.method,
 				URL: &url.URL{
@@ -65,13 +112,23 @@ func TestDiscoverySafeAuthenticator(t *testing.T) {
 				},
 			}
 
-			_, _, err := safeAuth.AuthenticateRequest(req)
+			resp, ok, err := safeAuth.AuthenticateRequest(req)
 
-			if tc.wantErr && err == nil {
-				t.Errorf("expected error %v, got nil", authErr)
+			if resp != tc.wantResp {
+				t.Errorf("expected resp %v, got %v", tc.wantResp, resp)
 			}
-			if !tc.wantErr && err != nil {
-				t.Errorf("expected nil error, got %v", err)
+			if ok != tc.wantOk {
+				t.Errorf("expected ok %v, got %v", tc.wantOk, ok)
+			}
+
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			} else {
+				if !errors.Is(err, tc.wantErr) {
+					t.Errorf("expected error %v, got %v", tc.wantErr, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
This PR fixes an issue where the `metaserver` incorrectly returns a `401 Unauthorised` error when a client requests a public discovery path (like /`readyz`) using a Bearer token that is not synced to the local edge node.

Previously, `authnunion. NewFailOnError` was used directly with the `BearerTokenAuthenticator`. If a token was provided but failed local validation (e.g., service account not found locally), the authenticator would return an error, causing `NewFailOnError` to immediately fail the entire request without falling back to the `AnonymousAuthenticator.`

This PR wraps the `BearerTokenAuthenticator `in a `discoverySafeAuthenticator.` If a token validation error occurs, it checks if the request is targeting a pass-through discovery path (`passthrough.IsPassThroughPath`). If it is, the error is safely ignored, allowing the request to gracefully fall back to the `AnonymousAuthenticator` and successfully pass through to the cloud API server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5961

**Special notes for your reviewer**:
This approach ensures that discovery paths can be accessed publicly just like native Kubernetes, while preserving strict authentication failures for protected resource paths.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix: Allow unauthenticated access to metaserver discovery paths like /readyz by ignoring local token validation errors
```
