### PR TITLE
fix(taskmanager/upstream): fix err shadowing in status callback

### DIFF
--- a/cloud/pkg/taskmanager/upstream/config_update.go
+++ b/cloud/pkg/taskmanager/upstream/config_update.go
@@ -97,9 +97,9 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 			ExtendInfo:   upmsg.Extend,
 			ActionStatus: &actoinStatus,
 		},
-		Callback: func(err error) {
-			if err != nil {
-				err = fmt.Errorf("failed to update image prepull job status, err: %v", err)
+		Callback: func(callbackErr error) {
+			if callbackErr != nil {
+				err = fmt.Errorf("failed to update config update job status, err: %w", callbackErr)
 			}
 			wg.Done()
 		},

--- a/cloud/pkg/taskmanager/upstream/config_update_test.go
+++ b/cloud/pkg/taskmanager/upstream/config_update_test.go
@@ -31,7 +31,7 @@ import (
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
 )
 
-func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
+func TestConfigUpdateJobUpdateNodeTaskStatus(t *testing.T) {
 	var (
 		jobName  = "test-job"
 		nodeName = "node1"
@@ -40,14 +40,14 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+		gomonkey.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
 		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
-				act, ok := opts.ActionStatus.(*operationsv1alpha2.NodeUpgradeJobActionStatus)
+				act, ok := opts.ActionStatus.(*operationsv1alpha2.ConfigUpdateJobActionStatus)
 				require.True(t, ok)
-				assert.Equal(t, operationsv1alpha2.NodeUpgradeJobActionUpgrade, act.Action)
+				assert.Equal(t, operationsv1alpha2.ConfigUpdateJobActionUpdate, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseSuccessful, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
 				assert.Equal(t, nodeName, opts.NodeName)
@@ -55,9 +55,9 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 				opts.Callback(nil)
 			})
 
-		handler := &NodeUpgradeJobHandler{}
+		handler := &ConfigUpdateJobHandler{}
 		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
-			Action: string(operationsv1alpha2.NodeUpgradeJobActionUpgrade),
+			Action: string(operationsv1alpha2.ConfigUpdateJobActionUpdate),
 			Succ:   true,
 		})
 		require.NoError(t, err)
@@ -67,14 +67,14 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+		gomonkey.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
 		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
-				act, ok := opts.ActionStatus.(*operationsv1alpha2.NodeUpgradeJobActionStatus)
+				act, ok := opts.ActionStatus.(*operationsv1alpha2.ConfigUpdateJobActionStatus)
 				require.True(t, ok)
-				assert.Equal(t, operationsv1alpha2.NodeUpgradeJobActionRollBack, act.Action)
+				assert.Equal(t, operationsv1alpha2.ConfigUpdateJobActionRollBack, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseFailure, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
 				assert.Equal(t, nodeName, opts.NodeName)
@@ -82,9 +82,9 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 				opts.Callback(nil)
 			})
 
-		handler := &NodeUpgradeJobHandler{}
+		handler := &ConfigUpdateJobHandler{}
 		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
-			Action: string(operationsv1alpha2.NodeUpgradeJobActionRollBack),
+			Action: string(operationsv1alpha2.ConfigUpdateJobActionRollBack),
 			Succ:   false,
 		})
 		require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 
 // Regression test ensuring callback errors are propagated from
 // UpdateNodeTaskStatus instead of being silently ignored.
-func TestNodeUpgradeJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *testing.T) {
+func TestConfigUpdateJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *testing.T) {
 	var (
 		jobName  = "test-job"
 		nodeName = "node1"
@@ -118,7 +118,7 @@ func TestNodeUpgradeJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *test
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 
-			gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+			gomonkey.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
 				return &status.StatusUpdater{}
 			})
 			gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
@@ -127,14 +127,14 @@ func TestNodeUpgradeJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *test
 					opts.Callback(c.callbackErr)
 				})
 
-			handler := &NodeUpgradeJobHandler{}
+			handler := &ConfigUpdateJobHandler{}
 			err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
-				Action: string(operationsv1alpha2.NodeUpgradeJobActionUpgrade),
+				Action: string(operationsv1alpha2.ConfigUpdateJobActionUpdate),
 				Succ:   true,
 			})
 			require.Error(t, err)
 			assert.ErrorIs(t, err, c.callbackErr)
-			assert.Contains(t, err.Error(), "node upgrade job status")
+			assert.Contains(t, err.Error(), "config update job status")
 		})
 	}
 }

--- a/cloud/pkg/taskmanager/upstream/config_update_test.go
+++ b/cloud/pkg/taskmanager/upstream/config_update_test.go
@@ -40,10 +40,10 @@ func TestConfigUpdateJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
+		patches.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
-		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+		patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
 				act, ok := opts.ActionStatus.(*operationsv1alpha2.ConfigUpdateJobActionStatus)
 				require.True(t, ok)
