### PR TITLE
cloudcore: harden HA controller synchronization

### DIFF
--- a/build/cloud/03-clusterrole.yaml
+++ b/build/cloud/03-clusterrole.yaml
@@ -20,7 +20,7 @@ rules:
   verbs: ["delete"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  verbs: ["get", "list", "watch", "create", "update"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["devices.kubeedge.io"]
   resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/build/cloud/ha/01-ha-prepare.yaml
+++ b/build/cloud/ha/01-ha-prepare.yaml
@@ -39,7 +39,7 @@ rules:
     verbs: ["delete"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "list", "watch", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["devices.kubeedge.io"]
     resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/cloud/pkg/cloudhub/common/testing/test_framework.go
+++ b/cloud/pkg/cloudhub/common/testing/test_framework.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
 )
 
 var (
@@ -272,6 +273,7 @@ const (
 	TestPodUID                    = "c7399134-f4fb-43e6-8088-c273bfffe7af"
 	TestDiffPodUID                = "c7399134-f4fb-43e6-8088-c273bfffe999"
 	TestConfigMapUID              = "22b0074a-8c07-4fc2-adad-1589f7f6f8b1"
+	TestNodeUID                   = "407c69f3-5790-4fa5-9f7b-5e2d5dfe1674"
 	KeepaliveInterval             = 2 * time.Second
 	NormalSendKeepaliveInterval   = 1 * time.Second
 	AbnormalSendKeepaliveInterval = 3 * time.Second
@@ -329,6 +331,22 @@ func NewObjectSync(object v12.Object, kind string) *v1alpha1.ObjectSync {
 	}
 }
 
+func NewClusterObjectSync(object v12.Object, kind string) *v1alpha1.ClusterObjectSync {
+	return &v1alpha1.ClusterObjectSync{
+		ObjectMeta: v12.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", TestNodeID, object.GetUID()),
+		},
+		Spec: v1alpha1.ObjectSyncSpec{
+			ObjectAPIVersion: "v1",
+			ObjectKind:       kind,
+			ObjectName:       object.GetName(),
+		},
+		Status: v1alpha1.ObjectSyncStatus{
+			ObjectResourceVersion: object.GetResourceVersion(),
+		},
+	}
+}
+
 func NewPodMessage(pod *v1.Pod, operation string) *beehivemodel.Message {
 	resource, err := messagelayer.BuildResource(pod.Spec.NodeName, pod.Namespace, "pod", pod.Name)
 	if err != nil {
@@ -340,6 +358,36 @@ func NewPodMessage(pod *v1.Pod, operation string) *beehivemodel.Message {
 		FillBody(pod)
 
 	return message.BuildRouter("edgecontroller", "resource", resource, operation)
+}
+
+func NewTestNodeResource(name, UID, resourceVersion string) *v1.Node {
+	return &v1.Node{
+		TypeMeta: v12.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name:            name,
+			ResourceVersion: resourceVersion,
+			UID:             types.UID(UID),
+			Labels: map[string]string{
+				"version": resourceVersion,
+			},
+		},
+	}
+}
+
+func NewNodeMessage(node *v1.Node, operation string) *beehivemodel.Message {
+	resource, err := messagelayer.BuildResource(node.Name, models.NullNamespace, beehivemodel.ResourceTypeNode, node.Name)
+	if err != nil {
+		klog.Warningf("built message resource failed with error: %s", err)
+		return nil
+	}
+	message := beehivemodel.NewMessage("").
+		SetResourceVersion(node.ResourceVersion).
+		FillBody(node)
+
+	return message.BuildRouter(modules.EdgeControllerModuleName, "resource", resource, operation)
 }
 
 func NewTestConfigMapResource(name, UID, resourceVersion string) *v1.ConfigMap {

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -24,6 +24,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -214,7 +215,10 @@ func (md *messageDispatcher) PubToController(info *model.HubInfo, msg *beehivemo
 }
 
 func (md *messageDispatcher) enqueueNoAckMessage(nodeID string, msg *beehivemodel.Message) {
-	nodeMessagePool := md.GetNodeMessagePool(nodeID)
+	nodeMessagePool := md.getActiveNodeMessagePool(nodeID)
+	if nodeMessagePool == nil {
+		return
+	}
 
 	messageKey, err := common.NoAckMessageKeyFunc(msg)
 	if err != nil {
@@ -234,7 +238,10 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 		return
 	}
 
-	nodeMessagePool := md.GetNodeMessagePool(nodeID)
+	nodeMessagePool := md.getActiveNodeMessagePool(nodeID)
+	if nodeMessagePool == nil {
+		return
+	}
 	nodeQueue := nodeMessagePool.AckMessageQueue
 	nodeStore := nodeMessagePool.AckMessageStore
 
@@ -302,6 +309,15 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
+	case err == nil:
+		clusterObjectSync, err = md.ensureClusterObjectSyncStatusInitialized(clusterObjectSync.Name)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize clusterObjectSync status",
+				"clusterObjectSyncName", clusterObjectSyncName,
+				"resourceName", resourceName)
+			return false
+		}
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil && apierrors.IsNotFound(err):
 		// If clusterObjectSync is not exist, this indicates that the message is coming
@@ -317,10 +333,16 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			},
 		}
 
-		clusterObjectSync, err := md.reliableClient.
+		clusterObjectSync, err = md.reliableClient.
 			ReliablesyncsV1alpha1().
 			ClusterObjectSyncs().
 			Create(context.Background(), clusterObjectSync, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			clusterObjectSync, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ClusterObjectSyncs().
+				Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
+		}
 		if err != nil {
 			klog.ErrorS(err, "Failed to create clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
@@ -328,11 +350,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			return false
 		}
 
-		clusterObjectSync.Status.ObjectResourceVersion = "0"
-		_, err = md.reliableClient.
-			ReliablesyncsV1alpha1().
-			ClusterObjectSyncs().
-			UpdateStatus(context.Background(), clusterObjectSync, metav1.UpdateOptions{})
+		clusterObjectSync, err = md.ensureClusterObjectSyncStatusInitialized(clusterObjectSync.Name)
 		if err != nil {
 			klog.ErrorS(err, "Failed to update clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
@@ -340,7 +358,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			return false
 		}
 
-		return true
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil:
 		klog.Errorf("failed to get clusterObjectSync %s: %v", clusterObjectSyncName, err)
@@ -366,6 +384,16 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
+	case err == nil:
+		objectSync, err = md.ensureObjectSyncStatusInitialized(resourceNamespace, objectSync.Name)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize objectSync status",
+				"objectSyncName", objectSyncName,
+				"resourceNamespace", resourceNamespace,
+				"resourceName", resourceName)
+			return false
+		}
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil && apierrors.IsNotFound(err):
 		// If objectSync is not exist, this indicates that the message is coming
@@ -382,10 +410,16 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 			},
 		}
 
