### PR TITLE
docs: fix wording in proposal docs

### DIFF
--- a/docs/proposals/sig-device-iot/provide-a-commom-mqtt-mapper.md
+++ b/docs/proposals/sig-device-iot/provide-a-commom-mqtt-mapper.md
@@ -18,11 +18,11 @@ In the current hardware device market, the MQTT (Message Queuing Telemetry Trans
 
 Firstly, different device manufacturers may implement customizations and extensions to the MQTT protocol, leading to interoperability issues between devices. Secondly, the diversity of serialization formats presents another challenge when handling device data. JSON, YAML, and XML are common serialization methods, each with its unique advantages and application scenarios.
 
-Therefore, developing a universal MQTT can help developers simplify the device integration process, improve system flexibility and reliability.
+Therefore, developing a universal MQTT mapper can help developers simplify the device integration process and improve system flexibility and reliability.
 
 ### Goals
 
-For developers or end users of a common MQTT mapper solutions, the goals of a common MQTT mapper are:
+For developers or end users of a common MQTT mapper solution, the goals of a common MQTT mapper are:
 
 - Add a new Mapper for the MQTT protocol to the kubeedge/mappers-go project using the latest mapper-framework.
 
@@ -64,7 +64,7 @@ The architectures and related concepts are shown in the below figure. In the fig
 
 1. Generate Mapper files through the Mapper-Framework framework
 
-   1)Download kubeedge-master.zip from the official website, take the mapper-framewokr under the staging folder in it, and transfer it to the VM master node.
+   1)Download kubeedge-master.zip from the official website, take the mapper-framework under the staging folder in it, and transfer it to the VM master node.
 
    2)Execute a command:
 

--- a/docs/proposals/sig-device-iot/provide-a-commom-mqtt-mapper.md
+++ b/docs/proposals/sig-device-iot/provide-a-commom-mqtt-mapper.md
@@ -64,7 +64,7 @@ The architectures and related concepts are shown in the below figure. In the fig
 
 1. Generate Mapper files through the Mapper-Framework framework
 
-   1)Download kubeedge-master.zip from the official website, take the mapper-framework under the staging folder in it, and transfer it to the VM master node.
+   1) Download kubeedge-master.zip from the official website, extract the mapper-framework directory from its staging folder, and transfer it to the VM master node.
 
    2)Execute a command:
 

--- a/docs/proposals/sig-node/exec-logs.md
+++ b/docs/proposals/sig-node/exec-logs.md
@@ -32,7 +32,7 @@ For `kubectl exec` commands, kube-apiserver will establish a long connection wit
 
 The native kubernetes cluster is set up in data center, so kube-apiserver can directly access kubelet.
 
-However, in edge computing scenarios, edge nodes are mostly in private network environments, and kube-apiserver cannot directly access edge nodes, so the native `kubectl exec`, `kubectl logs` and `kubectl attach` commands can not work.
+However, in edge computing scenarios, edge nodes are mostly in private network environments, and kube-apiserver cannot directly access edge nodes, so the native `kubectl exec`, `kubectl logs` and `kubectl attach` commands cannot work.
 
 Therefore, we need to establish a data tunnel to forward data requests between the cloud and the node.
 
@@ -83,7 +83,7 @@ In the edge computing scenarios, kube-apiserver cannot directly access the node 
 	For the tunnel channel, we have two options:
 
 	+ 1-1 We can use (cloudhub <-> edgehub) tunnel, but now cloudhub and edgehub are mainly used to transfer kubernetes resource data (pod, node, configmap, service ...), which is not very suitable for `exec, attach and logs` streaming data transmission.
-	+ 1-2 Re-establish a websocket tunnel between cloudcore and edgecore and supports TLS authentication.
+	+ 1-2 Re-establish a websocket tunnel between cloudcore and edgecore that supports TLS authentication.
 		
 	This proposal chooses the second solution. The new tunnel is specifically responsible for the forwarding of streaming data, which can be used as `/metric` data transmission tunnel without affecting the logic of cloudhub and edgehub. 
 
@@ -102,7 +102,7 @@ For the data transmission in the tunnel proxy, there are several considerations:
 - In order to distinguish the data of `logs, exec, attach, /metric` connection types, we need to add type definition to distinguish these data.
 - Distinguish which connection the data belongs to. We need to use a session-like definition.
 - cloudcore tunnel needs to support SPDY and websocket protocols.
-- Supports TLS authentication.
+- Support TLS authentication.
 
 The message structure is as follows (working in process ...)：
 
@@ -117,7 +117,7 @@ type TunnelMsg struct {
 
 2. Redirect requests made by kube-apiserver to the cloud tunnel service 
 
-We will not modify the code of kube-apiserver, so the connection request address initiated by kube-apiserver is {edgenodeip}:10250, and the 10250 port is getted by (`node.Status.DaemonEndpoints.KubeletEndpoint.Port`), so we need DNAT.
+We will not modify the code of kube-apiserver, so the connection request address initiated by kube-apiserver is {edgenodeip}:10250, and the 10250 port is obtained from (`node.Status.DaemonEndpoints.KubeletEndpoint.Port`), so we need DNAT.
 
 ```
  kubectl get node {nodename} -o=jsonpath="{.status.daemonEndpoints.kubeletEndpoint['Port']}"

--- a/docs/proposals/sig-node/exec-logs.md
+++ b/docs/proposals/sig-node/exec-logs.md
@@ -83,7 +83,7 @@ In the edge computing scenarios, kube-apiserver cannot directly access the node 
 	For the tunnel channel, we have two options:
 
 	+ 1-1 We can use (cloudhub <-> edgehub) tunnel, but now cloudhub and edgehub are mainly used to transfer kubernetes resource data (pod, node, configmap, service ...), which is not very suitable for `exec, attach and logs` streaming data transmission.
-	+ 1-2 Re-establish a websocket tunnel between cloudcore and edgecore that supports TLS authentication.
+	+ 1-2 Establish a separate WebSocket tunnel between CloudCore and EdgeCore that supports TLS authentication.
 		
 	This proposal chooses the second solution. The new tunnel is specifically responsible for the forwarding of streaming data, which can be used as `/metric` data transmission tunnel without affecting the logic of cloudhub and edgehub. 
 
@@ -117,7 +117,7 @@ type TunnelMsg struct {
 
 2. Redirect requests made by kube-apiserver to the cloud tunnel service 
 
-We will not modify the code of kube-apiserver, so the connection request address initiated by kube-apiserver is {edgenodeip}:10250, and the 10250 port is obtained from (`node.Status.DaemonEndpoints.KubeletEndpoint.Port`), so we need DNAT.
+We do not modify kube-apiserver. It reads the target kubelet port from `node.Status.DaemonEndpoints.KubeletEndpoint.Port` and connects to `{edgeNodeIP}:10250`, so the traffic must be redirected through DNAT.
 
 ```
  kubectl get node {nodename} -o=jsonpath="{.status.daemonEndpoints.kubeletEndpoint['Port']}"


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR fixes several wording and spelling issues in proposal documents.

The updates include:
- improving wording in the exec logs proposal
- fixing the `getted` typo
- clarifying MQTT mapper wording
- fixing the `mapper-framewokr` typo

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

```release-note
NONE