### PR TITLE
fix(metaserver): fix pointer reassignment in MergePatchedResource

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -184,7 +184,6 @@ func MergePatchedResource(ctx context.Context, originalObj *unstructured.Unstruc
 		if err = patchutil.StrategicPatchObject(ctx, defaulter, originalObj, []byte((*metas)[0]), updatedResource, schemaReferenceObj, ""); err != nil {
 			return err
 		}
-		originalObj = updatedResource
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In the SQLite store implementation of MetaServer (`edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go`), the function `MergePatchedResource` is called when fetching or listing Pods to merge local pod patches.

However, the function attempted to update the caller's `unstructured.Unstructured` object by reassigning the parameter pointer itself (`originalObj = updatedResource`), which only changes the local copy of the pointer inside the function scope and silently discards the patched resource updates.

This PR fixes it by dereferencing the pointer (`*originalObj = *updatedResource`) to copy the patched updates back to the caller's object.

**Which issue(s) this PR fixes**:
Fixes #6945

**Special notes for your reviewer**:
This is a high-severity bug fix that ensures pod patches are successfully merged and returned instead of being silently discarded.

**Does this PR introduce a user-facing change?**:
```release-note
NONE