-		objectSyncStatus, err := md.reliableClient.
+		objectSync, err = md.reliableClient.
 			ReliablesyncsV1alpha1().
 			ObjectSyncs(resourceNamespace).
 			Create(context.Background(), objectSync, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			objectSync, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ObjectSyncs(resourceNamespace).
+				Get(context.Background(), objectSyncName, metav1.GetOptions{})
+		}
 		if err != nil {
 			klog.ErrorS(err, "Failed to create objectSync",
 				"objectSyncName", objectSyncName,
@@ -394,11 +428,7 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 			return false
 		}
 
-		objectSyncStatus.Status.ObjectResourceVersion = "0"
-		_, err = md.reliableClient.
-			ReliablesyncsV1alpha1().
-			ObjectSyncs(resourceNamespace).
-			UpdateStatus(context.Background(), objectSyncStatus, metav1.UpdateOptions{})
+		objectSync, err = md.ensureObjectSyncStatusInitialized(resourceNamespace, objectSync.Name)
 		if err != nil {
 			klog.ErrorS(err, "Failed to update objectSync",
 				"objectSyncName", objectSyncName,
@@ -407,13 +437,63 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 			return false
 		}
 
-		return true
+		return synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0
 
 	case err != nil:
 		klog.Errorf("failed to get ObjectSync %s/%s: %v", resourceNamespace, objectSyncName, err)
 	}
 
 	return false
+}
+
+func (md *messageDispatcher) ensureObjectSyncStatusInitialized(namespace, name string) (*v1alpha1.ObjectSync, error) {
+	var objectSync *v1alpha1.ObjectSync
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(namespace).
+			Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if latest.Status.ObjectResourceVersion != "" {
+			objectSync = latest
+			return nil
+		}
+		latest = latest.DeepCopy()
+		latest.Status.ObjectResourceVersion = "0"
+		objectSync, err = md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(namespace).
+			UpdateStatus(context.Background(), latest, metav1.UpdateOptions{})
+		return err
+	})
+	return objectSync, err
+}
+
+func (md *messageDispatcher) ensureClusterObjectSyncStatusInitialized(name string) (*v1alpha1.ClusterObjectSync, error) {
+	var clusterObjectSync *v1alpha1.ClusterObjectSync
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if latest.Status.ObjectResourceVersion != "" {
+			clusterObjectSync = latest
+			return nil
+		}
+		latest = latest.DeepCopy()
+		latest.Status.ObjectResourceVersion = "0"
+		clusterObjectSync, err = md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			UpdateStatus(context.Background(), latest, metav1.UpdateOptions{})
+		return err
+	})
+	return clusterObjectSync, err
 }
 
 func isDeleteMessage(msg *beehivemodel.Message) bool {
@@ -507,13 +587,21 @@ func isVolumeOperation(op string) bool {
 func (md *messageDispatcher) GetNodeMessagePool(nodeID string) *common.NodeMessagePool {
 	nsp, exist := md.NodeMessagePools.Load(nodeID)
 	if !exist {
-		klog.Warningf("message pool for edge node %s not found and created now", nodeID)
-		nodeMessagePool := common.InitNodeMessagePool(nodeID)
-		md.NodeMessagePools.Store(nodeID, nodeMessagePool)
-		return nodeMessagePool
+		klog.V(4).Infof("message pool for edge node %s not found", nodeID)
+		return nil
 	}
 
 	return nsp.(*common.NodeMessagePool)
+}
+
+func (md *messageDispatcher) getActiveNodeMessagePool(nodeID string) *common.NodeMessagePool {
+	if md.SessionManager != nil {
+		if _, exist := md.SessionManager.GetSession(nodeID); !exist {
+			klog.V(4).Infof("skip message for node %s because this CloudHub instance has no active session", nodeID)
+			return nil
+		}
+	}
+	return md.GetNodeMessagePool(nodeID)
 }
 
 func (md *messageDispatcher) AddNodeMessagePool(nodeID string, pool *common.NodeMessagePool) {

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -302,17 +302,25 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 	}
 
 	clusterObjectSyncName := synccontroller.BuildObjectSyncName(nodeID, resourceUID)
+	desiredSpec := objectSyncSpecFromMessage(msg, resourceName)
 	clusterObjectSync, err := md.clusterObjectSyncLister.Get(clusterObjectSyncName)
 
 	switch {
 	case err == nil && clusterObjectSync.Status.ObjectResourceVersion != "":
+		clusterObjectSync, err = md.ensureClusterObjectSyncInitialized(clusterObjectSync.Name, desiredSpec)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize clusterObjectSync",
+				"clusterObjectSyncName", clusterObjectSyncName,
+				"resourceName", resourceName)
+			return false
+		}
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
 	case err == nil:
-		clusterObjectSync, err = md.ensureClusterObjectSyncStatusInitialized(clusterObjectSync.Name)
+		clusterObjectSync, err = md.ensureClusterObjectSyncInitialized(clusterObjectSync.Name, desiredSpec)
 		if err != nil {
-			klog.ErrorS(err, "Failed to initialize clusterObjectSync status",
+			klog.ErrorS(err, "Failed to initialize clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
 				"resourceName", resourceName)
 			return false
@@ -326,11 +334,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterObjectSyncName,
 			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
+			Spec: desiredSpec,
 		}
 
 		clusterObjectSync, err = md.reliableClient.
@@ -350,7 +354,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			return false
 		}
 
-		clusterObjectSync, err = md.ensureClusterObjectSyncStatusInitialized(clusterObjectSync.Name)
+		clusterObjectSync, err = md.ensureClusterObjectSyncInitialized(clusterObjectSync.Name, desiredSpec)
 		if err != nil {
 			klog.ErrorS(err, "Failed to update clusterObjectSync",
 				"clusterObjectSyncName", clusterObjectSyncName,
@@ -377,17 +381,26 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 	}
 
 	objectSyncName := synccontroller.BuildObjectSyncName(nodeID, resourceUID)
+	desiredSpec := objectSyncSpecFromMessage(msg, resourceName)
 	objectSync, err := md.objectSyncLister.ObjectSyncs(resourceNamespace).Get(objectSyncName)
 
 	switch {
 	case err == nil && objectSync.Status.ObjectResourceVersion != "":
+		objectSync, err = md.ensureObjectSyncInitialized(resourceNamespace, objectSync.Name, desiredSpec)
+		if err != nil {
+			klog.ErrorS(err, "Failed to initialize objectSync",
+				"objectSyncName", objectSyncName,
+				"resourceNamespace", resourceNamespace,
+				"resourceName", resourceName)
+			return false
+		}
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
 	case err == nil:
-		objectSync, err = md.ensureObjectSyncStatusInitialized(resourceNamespace, objectSync.Name)
+		objectSync, err = md.ensureObjectSyncInitialized(resourceNamespace, objectSync.Name, desiredSpec)
 		if err != nil {
-			klog.ErrorS(err, "Failed to initialize objectSync status",
+			klog.ErrorS(err, "Failed to initialize objectSync",
 				"objectSyncName", objectSyncName,
 				"resourceNamespace", resourceNamespace,
 				"resourceName", resourceName)
@@ -403,11 +416,7 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 				Name:      objectSyncName,
 				Namespace: resourceNamespace,
 			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
+			Spec: desiredSpec,
 		}
 
 		objectSync, err = md.reliableClient.
@@ -428,7 +437,7 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 			return false
 		}
 
-		objectSync, err = md.ensureObjectSyncStatusInitialized(resourceNamespace, objectSync.Name)
+		objectSync, err = md.ensureObjectSyncInitialized(resourceNamespace, objectSync.Name, desiredSpec)
 		if err != nil {
 			klog.ErrorS(err, "Failed to update objectSync",
 				"objectSyncName", objectSyncName,
@@ -446,7 +455,32 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 	return false
 }
 
-func (md *messageDispatcher) ensureObjectSyncStatusInitialized(namespace, name string) (*v1alpha1.ObjectSync, error) {
+func objectSyncSpecFromMessage(msg *beehivemodel.Message, resourceName string) v1alpha1.ObjectSyncSpec {
+	return v1alpha1.ObjectSyncSpec{
+		ObjectAPIVersion: util.GetMessageAPIVersion(msg),
+		ObjectKind:       util.GetMessageResourceType(msg),
+		ObjectName:       resourceName,
+	}
+}
+
+func fillMissingObjectSyncSpec(spec *v1alpha1.ObjectSyncSpec, desired v1alpha1.ObjectSyncSpec) bool {
+	updated := false
+	if spec.ObjectAPIVersion == "" && desired.ObjectAPIVersion != "" {
+		spec.ObjectAPIVersion = desired.ObjectAPIVersion
+		updated = true
+	}
+	if spec.ObjectKind == "" && desired.ObjectKind != "" {
+		spec.ObjectKind = desired.ObjectKind
+		updated = true
+	}
+	if spec.ObjectName == "" && desired.ObjectName != "" {
+		spec.ObjectName = desired.ObjectName
+		updated = true
+	}
+	return updated
+}
+
+func (md *messageDispatcher) ensureObjectSyncInitialized(namespace, name string, desiredSpec v1alpha1.ObjectSyncSpec) (*v1alpha1.ObjectSync, error) {
 	var objectSync *v1alpha1.ObjectSync
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest, err := md.reliableClient.
@@ -456,22 +490,32 @@ func (md *messageDispatcher) ensureObjectSyncStatusInitialized(namespace, name s
 		if err != nil {
 			return err
 		}
+		latest = latest.DeepCopy()
+		if fillMissingObjectSyncSpec(&latest.Spec, desiredSpec) {
+			latest, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ObjectSyncs(namespace).
+				Update(context.Background(), latest, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		}
 		if latest.Status.ObjectResourceVersion != "" {
 			objectSync = latest
 			return nil
 		}
-		latest = latest.DeepCopy()
-		latest.Status.ObjectResourceVersion = "0"
+		statusLatest := latest.DeepCopy()
+		statusLatest.Status.ObjectResourceVersion = "0"
 		objectSync, err = md.reliableClient.
 			ReliablesyncsV1alpha1().
 			ObjectSyncs(namespace).
-			UpdateStatus(context.Background(), latest, metav1.UpdateOptions{})
+			UpdateStatus(context.Background(), statusLatest, metav1.UpdateOptions{})
 		return err
 	})
 	return objectSync, err
 }
 
-func (md *messageDispatcher) ensureClusterObjectSyncStatusInitialized(name string) (*v1alpha1.ClusterObjectSync, error) {
+func (md *messageDispatcher) ensureClusterObjectSyncInitialized(name string, desiredSpec v1alpha1.ObjectSyncSpec) (*v1alpha1.ClusterObjectSync, error) {
 	var clusterObjectSync *v1alpha1.ClusterObjectSync
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest, err := md.reliableClient.
@@ -481,16 +525,26 @@ func (md *messageDispatcher) ensureClusterObjectSyncStatusInitialized(name strin
 		if err != nil {
 			return err
 		}
+		latest = latest.DeepCopy()
+		if fillMissingObjectSyncSpec(&latest.Spec, desiredSpec) {
+			latest, err = md.reliableClient.
+				ReliablesyncsV1alpha1().
+				ClusterObjectSyncs().
+				Update(context.Background(), latest, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		}
 		if latest.Status.ObjectResourceVersion != "" {
 			clusterObjectSync = latest
 			return nil
 		}
-		latest = latest.DeepCopy()
-		latest.Status.ObjectResourceVersion = "0"
+		statusLatest := latest.DeepCopy()
+		statusLatest.Status.ObjectResourceVersion = "0"
 		clusterObjectSync, err = md.reliableClient.
 			ReliablesyncsV1alpha1().
 			ClusterObjectSyncs().
-			UpdateStatus(context.Background(), latest, metav1.UpdateOptions{})
+			UpdateStatus(context.Background(), statusLatest, metav1.UpdateOptions{})
 		return err
 	})
 	return clusterObjectSync, err

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	policyv1alpha1 "github.com/kubeedge/api/apis/policy/v1alpha1"
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
 	"github.com/kubeedge/api/client/clientset/versioned/fake"
 	syncinformer "github.com/kubeedge/api/client/informers/externalversions"
@@ -34,6 +36,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common"
 	tf "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/testing"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/session"
+	"github.com/kubeedge/kubeedge/cloud/pkg/synccontroller"
 	mockcon "github.com/kubeedge/kubeedge/pkg/viaduct/pkg/conn/testing"
 )
 
@@ -437,6 +440,80 @@ func TestEnqueueAckMessageInitializesExistingClusterObjectSyncAfterCreateRace(t 
 	}
 	if got.Status.ObjectResourceVersion != "0" {
 		t.Fatalf("expected existing clusterObjectSync status to be initialized to 0, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestEnqueueAckMessageBackfillsExistingObjectSyncSpec(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	nmp := common.InitNodeMessagePool(tf.TestNodeID)
+	manager := session.NewSessionManager(10)
+	manager.AddSession(session.NewNodeSession(tf.TestNodeID, tf.TestProjectID, nil, tf.KeepaliveInterval, nmp, client))
+
+	serviceAccountAccess := &policyv1alpha1.ServiceAccountAccess{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "orangepi-agent",
+			Namespace:       tf.TestNamespace,
+			UID:             types.UID("saa-uid"),
+			ResourceVersion: "3",
+		},
+	}
+	msg := beehivemodel.NewMessage("").
+		SetResourceVersion(serviceAccountAccess.ResourceVersion).
+		FillBody(serviceAccountAccess).
+		BuildRouter("edgecontroller", "resource", "node/"+tf.TestNodeID+"/"+tf.TestNamespace+"/serviceaccountaccess/orangepi-agent", "update")
+
+	existingObjectSync := &v1alpha1.ObjectSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      synccontroller.BuildObjectSyncName(tf.TestNodeID, string(serviceAccountAccess.UID)),
+			Namespace: tf.TestNamespace,
+		},
+		Spec: v1alpha1.ObjectSyncSpec{
+			ObjectName: serviceAccountAccess.Name,
+		},
+		Status: v1alpha1.ObjectSyncStatus{
+			ObjectResourceVersion: "2",
+		},
+	}
+	if _, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Create(
+		t.Context(), existingObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed objectSync: %v", err)
+	}
+
+	objectSyncIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if err := objectSyncIndexer.Add(existingObjectSync); err != nil {
+		t.Fatalf("failed to seed objectSync lister: %v", err)
+	}
+	objectSyncLister := synclisters.NewObjectSyncLister(objectSyncIndexer)
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp)
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists, _ := nmp.AckMessageStore.Get(msg); !exists {
+		t.Fatalf("expected message to be enqueued after objectSync spec backfill")
+	}
+	got, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Get(
+		t.Context(), existingObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get objectSync: %v", err)
+	}
+	if got.Spec.ObjectAPIVersion != "policy.kubeedge.io/v1alpha1" {
+		t.Fatalf("expected objectSync apiVersion to be backfilled, got %q", got.Spec.ObjectAPIVersion)
+	}
+	if got.Spec.ObjectKind != "ServiceAccountAccess" {
+		t.Fatalf("expected objectSync kind to be backfilled, got %q", got.Spec.ObjectKind)
+	}
+	if got.Spec.ObjectName != serviceAccountAccess.Name {
+		t.Fatalf("expected objectSync name to stay %q, got %q", serviceAccountAccess.Name, got.Spec.ObjectName)
+	}
+	if got.Status.ObjectResourceVersion != "2" {
+		t.Fatalf("expected objectSync status to remain 2 before ack, got %q", got.Status.ObjectResourceVersion)
 	}
 }
 

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -358,6 +359,105 @@ func TestEnqueueAckMessage(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			executeTest(t, test)
 		})
+	}
+}
+
+func TestEnqueueAckMessageInitializesExistingObjectSyncAfterCreateRace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	nmp := common.InitNodeMessagePool(tf.TestNodeID)
+	manager := session.NewSessionManager(10)
+	manager.AddSession(session.NewNodeSession(tf.TestNodeID, tf.TestProjectID, nil, tf.KeepaliveInterval, nmp, client))
+
+	msg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3"), "update")
+	existingObjectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, ""), "Pod")
+	existingObjectSync.Status.ObjectResourceVersion = ""
+	if _, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Create(
+		t.Context(), existingObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed objectSync: %v", err)
+	}
+
+	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp)
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists, _ := nmp.AckMessageStore.Get(msg); !exists {
+		t.Fatalf("expected message to be enqueued after objectSync create race")
+	}
+	got, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Get(
+		t.Context(), existingObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get objectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "0" {
+		t.Fatalf("expected existing objectSync status to be initialized to 0, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestEnqueueAckMessageInitializesExistingClusterObjectSyncAfterCreateRace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	nmp := common.InitNodeMessagePool(tf.TestNodeID)
+	manager := session.NewSessionManager(10)
+	manager.AddSession(session.NewNodeSession(tf.TestNodeID, tf.TestProjectID, nil, tf.KeepaliveInterval, nmp, client))
+
+	msg := tf.NewNodeMessage(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, "3"), "update")
+	existingClusterObjectSync := tf.NewClusterObjectSync(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, ""), "Node")
+	existingClusterObjectSync.Status.ObjectResourceVersion = ""
+	if _, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Create(
+		t.Context(), existingClusterObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed clusterObjectSync: %v", err)
+	}
+
+	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+	dispatcher.AddNodeMessagePool(tf.TestNodeID, nmp)
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists, _ := nmp.AckMessageStore.Get(msg); !exists {
+		t.Fatalf("expected message to be enqueued after clusterObjectSync create race")
+	}
+	got, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Get(
+		t.Context(), existingClusterObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get clusterObjectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "0" {
+		t.Fatalf("expected existing clusterObjectSync status to be initialized to 0, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestEnqueueAckMessageSkipsWhenNodeHasNoLocalSession(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	manager := session.NewSessionManager(10)
+
+	msg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3"), "update")
+	objectSyncLister := synclisters.NewObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	clusterObjectSyncLister := synclisters.NewClusterObjectSyncLister(cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}))
+	dispatcher := &messageDispatcher{
+		reliableClient:          client,
+		SessionManager:          manager,
+		objectSyncLister:        objectSyncLister,
+		clusterObjectSyncLister: clusterObjectSyncLister,
+	}
+
+	dispatcher.enqueueAckMessage(tf.TestNodeID, msg)
+
+	if _, exists := dispatcher.NodeMessagePools.Load(tf.TestNodeID); exists {
+		t.Fatalf("expected dispatcher not to create a local message pool without a node session")
 	}
 }
 

--- a/cloud/pkg/cloudhub/session/node_session.go
+++ b/cloud/pkg/cloudhub/session/node_session.go
@@ -26,6 +26,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -406,60 +407,7 @@ func (ns *NodeSession) saveNamespaceResourceSuccess(msg *beehivemodel.Message) {
 		return
 	}
 
-	objectSync, err := ns.reliableClient.
-		ReliablesyncsV1alpha1().
-		ObjectSyncs(resourceNamespace).
-		Get(context.Background(), objectSyncName, metav1.GetOptions{})
-
-	switch {
-	case err == nil:
-
-	case apierrors.IsNotFound(err):
-		// create objectSync if not found
-		objectSync = &v1alpha1.ObjectSync{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      objectSyncName,
-				Namespace: resourceNamespace,
-			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
-		}
-
-		if objectSync.Spec.ObjectKind == "" {
-			klog.ErrorS(nil, "failed to init objectSync, ObjectKind is empty",
-				"objectSyncName", objectSyncName,
-				"resourceType", resourceType,
-				"resourceNamespace", resourceNamespace,
-				"resourceName", resourceName,
-				"message", msg.GetContent())
-			return
-		}
-
-		objectSync, err = ns.reliableClient.
-			ReliablesyncsV1alpha1().
-			ObjectSyncs(resourceNamespace).
-			Create(context.Background(), objectSync, metav1.CreateOptions{})
-		if err != nil {
-			klog.Errorf("Failed to create objectSync: %s, err: %v", objectSyncName, err)
-			return
-		}
-
-	default:
-		// request objectSync from KubeAPIServer err
-		klog.Errorf("Failed to get objectSync: %s, err: %v", objectSyncName, err)
-		return
-	}
-
-	objectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
-	_, err = ns.reliableClient.
-		ReliablesyncsV1alpha1().
-		ObjectSyncs(resourceNamespace).
-		UpdateStatus(context.Background(), objectSync, metav1.UpdateOptions{})
-
-	if err != nil {
+	if err := ns.saveObjectSyncSuccessPoint(resourceNamespace, objectSyncName, resourceName, resourceType, msg); err != nil {
 		klog.ErrorS(err, "failed to update objectSync",
 			"objectSyncName", objectSyncName,
 			"resourceType", resourceType,
@@ -467,6 +415,64 @@ func (ns *NodeSession) saveNamespaceResourceSuccess(msg *beehivemodel.Message) {
 			"resourceName", resourceName)
 		return
 	}
+}
+
+func (ns *NodeSession) saveObjectSyncSuccessPoint(resourceNamespace, objectSyncName, resourceName, resourceType string, msg *beehivemodel.Message) error {
+	if msg.GetResourceVersion() == "" {
+		return fmt.Errorf("message resourceVersion is empty")
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		objectSync, err := ns.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(resourceNamespace).
+			Get(context.Background(), objectSyncName, metav1.GetOptions{})
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			objectSync = &v1alpha1.ObjectSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      objectSyncName,
+					Namespace: resourceNamespace,
+				},
+				Spec: v1alpha1.ObjectSyncSpec{
+					ObjectAPIVersion: util.GetMessageAPIVersion(msg),
+					ObjectKind:       util.GetMessageResourceType(msg),
+					ObjectName:       resourceName,
+				},
+			}
+			if objectSync.Spec.ObjectKind == "" {
+				return fmt.Errorf("failed to init objectSync %s, ObjectKind is empty for resourceType %s", objectSyncName, resourceType)
+			}
+			objectSync, err = ns.reliableClient.
+				ReliablesyncsV1alpha1().
+				ObjectSyncs(resourceNamespace).
+				Create(context.Background(), objectSync, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				objectSync, err = ns.reliableClient.
+					ReliablesyncsV1alpha1().
+					ObjectSyncs(resourceNamespace).
+					Get(context.Background(), objectSyncName, metav1.GetOptions{})
+			}
+			if err != nil {
+				return err
+			}
+		default:
+			return err
+		}
+
+		currentResourceVersion := objectSync.Status.ObjectResourceVersion
+		if currentResourceVersion != "" && synccontroller.CompareResourceVersion(msg.GetResourceVersion(), currentResourceVersion) <= 0 {
+			return nil
+		}
+
+		objectSync = objectSync.DeepCopy()
+		objectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
+		_, err = ns.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(resourceNamespace).
+			UpdateStatus(context.Background(), objectSync, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func (ns *NodeSession) saveNonNamespaceResourceSuccess(msg *beehivemodel.Message) {
@@ -487,61 +493,66 @@ func (ns *NodeSession) saveNonNamespaceResourceSuccess(msg *beehivemodel.Message
 		return
 	}
 
-	clusterObjectSync, err := ns.reliableClient.
-		ReliablesyncsV1alpha1().ClusterObjectSyncs().
-		Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
-
-	switch {
-	case err == nil:
-
-	case apierrors.IsNotFound(err):
-		// create clusterObjectSync if not found
-		clusterObjectSync = &v1alpha1.ClusterObjectSync{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: clusterObjectSyncName,
-			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
-		}
-
-		if clusterObjectSync.Spec.ObjectKind == "" {
-			klog.ErrorS(nil, "failed to init objectSync, ObjectKind is empty",
-				"objectSyncName", clusterObjectSyncName,
-				"resourceType", resourceType,
-				"resourceName", resourceName,
-				"message", msg.GetContent())
-			return
-		}
-
-		clusterObjectSync, err = ns.reliableClient.
-			ReliablesyncsV1alpha1().ClusterObjectSyncs().
-			Create(context.Background(), clusterObjectSync, metav1.CreateOptions{})
-		if err != nil {
-			klog.Errorf("Failed to create clusterObjectSync: %s, err: %v", clusterObjectSyncName, err)
-			return
-		}
-
-	default:
-		// request clusterObjectSync from KubeAPIServer err
-		klog.Errorf("Failed to get clusterObjectSync: %s, err: %v", clusterObjectSyncName, err)
-		return
-	}
-
-	clusterObjectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
-	_, err = ns.reliableClient.
-		ReliablesyncsV1alpha1().ClusterObjectSyncs().
-		UpdateStatus(context.Background(), clusterObjectSync, metav1.UpdateOptions{})
-
-	if err != nil {
+	if err := ns.saveClusterObjectSyncSuccessPoint(clusterObjectSyncName, resourceName, resourceType, msg); err != nil {
 		klog.ErrorS(err, "failed to update clusterObjectSync",
 			"objectSyncName", clusterObjectSyncName,
 			"resourceType", resourceType,
 			"resourceName", resourceName)
 		return
 	}
+}
+
+func (ns *NodeSession) saveClusterObjectSyncSuccessPoint(clusterObjectSyncName, resourceName, resourceType string, msg *beehivemodel.Message) error {
+	if msg.GetResourceVersion() == "" {
+		return fmt.Errorf("message resourceVersion is empty")
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		clusterObjectSync, err := ns.reliableClient.
+			ReliablesyncsV1alpha1().ClusterObjectSyncs().
+			Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			clusterObjectSync = &v1alpha1.ClusterObjectSync{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterObjectSyncName,
+				},
+				Spec: v1alpha1.ObjectSyncSpec{
+					ObjectAPIVersion: util.GetMessageAPIVersion(msg),
+					ObjectKind:       util.GetMessageResourceType(msg),
+					ObjectName:       resourceName,
+				},
+			}
+			if clusterObjectSync.Spec.ObjectKind == "" {
+				return fmt.Errorf("failed to init clusterObjectSync %s, ObjectKind is empty for resourceType %s", clusterObjectSyncName, resourceType)
+			}
+			clusterObjectSync, err = ns.reliableClient.
+				ReliablesyncsV1alpha1().ClusterObjectSyncs().
+				Create(context.Background(), clusterObjectSync, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				clusterObjectSync, err = ns.reliableClient.
+					ReliablesyncsV1alpha1().ClusterObjectSyncs().
+					Get(context.Background(), clusterObjectSyncName, metav1.GetOptions{})
+			}
+			if err != nil {
+				return err
+			}
+		default:
+			return err
+		}
+
+		currentResourceVersion := clusterObjectSync.Status.ObjectResourceVersion
+		if currentResourceVersion != "" && synccontroller.CompareResourceVersion(msg.GetResourceVersion(), currentResourceVersion) <= 0 {
+			return nil
+		}
+
+		clusterObjectSync = clusterObjectSync.DeepCopy()
+		clusterObjectSync.Status.ObjectResourceVersion = msg.GetResourceVersion()
+		_, err = ns.reliableClient.
+			ReliablesyncsV1alpha1().ClusterObjectSyncs().
+			UpdateStatus(context.Background(), clusterObjectSync, metav1.UpdateOptions{})
+		return err
+	})
 }
 
 func (ns *NodeSession) deleteSuccessPoint(resourceNamespace, objectSyncName string, msg *beehivemodel.Message) {

--- a/cloud/pkg/cloudhub/session/node_session_test.go
+++ b/cloud/pkg/cloudhub/session/node_session_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -337,6 +338,62 @@ func TestNodeSessionSendAckMessage(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			executeTest(t, test)
 		})
