### PR TITLE
pkg/security/certs: return error from ReadPEMFile when no PEM block is found

### DIFF
--- a/pkg/security/certs/io.go
+++ b/pkg/security/certs/io.go
@@ -28,6 +28,9 @@ func ReadPEMFile(file string) (*pem.Block, error) {
 		return nil, err
 	}
 	p, _ := pem.Decode(bff)
+	if p == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from file %s", file)
+	}
 	return p, nil
 }
 

--- a/pkg/security/certs/io_test.go
+++ b/pkg/security/certs/io_test.go
@@ -22,3 +22,20 @@ func TestReadWrite(t *testing.T) {
 		t.Fatalf("failed to clean testdata, err: %v", err)
 	}
 }
+
+func TestReadPEMFileNoBlock(t *testing.T) {
+	file := "./testdata/ca/invalid.crt"
+	if err := os.MkdirAll("./testdata/ca", 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("not a pem block"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadPEMFile(file); err == nil {
+		t.Fatal("expected error when file contains no PEM block, got nil")
+	}
+	// Clean
+	if err := os.RemoveAll("testdata"); err != nil {
+		t.Fatalf("failed to clean testdata, err: %v", err)
+	}
+}

--- a/pkg/security/certs/io_test.go
+++ b/pkg/security/certs/io_test.go
@@ -2,6 +2,7 @@ package certs
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -24,18 +25,11 @@ func TestReadWrite(t *testing.T) {
 }
 
 func TestReadPEMFileNoBlock(t *testing.T) {
-	file := "./testdata/ca/invalid.crt"
-	if err := os.MkdirAll("./testdata/ca", 0700); err != nil {
-		t.Fatal(err)
-	}
+	file := filepath.Join(t.TempDir(), "invalid.crt")
 	if err := os.WriteFile(file, []byte("not a pem block"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ReadPEMFile(file); err == nil {
 		t.Fatal("expected error when file contains no PEM block, got nil")
-	}
-	// Clean
-	if err := os.RemoveAll("testdata"); err != nil {
-		t.Fatalf("failed to clean testdata, err: %v", err)
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
`ReadPEMFile` returned `(nil, nil)` when `pem.Decode` found no PEM block, so cloudhub's `InitConfigure` panicked on `block.Bytes` for an empty/non PEM TLS file instead of taking its existing "failed to load" warning path. It now returns an error in that case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6933

**Special notes for your reviewer**:
Added `TestReadPEMFileNoBlock` , all four cloudhub callers already handle a non nil error, so no caller changes were needed.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
