### PR TITLE
servicebus: add unit tests to improve coverage

### DIFF
--- a/edge/pkg/servicebus/servicebus.go
+++ b/edge/pkg/servicebus/servicebus.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
 	servicebusConfig "github.com/kubeedge/kubeedge/edge/pkg/servicebus/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/servicebus/util"
 	"github.com/kubeedge/kubeedge/pkg/features"
@@ -56,6 +57,11 @@ type serverResponse struct {
 	Code int    `json:"code"`
 	Msg  string `json:"msg"`
 	Body string `json:"body"`
+}
+
+type basicHandlerDeps struct {
+	getURLByKey func(string) (*models.TargetUrls, error)
+	sendSync    func(string, beehiveModel.Message, time.Duration) (beehiveModel.Message, error)
 }
 
 var htc = new(http.Client)
@@ -250,8 +256,14 @@ func server(stopChan <-chan struct{}) {
 	klog.Infof("[servicebus]start to listen and server at %v", s.Addr)
 	utilruntime.HandleError(s.ListenAndServe())
 }
-
 func buildBasicHandler(timeout time.Duration) http.Handler {
+	return buildBasicHandlerWithDeps(timeout, basicHandlerDeps{
+		getURLByKey: dbclient.NewServiceBusService().GetUrlsByKey,
+		sendSync:    beehiveContext.SendSync,
+	})
+}
+
+func buildBasicHandlerWithDeps(timeout time.Duration, deps basicHandlerDeps) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		sReq := &serverRequest{}
 		sResp := &serverResponse{}
@@ -275,7 +287,7 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 			}
 			return
 		}
