### PR TITLE
synccontroller: harden ObjectSync delivery in HA

### DIFF
--- a/cloud/pkg/cloudhub/common/testing/test_framework.go
+++ b/cloud/pkg/cloudhub/common/testing/test_framework.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
 )
 
 var (
@@ -272,6 +273,7 @@ const (
 	TestPodUID                    = "c7399134-f4fb-43e6-8088-c273bfffe7af"
 	TestDiffPodUID                = "c7399134-f4fb-43e6-8088-c273bfffe999"
 	TestConfigMapUID              = "22b0074a-8c07-4fc2-adad-1589f7f6f8b1"
+	TestNodeUID                   = "407c69f3-5790-4fa5-9f7b-5e2d5dfe1674"
 	KeepaliveInterval             = 2 * time.Second
 	NormalSendKeepaliveInterval   = 1 * time.Second
 	AbnormalSendKeepaliveInterval = 3 * time.Second
@@ -329,6 +331,22 @@ func NewObjectSync(object v12.Object, kind string) *v1alpha1.ObjectSync {
 	}
 }
 
+func NewClusterObjectSync(object v12.Object, kind string) *v1alpha1.ClusterObjectSync {
+	return &v1alpha1.ClusterObjectSync{
+		ObjectMeta: v12.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", TestNodeID, object.GetUID()),
+		},
+		Spec: v1alpha1.ObjectSyncSpec{
+			ObjectAPIVersion: "v1",
+			ObjectKind:       kind,
+			ObjectName:       object.GetName(),
+		},
+		Status: v1alpha1.ObjectSyncStatus{
+			ObjectResourceVersion: object.GetResourceVersion(),
+		},
+	}
+}
+
 func NewPodMessage(pod *v1.Pod, operation string) *beehivemodel.Message {
 	resource, err := messagelayer.BuildResource(pod.Spec.NodeName, pod.Namespace, "pod", pod.Name)
 	if err != nil {
@@ -340,6 +358,36 @@ func NewPodMessage(pod *v1.Pod, operation string) *beehivemodel.Message {
 		FillBody(pod)
 
 	return message.BuildRouter("edgecontroller", "resource", resource, operation)
+}
+
+func NewTestNodeResource(name, UID, resourceVersion string) *v1.Node {
+	return &v1.Node{
+		TypeMeta: v12.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name:            name,
+			ResourceVersion: resourceVersion,
+			UID:             types.UID(UID),
+			Labels: map[string]string{
+				"version": resourceVersion,
+			},
+		},
+	}
+}
+
+func NewNodeMessage(node *v1.Node, operation string) *beehivemodel.Message {
+	resource, err := messagelayer.BuildResource(node.Name, models.NullNamespace, beehivemodel.ResourceTypeNode, node.Name)
+	if err != nil {
+		klog.Warningf("built message resource failed with error: %s", err)
+		return nil
+	}
+	message := beehivemodel.NewMessage("").
+		SetResourceVersion(node.ResourceVersion).
+		FillBody(node)
+
+	return message.BuildRouter(modules.EdgeControllerModuleName, "resource", resource, operation)
 }
 
 func NewTestConfigMapResource(name, UID, resourceVersion string) *v1.ConfigMap {

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -24,6 +24,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -214,7 +215,10 @@ func (md *messageDispatcher) PubToController(info *model.HubInfo, msg *beehivemo
 }
 
 func (md *messageDispatcher) enqueueNoAckMessage(nodeID string, msg *beehivemodel.Message) {
-	nodeMessagePool := md.GetNodeMessagePool(nodeID)
+	nodeMessagePool := md.getActiveNodeMessagePool(nodeID)
+	if nodeMessagePool == nil {
+		return
+	}
 
 	messageKey, err := common.NoAckMessageKeyFunc(msg)
 	if err != nil {
@@ -234,7 +238,10 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 		return
 	}
 
-	nodeMessagePool := md.GetNodeMessagePool(nodeID)
+	nodeMessagePool := md.getActiveNodeMessagePool(nodeID)
+	if nodeMessagePool == nil {
+		return
+	}
 	nodeQueue := nodeMessagePool.AckMessageQueue
 	nodeStore := nodeMessagePool.AckMessageStore
 
@@ -302,6 +309,15 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
+	case err == nil:
+		clusterObjectSync, err = md.ensureClusterObjectSyncStatusInitialized(clusterObjectSync.Name)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize clusterObjectSync status",
+				"clusterObjectSyncName", clusterObjectSyncName,
+				"resourceName", resourceName)
+			return false
+		}
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil && apierrors.IsNotFound(err):
 		// If clusterObjectSync is not exist, this indicates that the message is coming
@@ -317,10 +333,16 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			},
 		}
 
