### PR TITLE
fix: use configured address in kubeletHealthCheck and handle ReadOnlyPort=0

### DIFF
--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"reflect"
@@ -158,7 +159,7 @@ func (e *edged) Start() {
 	defer e.cleanupContainers()
 
 	kubeletReadyChan := make(chan struct{}, 1)
-	go kubeletHealthCheck(e.KubeletServer.ReadOnlyPort, kubeletReadyChan)
+	go kubeletHealthCheck(e.KubeletServer.Address, e.KubeletServer.ReadOnlyPort, kubeletReadyChan)
 
 	select {
 	case <-beehiveContext.Done():
@@ -640,10 +641,26 @@ func filterPodByNodeName(pod *v1.Pod, nodeName string) bool {
 	return pod.Spec.NodeName == nodeName
 }
 
-func kubeletHealthCheck(port int32, kubeletReadyChan chan struct{}) {
-	url := fmt.Sprintf("http://localhost:%d/healthz/syncloop", port)
+func kubeletHealthCheck(address string, port int32, kubeletReadyChan chan struct{}) {
+	if port == 0 {
+		klog.Warning("ReadOnlyPort is disabled (port=0), skipping kubelet health check")
+		kubeletReadyChan <- struct{}{}
+		return
+	}
+
+	host := address
+	if host == "" || host == "0.0.0.0" {
+		host = "127.0.0.1"
+	} else if host == "::" {
+		host = "::1"
+	}
+
+	url := fmt.Sprintf("http://%s/healthz/syncloop", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 	for {
-		resp, err := http.Get(url)
+		resp, err := client.Get(url)
 		if err != nil {
 			klog.Warningf("failed to get kubelet healthz syncloop, err: %v", err)
 			time.Sleep(50 * time.Millisecond)

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -641,6 +641,16 @@ func filterPodByNodeName(pod *v1.Pod, nodeName string) bool {
 	return pod.Spec.NodeName == nodeName
 }
 
+func kubeletHealthCheckURL(address string, port int32) string {
+	host := address
+	if host == "" || host == "0.0.0.0" {
+		host = "127.0.0.1"
+	} else if host == "::" {
+		host = "::1"
+	}
+	return fmt.Sprintf("http://%s/healthz/syncloop", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+}
+
 func kubeletHealthCheck(address string, port int32, kubeletReadyChan chan struct{}) {
 	if port == 0 {
 		klog.Warning("ReadOnlyPort is disabled (port=0), skipping kubelet health check")
@@ -648,14 +658,7 @@ func kubeletHealthCheck(address string, port int32, kubeletReadyChan chan struct
 		return
 	}
 
-	host := address
-	if host == "" || host == "0.0.0.0" {
-		host = "127.0.0.1"
-	} else if host == "::" {
-		host = "::1"
-	}
-
-	url := fmt.Sprintf("http://%s/healthz/syncloop", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	url := kubeletHealthCheckURL(address, port)
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}

--- a/edge/pkg/edged/edged_test.go
+++ b/edge/pkg/edged/edged_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edged
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKubeletHealthCheckURL(t *testing.T) {
+	testCases := []struct {
+		name    string
+		address string
+		port    int32
+		want    string
+	}{
+		{
+			name:    "normal IPv4 address",
+			address: "192.168.1.10",
+			port:    10255,
+			want:    "http://192.168.1.10:10255/healthz/syncloop",
+		},
+		{
+			name:    "empty address maps to IPv4 loopback",
+			address: "",
+			port:    10255,
+			want:    "http://127.0.0.1:10255/healthz/syncloop",
+		},
+		{
+			name:    "wildcard IPv4 maps to loopback",
+			address: "0.0.0.0",
+			port:    10255,
+			want:    "http://127.0.0.1:10255/healthz/syncloop",
+		},
+		{
+			name:    "wildcard IPv6 maps to loopback",
+			address: "::",
+			port:    10255,
+			want:    "http://[::1]:10255/healthz/syncloop",
+		},
+		{
+			name:    "IPv6 address is bracketed",
+			address: "::1",
+			port:    10350,
+			want:    "http://[::1]:10350/healthz/syncloop",
+		},
+		{
+			name:    "full IPv6 address is bracketed",
+			address: "2001:db8::1",
+			port:    10350,
+			want:    "http://[2001:db8::1]:10350/healthz/syncloop",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := kubeletHealthCheckURL(tc.address, tc.port)
+			if got != tc.want {
+				t.Errorf("kubeletHealthCheckURL(%q, %d) = %q, want %q", tc.address, tc.port, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKubeletHealthCheckReadOnlyPortDisabled(t *testing.T) {
+	kubeletReadyChan := make(chan struct{}, 1)
+	// When ReadOnlyPort is 0, the health check must signal readiness and
+	// return immediately without polling.
+	kubeletHealthCheck("127.0.0.1", 0, kubeletReadyChan)
+
+	select {
+	case <-kubeletReadyChan:
+		// expected: readiness signaled
+	case <-time.After(2 * time.Second):
+		t.Fatal("kubeletHealthCheck did not signal readiness when ReadOnlyPort is 0")
+	}
+}


### PR DESCRIPTION
kubeletHealthCheck previously hardcoded `localhost` in the health check URL,
which breaks when:
1. ReadOnlyPort is disabled (set to 0) - causes infinite poll loop
2. Kubelet is bound to a specific IP instead of 0.0.0.0

Now uses KubeletConfiguration.Address for the health check URL and
gracefully skips the check when ReadOnlyPort is 0. Includes IPv6 support
via `net.JoinHostPort`, wildcard address (`0.0.0.0`, `::`) mapping to
loopback for the health check, an HTTP client timeout to prevent
indefinite blocking, and regression tests for the address/URL handling.

Fixes #6952

/kind bug

```release-note
Fix edged kubeletHealthCheck to use the configured address instead of hardcoded localhost, and to gracefully handle ReadOnlyPort=0, wildcard bind addresses, IPv6, and HTTP client timeouts.
```