### PR TITLE
pkg/viaduct/conn/quic: fix "steam" typo in serveSession doc comment

### DIFF
--- a/pkg/viaduct/pkg/conn/quic.go
+++ b/pkg/viaduct/pkg/conn/quic.go
@@ -101,8 +101,7 @@ func (conn *QuicConnection) serveControlLan() {
 	}
 }
 
-// ServeSession accept streams from remote peer
-// then, receive messages from the steam
+// serveSession accepts streams from the remote peer and receives messages from each stream.
 func (conn *QuicConnection) serveSession() {
 	for {
 		stream, err := conn.session.AcceptStream()


### PR DESCRIPTION
### What type of PR is this?
/kind documentation

### What this PR does / why we need it:

This PR fixes a typo in the `serveSession` documentation comment in `pkg/viaduct/pkg/conn/quic.go`.

The comment currently says **"steam"** instead of **"stream"**. This change improves readability and makes the documentation clearer for developers working with the QUIC transport implementation.

### Which issue(s) this PR fixes:

Fixes #6939 

### Special notes for your reviewer:

- Documentation-only change.
- No functional or behavioral changes.

### Does this PR introduce a user-facing change?

```release-note
NONE
```