-		clusterObjectSync, err := md.reliableClient.
+		clusterObjectSync, err = md.reliableClient.
 			ReliablesyncsV1alpha1().
 			ClusterObjectSyncs().
 			Create(context.Background(), clusterObjectSync, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			clusterObjectSync, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ClusterObjectSyncs().
+				Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
+		}
 		if err != nil {
 			klog.ErrorS(err, "Failed to create clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
@@ -328,11 +350,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			return false
 		}
 
-		clusterObjectSync.Status.ObjectResourceVersion = "0"
-		_, err = md.reliableClient.
-			ReliablesyncsV1alpha1().
-			ClusterObjectSyncs().
-			UpdateStatus(context.Background(), clusterObjectSync, metav1.UpdateOptions{})
+		clusterObjectSync, err = md.ensureClusterObjectSyncStatusInitialized(clusterObjectSync.Name)
 		if err != nil {
 			klog.ErrorS(err, "Failed to update clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
@@ -340,7 +358,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			return false
 		}
 
-		return true
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil:
 		klog.Errorf("failed to get clusterObjectSync %s: %v", clusterObjectSyncName, err)
@@ -366,6 +384,16 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
+	case err == nil:
+		objectSync, err = md.ensureObjectSyncStatusInitialized(resourceNamespace, objectSync.Name)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize objectSync status",
+				"objectSyncName", objectSyncName,
+				"resourceNamespace", resourceNamespace,
+				"resourceName", resourceName)
+			return false
+		}
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil && apierrors.IsNotFound(err):
 		// If objectSync is not exist, this indicates that the message is coming
@@ -382,10 +410,16 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 			},
 		}
 