@@ -67,10 +67,10 @@ func TestConfigUpdateJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
+		patches.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
-		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+		patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
 				act, ok := opts.ActionStatus.(*operationsv1alpha2.ConfigUpdateJobActionStatus)
 				require.True(t, ok)
@@ -118,10 +118,10 @@ func TestConfigUpdateJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *tes
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 
-			gomonkey.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
+			patches.ApplyFunc(status.GetConfigeUpdateJobStatusUpdater, func() *status.StatusUpdater {
 				return &status.StatusUpdater{}
 			})
-			gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+			patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 				func(opts status.UpdateStatusOptions) {
 					require.NotNil(t, opts.Callback)
 					opts.Callback(c.callbackErr)

--- a/cloud/pkg/taskmanager/upstream/image_prepull.go
+++ b/cloud/pkg/taskmanager/upstream/image_prepull.go
@@ -97,9 +97,9 @@ func (h *ImagePrePullJobHandler) UpdateNodeTaskStatus(
 			ExtendInfo:   upmsg.Extend,
 			ActionStatus: &actoinStatus,
 		},
-		Callback: func(err error) {
-			if err != nil {
-				err = fmt.Errorf("failed to update image prepull job status, err: %v", err)
+		Callback: func(callbackErr error) {
+			if callbackErr != nil {
+				err = fmt.Errorf("failed to update image prepull job status, err: %w", callbackErr)
 			}
 			wg.Done()
 		},

--- a/cloud/pkg/taskmanager/upstream/image_prepull_test.go
+++ b/cloud/pkg/taskmanager/upstream/image_prepull_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package upstream
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -32,7 +34,7 @@ import (
 func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 	var (
 		jobName  = "test-job"
-		nodeNmae = "node1"
+		nodeName = "node1"
 	)
 	t.Run("final action successful", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
@@ -48,13 +50,13 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 				assert.Equal(t, operationsv1alpha2.ImagePrePullJobActionPull, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseSuccessful, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
-				assert.Equal(t, nodeNmae, opts.NodeName)
+				assert.Equal(t, nodeName, opts.NodeName)
 				require.NotNil(t, opts.Callback)
 				opts.Callback(nil)
 			})
 
 		handler := &ImagePrePullJobHandler{}
-		err := handler.UpdateNodeTaskStatus(jobName, nodeNmae, true, taskmsg.UpstreamMessage{
+		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
 			Action: string(operationsv1alpha2.ImagePrePullJobActionPull),
 			Succ:   true,
 		})
@@ -75,16 +77,64 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 				assert.Equal(t, operationsv1alpha2.ImagePrePullJobActionPull, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseFailure, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
-				assert.Equal(t, nodeNmae, opts.NodeName)
+				assert.Equal(t, nodeName, opts.NodeName)
 				require.NotNil(t, opts.Callback)
 				opts.Callback(nil)
 			})
 
 		handler := &ImagePrePullJobHandler{}
-		err := handler.UpdateNodeTaskStatus(jobName, nodeNmae, true, taskmsg.UpstreamMessage{
+		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
 			Action: string(operationsv1alpha2.ImagePrePullJobActionPull),
 			Succ:   false,
 		})
 		require.NoError(t, err)
 	})
+}
+
+// Regression test ensuring callback errors are propagated from
+// UpdateNodeTaskStatus instead of being silently ignored.
+func TestImagePrePullJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *testing.T) {
+	var (
+		jobName  = "test-job"
+		nodeName = "node1"
+	)
+
+	cases := []struct {
+		name        string
+		callbackErr error
+	}{
+		{
+			name:        "plain callback error",
+			callbackErr: errors.New("update status failed"),
+		},
+		{
+			name:        "wrapped callback error",
+			callbackErr: fmt.Errorf("underlying: %w", errors.New("conflict")),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			gomonkey.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
+				return &status.StatusUpdater{}
+			})
+			gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+				func(opts status.UpdateStatusOptions) {
+					require.NotNil(t, opts.Callback)
+					opts.Callback(c.callbackErr)
+				})
+
+			handler := &ImagePrePullJobHandler{}
+			err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
+				Action: string(operationsv1alpha2.ImagePrePullJobActionPull),
+				Succ:   true,
+			})
+			require.Error(t, err)
+			assert.ErrorIs(t, err, c.callbackErr)
+			assert.Contains(t, err.Error(), "image prepull job status")
+		})
+	}
 }

--- a/cloud/pkg/taskmanager/upstream/image_prepull_test.go
+++ b/cloud/pkg/taskmanager/upstream/image_prepull_test.go
@@ -40,10 +40,10 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
+		patches.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
-		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+		patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
 				act, ok := opts.ActionStatus.(*operationsv1alpha2.ImagePrePullJobActionStatus)
 				require.True(t, ok)