+	}
+}
+
+func TestSaveNamespaceResourceSuccessDoesNotMoveObjectSyncStatusBackward(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	existingObjectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "5"), "Pod")
+	if _, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Create(
+		t.Context(), existingObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed objectSync: %v", err)
+	}
+
+	session := NewNodeSession(
+		tf.TestNodeID,
+		tf.TestProjectID,
+		nil,
+		tf.KeepaliveInterval,
+		common.InitNodeMessagePool(tf.TestNodeID),
+		client,
+	)
+	session.saveNamespaceResourceSuccess(tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "3"), "update"))
+
+	got, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Get(
+		t.Context(), existingObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get objectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "5" {
+		t.Fatalf("expected objectSync status to stay at 5, got %q", got.Status.ObjectResourceVersion)
+	}
+}
+
+func TestSaveNonNamespaceResourceSuccessDoesNotMoveClusterObjectSyncStatusBackward(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	existingClusterObjectSync := tf.NewClusterObjectSync(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, "5"), "Node")
+	if _, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Create(
+		t.Context(), existingClusterObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed clusterObjectSync: %v", err)
+	}
+
+	session := NewNodeSession(
+		tf.TestNodeID,
+		tf.TestProjectID,
+		nil,
+		tf.KeepaliveInterval,
+		common.InitNodeMessagePool(tf.TestNodeID),
+		client,
+	)
+	session.saveNonNamespaceResourceSuccess(tf.NewNodeMessage(tf.NewTestNodeResource(tf.TestNodeID, tf.TestNodeUID, "3"), "update"))
+
+	got, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().Get(
+		t.Context(), existingClusterObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get clusterObjectSync: %v", err)
+	}
+	if got.Status.ObjectResourceVersion != "5" {
+		t.Fatalf("expected clusterObjectSync status to stay at 5, got %q", got.Status.ObjectResourceVersion)
 	}
 }
 