-		objectSyncStatus, err := md.reliableClient.
+		objectSync, err = md.reliableClient.
 			ReliablesyncsV1alpha1().
 			ObjectSyncs(resourceNamespace).
 			Create(context.Background(), objectSync, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			objectSync, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ObjectSyncs(resourceNamespace).
+				Get(context.Background(), objectSyncName, metav1.GetOptions{})
+		}
 		if err != nil {
 			klog.ErrorS(err, "Failed to create objectSync",
 				"objectSyncName", objectSyncName,
@@ -394,11 +428,7 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 			return false
 		}
 
-		objectSyncStatus.Status.ObjectResourceVersion = "0"
-		_, err = md.reliableClient.
-			ReliablesyncsV1alpha1().
-			ObjectSyncs(resourceNamespace).
-			UpdateStatus(context.Background(), objectSyncStatus, metav1.UpdateOptions{})
+		objectSync, err = md.ensureObjectSyncStatusInitialized(resourceNamespace, objectSync.Name)
 		if err != nil {
 			klog.ErrorS(err, "Failed to update objectSync",
 				"objectSyncName", objectSyncName,
@@ -407,13 +437,63 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 			return false
 		}
 
-		return true
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil:
 		klog.Errorf("failed to get ObjectSync %s/%s: %v", resourceNamespace, objectSyncName, err)
 	}
 
 	return false
+}
+
+func (md *messageDispatcher) ensureObjectSyncStatusInitialized(namespace, name string) (*v1alpha1.ObjectSync, error) {
+	var objectSync *v1alpha1.ObjectSync
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(namespace).
+			Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if latest.Status.ObjectResourceVersion != "" {
+			objectSync = latest
+			return nil
+		}
+		latest = latest.DeepCopy()
+		latest.Status.ObjectResourceVersion = "0"
+		objectSync, err = md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(namespace).
+			UpdateStatus(context.Background(), latest, metav1.UpdateOptions{})
+		return err
+	})
+	return objectSync, err
+}
+
+func (md *messageDispatcher) ensureClusterObjectSyncStatusInitialized(name string) (*v1alpha1.ClusterObjectSync, error) {
+	var clusterObjectSync *v1alpha1.ClusterObjectSync
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if latest.Status.ObjectResourceVersion != "" {
+			clusterObjectSync = latest
+			return nil
+		}
+		latest = latest.DeepCopy()
+		latest.Status.ObjectResourceVersion = "0"
+		clusterObjectSync, err = md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			UpdateStatus(context.Background(), latest, metav1.UpdateOptions{})
+		return err
+	})
+	return clusterObjectSync, err
 }
 
 func isDeleteMessage(msg *beehivemodel.Message) bool {
@@ -507,13 +587,21 @@ func isVolumeOperation(op string) bool {
 func (md *messageDispatcher) GetNodeMessagePool(nodeID string) *common.NodeMessagePool {
 	nsp, exist := md.NodeMessagePools.Load(nodeID)
 	if !exist {
-		klog.Warningf("message pool for edge node %s not found and created now", nodeID)
-		nodeMessagePool := common.InitNodeMessagePool(nodeID)
-		md.NodeMessagePools.Store(nodeID, nodeMessagePool)
-		return nodeMessagePool
+		klog.V(4).Infof("message pool for edge node %s not found", nodeID)
+		return nil
 	}
 
 	return nsp.(*common.NodeMessagePool)
+}
+
+func (md *messageDispatcher) getActiveNodeMessagePool(nodeID string) *common.NodeMessagePool {
+	if md.SessionManager != nil {
+		if _, exist := md.SessionManager.GetSession(nodeID); !exist {
+			klog.V(4).Infof("skip message for node %s because this CloudHub instance has no active session", nodeID)
+			return nil
+		}
+	}
+	return md.GetNodeMessagePool(nodeID)
 }
 
 func (md *messageDispatcher) AddNodeMessagePool(nodeID string, pool *common.NodeMessagePool) {

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -240,6 +240,12 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 
 	nodeMessagePool := md.getActiveNodeMessagePool(nodeID)
 	if nodeMessagePool == nil {
+		// A controller and the target edge session can be hosted by different
+		// CloudCore replicas. Persist the resource sync point so the replica
+		// with the active session can deliver it through syncController.
+		if !isDeleteMessage(msg) && msg.GetOperation() != beehivemodel.ResponseOperation {
+			md.shouldEnqueueResource(nodeID, msg)
+		}
 		return
 	}
 	nodeQueue := nodeMessagePool.AckMessageQueue
@@ -285,12 +291,15 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 
 	// If the message doesn't exist in the store, then compare it with
 	// the version stored in the objectSync or clusterObjectSync.
+	shouldEnqueue = md.shouldEnqueueResource(nodeID, msg)
+}
+
+func (md *messageDispatcher) shouldEnqueueResource(nodeID string, msg *beehivemodel.Message) bool {
 	resourceNamespace, _ := messagelayer.GetNamespace(*msg)
 	if resourceNamespace == models.NullNamespace {
-		shouldEnqueue = md.enqueueNonNamespacedResource(nodeID, msg)
-	} else {
-		shouldEnqueue = md.enqueueNamespacedResource(nodeID, msg)
+		return md.enqueueNonNamespacedResource(nodeID, msg)
 	}
+	return md.enqueueNamespacedResource(nodeID, msg)
 }
 
 func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *beehivemodel.Message) bool {
@@ -597,7 +606,7 @@ func (md *messageDispatcher) GetNodeMessagePool(nodeID string) *common.NodeMessa
 func (md *messageDispatcher) getActiveNodeMessagePool(nodeID string) *common.NodeMessagePool {
 	if md.SessionManager != nil {
 		if _, exist := md.SessionManager.GetSession(nodeID); !exist {
-			klog.V(4).Infof("skip message for node %s because this CloudHub instance has no active session", nodeID)
+			klog.V(4).Infof("skip local enqueue for node %s because this CloudHub instance has no active session", nodeID)
 			return nil
 		}
 	}

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -358,6 +359,105 @@ func TestEnqueueAckMessage(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			executeTest(t, test)
 		})
+	}
+}
+
+func TestEnqueueAckMessageInitializesExistingObjectSyncAfterCreateRace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	nmp := common.InitNodeMessagePool(tf.TestNodeID)
+	manager := session.NewSessionManager(10)
+	manager.AddSession(session.NewNodeSession(tf.TestNodeID, tf.TestProjectID, nil, tf.KeepaliveInterval, nmp, client))
+
+	msg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3"), "update")
+	existingObjectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, ""), "Pod")
+	existingObjectSync.Status.ObjectResourceVersion = ""
+	if _, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Create(
+		t.Context(), existingObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed objectSync: %v", err)
+	}
+
+	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp)
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists, _ := nmp.AckMessageStore.Get(msg); !exists {
+		t.Fatalf("expected message to be enqueued after objectSync create race")
+	}
+	got, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Get(
+		t.Context(), existingObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get objectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "0" {
+		t.Fatalf("expected existing objectSync status to be initialized to 0, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestEnqueueAckMessageInitializesExistingClusterObjectSyncAfterCreateRace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	nmp := common.InitNodeMessagePool(tf.TestNodeID)
+	manager := session.NewSessionManager(10)
+	manager.AddSession(session.NewNodeSession(tf.TestNodeID, tf.TestProjectID, nil, tf.KeepaliveInterval, nmp, client))
+
+	msg := tf.NewNodeMessage(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, "3"), "update")
+	existingClusterObjectSync := tf.NewClusterObjectSync(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, ""), "Node")
+	existingClusterObjectSync.Status.ObjectResourceVersion = ""
+	if _, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Create(
+		t.Context(), existingClusterObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed clusterObjectSync: %v", err)
+	}
+
+	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp)
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists, _ := nmp.AckMessageStore.Get(msg); !exists {
+		t.Fatalf("expected message to be enqueued after clusterObjectSync create race")
+	}
+	got, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Get(
+		t.Context(), existingClusterObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get clusterObjectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "0" {
+		t.Fatalf("expected existing clusterObjectSync status to be initialized to 0, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestEnqueueAckMessageSkipsWhenNodeHasNoLocalSession(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	manager := session.NewSessionManager(10)
+
+	msg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3"), "update")
+	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists := dispatcher.NodeMessagePools.Load(tf.TestNodeID); exists {
+		t.Fatalf("expected dispatcher not to create a local message pool without a node session")
 	}
 }
 

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -440,11 +440,12 @@ func TestEnqueueAckMessageInitializesExistingClusterObjectSyncAfterCreateRace(t 
 	}
 }
 
-func TestEnqueueAckMessageSkipsWhenNodeHasNoLocalSession(t *testing.T) {
+func TestEnqueueAckMessagePersistsObjectSyncWithoutLocalSession(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	manager := session.NewSessionManager(10)
 
-	msg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3"), "update")
+	pod := tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3")
+	msg := tf.NewPodMessage(pod, "update")
 	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
 	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
 	dispatcher := &messageDispatcher{
@@ -458,6 +459,56 @@ func TestEnqueueAckMessageSkipsWhenNodeHasNoLocalSession(t *testing.T) {
 
 	if _, exists := dispatcher.NodeMessagePools.Load(tf.TestNodeID); exists {
 		t.Fatalf("expected dispatcher not to create a local message pool without a node session")
+	}
+	objectSyncName := fmt.Sprintf("%s.%s", tf.TestNodeID, pod.UID)
+	got, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Get(
+		t.Context(), objectSyncName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected shared objectSync to be persisted without a local node session: %v", err)
+	}
+	if got.Spec.ObjectAPIVersion != "v1" ||
+		got.Spec.ObjectKind != "Pod" ||
+		got.Spec.ObjectName != pod.Name {
+		t.Fatalf("unexpected objectSync spec: %#v", got.Spec)
+	}
+	if got.Status.ObjectResourceVersion != "0" {
+		t.Fatalf("expected new objectSync status to be initialized to 0, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestEnqueueAckMessagePersistsClusterObjectSyncWithoutLocalSession(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	manager := session.NewSessionManager(10)
+
+	node := tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, "3")
+	msg := tf.NewNodeMessage(node, "update")
+	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists := dispatcher.NodeMessagePools.Load(tf.TestNodeID); exists {
+		t.Fatalf("expected dispatcher not to create a local message pool without a node session")
+	}
+	clusterObjectSyncName := fmt.Sprintf("%s.%s", tf.TestNodeID, node.UID)
+	got, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Get(
+		t.Context(), clusterObjectSyncName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected shared clusterObjectSync to be persisted without a local node session: %v", err)
+	}
+	if got.Spec.ObjectAPIVersion != "v1" ||
+		got.Spec.ObjectKind != "Node" ||
+		got.Spec.ObjectName != node.Name {
+		t.Fatalf("unexpected clusterObjectSync spec: %#v", got.Spec)
+	}
+	if got.Status.ObjectResourceVersion != "0" {
+		t.Fatalf("expected new clusterObjectSync status to be initialized to 0, got %q", got.Status.ObjectResourceVersion)
 	}
 }
 

--- a/cloud/pkg/cloudhub/session/node_session.go
+++ b/cloud/pkg/cloudhub/session/node_session.go
@@ -26,6 +26,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -406,60 +407,7 @@ func (ns *NodeSession) saveNamespaceResourceSuccess(msg *beehivemodel.Message) {
 		return
 	}
 
-	objectSync, err := ns.reliableClient.
-		ReliablesyncsV1alpha1().
-		ObjectSyncs(resourceNamespace).
-		Get(context.Background(), objectSyncName, metav1.GetOptions{})
-
-	switch {
-	case err == nil:
-
-	case apierrors.IsNotFound(err):
-		// create objectSync if not found
-		objectSync = &v1alpha1.ObjectSync{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      objectSyncName,
-				Namespace: resourceNamespace,
-			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
-		}
-
-		if objectSync.Spec.ObjectKind == "" {
-			klog.ErrorS(nil, "failed to init objectSync, ObjectKind is empty",
-				"objectSyncName", objectSyncName,
-				"resourceType", resourceType,
-				"resourceNamespace", resourceNamespace,
-				"resourceName", resourceName,
-				"message", msg.GetContent())
-			return
-		}
-
-		objectSync, err = ns.reliableClient.
-			ReliablesyncsV1alpha1().
-			ObjectSyncs(resourceNamespace).
-			Create(context.Background(), objectSync, metav1.CreateOptions{})
-		if err != nil {
-			klog.Errorf("Failed to create objectSync: %s, err: %v", objectSyncName, err)
-			return
-		}
-
-	default:
-		// request objectSync from KubeAPIServer err
-		klog.Errorf("Failed to get objectSync: %s, err: %v", objectSyncName, err)
-		return
-	}
-
-	objectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
-	_, err = ns.reliableClient.
-		ReliablesyncsV1alpha1().
-		ObjectSyncs(resourceNamespace).
-		UpdateStatus(context.Background(), objectSync, metav1.UpdateOptions{})
-
-	if err != nil {
+	if err := ns.saveObjectSyncSuccessPoint(resourceNamespace, objectSyncName, resourceName, resourceType, msg); err != nil {
 		klog.ErrorS(err, "failed to update objectSync",
 			"objectSyncName", objectSyncName,
 			"resourceType", resourceType,
@@ -467,6 +415,64 @@ func (ns *NodeSession) saveNamespaceResourceSuccess(msg *beehivemodel.Message) {
 			"resourceName", resourceName)
 		return
 	}
+}
+
+func (ns *NodeSession) saveObjectSyncSuccessPoint(resourceNamespace, objectSyncName, resourceName, resourceType string, msg *beehivemodel.Message) error {
+	if msg.GetResourceVersion() == "" {
+		return fmt.Errorf("message resourceVersion is empty")
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		objectSync, err := ns.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(resourceNamespace).
+			Get(context.Background(), objectSyncName, metav1.GetOptions{})
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			objectSync = &v1alpha1.ObjectSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      objectSyncName,
+					Namespace: resourceNamespace,
+				},
+				Spec: v1alpha1.ObjectSyncSpec{
+					ObjectAPIVersion: util.GetMessageAPIVersion(msg),
+					ObjectKind:       util.GetMessageResourceType(msg),
+					ObjectName:       resourceName,
+				},
+			}
+			if objectSync.Spec.ObjectKind == "" {
+				return fmt.Errorf("failed to init objectSync %s, ObjectKind is empty for resourceType %s", objectSyncName, resourceType)
+			}
+			objectSync, err = ns.reliableClient.
+				ReliablesyncsV1alpha1().
+				ObjectSyncs(resourceNamespace).
+				Create(context.Background(), objectSync, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				objectSync, err = ns.reliableClient.
+					ReliablesyncsV1alpha1().
+					ObjectSyncs(resourceNamespace).
+					Get(context.Background(), objectSyncName, metav1.GetOptions{})
+			}
+			if err != nil {
+				return err
+			}
+		default:
+			return err
+		}
+
+		currentResourceVersion := objectSync.Status.ObjectResourceVersion
+		if currentResourceVersion != "" && synccontroller.CompareResourceVersion(msg.GetResourceVersion(), currentResourceVersion) <= 0 {
+			return nil
+		}
+
+		objectSync = objectSync.DeepCopy()
+		objectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
+		_, err = ns.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(resourceNamespace).
+			UpdateStatus(context.Background(), objectSync, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func (ns *NodeSession) saveNonNamespaceResourceSuccess(msg *beehivemodel.Message) {
@@ -487,61 +493,66 @@ func (ns *NodeSession) saveNonNamespaceResourceSuccess(msg *beehivemodel.Message
 		return
 	}
 
-	clusterObjectSync, err := ns.reliableClient.
-		ReliablesyncsV1alpha1().ClusterObjectSyncs().
-		Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
-
-	switch {
-	case err == nil:
-
-	case apierrors.IsNotFound(err):
-		// create clusterObjectSync if not found
-		clusterObjectSync = &v1alpha1.ClusterObjectSync{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: clusterObjectSyncName,
-			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
-		}
-
-		if clusterObjectSync.Spec.ObjectKind == "" {
-			klog.ErrorS(nil, "failed to init objectSync, ObjectKind is empty",
-				"objectSyncName", clusterObjectSyncName,
-				"resourceType", resourceType,
-				"resourceName", resourceName,
-				"message", msg.GetContent())
-			return
-		}
-
-		clusterObjectSync, err = ns.reliableClient.
-			ReliablesyncsV1alpha1().ClusterObjectSyncs().
-			Create(context.Background(), clusterObjectSync, metav1.CreateOptions{})
-		if err != nil {
-			klog.Errorf("Failed to create clusterObjectSync: %s, err: %v", clusterObjectSyncName, err)
-			return
-		}
-
-	default:
-		// request clusterObjectSync from KubeAPIServer err
-		klog.Errorf("Failed to get clusterObjectSync: %s, err: %v", clusterObjectSyncName, err)
-		return
-	}
-
-	clusterObjectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
-	_, err = ns.reliableClient.
-		ReliablesyncsV1alpha1().ClusterObjectSyncs().
-		UpdateStatus(context.Background(), clusterObjectSync, metav1.UpdateOptions{})
-
-	if err != nil {
+	if err := ns.saveClusterObjectSyncSuccessPoint(clusterObjectSyncName, resourceName, resourceType, msg); err != nil {
 		klog.ErrorS(err, "failed to update clusterObjectSync",
 			"objectSyncName", clusterObjectSyncName,
 			"resourceType", resourceType,
 			"resourceName", resourceName)
 		return
 	}
+}
+
+func (ns *NodeSession) saveClusterObjectSyncSuccessPoint(clusterObjectSyncName, resourceName, resourceType string, msg *beehivemodel.Message) error {
+	if msg.GetResourceVersion() == "" {
+		return fmt.Errorf("message resourceVersion is empty")
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		clusterObjectSync, err := ns.reliableClient.
+			ReliablesyncsV1alpha1().ClusterObjectSyncs().
+			Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			clusterObjectSync = &v1alpha1.ClusterObjectSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterObjectSyncName,
+				},
+				Spec: v1alpha1.ObjectSyncSpec{
+					ObjectAPIVersion: util.GetMessageAPIVersion(msg),
+					ObjectKind:       util.GetMessageResourceType(msg),
+					ObjectName:       resourceName,
+				},
+			}
+			if clusterObjectSync.Spec.ObjectKind == "" {
+				return fmt.Errorf("failed to init clusterObjectSync %s, ObjectKind is empty for resourceType %s", clusterObjectSyncName, resourceType)
+			}
+			clusterObjectSync, err = ns.reliableClient.
+				ReliablesyncsV1alpha1().ClusterObjectSyncs().
+				Create(context.Background(), clusterObjectSync, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				clusterObjectSync, err = ns.reliableClient.
+					ReliablesyncsV1alpha1().ClusterObjectSyncs().
+					Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
+			}
+			if err != nil {
+				return err
+			}
+		default:
+			return err
+		}
+
+		currentResourceVersion := clusterObjectSync.Status.ObjectResourceVersion
+		if currentResourceVersion != "" && synccontroller.CompareResourceVersion(msg.GetResourceVersion(), currentResourceVersion) <= 0 {
+			return nil
+		}
+
+		clusterObjectSync = clusterObjectSync.DeepCopy()
+		clusterObjectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
+		_, err = ns.reliableClient.
+			ReliablesyncsV1alpha1().ClusterObjectSyncs().
+			UpdateStatus(context.Background(), clusterObjectSync, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func (ns *NodeSession) deleteSuccessPoint(resourceNamespace, objectSyncName string, msg *beehivemodel.Message) {

--- a/cloud/pkg/cloudhub/session/node_session_test.go
+++ b/cloud/pkg/cloudhub/session/node_session_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -337,6 +338,62 @@ func TestNodeSessionSendAckMessage(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			executeTest(t, test)
 		})
+	}
+}
+
+func TestSaveNamespaceResourceSuccessDoesNotMoveObjectSyncStatusBackward(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	existingObjectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "5"), "Pod")
+	if _, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Create(
+		t.Context(), existingObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed objectSync: %v", err)
+	}
+
+	session := NewNodeSession(
+		tf.TestNodeID,
+		tf.TestProjectID,
+		nil,
+		tf.KeepaliveInterval,
+		common.InitNodeMessagePool(tf.TestNodeID),
+		client,
+	)
+	session.saveNamespaceResourceSuccess(tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3"), "update"))
+
+	got, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Get(
+		t.Context(), existingObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get objectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "5" {
+		t.Fatalf("expected objectSync status to stay at 5, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestSaveNonNamespaceResourceSuccessDoesNotMoveClusterObjectSyncStatusBackward(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	existingClusterObjectSync := tf.NewClusterObjectSync(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, "5"), "Node")
+	if _, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Create(
+		t.Context(), existingClusterObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed clusterObjectSync: %v", err)
+	}
+
+	session := NewNodeSession(
+		tf.TestNodeID,
+		tf.TestProjectID,
+		nil,
+		tf.KeepaliveInterval,
+		common.InitNodeMessagePool(tf.TestNodeID),
+		client,
+	)
+	session.saveNonNamespaceResourceSuccess(tf.NewNodeMessage(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, "3"), "update"))
+
+	got, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Get(
+		t.Context(), existingClusterObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get clusterObjectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "5" {
+		t.Fatalf("expected clusterObjectSync status to stay at 5, got %q", got.Status.ObjectResourceVersion)
 	}
 }
 

--- a/cloud/pkg/synccontroller/clusterobjectsync.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync.go
@@ -117,14 +117,15 @@ func sendClusterObjectSyncEvent(nodeName string, sync *v1alpha1.ClusterObjectSyn
 		klog.Warningf("failed to set metatype :%v", err)
 	}
 
-	if sync.Status.ObjectResourceVersion == "" {
-		klog.Errorf("The ObjectResourceVersion is empty in status of clusterObjectSync: %s", sync.Name)
-		return
+	syncedResourceVersion := sync.Status.ObjectResourceVersion
+	if syncedResourceVersion == "" {
+		klog.Warningf("The ObjectResourceVersion is empty in status of clusterObjectSync: %s, treat it as 0", sync.Name)
+		syncedResourceVersion = "0"
 	}
 
-	if compareResourceVersionFunc(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
+	if compareResourceVersionFunc(objectResourceVersion, syncedResourceVersion) > 0 {
 		// trigger the update event
-		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
+		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, syncedResourceVersion)
 		msg := buildEdgeControllerMessageFunc(nodeName, models.NullNamespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
 		sendToEdge(commonconst.DefaultContextSendModuleName, *msg)
 	}

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -89,14 +89,15 @@ func (sctl *SyncController) gcOrphanedObjectSync(sync *v1alpha1.ObjectSync) {
 
 func sendEvents(nodeName string, sync *v1alpha1.ObjectSync, resourceType string,
 	objectResourceVersion string, obj interface{}) {
-	if sync.Status.ObjectResourceVersion == "" {
-		klog.Errorf("The ObjectResourceVersion is empty in status of objectsync: %s", sync.Name)
-		return
+	syncedResourceVersion := sync.Status.ObjectResourceVersion
+	if syncedResourceVersion == "" {
+		klog.Warningf("The ObjectResourceVersion is empty in status of objectsync: %s, treat it as 0", sync.Name)
+		syncedResourceVersion = "0"
 	}
 
-	if CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
+	if CompareResourceVersion(objectResourceVersion, syncedResourceVersion) > 0 {
 		// trigger the update event
-		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
+		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, syncedResourceVersion)
 		msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
 		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
 	}

--- a/cloud/pkg/synccontroller/objectsync_test.go
+++ b/cloud/pkg/synccontroller/objectsync_test.go
@@ -19,6 +19,7 @@ package synccontroller
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -175,6 +176,41 @@ func TestSendEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestSendEventsTreatsEmptyObjectSyncStatusAsZero(t *testing.T) {
+	cloudHub := &common.ModuleInfo{
+		ModuleName: modules.CloudHubModuleName,
+		ModuleType: common.MsgCtxTypeChannel,
+	}
+	beehiveContext.InitContext([]string{common.MsgCtxTypeChannel})
+	beehiveContext.AddModule(cloudHub)
+	beehiveContext.AddModuleGroup(modules.CloudHubModuleName, modules.CloudHubModuleGroup)
+
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, ""), "Pod")
+	objectSync.Status.ObjectResourceVersion = ""
+	obj := tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2")
+
+	go sendEvents(tf.TestNodeID, objectSync, "pod", obj.ResourceVersion, obj)
+
+	select {
+	case message := <-receiveCloudHubMessage():
+		if message.GetOperation() != model.UpdateOperation {
+			t.Fatalf("expected update operation, got %q", message.GetOperation())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected update message for empty objectSync status")
+	}
+}
+
+func receiveCloudHubMessage() <-chan model.Message {
+	ch := make(chan model.Message, 1)
+	go func() {
+		message, _ := beehiveContext.Receive(modules.CloudHubModuleName)
+		ch <- message
+	}()
+	return ch
+}
+
 func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/cloud/pkg/synccontroller/synccontroller.go
+++ b/cloud/pkg/synccontroller/synccontroller.go
@@ -174,7 +174,7 @@ func (sctl *SyncController) deleteObjectSyncs() {
 				if isGarbage {
 					klog.Infof("ObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
 					err = sctl.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(sync.Namespace).Delete(context.Background(), sync.Name, *metav1.NewDeleteOptions(0))
-					if err != nil {
+					if err != nil && !errors.IsNotFound(err) {
 						klog.Warningf("failed to delete objectSync %s for edgenode %s, err: %v", sync.Name, nodeName, err)
 						return err
 					}
@@ -208,7 +208,7 @@ func (sctl *SyncController) deleteClusterObjectSyncs() {
 				if isGarbage {
 					klog.Infof("ClusterObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
 					err = sctl.crdclient.ReliablesyncsV1alpha1().ClusterObjectSyncs().Delete(context.Background(), sync.Name, *metav1.NewDeleteOptions(0))
-					if err != nil {
+					if err != nil && !errors.IsNotFound(err) {
 						klog.Warningf("failed to delete ClusterObjectSync %s for edgenode %s, err: %v", sync.Name, nodeName, err)
 						return err
 					}

--- a/cloud/pkg/synccontroller/synccontroller_test.go
+++ b/cloud/pkg/synccontroller/synccontroller_test.go
@@ -23,9 +23,13 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	configv1alpha1 "github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -220,5 +224,36 @@ func TestDeleteObjectSyncs(t *testing.T) {
 				t.Errorf("deleteObjectSyncs() list returned unexpected result. got = %v, want = %v", len(got.Items), tt.ExpectedSyncs)
 			}
 		})
+	}
+}
+
+func TestDeleteObjectSyncsIgnoresAlreadyDeletedObjectSync(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	crdClient := crdfake.NewSimpleClientset()
+	crdInformers := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	if err := crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Informer().GetIndexer().Add(objectSync); err != nil {
+		t.Fatalf("failed to seed objectSync informer: %v", err)
+	}
+
+	deleteCalls := 0
+	crdClient.Fake.PrependReactor("delete", "objectsyncs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteCalls++
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: "reliablesyncs.kubeedge.io", Resource: "objectsyncs"},
+			action.(k8stesting.DeleteAction).GetName(),
+		)
+	})
+
+	client := fake.NewSimpleClientset()
+	informers := informers.NewSharedInformerFactory(client, 0)
+	testController := &SyncController{}
+	testController.nodeLister = informers.Core().V1().Nodes().Lister()
+	testController.crdclient = crdClient
+	testController.objectSyncLister = crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Lister()
+
+	testController.deleteObjectSyncs()
+
+	if deleteCalls != 1 {
+		t.Fatalf("expected one delete attempt for already deleted objectSync, got %d", deleteCalls)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR hardens reliable resource delivery when CloudCore runs with multiple replicas.

The concrete failures addressed are:

- Multiple replicas can observe the same downstream resource and race while creating the same ObjectSync or ClusterObjectSync. An `AlreadyExists` response is treated as a successful create race, and the existing object is fetched before status initialization continues.
- A delayed ACK can overwrite `status.objectResourceVersion` with an older value. ACK updates are monotonic and ignore resource versions that are not newer than the stored value.
- CloudHub queues and edge sessions are local to each CloudCore Pod. A replica that does not own the target edge session must not create a local message pool or enqueue locally, but it must still persist the shared ObjectSync or ClusterObjectSync. The synccontroller on the session-owning replica can then observe that sync point and deliver the resource.
- Existing ObjectSync records with an empty status are treated as resource version `0`, allowing synccontroller compensation to resend the current object.
- Cleanup ignores `NotFound` when another replica has already deleted a stale ObjectSync.

This deliberately does not add global leader election to synccontroller. Reliable-sync delivery must execute on the CloudHub replica that owns the target edge-node connection; a global leader may not own that session.

**Special notes for your reviewer**:

Validation performed:

- `go test -count=1 ./cloud/pkg/cloudhub/dispatcher ./cloud/pkg/cloudhub/session ./cloud/pkg/synccontroller`
- `go test -race -count=1 ./cloud/pkg/cloudhub/dispatcher`
- `make verify`
- `git diff --check`
- Reproduced and validated on a three-replica ACK CloudCore deployment where the controller and edge session were on different replicas. Before the fix, the shared ObjectSync was absent and MetaServer requests remained unauthorized. After the fix, the source and acknowledged resource versions converged and the affected reporters succeeded.

The ObjectSync GVK/spec backfill change is intentionally excluded and is submitted separately in #7025.

**Does this PR introduce a user-facing change?**:

```release-note
CloudCore reliable sync now handles multi-replica ObjectSync creation races, stale ACKs, and split controller/session ownership without dropping shared sync state.
```
