### PR TITLE
fix(viaduct): align WSLane and WSLaneWithoutPack Read with io.Reader …

### DIFF
--- a/pkg/viaduct/pkg/lane/ws.go
+++ b/pkg/viaduct/pkg/lane/ws.go
@@ -33,10 +33,10 @@ func (l *WSLane) Read(p []byte) (int, error) {
 		if !errors.Is(err, io.EOF) {
 			klog.Errorf("read message error(%+v)", err)
 		}
-		return len(msgData), err
+		return 0, err
 	}
-	p = append(p[:0], msgData...)
-	return len(msgData), err
+	n := copy(p, msgData)
+	return n, nil
 }
 
 func (l *WSLane) ReadMessage(msg *model.Message) error {

--- a/pkg/viaduct/pkg/lane/ws.go
+++ b/pkg/viaduct/pkg/lane/ws.go
@@ -17,6 +17,7 @@ type WSLane struct {
 	writeDeadline time.Time
 	readDeadline  time.Time
 	conn          *websocket.Conn
+	buf           []byte // Buffer to store unread message data
 }
 
 func NewWSLane(van interface{}) *WSLane {
@@ -28,14 +29,19 @@ func NewWSLane(van interface{}) *WSLane {
 }
 
 func (l *WSLane) Read(p []byte) (int, error) {
-	_, msgData, err := l.conn.ReadMessage()
-	if err != nil {
-		if !errors.Is(err, io.EOF) {
-			klog.Errorf("read message error(%+v)", err)
+	if len(l.buf) == 0 {
+		_, msgData, err := l.conn.ReadMessage()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				klog.Errorf("read message error(%+v)", err)
+			}
+			return 0, err
 		}
-		return 0, err
+		l.buf = msgData
 	}
-	n := copy(p, msgData)
+
+	n := copy(p, l.buf)
+	l.buf = l.buf[n:]
 	return n, nil
 }
 

--- a/pkg/viaduct/pkg/lane/wsnopack.go
+++ b/pkg/viaduct/pkg/lane/wsnopack.go
@@ -31,10 +31,10 @@ func (l *WSLaneWithoutPack) Read(p []byte) (int, error) {
 		if !errors.Is(err, io.EOF) {
 			klog.Errorf("read message error(%+v)", err)
 		}
-		return len(msgData), err
+		return 0, err
 	}
-	p = append(p[:0], msgData...)
-	return len(msgData), err
+	n := copy(p, msgData)
+	return n, nil
 }
 
 func (l *WSLaneWithoutPack) ReadMessage(msg *model.Message) error {

--- a/pkg/viaduct/pkg/lane/wsnopack.go
+++ b/pkg/viaduct/pkg/lane/wsnopack.go
@@ -15,6 +15,7 @@ type WSLaneWithoutPack struct {
 	writeDeadline time.Time
 	readDeadline  time.Time
 	conn          *websocket.Conn
+	buf           []byte // Buffer to store unread message data
 }
 
 func NewWSLaneWithoutPack(van interface{}) *WSLaneWithoutPack {
@@ -26,14 +27,19 @@ func NewWSLaneWithoutPack(van interface{}) *WSLaneWithoutPack {
 }
 
 func (l *WSLaneWithoutPack) Read(p []byte) (int, error) {
-	_, msgData, err := l.conn.ReadMessage()
-	if err != nil {
-		if !errors.Is(err, io.EOF) {
-			klog.Errorf("read message error(%+v)", err)
+	if len(l.buf) == 0 {
+		_, msgData, err := l.conn.ReadMessage()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				klog.Errorf("read message error(%+v)", err)
+			}
+			return 0, err
 		}
-		return 0, err
+		l.buf = msgData
 	}
-	n := copy(p, msgData)
+
+	n := copy(p, l.buf)
+	l.buf = l.buf[n:]
 	return n, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The `Read` methods in both `WSLane` and `WSLaneWithoutPack` populated the caller's slice using `p = append(p[:0], msgData...)`. 

Since slices are passed by value (slice header copy is modified), appending to `p[:0]` when `len(msgData) > cap(p)` allocates a new underlying array, leaving the caller's original slice pointer unchanged and causing silent data loss.

In addition, returning `len(msgData)` when the message size is larger than `len(p)` violates the `io.Reader` specification, leading to out of bounds panics or data corruption on the caller side.

This PR fixes this by using `copy(p, msgData)` to populate the slice up to its length and returning the actual number of bytes copied.

**Which issue(s) this PR fixes**:
Fixes #6942

**Special notes for your reviewer**:
This is a straightforward change aligning the WebSocket lane `Read` implementations with the standard library `io.Reader` contract to prevent data loss.

**Does this PR introduce a user-facing change?**:
```release-note
NONE