--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -210,7 +210,11 @@ func (dc *DownstreamController) getOrCreateDeviceStatusForDevice(device *v1beta1
 		return nil, err
 	}
 
-	return dc.crdClient.DevicesV1beta1().DeviceStatuses(device.Namespace).Create(context.Background(), deviceStatus, metav1.CreateOptions{})
+	deviceStatus, err = dc.crdClient.DevicesV1beta1().DeviceStatuses(device.Namespace).Create(context.Background(), deviceStatus, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return dc.crdClient.DevicesV1beta1().DeviceStatuses(device.Namespace).Get(context.Background(), device.Name, metav1.GetOptions{})
+	}
+	return deviceStatus, err
 }
 
 // createDevice creates a device from CRD

--- a/cloud/pkg/devicecontroller/controller/downstream_test.go
+++ b/cloud/pkg/devicecontroller/controller/downstream_test.go
@@ -17,11 +17,20 @@ limitations under the License.
 package controller
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kubeedge/api/apis/devices/v1beta1"
+	crdfake "github.com/kubeedge/api/client/clientset/versioned/fake"
+	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ktesting "k8s.io/client-go/testing"
 )
 
 func TestRemoveTwinWithNameChanged(t *testing.T) {
@@ -124,4 +133,55 @@ func TestRemoveTwinWithNameChanged(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.deviceStatus.Status.Twins)
 		})
 	}
