### PR TITLE
policycontroller: add leader election

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
   verbs: ["delete"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  verbs: ["get", "list", "watch", "create", "update"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["devices.kubeedge.io"]
   resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/build/cloud/ha/01-ha-prepare.yaml
+++ b/build/cloud/ha/01-ha-prepare.yaml
@@ -39,7 +39,7 @@ rules:
     verbs: ["delete"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "list", "watch", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["devices.kubeedge.io"]
     resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/cloud/pkg/policycontroller/policycontroller.go
+++ b/cloud/pkg/policycontroller/policycontroller.go
@@ -3,6 +3,7 @@ package policycontroller
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -19,7 +20,13 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	pm "github.com/kubeedge/kubeedge/cloud/pkg/policycontroller/manager"
+	"github.com/kubeedge/kubeedge/common/constants"
 	kefeatures "github.com/kubeedge/kubeedge/pkg/features"
+)
+
+const (
+	podNamespaceEnv                  = "POD_NAMESPACE"
+	policyControllerLeaderElectionID = "kubeedge-policycontroller"
 )
 
 // policyController use beehive context message layer
@@ -37,16 +44,29 @@ func init() {
 	utilruntime.Must(policyv1alpha1.AddToScheme(accessScheme))
 }
 
-func NewAccessRoleControllerManager(ctx context.Context, kubeCfg *rest.Config) (manager.Manager, error) {
-	controllerManager, err := controllerruntime.NewManager(kubeCfg, controllerruntime.Options{
+func policyControllerLeaderElectionNamespace() string {
+	if namespace := os.Getenv(podNamespaceEnv); namespace != "" {
+		return namespace
+	}
+	return constants.SystemNamespace
+}
+
+func newAccessRoleControllerManagerOptions() controllerruntime.Options {
+	return controllerruntime.Options{
 		Scheme: accessScheme,
 		Metrics: controllerruntimemetrics.Options{
 			SecureServing: false,
 			BindAddress:   "0",
 		}, // disable metrics
-		// TODO: leader election
+		LeaderElection:          true,
+		LeaderElectionID:        policyControllerLeaderElectionID,
+		LeaderElectionNamespace: policyControllerLeaderElectionNamespace(),
 		// TODO: /healthz
-	})
+	}
+}
+
+func NewAccessRoleControllerManager(ctx context.Context, kubeCfg *rest.Config) (manager.Manager, error) {
+	controllerManager, err := controllerruntime.NewManager(kubeCfg, newAccessRoleControllerManagerOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create controller manager: %w", err)
 	}

--- a/cloud/pkg/policycontroller/policycontroller_test.go
+++ b/cloud/pkg/policycontroller/policycontroller_test.go
@@ -252,6 +252,38 @@ func TestNewAccessRoleControllerManager(t *testing.T) {
 	}
 }
 
+func TestPolicyControllerManagerOptionsEnableLeaderElection(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "edge-system")
+
+	opts := newAccessRoleControllerManagerOptions()
+
+	if !opts.LeaderElection {
+		t.Fatal("expected policycontroller manager to enable leader election")
+	}
+	if opts.LeaderElectionID != policyControllerLeaderElectionID {
+		t.Fatalf("LeaderElectionID = %q, want %q", opts.LeaderElectionID, policyControllerLeaderElectionID)
+	}
+	if opts.LeaderElectionNamespace != "edge-system" {
+		t.Fatalf("LeaderElectionNamespace = %q, want %q", opts.LeaderElectionNamespace, "edge-system")
+	}
+}
+
+func TestPolicyControllerLeaderElectionNamespaceFallsBackToSystemNamespace(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+
+	if got := policyControllerLeaderElectionNamespace(); got != "kubeedge" {
+		t.Fatalf("policyControllerLeaderElectionNamespace() = %q, want %q", got, "kubeedge")
+	}
+}
+
+func TestPolicyControllerLeaderElectionNamespaceUsesPodNamespace(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "custom-kubeedge")
+
+	if got := policyControllerLeaderElectionNamespace(); got != "custom-kubeedge" {
+		t.Fatalf("policyControllerLeaderElectionNamespace() = %q, want %q", got, "custom-kubeedge")
+	}
+}
+
 func TestSetupControllers(t *testing.T) {
 	setupFunc := reflect.ValueOf(setupControllers)
 	if !setupFunc.IsValid() {

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: ["delete"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "list", "watch", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["devices.kubeedge.io"]
     resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/tests/scripts/cloudcore_leader_election_rbac_test.sh
+++ b/tests/scripts/cloudcore_leader_election_rbac_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+assert_lease_verbs() {
+  local file="$1"
+  local line
+  line="$(awk '
+    /apiGroups:/ { in_coordination = ($0 ~ /"coordination\.k8s\.io"/) ? 1 : 0; in_leases = 0; next }
+    in_coordination && /resources:/ { in_leases = ($0 ~ /"leases"/) ? 1 : 0; next }
+    in_coordination && in_leases && /verbs:/ { print; exit }
+  ' "${ROOT_DIR}/${file}")"
+
+  if [[ -z "${line}" ]]; then
+    echo "missing leases verbs in ${file}" >&2
+    exit 1
+  fi
+
+  for verb in get list watch create update patch delete; do
+    if [[ "${line}" != *"\"${verb}\""* ]]; then
+      echo "missing lease verb ${verb} in ${file}: ${line}" >&2
+      exit 1
+    fi
+  done
+}
+
+assert_lease_verbs "manifests/charts/cloudcore/templates/rbac_cloudcore.yaml"
+assert_lease_verbs "build/cloud/03-clusterrole.yaml"
+assert_lease_verbs "build/cloud/ha/01-ha-prepare.yaml"


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This PR enables controller-runtime leader election for CloudCore's policycontroller manager. With multiple CloudCore replicas and RequireAuthorization enabled, all policycontroller instances could reconcile the same ServiceAccountAccess object concurrently. That can cause update conflicts while updating ServiceAccountAccess spec/status and may leave related ObjectSync resources behind.

The policycontroller manager now uses a Lease named `kubeedge-policycontroller` in the CloudCore namespace, so only the current leader runs the ServiceAccountAccess reconciler while standby replicas can take over after a leader failure.

This PR also grants the CloudCore ServiceAccount the remaining Lease permissions required by controller-runtime leader election and adds focused tests for the manager options and RBAC manifests.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

The leader election namespace is read from `POD_NAMESPACE` when available and falls back to the KubeEdge system namespace. This keeps the default manifests working while allowing deployments in a custom namespace when the Pod namespace is injected through the Downward API.

Local validation:

- `go test ./cloud/pkg/policycontroller -count=1`
- `bash tests/scripts/cloudcore_leader_election_rbac_test.sh`
- `git diff --check upstream/master...HEAD`
- `make all WHAT=cloudcore BUILD_WITH_CONTAINER=false`
- `env GOCACHE=/private/tmp/kubeedge-go-cache make verify-crds`

**Does this PR introduce a user-facing change?**:

```release-note
CloudCore policycontroller now uses leader election so only one replica reconciles ServiceAccountAccess resources at a time in HA deployments.
```
