### PR TITLE
test(e2e): tolerate transient NotFound for StatefulSet

### DIFF
--- a/tests/e2e/apps/deployment.go
+++ b/tests/e2e/apps/deployment.go
@@ -313,8 +313,12 @@ var _ = GroupDescribe("Application deployment test in E2E scenario", func() {
 
 				ginkgo.By(fmt.Sprintf("wait for pod %s running again", fmt.Sprintf("%s-1", UID)))
 				err = wait.Poll(5*time.Second, 120*time.Second, func() (bool, error) {
+
 					pod, err := clientSet.CoreV1().Pods("default").Get(context.TODO(), deletePodName, metav1.GetOptions{})
 					if err != nil {
+						if errors.IsNotFound(err) {
+							return false, nil
+						}
 						return false, err
 					}
 					if pod.Status.Phase == corev1.PodRunning {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Improves the reliability of E2E tests by tolerating transient `NotFound` errors when deleting `StatefulSet` resources, eliminating flaky failures.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```