+}
+
+func TestGetOrCreateDeviceStatusForDeviceHandlesAlreadyExistsRace(t *testing.T) {
+	device := &v1beta1.Device{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       "Device",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lite-node",
+			Namespace: "led",
+			UID:       types.UID("device-uid"),
+		},
+	}
+	existingStatus := &v1beta1.DeviceStatus{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       "DeviceStatus",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      device.Name,
+			Namespace: device.Namespace,
+		},
+	}
+
+	deviceStatuses := schema.GroupResource{Group: v1beta1.GroupName, Resource: "devicestatuses"}
+	getCalls := 0
+	crdClient := crdfake.NewSimpleClientset()
+	crdClient.Fake.PrependReactor("get", "devicestatuses", func(action ktesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 1 {
+			return true, nil, apierrors.NewNotFound(deviceStatuses, action.(ktesting.GetAction).GetName())
+		}
+		return true, existingStatus.DeepCopy(), nil
+	})
+	crdClient.Fake.PrependReactor("create", "devicestatuses", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deviceStatus := action.(ktesting.CreateAction).GetObject().(*v1beta1.DeviceStatus)
+		return true, nil, apierrors.NewAlreadyExists(deviceStatuses, deviceStatus.Name)
+	})
+
+	dc := &DownstreamController{
+		crdClient: crdClient,
+		deviceStatusManager: &manager.DeviceStatusManager{
+			DeviceStatus: sync.Map{},
+		},
+	}
+
+	status, err := dc.getOrCreateDeviceStatusForDevice(device)
+	assert.NoError(t, err)
+	assert.Equal(t, existingStatus.Name, status.Name)
+	assert.Equal(t, 2, getCalls)
 }

