### PR TITLE
devicetwin: skip twin sync updates with missing metadata

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -557,7 +557,7 @@ func isTwinValueDiff(twin *dttype.MsgTwin, msgTwin *dttype.MsgTwin, dealType int
 		msgTwinValue = msgTwin.Actual
 		hasTwin = true
 	}
-	if msgTwinValue != nil {
+	if msgTwinValue != nil && msgTwinValue.Value != nil {
 		hasMsgTwin = true
 	}
 
@@ -1011,8 +1011,9 @@ func DealMsgTwin(context *dtcontext.DTContext, deviceID string, msgTwins map[str
 	var err error
 	for key, msgTwin := range msgTwins {
 		if twin, exist := twins[key]; exist {
-			if dealType >= 1 && msgTwin != nil && (msgTwin.Metadata == nil) {
-				klog.Info("Not found metadata of twin")
+			if dealType >= 1 && (msgTwin == nil || msgTwin.Metadata == nil) {
+				klog.Warningf("Skip syncing twin %s of device %s: metadata is missing", key, deviceID)
+				continue
 			}
 			if msgTwin == nil && dealType == 0 || dealType >= 1 && strings.Compare(msgTwin.Metadata.Type, dtcommon.TypeDeleted) == 0 {
 				dealTwinDelete(&returnResult, deviceID, key, twin, msgTwin, dealType)

--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -1010,11 +1010,11 @@ func DealMsgTwin(context *dtcontext.DTContext, deviceID string, msgTwins map[str
 
 	var err error
 	for key, msgTwin := range msgTwins {
+		if dealType >= 1 && (msgTwin == nil || msgTwin.Metadata == nil) {
+			klog.Warningf("Skip syncing twin %s of device %s: metadata is missing", key, deviceID)
+			continue
+		}
 		if twin, exist := twins[key]; exist {
-			if dealType >= 1 && (msgTwin == nil || msgTwin.Metadata == nil) {
-				klog.Warningf("Skip syncing twin %s of device %s: metadata is missing", key, deviceID)
-				continue
-			}
 			if msgTwin == nil && dealType == 0 || dealType >= 1 && strings.Compare(msgTwin.Metadata.Type, dtcommon.TypeDeleted) == 0 {
 				dealTwinDelete(&returnResult, deviceID, key, twin, msgTwin, dealType)
 				continue

--- a/edge/pkg/devicetwin/dtmanager/twin_test.go
+++ b/edge/pkg/devicetwin/dtmanager/twin_test.go
@@ -1570,6 +1570,12 @@ func TestDealMsgTwinMissingMetadata(t *testing.T) {
 			name:     "TestDealMsgTwinMissingMetadata(): Case 2: nil synced twin is skipped",
 			msgTwins: map[string]*dttype.MsgTwin{key1: nil},
 		},
+		{
+			name: "TestDealMsgTwinMissingMetadata(): Case 3: uncached synced twin without metadata is skipped",
+			msgTwins: map[string]*dttype.MsgTwin{
+				"key2": {Expected: &dttype.TwinValue{Value: &str}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/edge/pkg/devicetwin/dtmanager/twin_test.go
+++ b/edge/pkg/devicetwin/dtmanager/twin_test.go
@@ -1530,3 +1530,97 @@ func generateTwinContent(eventID, deviceID string) ([]byte, []byte, dtcontext.DT
 	context := contextFunc(deviceID)
 	return content, contentKeyTwin, context
 }
+
+// TestDealMsgTwinMissingMetadata verifies that a twin sync update whose twin is nil or
+// carries no metadata is skipped instead of dereferencing a nil Metadata and panicking.
+func TestDealMsgTwinMissingMetadata(t *testing.T) {
+	str := typeString
+	emptyResult := dttype.DealTwinResult{
+		Add:        make([]models.DeviceTwin, 0),
+		Delete:     make([]models.DeviceDelete, 0),
+		Update:     make([]models.DeviceTwinUpdate, 0),
+		Result:     make(map[string]*dttype.MsgTwin),
+		SyncResult: make(map[string]*dttype.MsgTwin),
+		Document:   make(map[string]*dttype.TwinDoc),
+	}
+
+	newContext := func() *dtcontext.DTContext {
+		context := contextFunc(deviceA)
+		twin := map[string]*dttype.MsgTwin{
+			key1: {
+				Expected: &dttype.TwinValue{Value: &str},
+				Metadata: &dttype.TypeMetadata{Type: typeString},
+			},
+		}
+		context.DeviceList.Store(deviceA, &dttype.Device{Twin: twin})
+		return &context
+	}
+
+	tests := []struct {
+		name     string
+		msgTwins map[string]*dttype.MsgTwin
+	}{
+		{
+			name: "TestDealMsgTwinMissingMetadata(): Case 1: synced twin without metadata is skipped",
+			msgTwins: map[string]*dttype.MsgTwin{
+				key1: {Expected: &dttype.TwinValue{Value: &str}},
+			},
+		},
+		{
+			name:     "TestDealMsgTwinMissingMetadata(): Case 2: nil synced twin is skipped",
+			msgTwins: map[string]*dttype.MsgTwin{key1: nil},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DealMsgTwin(newContext(), deviceA, tt.msgTwins, SyncDealType); !reflect.DeepEqual(got, emptyResult) {
+				t.Errorf("DTManager.DealMsgTwin() case failed: got = %+v, want = %+v", got, emptyResult)
+			}
+		})
+	}
+}
+
+// TestIsTwinValueDiffNilValue verifies that a twin value object with a nil Value is treated
+// as carrying no value rather than dereferencing the nil Value pointer and panicking.
+func TestIsTwinValueDiffNilValue(t *testing.T) {
+	cachedValue := typeString
+	newValue := valueType
+	twin := &dttype.MsgTwin{
+		Expected: &dttype.TwinValue{Value: &cachedValue},
+		Metadata: &dttype.TypeMetadata{Type: typeString},
+	}
+
+	tests := []struct {
+		name    string
+		msgTwin *dttype.MsgTwin
+		want    bool
+	}{
+		{
+			name: "TestIsTwinValueDiffNilValue(): Case 1: nil expected value reports no diff",
+			msgTwin: &dttype.MsgTwin{
+				Expected: &dttype.TwinValue{},
+				Metadata: &dttype.TypeMetadata{Type: typeString},
+			},
+			want: false,
+		},
+		{
+			name: "TestIsTwinValueDiffNilValue(): Case 2: present expected value reports diff",
+			msgTwin: &dttype.MsgTwin{
+				Expected: &dttype.TwinValue{Value: &newValue},
+				Metadata: &dttype.TypeMetadata{Type: typeString},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isTwinValueDiff(twin, tt.msgTwin, DealExpected)
+			if err != nil {
+				t.Errorf("DTManager.isTwinValueDiff() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("DTManager.isTwinValueDiff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When edgecore handles a twin sync update from the cloud (`TwinCloudSync`), `DealMsgTwin`
reads `msgTwin.Metadata.Type` for an already-cached twin key without checking that
`Metadata` is set. The unmarshaller allows a twin to arrive without metadata (and allows a
twin value with a nil `Value`), so such a payload dereferences a nil pointer and panics.
The panic is recovered in `DTModule.Start`, but the `TwinWorker` goroutine exits and twin
sync stops on the node until the health check restarts it, at which point the same message
can crash it again.

This skips a synced twin that has no metadata (logging a warning) instead of dereferencing
it, so the worker keeps processing the rest of the message and stays alive. It also treats
a twin value whose `Value` is nil as carrying no value, fixing a second nil dereference on
the same path in `isTwinValueDiff`. The non-sync (MQTT) path is unchanged. Added unit tests
covering both cases.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6950 

**Special notes for your reviewer**:
The MQTT/local update path (`dealType == RestDealType`) already guards `msgTwin.Metadata`,
so only the cloud sync path (`dealType >= 1`) was affected and only that path is changed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a nil pointer panic in devicetwin when a twin sync update from the cloud is missing metadata.
```