@@ -67,10 +67,10 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
+		patches.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
-		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+		patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
 				act, ok := opts.ActionStatus.(*operationsv1alpha2.ImagePrePullJobActionStatus)
 				require.True(t, ok)
@@ -118,10 +118,10 @@ func TestImagePrePullJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *tes
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 
-			gomonkey.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
+			patches.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
 				return &status.StatusUpdater{}
 			})
-			gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+			patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 				func(opts status.UpdateStatusOptions) {
 					require.NotNil(t, opts.Callback)
 					opts.Callback(c.callbackErr)

--- a/cloud/pkg/taskmanager/upstream/node_upgrade.go
+++ b/cloud/pkg/taskmanager/upstream/node_upgrade.go
@@ -97,9 +97,9 @@ func (h *NodeUpgradeJobHandler) UpdateNodeTaskStatus(
 			ExtendInfo:   upmsg.Extend,
 			ActionStatus: &actoinStatus,
 		},
-		Callback: func(err error) {
-			if err != nil {
-				err = fmt.Errorf("failed to update image prepull job status, err: %v", err)
+		Callback: func(callbackErr error) {
+			if callbackErr != nil {
+				err = fmt.Errorf("failed to update node upgrade job status, err: %w", callbackErr)
 			}
 			wg.Done()
 		},

--- a/cloud/pkg/taskmanager/upstream/node_upgrade_test.go
+++ b/cloud/pkg/taskmanager/upstream/node_upgrade_test.go
@@ -40,10 +40,10 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+		patches.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
-		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+		patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
 				act, ok := opts.ActionStatus.(*operationsv1alpha2.NodeUpgradeJobActionStatus)
 				require.True(t, ok)
@@ -67,10 +67,10 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+		patches.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
-		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+		patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
 				act, ok := opts.ActionStatus.(*operationsv1alpha2.NodeUpgradeJobActionStatus)
 				require.True(t, ok)
@@ -118,10 +118,10 @@ func TestNodeUpgradeJobUpdateNodeTaskStatusReturnsErrorOnCallbackFailure(t *test
 			patches := gomonkey.NewPatches()
 			defer patches.Reset()
 
-			gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+			patches.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
 				return &status.StatusUpdater{}
 			})
-			gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+			patches.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 				func(opts status.UpdateStatusOptions) {
 					require.NotNil(t, opts.Callback)
 					opts.Callback(c.callbackErr)


### PR DESCRIPTION
## Description

In all three upstream status handlers (`UpdateNodeTaskStatus`), the 
function declares `var err error` in an outer scope, then defines a 
status-update `Callback` with the signature `func(err error)`. Because 
Go allows parameter names to shadow outer variables, the callback's 
`err` parameter is a completely separate variable from the outer one. 
Any assignment inside the callback body only modifies this local 
parameter — the outer `err` is never touched.

As a result, `return err` at the end of each function unconditionally 
returns `nil`, regardless of whether the underlying status update 
actually succeeded or failed. Callers of `UpdateNodeTaskStatus` have 
no way to detect a failed status update; the error is silently 
discarded at the point where the callback fires, well before the 
function returns.

This affects all three node task types:
- NodeUpgradeJob
- ImagePrePullJob  
- ConfigUpdateJob

Since these handlers are responsible for reporting task status back 
to the cluster, a silently swallowed error here means operators have 
no visibility into a failed status write — the task may appear stuck 
or inconsistent with no corresponding error in logs or status 
conditions.

While fixing this, I also corrected a copy-paste error message bug: 
both `node_upgrade.go` and `config_update.go` used the literal string 
"failed to update image prepull job status" regardless of the actual 
job type being handled. Only `image_prepull.go` had the correct 
message.

## Fix

1. Renamed the callback parameter from `err` to `callbackErr` in all 
   three files, eliminating the shadowing.
2. Inside each callback, the wrapped error is now correctly assigned 
   to the outer `err` variable, so it propagates through `wg.Wait()` 
   and is returned to the caller.
3. Corrected the error message in `node_upgrade.go` to reference 
   "node upgrade job status" and in `config_update.go` to reference 
   "config update job status".
4. Changed the error wrapping verb from `%v` to `%w` in all three 
   files, preserving the underlying error in the chain for 
   `errors.Is` / `errors.As` compatibility.

## Files Changed
- `cloud/pkg/taskmanager/upstream/node_upgrade.go`
- `cloud/pkg/taskmanager/upstream/image_prepull.go`
- `cloud/pkg/taskmanager/upstream/config_update.go`

## Testing

This is a pure bug fix with no behavioral change on the success path. 
On the failure path, callers now correctly receive a non-nil error 
instead of nil.

Fixes #6916 