-		if targetURL, _ := dbclient.NewServiceBusService().GetUrlsByKey(sReq.TargetURL); targetURL == nil {
+		if targetURL, _ := deps.getURLByKey(sReq.TargetURL); targetURL == nil {
 			sResp.Code = http.StatusBadRequest
 			sResp.Msg = fmt.Sprintf("url %s is not allowed and please make a rule for this url in the cloud", sReq.TargetURL)
 			if _, err := w.Write(marshalResult(sResp)); err != nil {
@@ -286,7 +298,7 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 		}
 		msg := beehiveModel.NewMessage("").BuildRouter(modules.ServiceBusModuleName, modules.UserGroup,
 			sReq.TargetURL, beehiveModel.UploadOperation).FillBody(byteData)
-		responseMessage, err := beehiveContext.SendSync(modules.EdgeHubModuleName, *msg, timeout)
+		responseMessage, err := deps.sendSync(modules.EdgeHubModuleName, *msg, timeout)
 		if err != nil {
 			sResp.Code = http.StatusBadRequest
 			sResp.Msg = err.Error()

--- a/edge/pkg/servicebus/servicebus_test.go
+++ b/edge/pkg/servicebus/servicebus_test.go
@@ -283,7 +283,6 @@ func TestBuildBasicHandler_OversizedBody(t *testing.T) {
 	assert.Equal(t, "can't read data from body of the http's request", resp.Msg)
 }
 
-
 func TestBuildBasicHandler_UnregisteredURL(t *testing.T) {
 	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
 		getURLByKey: func(string) (*models.TargetUrls, error) {

--- a/edge/pkg/servicebus/servicebus_test.go
+++ b/edge/pkg/servicebus/servicebus_test.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicebus
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/beehive/pkg/core"
+
+	commonType "github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/pkg/features"
+)
+
+// TestNewServicebus tests the constructor for servicebus.
+func TestNewServicebus(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name    string
+		enable  bool
+		server  string
+		port    int
+		timeout int
+	}{
+		{
+			name:    "default values",
+			enable:  true,
+			server:  "127.0.0.1",
+			port:    9060,
+			timeout: 60,
+		},
+		{
+			name:    "disabled with custom server",
+			enable:  false,
+			server:  "0.0.0.0",
+			port:    8080,
+			timeout: 30,
+		},
+		{
+			name:    "zero timeout",
+			enable:  true,
+			server:  "localhost",
+			port:    0,
+			timeout: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := newServicebus(tt.enable, tt.server, tt.port, tt.timeout)
+			assert.NotNil(sb, "newServicebus() should not return nil")
+			assert.Equal(tt.enable, sb.enable, "servicebus.enable = %v, want %v", sb.enable, tt.enable)
+			assert.Equal(tt.server, sb.server, "servicebus.server = %v, want %v", sb.server, tt.server)
+			assert.Equal(tt.port, sb.port, "servicebus.port = %v, want %v", sb.port, tt.port)
+			assert.Equal(tt.timeout, sb.timeout, "servicebus.timeout = %v, want %v", sb.timeout, tt.timeout)
+			assert.NotNil(sb.sbs, "servicebus.sbs (ServiceBusService) should not be nil")
+		})
+	}
+}
+
+func TestName(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "ServiceBusNameTest",
+			want: modules.ServiceBusModuleName,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := &servicebus{}
+			assert.Equal(tt.want, sb.Name(), "servicebus.Name() = %v, want %v", sb.Name(), tt.want)
+		})
+	}
+}
+
+// TestGroup tests the Group() method of servicebus.
+func TestGroup(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "ServiceBusGroupTest",
+			want: modules.BusGroup,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := &servicebus{}
+			assert.Equal(tt.want, sb.Group(), "servicebus.Group() = %v, want %v", sb.Group(), tt.want)
+		})
+	}
+}
+
+func TestEnable(t *testing.T) {
+	tests := []struct {
+		name string
+		sb   *servicebus
+		want bool
+	}{
+		{
+			name: "Enable true",
+			want: true,
+			sb:   &servicebus{enable: true},
+		},
+		{
+			name: "Enable false",
+			want: false,
+			sb:   &servicebus{enable: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tt.want, tt.sb.Enable(),
+				"servicebus.Enable() returned unexpected result. got = %v, want = %v", tt.sb.Enable(), tt.want)
+		})
+	}
+}
+
+// TestRestartPolicy tests the RestartPolicy() method with feature gate toggling.
+func TestRestartPolicy(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name           string
+		featureEnabled bool
+		wantNil        bool
+	}{
+		{
+			name:           "feature gate disabled returns nil",
+			featureEnabled: false,
+			wantNil:        true,
+		},
+		{
+			name:           "feature gate enabled returns policy",
+			featureEnabled: true,
+			wantNil:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := features.DefaultMutableFeatureGate.SetFromMap(
+				map[string]bool{string(features.ModuleRestart): tt.featureEnabled})
+			assert.NoError(err, "Failed to set feature gate")
+
+			sb := &servicebus{}
+			got := sb.RestartPolicy()
+
+			if tt.wantNil {
+				assert.Nil(got, "RestartPolicy() should return nil when feature gate is disabled")
+				return
+			}
+
+			assert.NotNil(got, "RestartPolicy() should return non-nil policy when feature gate is enabled")
+			assert.Equal(core.RestartTypeOnFailure, got.RestartType,
+				"RestartType = %v, want %v", got.RestartType, core.RestartTypeOnFailure)
+			assert.Equal(2.0, got.IntervalTimeGrowthRate,
+				"IntervalTimeGrowthRate = %v, want 2.0", got.IntervalTimeGrowthRate)
+		})
+	}
+
+	_ = features.DefaultMutableFeatureGate.SetFromMap(
+		map[string]bool{string(features.ModuleRestart): false})
+}
+
+// TestBuildErrorResponse tests the buildErrorResponse helper with various status codes and messages.
+func TestBuildErrorResponse(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name       string
+		parentID   string
+		content    string
+		statusCode int
+	}{
+		{
+			name:       "bad request error",
+			parentID:   "msg-001",
+			content:    "the format of resource is incorrect",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "not found error",
+			parentID:   "msg-002",
+			content:    "error to call service",
+			statusCode: http.StatusNotFound,
+		},
+		{
+			name:       "internal server error",
+			parentID:   "msg-003",
+			content:    "error to receive response, err: connection reset",
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			name:       "empty parent ID",
+			parentID:   "",
+			content:    "some error",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "empty content",
+			parentID:   "msg-004",
+			content:    "",
+			statusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := buildErrorResponse(tt.parentID, tt.content, tt.statusCode)
+			assert.NoError(err, "buildErrorResponse() returned unexpected error")
+
+			assert.Equal(tt.parentID, msg.GetParentID(),
+				"ParentID = %q, want %q", msg.GetParentID(), tt.parentID)
+
+			assert.Equal(modules.ServiceBusModuleName, msg.GetSource(),
+				"Source = %q, want %q", msg.GetSource(), modules.ServiceBusModuleName)
+			assert.Equal(modules.UserGroup, msg.GetGroup(),
+				"Group = %q, want %q", msg.GetGroup(), modules.UserGroup)
+
+			body := msg.GetContent()
+			httpResp, ok := body.(commonType.HTTPResponse)
+			assert.True(ok, "Content type = %T, want commonType.HTTPResponse", body)
+
+			assert.Equal(tt.statusCode, httpResp.StatusCode,
+				"HTTPResponse.StatusCode = %d, want %d", httpResp.StatusCode, tt.statusCode)
+			assert.Equal(tt.content, string(httpResp.Body),
+				"HTTPResponse.Body = %q, want %q", string(httpResp.Body), tt.content)
+			assert.Equal("kubeedge-edgecore", httpResp.Header.Get("Server"),
+				"HTTPResponse.Header[Server] = %q, want %q", httpResp.Header.Get("Server"), "kubeedge-edgecore")
+		})
+	}
+}
+
+// TestMarshalResult tests the marshalResult helper for JSON serialization.
+func TestMarshalResult(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name string
+		resp *serverResponse
+	}{
+		{
+			name: "success response",
+			resp: &serverResponse{
+				Code: http.StatusOK,
+				Msg:  "receive response from cloud successfully",
+				Body: `{"key":"value"}`,
+			},
+		},
+		{
+			name: "error response with empty body",
+			resp: &serverResponse{
+				Code: http.StatusBadRequest,
+				Msg:  "invalid params",
+				Body: "",
+			},
+		},
+		{
+			name: "zero value response",
+			resp: &serverResponse{},
+		},
+		{
+			name: "response with special characters in body",
+			resp: &serverResponse{
+				Code: http.StatusOK,
+				Msg:  "ok",
+				Body: `{"msg":"hello \"world\"","list":[1,2,3]}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := marshalResult(tt.resp)
+			assert.NotNil(result, "marshalResult should not return nil")
+
+			var decoded serverResponse
+			err := json.Unmarshal(result, &decoded)
+			assert.NoError(err, "marshalResult produced invalid JSON")
+
+			assert.Equal(tt.resp.Code, decoded.Code,
+				"Code = %d, want %d", decoded.Code, tt.resp.Code)
+			assert.Equal(tt.resp.Msg, decoded.Msg,
+				"Msg = %q, want %q", decoded.Msg, tt.resp.Msg)
+			assert.Equal(tt.resp.Body, decoded.Body,
+				"Body = %q, want %q", decoded.Body, tt.resp.Body)
+
+			// Verify expected JSON field names
+			var raw map[string]json.RawMessage
+			err = json.Unmarshal(result, &raw)
+			assert.NoError(err, "failed to unmarshal as map")
+			for _, key := range []string{"code", "msg", "body"} {
+				_, ok := raw[key]
+				assert.True(ok, "JSON output missing expected key %q", key)
+			}
+		})
+	}
+}
+
+// TestBuildBasicHandler_InvalidBody tests the handler with an invalid JSON body.
+func TestBuildBasicHandler_InvalidBody(t *testing.T) {
+	assert := assert.New(t)
+
+	handler := buildBasicHandler(5 * time.Second)
+	body := strings.NewReader("this is not json")
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var resp serverResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(err, "failed to unmarshal response")
+	assert.Equal(http.StatusBadRequest, resp.Code)
+	assert.Equal("invalid params", resp.Msg)
+}
+
+// TestBuildBasicHandler_EmptyBody tests the handler with an empty body.
+func TestBuildBasicHandler_EmptyBody(t *testing.T) {
+	assert := assert.New(t)
+
+	handler := buildBasicHandler(5 * time.Second)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var resp serverResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(err, "failed to unmarshal response")
+	assert.Equal(http.StatusBadRequest, resp.Code)
+}
+
+// TestBuildBasicHandler_OversizedBody tests the handler rejects bodies exceeding maxBodySize.
+func TestBuildBasicHandler_OversizedBody(t *testing.T) {
+	assert := assert.New(t)
+
+	handler := buildBasicHandler(5 * time.Second)
+	oversized := strings.Repeat("x", int(maxBodySize)+1)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(oversized))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var resp serverResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(err, "failed to unmarshal response")
+	assert.Equal(http.StatusBadRequest, resp.Code)
+	assert.Equal("can't read data from body of the http's request", resp.Msg)
+}
+
+func TestBuildBasicHandler_ReturnsHandler(t *testing.T) {
+	assert := assert.New(t)
+
+	handler := buildBasicHandler(10 * time.Second)
+	assert.NotNil(handler, "buildBasicHandler should return a non-nil handler")
+}

--- a/edge/pkg/servicebus/servicebus_test.go
+++ b/edge/pkg/servicebus/servicebus_test.go
@@ -35,8 +35,6 @@ import (
 
 // TestNewServicebus tests the constructor for servicebus.
 func TestNewServicebus(t *testing.T) {
-	assert := assert.New(t)
-
 	tests := []struct {
 		name    string
 		enable  bool
@@ -69,6 +67,7 @@ func TestNewServicebus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 			sb := newServicebus(tt.enable, tt.server, tt.port, tt.timeout)
 			assert.NotNil(sb, "newServicebus() should not return nil")
 			assert.Equal(tt.enable, sb.enable, "servicebus.enable = %v, want %v", sb.enable, tt.enable)
@@ -81,8 +80,6 @@ func TestNewServicebus(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
-	assert := assert.New(t)
-
 	tests := []struct {
 		name string
 		want string
@@ -94,6 +91,7 @@ func TestName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 			sb := &servicebus{}
 			assert.Equal(tt.want, sb.Name(), "servicebus.Name() = %v, want %v", sb.Name(), tt.want)
 		})
@@ -102,8 +100,6 @@ func TestName(t *testing.T) {
 
 // TestGroup tests the Group() method of servicebus.
 func TestGroup(t *testing.T) {
-	assert := assert.New(t)
-
 	tests := []struct {
 		name string
 		want string
@@ -115,6 +111,7 @@ func TestGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 			sb := &servicebus{}
 			assert.Equal(tt.want, sb.Group(), "servicebus.Group() = %v, want %v", sb.Group(), tt.want)
 		})
@@ -150,7 +147,11 @@ func TestEnable(t *testing.T) {
 
 // TestRestartPolicy tests the RestartPolicy() method with feature gate toggling.
 func TestRestartPolicy(t *testing.T) {
-	assert := assert.New(t)
+	originalState := features.DefaultFeatureGate.Enabled(features.ModuleRestart)
+	t.Cleanup(func() {
+		_ = features.DefaultMutableFeatureGate.SetFromMap(
+			map[string]bool{string(features.ModuleRestart): originalState})
+	})
 
 	tests := []struct {
 		name           string
@@ -171,6 +172,7 @@ func TestRestartPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 			err := features.DefaultMutableFeatureGate.SetFromMap(
 				map[string]bool{string(features.ModuleRestart): tt.featureEnabled})
 			assert.NoError(err, "Failed to set feature gate")
@@ -190,15 +192,10 @@ func TestRestartPolicy(t *testing.T) {
 				"IntervalTimeGrowthRate = %v, want 2.0", got.IntervalTimeGrowthRate)
 		})
 	}
-
-	_ = features.DefaultMutableFeatureGate.SetFromMap(
-		map[string]bool{string(features.ModuleRestart): false})
 }
 
 // TestBuildErrorResponse tests the buildErrorResponse helper with various status codes and messages.
 func TestBuildErrorResponse(t *testing.T) {
-	assert := assert.New(t)
-
 	tests := []struct {
 		name       string
 		parentID   string
@@ -239,6 +236,7 @@ func TestBuildErrorResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 			msg, err := buildErrorResponse(tt.parentID, tt.content, tt.statusCode)
 			assert.NoError(err, "buildErrorResponse() returned unexpected error")
 
@@ -266,8 +264,6 @@ func TestBuildErrorResponse(t *testing.T) {
 
 // TestMarshalResult tests the marshalResult helper for JSON serialization.
 func TestMarshalResult(t *testing.T) {
-	assert := assert.New(t)
-
 	tests := []struct {
 		name string
 		resp *serverResponse
@@ -304,6 +300,7 @@ func TestMarshalResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 			result := marshalResult(tt.resp)
 			assert.NotNil(result, "marshalResult should not return nil")
 

--- a/edge/pkg/servicebus/servicebus_test.go
+++ b/edge/pkg/servicebus/servicebus_test.go
@@ -375,23 +375,33 @@ func TestBuildBasicHandler_InvalidResponseContent(t *testing.T) {
 func TestBuildBasicHandler_SuccessPath(t *testing.T) {
 	cloudResponse := `{"result":"ok","count":42}`
 
-	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
-		getURLByKey: func(key string) (*models.TargetUrls, error) {
-			return &models.TargetUrls{URL: key}, nil
-		},
-		sendSync: func(module string, msg beehiveModel.Message, timeout time.Duration) (beehiveModel.Message, error) {
-			assert.Equal(t, modules.EdgeHubModuleName, module)
-			respMsg := beehiveModel.NewMessage("").FillBody([]byte(cloudResponse))
-			return *respMsg, nil
-		},
-	})
-
 	reqBody, err := json.Marshal(serverRequest{
 		Method:    "GET",
 		TargetURL: "http://example.com/api",
 		Payload:   nil,
 	})
 	require.NoError(t, err)
+
+	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
+		getURLByKey: func(key string) (*models.TargetUrls, error) {
+			return &models.TargetUrls{URL: key}, nil
+		},
+		sendSync: func(module string, msg beehiveModel.Message, timeout time.Duration) (beehiveModel.Message, error) {
+			assert.Equal(t, modules.EdgeHubModuleName, module)
+			assert.Equal(t, modules.ServiceBusModuleName, msg.GetSource())
+			assert.Equal(t, modules.UserGroup, msg.GetGroup())
+			assert.Equal(t, "http://example.com/api", msg.GetResource())
+			assert.Equal(t, beehiveModel.UploadOperation, msg.GetOperation())
+			assert.Equal(t, 5*time.Second, timeout)
+
+			content, err := msg.GetContentData()
+			require.NoError(t, err, "failed to extract message content")
+			assert.Equal(t, string(reqBody), string(content))
+
+			respMsg := beehiveModel.NewMessage("").FillBody([]byte(cloudResponse))
+			return *respMsg, nil
+		},
+	})
 
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(reqBody)))
 	w := httptest.NewRecorder()

--- a/edge/pkg/servicebus/servicebus_test.go
+++ b/edge/pkg/servicebus/servicebus_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The KubeEdge Authors.
+Copyright 2026 The KubeEdge Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package servicebus
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -25,15 +26,17 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kubeedge/beehive/pkg/core"
+	beehiveModel "github.com/kubeedge/beehive/pkg/core/model"
 
 	commonType "github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
 	"github.com/kubeedge/kubeedge/pkg/features"
 )
 
-// TestNewServicebus tests the constructor for servicebus.
 func TestNewServicebus(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -67,85 +70,16 @@ func TestNewServicebus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
 			sb := newServicebus(tt.enable, tt.server, tt.port, tt.timeout)
-			assert.NotNil(sb, "newServicebus() should not return nil")
-			assert.Equal(tt.enable, sb.enable, "servicebus.enable = %v, want %v", sb.enable, tt.enable)
-			assert.Equal(tt.server, sb.server, "servicebus.server = %v, want %v", sb.server, tt.server)
-			assert.Equal(tt.port, sb.port, "servicebus.port = %v, want %v", sb.port, tt.port)
-			assert.Equal(tt.timeout, sb.timeout, "servicebus.timeout = %v, want %v", sb.timeout, tt.timeout)
-			assert.NotNil(sb.sbs, "servicebus.sbs (ServiceBusService) should not be nil")
+			require.NotNil(t, sb, "newServicebus() should not return nil")
+			assert.Equal(t, tt.enable, sb.enable)
+			assert.Equal(t, tt.server, sb.server)
+			assert.Equal(t, tt.port, sb.port)
+			assert.Equal(t, tt.timeout, sb.timeout)
+			assert.NotNil(t, sb.sbs, "servicebus.sbs (ServiceBusService) should not be nil")
 		})
 	}
 }
-
-func TestName(t *testing.T) {
-	tests := []struct {
-		name string
-		want string
-	}{
-		{
-			name: "ServiceBusNameTest",
-			want: modules.ServiceBusModuleName,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
-			sb := &servicebus{}
-			assert.Equal(tt.want, sb.Name(), "servicebus.Name() = %v, want %v", sb.Name(), tt.want)
-		})
-	}
-}
-
-// TestGroup tests the Group() method of servicebus.
-func TestGroup(t *testing.T) {
-	tests := []struct {
-		name string
-		want string
-	}{
-		{
-			name: "ServiceBusGroupTest",
-			want: modules.BusGroup,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
-			sb := &servicebus{}
-			assert.Equal(tt.want, sb.Group(), "servicebus.Group() = %v, want %v", sb.Group(), tt.want)
-		})
-	}
-}
-
-func TestEnable(t *testing.T) {
-	tests := []struct {
-		name string
-		sb   *servicebus
-		want bool
-	}{
-		{
-			name: "Enable true",
-			want: true,
-			sb:   &servicebus{enable: true},
-		},
-		{
-			name: "Enable false",
-			want: false,
-			sb:   &servicebus{enable: false},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
-			assert.Equal(tt.want, tt.sb.Enable(),
-				"servicebus.Enable() returned unexpected result. got = %v, want = %v", tt.sb.Enable(), tt.want)
-		})
-	}
-}
-
-// TestRestartPolicy tests the RestartPolicy() method with feature gate toggling.
 func TestRestartPolicy(t *testing.T) {
 	originalState := features.DefaultFeatureGate.Enabled(features.ModuleRestart)
 	t.Cleanup(func() {
@@ -172,29 +106,25 @@ func TestRestartPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
 			err := features.DefaultMutableFeatureGate.SetFromMap(
 				map[string]bool{string(features.ModuleRestart): tt.featureEnabled})
-			assert.NoError(err, "Failed to set feature gate")
+			require.NoError(t, err, "Failed to set feature gate")
 
 			sb := &servicebus{}
 			got := sb.RestartPolicy()
 
 			if tt.wantNil {
-				assert.Nil(got, "RestartPolicy() should return nil when feature gate is disabled")
+				assert.Nil(t, got, "RestartPolicy() should return nil when feature gate is disabled")
 				return
 			}
 
-			assert.NotNil(got, "RestartPolicy() should return non-nil policy when feature gate is enabled")
-			assert.Equal(core.RestartTypeOnFailure, got.RestartType,
-				"RestartType = %v, want %v", got.RestartType, core.RestartTypeOnFailure)
-			assert.Equal(2.0, got.IntervalTimeGrowthRate,
-				"IntervalTimeGrowthRate = %v, want 2.0", got.IntervalTimeGrowthRate)
+			require.NotNil(t, got, "RestartPolicy() should return non-nil policy when feature gate is enabled")
+			assert.Equal(t, core.RestartTypeOnFailure, got.RestartType)
+			assert.Equal(t, 2.0, got.IntervalTimeGrowthRate)
 		})
 	}
 }
 
-// TestBuildErrorResponse tests the buildErrorResponse helper with various status codes and messages.
 func TestBuildErrorResponse(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -236,33 +166,24 @@ func TestBuildErrorResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
 			msg, err := buildErrorResponse(tt.parentID, tt.content, tt.statusCode)
-			assert.NoError(err, "buildErrorResponse() returned unexpected error")
+			require.NoError(t, err, "buildErrorResponse() returned unexpected error")
 
-			assert.Equal(tt.parentID, msg.GetParentID(),
-				"ParentID = %q, want %q", msg.GetParentID(), tt.parentID)
-
-			assert.Equal(modules.ServiceBusModuleName, msg.GetSource(),
-				"Source = %q, want %q", msg.GetSource(), modules.ServiceBusModuleName)
-			assert.Equal(modules.UserGroup, msg.GetGroup(),
-				"Group = %q, want %q", msg.GetGroup(), modules.UserGroup)
+			assert.Equal(t, tt.parentID, msg.GetParentID())
+			assert.Equal(t, modules.ServiceBusModuleName, msg.GetSource())
+			assert.Equal(t, modules.UserGroup, msg.GetGroup())
 
 			body := msg.GetContent()
 			httpResp, ok := body.(commonType.HTTPResponse)
-			assert.True(ok, "Content type = %T, want commonType.HTTPResponse", body)
+			require.True(t, ok, "Content type = %T, want commonType.HTTPResponse", body)
 
-			assert.Equal(tt.statusCode, httpResp.StatusCode,
-				"HTTPResponse.StatusCode = %d, want %d", httpResp.StatusCode, tt.statusCode)
-			assert.Equal(tt.content, string(httpResp.Body),
-				"HTTPResponse.Body = %q, want %q", string(httpResp.Body), tt.content)
-			assert.Equal("kubeedge-edgecore", httpResp.Header.Get("Server"),
-				"HTTPResponse.Header[Server] = %q, want %q", httpResp.Header.Get("Server"), "kubeedge-edgecore")
+			assert.Equal(t, tt.statusCode, httpResp.StatusCode)
+			assert.Equal(t, tt.content, string(httpResp.Body))
+			assert.Equal(t, "kubeedge-edgecore", httpResp.Header.Get("Server"))
 		})
 	}
 }
 
-// TestMarshalResult tests the marshalResult helper for JSON serialization.
 func TestMarshalResult(t *testing.T) {
 	tests := []struct {
 		name string
@@ -300,38 +221,35 @@ func TestMarshalResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert := assert.New(t)
 			result := marshalResult(tt.resp)
-			assert.NotNil(result, "marshalResult should not return nil")
+			require.NotNil(t, result, "marshalResult should not return nil")
 
 			var decoded serverResponse
 			err := json.Unmarshal(result, &decoded)
-			assert.NoError(err, "marshalResult produced invalid JSON")
+			require.NoError(t, err, "marshalResult produced invalid JSON")
 
-			assert.Equal(tt.resp.Code, decoded.Code,
-				"Code = %d, want %d", decoded.Code, tt.resp.Code)
-			assert.Equal(tt.resp.Msg, decoded.Msg,
-				"Msg = %q, want %q", decoded.Msg, tt.resp.Msg)
-			assert.Equal(tt.resp.Body, decoded.Body,
-				"Body = %q, want %q", decoded.Body, tt.resp.Body)
+			assert.Equal(t, tt.resp.Code, decoded.Code)
+			assert.Equal(t, tt.resp.Msg, decoded.Msg)
+			assert.Equal(t, tt.resp.Body, decoded.Body)
 
-			// Verify expected JSON field names
 			var raw map[string]json.RawMessage
 			err = json.Unmarshal(result, &raw)
-			assert.NoError(err, "failed to unmarshal as map")
+			require.NoError(t, err, "failed to unmarshal as map")
 			for _, key := range []string{"code", "msg", "body"} {
 				_, ok := raw[key]
-				assert.True(ok, "JSON output missing expected key %q", key)
+				assert.True(t, ok, "JSON output missing expected key %q", key)
 			}
 		})
 	}
 }
 
-// TestBuildBasicHandler_InvalidBody tests the handler with an invalid JSON body.
 func TestBuildBasicHandler_InvalidBody(t *testing.T) {
-	assert := assert.New(t)
-
-	handler := buildBasicHandler(5 * time.Second)
+	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
+		getURLByKey: func(string) (*models.TargetUrls, error) { return nil, nil },
+		sendSync: func(string, beehiveModel.Message, time.Duration) (beehiveModel.Message, error) {
+			return beehiveModel.Message{}, nil
+		},
+	})
 	body := strings.NewReader("this is not json")
 	req := httptest.NewRequest(http.MethodPost, "/", body)
 	w := httptest.NewRecorder()
@@ -340,32 +258,18 @@ func TestBuildBasicHandler_InvalidBody(t *testing.T) {
 
 	var resp serverResponse
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.NoError(err, "failed to unmarshal response")
-	assert.Equal(http.StatusBadRequest, resp.Code)
-	assert.Equal("invalid params", resp.Msg)
+	require.NoError(t, err, "failed to unmarshal response")
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, "invalid params", resp.Msg)
 }
 
-// TestBuildBasicHandler_EmptyBody tests the handler with an empty body.
-func TestBuildBasicHandler_EmptyBody(t *testing.T) {
-	assert := assert.New(t)
-
-	handler := buildBasicHandler(5 * time.Second)
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
-	w := httptest.NewRecorder()
-
-	handler.ServeHTTP(w, req)
-
-	var resp serverResponse
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.NoError(err, "failed to unmarshal response")
-	assert.Equal(http.StatusBadRequest, resp.Code)
-}
-
-// TestBuildBasicHandler_OversizedBody tests the handler rejects bodies exceeding maxBodySize.
 func TestBuildBasicHandler_OversizedBody(t *testing.T) {
-	assert := assert.New(t)
-
-	handler := buildBasicHandler(5 * time.Second)
+	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
+		getURLByKey: func(string) (*models.TargetUrls, error) { return nil, nil },
+		sendSync: func(string, beehiveModel.Message, time.Duration) (beehiveModel.Message, error) {
+			return beehiveModel.Message{}, nil
+		},
+	})
 	oversized := strings.Repeat("x", int(maxBodySize)+1)
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(oversized))
 	w := httptest.NewRecorder()
@@ -374,14 +278,130 @@ func TestBuildBasicHandler_OversizedBody(t *testing.T) {
 
 	var resp serverResponse
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.NoError(err, "failed to unmarshal response")
-	assert.Equal(http.StatusBadRequest, resp.Code)
-	assert.Equal("can't read data from body of the http's request", resp.Msg)
+	require.NoError(t, err, "failed to unmarshal response")
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, "can't read data from body of the http's request", resp.Msg)
 }
 
-func TestBuildBasicHandler_ReturnsHandler(t *testing.T) {
-	assert := assert.New(t)
 
-	handler := buildBasicHandler(10 * time.Second)
-	assert.NotNil(handler, "buildBasicHandler should return a non-nil handler")
+func TestBuildBasicHandler_UnregisteredURL(t *testing.T) {
+	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
+		getURLByKey: func(string) (*models.TargetUrls, error) {
+			return nil, nil
+		},
+		sendSync: func(string, beehiveModel.Message, time.Duration) (beehiveModel.Message, error) {
+			t.Fatal("sendSync should not be called for unregistered URL")
+			return beehiveModel.Message{}, nil
+		},
+	})
+
+	reqBody, err := json.Marshal(serverRequest{
+		Method:    "GET",
+		TargetURL: "http://example.com/unregistered",
+		Payload:   nil,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(reqBody)))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var resp serverResponse
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err, "failed to unmarshal response")
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Contains(t, resp.Msg, "is not allowed")
+	assert.Contains(t, resp.Msg, "http://example.com/unregistered")
+}
+
+func TestBuildBasicHandler_SendSyncFailure(t *testing.T) {
+	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
+		getURLByKey: func(string) (*models.TargetUrls, error) {
+			return &models.TargetUrls{URL: "http://example.com/api"}, nil
+		},
+		sendSync: func(string, beehiveModel.Message, time.Duration) (beehiveModel.Message, error) {
+			return beehiveModel.Message{}, fmt.Errorf("edge hub unreachable")
+		},
+	})
+
+	reqBody, err := json.Marshal(serverRequest{
+		Method:    "POST",
+		TargetURL: "http://example.com/api",
+		Payload:   map[string]string{"key": "value"},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(reqBody)))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var resp serverResponse
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err, "failed to unmarshal response")
+	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, "edge hub unreachable", resp.Msg)
+}
+
+func TestBuildBasicHandler_InvalidResponseContent(t *testing.T) {
+	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
+		getURLByKey: func(string) (*models.TargetUrls, error) {
+			return &models.TargetUrls{URL: "http://example.com/api"}, nil
+		},
+		sendSync: func(string, beehiveModel.Message, time.Duration) (beehiveModel.Message, error) {
+			msg := beehiveModel.NewMessage("").FillBody(make(chan int))
+			return *msg, nil
+		},
+	})
+
+	reqBody, err := json.Marshal(serverRequest{
+		Method:    "GET",
+		TargetURL: "http://example.com/api",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(reqBody)))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var resp serverResponse
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err, "failed to unmarshal response")
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+}
+
+func TestBuildBasicHandler_SuccessPath(t *testing.T) {
+	cloudResponse := `{"result":"ok","count":42}`
+
+	handler := buildBasicHandlerWithDeps(5*time.Second, basicHandlerDeps{
+		getURLByKey: func(key string) (*models.TargetUrls, error) {
+			return &models.TargetUrls{URL: key}, nil
+		},
+		sendSync: func(module string, msg beehiveModel.Message, timeout time.Duration) (beehiveModel.Message, error) {
+			assert.Equal(t, modules.EdgeHubModuleName, module)
+			respMsg := beehiveModel.NewMessage("").FillBody([]byte(cloudResponse))
+			return *respMsg, nil
+		},
+	})
+
+	reqBody, err := json.Marshal(serverRequest{
+		Method:    "GET",
+		TargetURL: "http://example.com/api",
+		Payload:   nil,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(reqBody)))
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var resp serverResponse
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err, "failed to unmarshal response")
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "receive response from cloud successfully", resp.Msg)
+	assert.Equal(t, cloudResponse, resp.Body)
 }


### PR DESCRIPTION
Added unit tests for `edge/pkg/servicebus` covering initialization, restart policies, HTTP response handling, and the full `buildBasicHandler` request lifecycle via a lightweight dependency-injection seam.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

**What this PR does / why we need it**:
This PR adds `servicebus_test.go` to the `edge/pkg/servicebus` package, which previously had 0% test coverage.

To enable deterministic testing of `buildBasicHandler` without live beehive or database dependencies, this PR introduces a small production-code change: a `basicHandlerDeps` struct and a `buildBasicHandlerWithDeps` helper. The existing `buildBasicHandler` remains the production entry point and delegates to `buildBasicHandlerWithDeps` with real implementations, so runtime behavior is unchanged.

**Covered test paths:**

- `newServicebus()` — constructor field assignment with various configurations.
- `RestartPolicy()` — behavior with `ModuleRestart` feature gate enabled vs disabled, with proper cleanup.
- `buildErrorResponse()` — various status codes, error messages, and HTTP header population.
- `marshalResult()` — JSON serialization round-trip of `serverResponse`, including special characters.
- `buildBasicHandler` — invalid JSON body, oversized body.
- `buildBasicHandler` — unregistered target URL (verifies `sendSync` is never called).
- `buildBasicHandler` — `SendSync` failure (verifies error propagation).
- `buildBasicHandler` — invalid response content from cloud (verifies `StatusInternalServerError`).
- `buildBasicHandler` — successful path, including full verification of the forwarded message contract (`source`, `group`, `resource`, `operation`, `timeout`, and body content).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6936

**Special notes for your reviewer**:
* Tested locally via `go test -race ./edge/pkg/servicebus`.
* Uses `testify/assert` and `testify/require` to match sibling test patterns (e.g., `devicetwin_test.go`).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