--- a/cloud/pkg/policycontroller/policycontroller.go
+++ b/cloud/pkg/policycontroller/policycontroller.go
@@ -3,6 +3,7 @@ package policycontroller
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -19,7 +20,13 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	pm "github.com/kubeedge/kubeedge/cloud/pkg/policycontroller/manager"
+	"github.com/kubeedge/kubeedge/common/constants"
 	kefeatures "github.com/kubeedge/kubeedge/pkg/features"
+)
+
+const (
+	podNamespaceEnv                  = "POD_NAMESPACE"
+	policyControllerLeaderElectionID = "kubeedge-policycontroller"
 )
 
 // policyController use beehive context message layer
@@ -37,16 +44,29 @@ func init() {
 	utilruntime.Must(policyv1alpha1.AddToScheme(accessScheme))
 }
 
-func NewAccessRoleControllerManager(ctx context.Context, kubeCfg *rest.Config) (manager.Manager, error) {
-	controllerManager, err := controllerruntime.NewManager(kubeCfg, controllerruntime.Options{
+func policyControllerLeaderElectionNamespace() string {
+	if namespace := os.Getenv(podNamespaceEnv); namespace != "" {
+		return namespace
+	}
+	return constants.SystemNamespace
+}
+
+func newAccessRoleControllerManagerOptions() controllerruntime.Options {
+	return controllerruntime.Options{
 		Scheme: accessScheme,
 		Metrics: controllerruntimemetrics.Options{
 			SecureServing: false,
 			BindAddress:   "0",
 		}, // disable metrics
-		// TODO: leader election
+		LeaderElection:          true,
+		LeaderElectionID:        policyControllerLeaderElectionID,
+		LeaderElectionNamespace: policyControllerLeaderElectionNamespace(),
 		// TODO: /healthz
-	})
+	}
+}
+
+func NewAccessRoleControllerManager(ctx context.Context, kubeCfg *rest.Config) (manager.Manager, error) {
+	controllerManager, err := controllerruntime.NewManager(kubeCfg, newAccessRoleControllerManagerOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create controller manager: %w", err)
 	}

--- a/cloud/pkg/policycontroller/policycontroller_test.go
+++ b/cloud/pkg/policycontroller/policycontroller_test.go
@@ -252,6 +252,38 @@ func TestNewAccessRoleControllerManager(t *testing.T) {
 	}
 }
 
+func TestPolicyControllerManagerOptionsEnableLeaderElection(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "edge-system")
+
+	opts := newAccessRoleControllerManagerOptions()
+
+	if !opts.LeaderElection {
+		t.Fatal("expected policycontroller manager to enable leader election")
+	}
+	if opts.LeaderElectionID != policyControllerLeaderElectionID {
+		t.Fatalf("LeaderElectionID = %q, want %q", opts.LeaderElectionID, policyControllerLeaderElectionID)
+	}
+	if opts.LeaderElectionNamespace != "edge-system" {
+		t.Fatalf("LeaderElectionNamespace = %q, want %q", opts.LeaderElectionNamespace, "edge-system")
+	}
+}
+
+func TestPolicyControllerLeaderElectionNamespaceFallsBackToSystemNamespace(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "")
+
+	if got := policyControllerLeaderElectionNamespace(); got != "kubeedge" {
+		t.Fatalf("policyControllerLeaderElectionNamespace() = %q, want %q", got, "kubeedge")
+	}
+}
+
+func TestPolicyControllerLeaderElectionNamespaceUsesPodNamespace(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "custom-kubeedge")
+
+	if got := policyControllerLeaderElectionNamespace(); got != "custom-kubeedge" {
+		t.Fatalf("policyControllerLeaderElectionNamespace() = %q, want %q", got, "custom-kubeedge")
+	}
+}
+
 func TestSetupControllers(t *testing.T) {
 	setupFunc := reflect.ValueOf(setupControllers)
 	if !setupFunc.IsValid() {

--- a/cloud/pkg/synccontroller/clusterobjectsync.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync.go
@@ -117,14 +117,15 @@ func sendClusterObjectSyncEvent(nodeName string, sync *v1alpha1.ClusterObjectSyn
 		klog.Warningf("failed to set metatype :%v", err)
 	}
 
-	if sync.Status.ObjectResourceVersion == "" {
-		klog.Errorf("The ObjectResourceVersion is empty in status of clusterObjectSync: %s", sync.Name)
-		return
+	syncedResourceVersion := sync.Status.ObjectResourceVersion
+	if syncedResourceVersion == "" {
+		klog.Warningf("The ObjectResourceVersion is empty in status of clusterObjectSync: %s, treat it as 0", sync.Name)
+		syncedResourceVersion = "0"
 	}
 
-	if compareResourceVersionFunc(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
+	if compareResourceVersionFunc(objectResourceVersion, syncedResourceVersion) > 0 {
 		// trigger the update event
-		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
+		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, syncedResourceVersion)
 		msg := buildEdgeControllerMessageFunc(nodeName, models.NullNamespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
 		sendToEdge(commonconst.DefaultContextSendModuleName, *msg)
 	}

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -89,14 +89,15 @@ func (sctl *SyncController) gcOrphanedObjectSync(sync *v1alpha1.ObjectSync) {
 
 func sendEvents(nodeName string, sync *v1alpha1.ObjectSync, resourceType string,
 	objectResourceVersion string, obj interface{}) {
-	if sync.Status.ObjectResourceVersion == "" {
-		klog.Errorf("The ObjectResourceVersion is empty in status of objectsync: %s", sync.Name)
-		return
+	syncedResourceVersion := sync.Status.ObjectResourceVersion
+	if syncedResourceVersion == "" {
+		klog.Warningf("The ObjectResourceVersion is empty in status of objectsync: %s, treat it as 0", sync.Name)
+		syncedResourceVersion = "0"
 	}
 
-	if CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
+	if CompareResourceVersion(objectResourceVersion, syncedResourceVersion) > 0 {
 		// trigger the update event
-		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
+		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, syncedResourceVersion)
 		msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
 		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
 	}

--- a/cloud/pkg/synccontroller/objectsync_test.go
+++ b/cloud/pkg/synccontroller/objectsync_test.go
@@ -19,6 +19,7 @@ package synccontroller
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -175,6 +176,41 @@ func TestSendEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestSendEventsTreatsEmptyObjectSyncStatusAsZero(t *testing.T) {
+	cloudHub := &common.ModuleInfo{
+		ModuleName: modules.CloudHubModuleName,
+		ModuleType: common.MsgCtxTypeChannel,
+	}
+	beehiveContext.InitContext([]string{common.MsgCtxTypeChannel})
+	beehiveContext.AddModule(cloudHub)
+	beehiveContext.AddModuleGroup(modules.CloudHubModuleName, modules.CloudHubModuleGroup)
+
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, ""), "Pod")
+	objectSync.Status.ObjectResourceVersion = ""
+	obj := tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2")
+
+	go sendEvents(tf.TestNodeID, objectSync, "pod", obj.ResourceVersion, obj)
+
+	select {
+	case message := <-receiveCloudHubMessage():
+		if message.GetOperation() != model.UpdateOperation {
+			t.Fatalf("expected update operation, got %q", message.GetOperation())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected update message for empty objectSync status")
+	}
+}
+
+func receiveCloudHubMessage() <-chan model.Message {
+	ch := make(chan model.Message, 1)
+	go func() {
+		message, _ := beehiveContext.Receive(modules.CloudHubModuleName)
+		ch <- message
+	}()
+	return ch
+}
+
 func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/cloud/pkg/synccontroller/synccontroller.go
+++ b/cloud/pkg/synccontroller/synccontroller.go
@@ -174,7 +174,7 @@ func (sctl *SyncController) deleteObjectSyncs() {
 				if isGarbage {
 					klog.Infof("ObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
 					err = sctl.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(sync.Namespace).Delete(context.Background(), sync.Name, *metav1.NewDeleteOptions(0))
-					if err != nil {
+					if err != nil && !errors.IsNotFound(err) {
 						klog.Warningf("failed to delete objectSync %s for edgenode %s, err: %v", sync.Name, nodeName, err)
 						return err
 					}
@@ -208,7 +208,7 @@ func (sctl *SyncController) deleteClusterObjectSyncs() {
 				if isGarbage {
 					klog.Infof("ClusterObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
 					err = sctl.crdclient.ReliablesyncsV1alpha1().ClusterObjectSyncs().Delete(context.Background(), sync.Name, *metav1.NewDeleteOptions(0))
-					if err != nil {
+					if err != nil && !errors.IsNotFound(err) {
 						klog.Warningf("failed to delete ClusterObjectSync %s for edgenode %s, err: %v", sync.Name, nodeName, err)
 						return err
 					}

--- a/cloud/pkg/synccontroller/synccontroller_test.go
+++ b/cloud/pkg/synccontroller/synccontroller_test.go
@@ -23,9 +23,13 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	configv1alpha1 "github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -220,5 +224,36 @@ func TestDeleteObjectSyncs(t *testing.T) {
 				t.Errorf("deleteObjectSyncs() list returned unexpected result. got = %v, want = %v", len(got.Items), tt.ExpectedSyncs)
 			}
 		})
+	}
+}
+
+func TestDeleteObjectSyncsIgnoresAlreadyDeletedObjectSync(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	crdClient := crdfake.NewSimpleClientset()
+	crdInformers := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	if err := crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Informer().GetIndexer().Add(objectSync); err != nil {
+		t.Fatalf("failed to seed objectSync informer: %v", err)
+	}
+
+	deleteCalls := 0
+	crdClient.Fake.PrependReactor("delete", "objectsyncs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteCalls++
+		return true, nil, apierrors.NewNotFound(
+			schema.GroupResource{Group: "reliablesyncs.kubeedge.io", Resource: "objectsyncs"},
+			action.(k8stesting.DeleteAction).GetName(),
+		)
+	})
+
+	client := fake.NewSimpleClientset()
+	informers := informers.NewSharedInformerFactory(client, 0)
+	testController := &SyncController{}
+	testController.nodeLister = informers.Core().V1().Nodes().Lister()
+	testController.crdclient = crdClient
+	testController.objectSyncLister = crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Lister()
+
+	testController.deleteObjectSyncs()
+
+	if deleteCalls != 1 {
+		t.Fatalf("expected one delete attempt for already deleted objectSync, got %d", deleteCalls)
 	}
 }

--- a/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/rbac_cloudcore.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: ["delete"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "list", "watch", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["devices.kubeedge.io"]
     resources: ["devices", "devicemodels", "devices/status", "devicemodels/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
@@ -41,4 +41,3 @@ rules:
   - apiGroups: ["operations.kubeedge.io"]
     resources: ["nodeupgradejobs", "nodeupgradejobs/status", "imageprepulljobs", "imageprepulljobs/status", "configupdatejobs", "configupdatejobs/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
-

--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -11,10 +12,12 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage"
-	"k8s.io/client-go/kubernetes/scheme"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 
+	kubeedgescheme "github.com/kubeedge/api/client/clientset/versioned/scheme"
 	beehiveModel "github.com/kubeedge/beehive/pkg/core/model"
 )
 
@@ -29,12 +32,10 @@ func SetMetaType(obj runtime.Object) error {
 	if err != nil {
 		return err
 	}
-	//gvr,_,_ := apiserverlite.ParseKey(accessor.GetSelfLink())
-	kinds, _, err := scheme.Scheme.ObjectKinds(obj)
+	gvk, err := getObjectKind(obj)
 	if err != nil {
 		return err
 	}
-	gvk := kinds[0]
 	obj.GetObjectKind().SetGroupVersionKind(gvk)
 	klog.V(6).Infof("[metaserver]successfully set MetaType for obj %v, %+v", obj.GetObjectKind(), accessor.GetName())
 	return nil
@@ -132,7 +133,11 @@ func UnstructuredAttr(obj runtime.Object) (labels.Set, fields.Set, error) {
 func GetMessageAPIVersion(msg *beehiveModel.Message) string {
 	obj, ok := msg.Content.(runtime.Object)
 	if ok {
-		return obj.GetObjectKind().GroupVersionKind().GroupVersion().String()
+		gvk, err := getObjectKind(obj)
+		if err != nil {
+			return ""
+		}
+		return gvk.GroupVersion().String()
 	}
 	return ""
 }
@@ -141,9 +146,33 @@ func GetMessageAPIVersion(msg *beehiveModel.Message) string {
 func GetMessageResourceType(msg *beehiveModel.Message) string {
 	obj, ok := msg.Content.(runtime.Object)
 	if ok {
-		return obj.GetObjectKind().GroupVersionKind().Kind
+		gvk, err := getObjectKind(obj)
+		if err != nil {
+			return ""
+		}
+		return gvk.Kind
 	}
 	return ""
+}
+
+func getObjectKind(obj runtime.Object) (schema.GroupVersionKind, error) {
+	if obj == nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("object is nil")
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if !gvk.Empty() {
+		return gvk, nil
+	}
+
+	for _, scheme := range []*runtime.Scheme{kubescheme.Scheme, kubeedgescheme.Scheme} {
+		kinds, _, err := scheme.ObjectKinds(obj)
+		if err == nil && len(kinds) > 0 {
+			return kinds[0], nil
+		}
+	}
+
+	return schema.GroupVersionKind{}, fmt.Errorf("no kind is registered for object %T", obj)
 }
 
 type key int

--- a/pkg/metaserver/util/util_test.go
+++ b/pkg/metaserver/util/util_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	policyv1alpha1 "github.com/kubeedge/api/apis/policy/v1alpha1"
 	beehiveModel "github.com/kubeedge/beehive/pkg/core/model"
 )
 
@@ -45,6 +46,14 @@ func TestGetMessageAPIVerison(t *testing.T) {
 					Content: "content",
 				}},
 			want: "",
+		},
+		{
+			name: "TestGetMessageAPIVerison(): Case 3: KubeEdge CRD without TypeMeta",
+			args: args{
+				msg: &beehiveModel.Message{
+					Content: &policyv1alpha1.ServiceAccountAccess{},
+				}},
+			want: "policy.kubeedge.io/v1alpha1",
 		},
 	}
 	for _, tt := range tests {
@@ -85,6 +94,14 @@ func TestGetMessageResourceType(t *testing.T) {
 					Content: "content",
 				}},
 			want: "",
+		},
+		{
+			name: "TestGetMessageResourceType(): Case 3: KubeEdge CRD without TypeMeta",
+			args: args{
+				msg: &beehiveModel.Message{
+					Content: &policyv1alpha1.ServiceAccountAccess{},
+				}},
+			want: "ServiceAccountAccess",
 		},
 	}
 	for _, tt := range tests {

--- a/tests/scripts/cloudcore_leader_election_rbac_test.sh
+++ b/tests/scripts/cloudcore_leader_election_rbac_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+assert_lease_verbs() {
+  local file="$1"
+  local line
+  line="$(awk '
+    /apiGroups:/ { in_coordination = ($0 ~ /"coordination\.k8s\.io"/) ? 1 : 0; in_leases = 0; next }
+    in_coordination && /resources:/ { in_leases = ($0 ~ /"leases"/) ? 1 : 0; next }
+    in_coordination && in_leases && /verbs:/ { print; exit }
+  ' "${ROOT_DIR}/${file}")"
+
+  if [[ -z "${line}" ]]; then
+    echo "missing leases verbs in ${file}" >&2
+    exit 1
+  fi
+
+  for verb in get list watch create update patch delete; do
+    if [[ "${line}" != *"\"${verb}\""* ]]; then
+      echo "missing lease verb ${verb} in ${file}: ${line}" >&2
+      exit 1
+    fi
+  done
+}
+
+assert_lease_verbs "manifests/charts/cloudcore/templates/rbac_cloudcore.yaml"
+assert_lease_verbs "build/cloud/03-clusterrole.yaml"
+assert_lease_verbs "build/cloud/ha/01-ha-prepare.yaml"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR hardens CloudCore HA behavior across policy, reliable sync, CloudHub dispatch, and device downlink paths:

- Enables controller-runtime leader election for the policycontroller manager so only one CloudCore replica reconciles `ServiceAccountAccess` at a time.
- Adds the required `coordination.k8s.io/leases` RBAC verbs for CloudCore manifests and Helm charts.
- Makes ObjectSync and ClusterObjectSync creation/status handling idempotent under multiple CloudCore replicas.
- Keeps ObjectSync status updates monotonic so stale ACKs cannot move `status.objectResourceVersion` backward.
- Sends downstream reliable-sync messages only from the CloudHub instance that owns the target edge-node session.
- Infers missing GVK metadata for Kubernetes and KubeEdge runtime objects, so CRDs such as `ServiceAccountAccess` are stored in ObjectSync specs with `objectAPIVersion` and `objectKind` instead of empty values.
- Backfills missing ObjectSync/ClusterObjectSync spec fields when existing records are encountered on the message path.
- Treats concurrent `DeviceStatus` create `AlreadyExists` responses as successful create races, then re-gets the existing `DeviceStatus` and continues Device/DeviceModel downlink.

Without this, three CloudCore replicas can concurrently reconcile or deliver the same edge-facing resources, produce update conflicts, and leave ObjectSync records unable to drive compensation for edge nodes. The DeviceStatus case can also short-circuit `deviceAdded()` before Device and DeviceModel messages are sent to the edge.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Validation performed:

- `go test ./cloud/pkg/devicecontroller/controller -run TestGetOrCreateDeviceStatusForDeviceHandlesAlreadyExistsRace -count=1`
- Verified the new regression test fails against the old DeviceStatus create logic with `devicestatuses.devices.kubeedge.io "lite-node" already exists`.
- `go test ./cloud/pkg/devicecontroller/... -count=1`
- `go test ./cloud/pkg/policycontroller ./cloud/pkg/synccontroller ./cloud/pkg/cloudhub/dispatcher ./cloud/pkg/cloudhub/session ./cloud/pkg/devicecontroller/... -count=1`
- `tests/scripts/cloudcore_leader_election_rbac_test.sh`
- Built and deployed `cloudcore:v1.23.0-ha-20260703-e6c6e60d2` to an ACK cluster with 3 CloudCore replicas.
- Verified Helm revision 32 and `deployment/cloudcore` stayed at 3/3 Ready with all three Pods running image digest `sha256:340ea3bbcd42e4146df67e3a767f153c9fab2d5fb007e12903ecd965484d6cd6`.
- Verified `kubeedge-policycontroller` Lease renews with a single holder.
- Triggered `ClusterRoleBinding/orangepi-agent` reconciliation and verified `ServiceAccountAccess/led/orangepi-agent` advanced without `object has been modified` conflicts.
- Repaired legacy ObjectSync records with empty CRD spec metadata and verified all Ready target nodes reached the current ServiceAccountAccess resourceVersion.
- Created temporary `Device/led/codex-ha-smoke-e6c6e60d2`; CloudCore created the matching DeviceStatus and advanced the Device ObjectSync to the Device resourceVersion, proving the DeviceStatus create race no longer short-circuits Device downlink.
- Deleted the temporary smoke Device and DeviceStatus after validation; no smoke ObjectSync remained.
- Verified no `Failed to ensure device status`, `devicestatuses.devices.kubeedge.io ... already exists`, `failed to update serviceaccountaccess`, `object has been modified`, panic, or fatal logs matched in CloudCore logs during validation.

This is a combined validation branch for the CloudCore HA work. It intentionally includes the policycontroller leader-election fix, synccontroller/cloudhub idempotency fixes, the CRD ObjectSync spec metadata fix, and the devicecontroller DeviceStatus create-race fix together because the live failure crosses these paths.

**Does this PR introduce a user-facing change?**:

```release-note
CloudCore HA now uses policycontroller leader election and more robust ObjectSync, CloudHub dispatch, and DeviceStatus create-race handling to avoid duplicate reconciliation and reliable-sync delivery races across replicas.
```
