### PR TITLE
fix(viaduct): respect read deadline on WSConnection

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -73,6 +73,7 @@ func (wsc *WebSocketClient) Init() error {
 
 	option := wsclient.Options{
 		HandshakeTimeout: wsc.config.HandshakeTimeout,
+		ReadDeadline:     wsc.config.ReadDeadline,
 		TLSConfig:        tlsConfig,
 		Type:             api.ProtocolTypeWS,
 		Addr:             wsc.config.URL,

--- a/pkg/viaduct/pkg/client/client.go
+++ b/pkg/viaduct/pkg/client/client.go
@@ -36,6 +36,15 @@ type Options struct {
 	AutoRoute bool
 	// HandshakeTimeout is the maximum duration that the cryptographic handshake may take.
 	HandshakeTimeout time.Duration
+	// ReadDeadline is a per-iteration read deadline applied by the WebSocket
+	// transport (handleMessage in pkg/viaduct/pkg/conn/ws.go). It surfaces a
+	// stalled half-open TCP connection as a read error within ReadDeadline
+	// instead of waiting for the kernel TCP retransmission timeout
+	// (tcp_retries2, ~15min on Linux). Currently honored only by the
+	// WebSocket transport; QUIC has the same defect (SetReadDeadline is a
+	// no-op there too) and will be addressed in a separate PR. Zero means
+	// no read deadline (legacy behavior).
+	ReadDeadline time.Duration
 	// consumer for raw data
 	Consumer io.Writer
 }

--- a/pkg/viaduct/pkg/client/ws.go
+++ b/pkg/viaduct/pkg/client/ws.go
@@ -66,7 +66,8 @@ func (c *WSClient) Connect() (conn.Connection, error) {
 				Headers:          c.exOpts.Header.Clone(),
 				PeerCertificates: peerCerts,
 			},
-			AutoRoute: c.options.AutoRoute,
+			AutoRoute:            c.options.AutoRoute,
+			ReadDeadlineInterval: c.options.ReadDeadline,
 		}), nil
 	}
 

--- a/pkg/viaduct/pkg/conn/factory.go
+++ b/pkg/viaduct/pkg/conn/factory.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"io"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -30,6 +31,12 @@ type ConnectionOptions struct {
 	AutoRoute bool
 	// OnReadTransportErr
 	OnReadTransportErr func(nodeID, projectID string)
+	// ReadDeadlineInterval is applied by handleMessage to the underlying
+	// connection on every iteration so a stalled half-open TCP socket
+	// surfaces as a read error within this interval. Zero means no read
+	// deadline (legacy behavior). The duration semantics distinguish this
+	// from WSConnection.ReadDeadline (a time.Time absolute deadline).
+	ReadDeadlineInterval time.Duration
 }
 
 // get connection interface by ConnTye

--- a/pkg/viaduct/pkg/conn/ws.go
+++ b/pkg/viaduct/pkg/conn/ws.go
@@ -20,30 +20,32 @@ import (
 )
 
 type WSConnection struct {
-	WriteDeadline      time.Time
-	ReadDeadline       time.Time
-	handler            mux.Handler
-	wsConn             *websocket.Conn
-	state              *ConnectionState
-	syncKeeper         *keeper.SyncKeeper
-	connUse            api.UseType
-	consumer           io.Writer
-	autoRoute          bool
-	messageFifo        *fifo.MessageFifo
-	locker             sync.Mutex
-	OnReadTransportErr func(nodeID, projectID string)
+	WriteDeadline        time.Time
+	ReadDeadline         time.Time
+	handler              mux.Handler
+	wsConn               *websocket.Conn
+	state                *ConnectionState
+	syncKeeper           *keeper.SyncKeeper
+	connUse              api.UseType
+	consumer             io.Writer
+	autoRoute            bool
+	messageFifo          *fifo.MessageFifo
+	locker               sync.Mutex
+	OnReadTransportErr   func(nodeID, projectID string)
+	readDeadlineInterval time.Duration
 }
 
 func NewWSConn(options *ConnectionOptions) *WSConnection {
 	return &WSConnection{
-		wsConn:             options.Base.(*websocket.Conn),
-		handler:            options.Handler,
-		syncKeeper:         keeper.NewSyncKeeper(),
-		state:              options.State,
-		connUse:            options.ConnUse,
-		autoRoute:          options.AutoRoute,
-		messageFifo:        fifo.NewMessageFifo(),
-		OnReadTransportErr: options.OnReadTransportErr,
+		wsConn:               options.Base.(*websocket.Conn),
+		handler:              options.Handler,
+		syncKeeper:           keeper.NewSyncKeeper(),
+		state:                options.State,
+		connUse:              options.ConnUse,
+		autoRoute:            options.AutoRoute,
+		messageFifo:          fifo.NewMessageFifo(),
+		OnReadTransportErr:   options.OnReadTransportErr,
+		readDeadlineInterval: options.ReadDeadlineInterval,
 	}
 }
 
@@ -99,16 +101,105 @@ func (conn *WSConnection) handleRawData() {
 	}
 }
 
-func (conn *WSConnection) handleMessage() {
+// pingLoop keeps guaranteed inbound traffic flowing on an otherwise idle
+// connection by sending WebSocket protocol pings every half of
+// readDeadlineInterval. The pongs sent back by the peer (gorilla answers
+// pings automatically as long as its read loop is running) reset the read
+// deadline via the pong handler registered in handleMessage, so the deadline
+// only expires when the connection is genuinely stalled.
+func (conn *WSConnection) pingLoop(stop <-chan struct{}) {
+	period := conn.readDeadlineInterval / 2
+	if period <= 0 {
+		// In-repo configuration is int32 seconds (>= 1s), but the field
+		// takes a raw Duration: guard the integer division against sub-2ns
+		// values so NewTicker cannot panic.
+		period = time.Millisecond
+	}
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
 	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			// WriteControl is safe for concurrent use with the data-plane
+			// writes going through conn.locker.
+			if err := conn.wsConn.WriteControl(websocket.PingMessage, nil, time.Now().Add(period)); err != nil {
+				var netErr net.Error
+				if errors.As(err, &netErr) && netErr.Timeout() {
+					// The write lock was held past the deadline (e.g. a
+					// large message on a slow link); the connection may
+					// well be healthy. Keep pinging — liveness is judged
+					// by the read deadline, not here.
+					continue
+				}
+				// If handleMessage already tore the connection down (stop is
+				// closed), this error is a consequence of that shutdown, not a
+				// new failure: exit quietly without a misleading log or a
+				// double close.
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// The connection is gone (closed or broken); close it so the
+				// read loop unblocks immediately instead of waiting for the
+				// read deadline to expire.
+				klog.V(2).Infof("ping loop stopped: %v", err)
+				_ = conn.wsConn.Close()
+				return
+			}
+		}
+	}
+}
+
+func (conn *WSConnection) handleMessage() {
+	if conn.readDeadlineInterval > 0 {
+		// A read deadline alone would tear down idle-but-healthy
+		// connections: nothing guarantees cloud-to-edge traffic within the
+		// interval (EdgeHub's keepalive is one-way; CloudHub sends no
+		// response to it). pingLoop provides that guarantee at the
+		// WebSocket protocol level, and every pong extends the deadline
+		// here, so expiry now means the peer stopped answering entirely.
+		conn.wsConn.SetPongHandler(func(string) error {
+			return conn.wsConn.SetReadDeadline(time.Now().Add(conn.readDeadlineInterval))
+		})
+		stopPing := make(chan struct{})
+		defer close(stopPing)
+		go conn.pingLoop(stopPing)
+	}
+	for {
+		// Arm/refresh the read deadline so a half-open TCP connection
+		// surfaces as a read error within readDeadlineInterval instead of
+		// waiting for kernel TCP retransmission (tcp_retries2, ~15min on Linux).
+		if conn.readDeadlineInterval > 0 {
+			_ = conn.wsConn.SetReadDeadline(time.Now().Add(conn.readDeadlineInterval))
+		}
 		msg := &model.Message{}
 		err := lane.NewLane(api.ProtocolTypeWS, conn.wsConn).ReadMessage(msg)
 		if err != nil {
-			if !errors.Is(err, io.EOF) {
+			// With pingLoop keeping pongs flowing, a deadline expiry means
+			// no inbound traffic at all for readDeadlineInterval: the
+			// connection is treated as half-open. This is the designed
+			// detection path, so keep it quiet; EdgeHub already logs the
+			// resulting reconnect at Warning level. Genuine transport
+			// errors still surface as Errorf.
+			var netErr net.Error
+			switch {
+			case errors.Is(err, io.EOF):
+				// silent: legacy behavior
+			case errors.As(err, &netErr) && netErr.Timeout():
+				klog.V(2).Infof("read deadline reached, will reconnect: %v", err)
+			default:
 				klog.Errorf("failed to read message, error: %+v", err)
 			}
 			conn.state.State = api.StatDisconnected
 			_ = conn.wsConn.Close()
+			// Close the FIFO so that callers blocked on ReadMessage()/Get()
+			// (e.g. EdgeHub's routeToEdge) observe the error immediately and
+			// can trigger a reconnect, instead of waiting for the next
+			// keepalive write to fail (up to one Heartbeat period).
+			conn.messageFifo.Close()
 
 			if conn.OnReadTransportErr != nil {
 				conn.OnReadTransportErr(conn.state.Headers.Get("node_id"),
@@ -151,12 +242,12 @@ func (conn *WSConnection) handleMessage() {
 
 func (conn *WSConnection) SetReadDeadline(t time.Time) error {
 	conn.ReadDeadline = t
-	return nil
+	return conn.wsConn.SetReadDeadline(t)
 }
 
 func (conn *WSConnection) SetWriteDeadline(t time.Time) error {
 	conn.WriteDeadline = t
-	return nil
+	return conn.wsConn.SetWriteDeadline(t)
 }
 
 func (conn *WSConnection) Read(raw []byte) (int, error) {

--- a/pkg/viaduct/pkg/conn/ws_test.go
+++ b/pkg/viaduct/pkg/conn/ws_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package conn
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/fifo"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/keeper"
+)
+
+// newTestWSConn spins up a server-side websocket and connects a client to
+// it. With serverReads=true the server runs a normal read loop, which makes
+// gorilla answer the client's pings with pongs automatically (an idle but
+// healthy peer). With serverReads=false the server swallows bytes at the TCP
+// level without WebSocket-level processing, so pings are never answered —
+// emulating a stalled/half-open peer while keeping the TCP connection open.
+// The returned WSConnection is configured with the supplied read deadline
+// interval; the caller must close srv to release the goroutine.
+func newTestWSConn(t *testing.T, readDeadlineInterval time.Duration, serverReads bool) (*WSConnection, *httptest.Server) {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(*http.Request) bool { return true },
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer c.Close()
+		if serverReads {
+			// Hold the connection without sending anything so the client
+			// side blocks on Read; pings are auto-answered with pongs.
+			for {
+				if _, _, err := c.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}
+		// Stalled peer: consume raw bytes so the TCP connection stays
+		// open but no pong (or any frame) is ever sent back.
+		buf := make([]byte, 1024)
+		for {
+			if _, err := c.UnderlyingConn().Read(buf); err != nil {
+				return
+			}
+		}
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial: %v", err)
+	}
+
+	conn := &WSConnection{
+		wsConn:               wsConn,
+		state:                &ConnectionState{State: api.StatConnected, Headers: http.Header{}},
+		connUse:              api.UseTypeMessage,
+		messageFifo:          fifo.NewMessageFifo(),
+		syncKeeper:           keeper.NewSyncKeeper(),
+		readDeadlineInterval: readDeadlineInterval,
+	}
+	return conn, srv
+}
+
+// TestHandleMessageReadDeadlineFiresWithinInterval verifies the half-open
+// detection: when readDeadlineInterval is set and the peer stops answering
+// entirely (not even pongs), handleMessage exits within roughly that
+// interval. Without the fix the goroutine would block until kernel TCP
+// retransmission timeout (~15min).
+func TestHandleMessageReadDeadlineFiresWithinInterval(t *testing.T) {
+	conn, srv := newTestWSConn(t, 100*time.Millisecond, false)
+	defer srv.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn.handleMessage()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleMessage did not return within 2s; deadline not applied")
+	}
+
+	// messageFifo must be closed so callers blocked on Get() observe the
+	// error immediately rather than waiting for the next keepalive failure.
+	msg := &model.Message{}
+	if err := conn.ReadMessage(msg); err == nil {
+		t.Fatal("expected ReadMessage to return error after handleMessage timeout")
+	}
+}
+
+// TestHandleMessageZeroReadDeadlineKeepsLegacyBehavior verifies that the
+// existing zero-value behavior (no deadline = block forever) is preserved.
+func TestHandleMessageZeroReadDeadlineKeepsLegacyBehavior(t *testing.T) {
+	conn, srv := newTestWSConn(t, 0, true)
+	defer srv.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn.handleMessage()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("handleMessage returned unexpectedly with no read deadline")
+	case <-time.After(300 * time.Millisecond):
+		// expected: blocks indefinitely
+	}
+
+	// Cleanup: close the underlying conn to unblock the goroutine.
+	_ = conn.wsConn.Close()
+	<-done
+}
+
+// TestHandleMessagePingKeepsIdleConnectionAlive verifies that an idle but
+// healthy connection is NOT torn down by the read deadline: pingLoop keeps
+// sending pings, the peer answers with pongs, and each pong extends the
+// deadline. Only after the peer stops answering does the deadline fire.
+func TestHandleMessagePingKeepsIdleConnectionAlive(t *testing.T) {
+	// Generous interval so that a scheduling hiccup on a loaded CI runner
+	// (ping every interval/2, pong must arrive within interval) does not
+	// fail the test spuriously.
+	interval := 800 * time.Millisecond
+	conn, srv := newTestWSConn(t, interval, true)
+	defer srv.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn.handleMessage()
+		close(done)
+	}()
+
+	// Idle for several intervals: without pong-driven deadline extension
+	// handleMessage would exit within ~interval.
+	select {
+	case <-done:
+		t.Fatal("handleMessage exited on an idle but healthy connection; pings/pongs did not extend the deadline")
+	case <-time.After(3 * interval):
+		// expected: still alive
+	}
+
+	// Cleanup: close the conn to unblock handleMessage. (Deadline expiry on
+	// a stalled peer is covered by
+	// TestHandleMessageReadDeadlineFiresWithinInterval.)
+	_ = conn.wsConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleMessage did not return after the connection was closed")
+	}
+}
+
+// TestSetReadDeadlinePropagatesToWSConn verifies the SetReadDeadline bug
+// fix: the call must reach gorilla/websocket's underlying conn. We trigger
+// this by setting a past deadline and observing that the next read errors
+// out immediately.
+func TestSetReadDeadlinePropagatesToWSConn(t *testing.T) {
+	conn, srv := newTestWSConn(t, 0, true)
+	defer srv.Close()
+	// Close the client conn explicitly so the server-side handler goroutine
+	// (looping on ReadMessage) exits even if srv.Close alone does not
+	// terminate the hijacked websocket connection.
+	defer conn.wsConn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+
+	if _, _, err := conn.wsConn.ReadMessage(); err == nil {
+		t.Fatal("expected immediate read error after past deadline; SetReadDeadline did not propagate")
+	}
+}

--- a/pkg/viaduct/pkg/conn/ws_test.go
+++ b/pkg/viaduct/pkg/conn/ws_test.go
@@ -18,6 +18,8 @@ package conn
 
 import (
 	"bytes"
+	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -26,7 +28,10 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/kubeedge/beehive/pkg/core/model"
 	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/fifo"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/keeper"
 )
 
 var upgrader = websocket.Upgrader{
@@ -119,5 +124,338 @@ func TestHandleRawDataDoesNotPanic(t *testing.T) {
 
 	if !bytes.Equal(consumer.Bytes(), payload) {
 		t.Errorf("unexpected payload: got %q, want %q", consumer.Bytes(), payload)
+	}
+}
+
+// newTestWSConn spins up a server-side websocket and connects a client to
+// it. With serverReads=true the server runs a normal read loop, which makes
+// gorilla answer the client's pings with pongs automatically (an idle but
+// healthy peer). With serverReads=false the server swallows bytes at the TCP
+// level without WebSocket-level processing, so pings are never answered —
+// emulating a stalled/half-open peer while keeping the TCP connection open.
+// The returned WSConnection is configured with the supplied read deadline
+// interval; the caller must close srv to release the goroutine.
+func newTestWSConn(t *testing.T, readDeadlineInterval time.Duration, serverReads bool) (*WSConnection, *httptest.Server) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer c.Close()
+		if serverReads {
+			// Hold the connection without sending anything so the client
+			// side blocks on Read; pings are auto-answered with pongs.
+			for {
+				if _, _, err := c.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}
+		// Stalled peer: consume raw bytes so the TCP connection stays
+		// open but no pong (or any frame) is ever sent back.
+		buf := make([]byte, 1024)
+		for {
+			if _, err := c.UnderlyingConn().Read(buf); err != nil {
+				return
+			}
+		}
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial: %v", err)
+	}
+
+	conn := &WSConnection{
+		wsConn:               wsConn,
+		state:                &ConnectionState{State: api.StatConnected, Headers: http.Header{}},
+		connUse:              api.UseTypeMessage,
+		messageFifo:          fifo.NewMessageFifo(),
+		syncKeeper:           keeper.NewSyncKeeper(),
+		readDeadlineInterval: readDeadlineInterval,
+	}
+	return conn, srv
+}
+
+// TestHandleMessageReadDeadlineFiresWithinInterval verifies the half-open
+// detection: when readDeadlineInterval is set and the peer stops answering
+// entirely (not even pongs), handleMessage exits within roughly that
+// interval. Without the fix the goroutine would block until kernel TCP
+// retransmission timeout (~15min).
+func TestHandleMessageReadDeadlineFiresWithinInterval(t *testing.T) {
+	conn, srv := newTestWSConn(t, 100*time.Millisecond, false)
+	defer srv.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn.handleMessage()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleMessage did not return within 2s; deadline not applied")
+	}
+
+	// messageFifo must be closed so callers blocked on Get() observe the
+	// error immediately rather than waiting for the next keepalive failure.
+	msg := &model.Message{}
+	if err := conn.ReadMessage(msg); err == nil {
+		t.Fatal("expected ReadMessage to return error after handleMessage timeout")
+	}
+}
+
+// TestHandleMessageZeroReadDeadlineKeepsLegacyBehavior verifies that the
+// existing zero-value behavior (no deadline = block forever) is preserved.
+func TestHandleMessageZeroReadDeadlineKeepsLegacyBehavior(t *testing.T) {
+	conn, srv := newTestWSConn(t, 0, true)
+	defer srv.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn.handleMessage()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("handleMessage returned unexpectedly with no read deadline")
+	case <-time.After(300 * time.Millisecond):
+		// expected: blocks indefinitely
+	}
+
+	// Cleanup: close the underlying conn to unblock the goroutine.
+	_ = conn.wsConn.Close()
+	<-done
+}
+
+// TestHandleMessagePingKeepsIdleConnectionAlive verifies that an idle but
+// healthy connection is NOT torn down by the read deadline: pingLoop keeps
+// sending pings, the peer answers with pongs, and each pong extends the
+// deadline. Only after the peer stops answering does the deadline fire.
+func TestHandleMessagePingKeepsIdleConnectionAlive(t *testing.T) {
+	// Generous interval so that a scheduling hiccup on a loaded CI runner
+	// (ping every interval/2, pong must arrive within interval) does not
+	// fail the test spuriously.
+	interval := 800 * time.Millisecond
+	conn, srv := newTestWSConn(t, interval, true)
+	defer srv.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn.handleMessage()
+		close(done)
+	}()
+
+	// Idle for several intervals: without pong-driven deadline extension
+	// handleMessage would exit within ~interval.
+	select {
+	case <-done:
+		t.Fatal("handleMessage exited on an idle but healthy connection; pings/pongs did not extend the deadline")
+	case <-time.After(3 * interval):
+		// expected: still alive
+	}
+
+	// Cleanup: close the conn to unblock handleMessage. (Deadline expiry on
+	// a stalled peer is covered by
+	// TestHandleMessageReadDeadlineFiresWithinInterval.)
+	_ = conn.wsConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleMessage did not return after the connection was closed")
+	}
+}
+
+// TestSetReadDeadlinePropagatesToWSConn verifies the SetReadDeadline bug
+// fix: the call must reach gorilla/websocket's underlying conn. We trigger
+// this by setting a past deadline and observing that the next read errors
+// out immediately.
+func TestSetReadDeadlinePropagatesToWSConn(t *testing.T) {
+	conn, srv := newTestWSConn(t, 0, true)
+	defer srv.Close()
+	// Close the client conn explicitly so the server-side handler goroutine
+	// (looping on ReadMessage) exits even if srv.Close alone does not
+	// terminate the hijacked websocket connection.
+	defer conn.wsConn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+
+	if _, _, err := conn.wsConn.ReadMessage(); err == nil {
+		t.Fatal("expected immediate read error after past deadline; SetReadDeadline did not propagate")
+	}
+}
+
+// TestNewWSConnWiresReadDeadlineInterval verifies the constructor path used in
+// production (as opposed to the struct literals in the tests above): the
+// interval configured on ConnectionOptions must reach the connection.
+func TestNewWSConnWiresReadDeadlineInterval(t *testing.T) {
+	_, client := wsTestPair(t)
+	called := false
+	conn := NewWSConn(&ConnectionOptions{
+		Base:                 client,
+		State:                &ConnectionState{State: api.StatConnected},
+		ConnUse:              api.UseTypeMessage,
+		AutoRoute:            true,
+		OnReadTransportErr:   func(string, string) { called = true },
+		ReadDeadlineInterval: 5 * time.Second,
+	})
+
+	if conn.readDeadlineInterval != 5*time.Second {
+		t.Fatalf("readDeadlineInterval = %v, want 5s", conn.readDeadlineInterval)
+	}
+	if conn.wsConn != client || !conn.autoRoute || conn.connUse != api.UseTypeMessage {
+		t.Fatal("NewWSConn did not carry over the basic options")
+	}
+	if conn.messageFifo == nil || conn.syncKeeper == nil {
+		t.Fatal("NewWSConn must initialize messageFifo and syncKeeper")
+	}
+	conn.OnReadTransportErr("", "")
+	if !called {
+		t.Fatal("OnReadTransportErr was not wired")
+	}
+}
+
+// TestPingLoopClosesConnOnTerminalWriteError verifies the terminal-error path:
+// when the connection is already broken and the read loop has not stopped the
+// ping loop, the ping loop closes the connection itself so the read side
+// unblocks immediately. A 1ns interval also exercises the sub-2ns period guard.
+func TestPingLoopClosesConnOnTerminalWriteError(t *testing.T) {
+	_, client := wsTestPair(t)
+	// Break the connection before the first ping so WriteControl fails with a
+	// non-timeout error.
+	_ = client.Close()
+
+	conn := &WSConnection{wsConn: client, readDeadlineInterval: time.Nanosecond}
+	stop := make(chan struct{})
+	defer close(stop)
+
+	done := make(chan struct{})
+	go func() {
+		conn.pingLoop(stop)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pingLoop did not stop after a terminal write error")
+	}
+}
+
+// wsTestPairSmallBuffers is wsTestPair with tiny kernel socket buffers and a
+// server that never reads, so a large client write blocks inside gorilla's
+// frame writer while holding its write lock.
+func wsTestPairSmallBuffers(t *testing.T) (server, client *websocket.Conn) {
+	t.Helper()
+	serverChan := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade failed: %v", err)
+			return
+		}
+		if tcp, ok := c.UnderlyingConn().(*net.TCPConn); ok {
+			_ = tcp.SetReadBuffer(4096)
+		}
+		serverChan <- c
+	}))
+	t.Cleanup(srv.Close)
+
+	dialer := websocket.Dialer{
+		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			c, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			if tcp, ok := c.(*net.TCPConn); ok {
+				_ = tcp.SetWriteBuffer(4096)
+			}
+			return c, nil
+		},
+	}
+	c, _, err := dialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	select {
+	case s := <-serverChan:
+		t.Cleanup(func() { _ = s.Close() })
+		return s, c
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for server WebSocket connection")
+		return nil, nil
+	}
+}
+
+// TestPingLoopKeepsRunningWhileWriteBlocked verifies the transient-timeout
+// path: while a large data frame is blocked on the socket (peer not reading),
+// gorilla holds its write lock, so WriteControl fails with a timeout. That must
+// not stop the ping loop; liveness is judged by the read deadline, not by the
+// ping writer.
+func TestPingLoopKeepsRunningWhileWriteBlocked(t *testing.T) {
+	server, client := wsTestPairSmallBuffers(t)
+
+	// A frame far larger than the socket buffers blocks in the frame writer
+	// until the peer reads or the connection is torn down.
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- client.WriteMessage(websocket.BinaryMessage, make([]byte, 8<<20))
+	}()
+
+	conn := &WSConnection{wsConn: client, readDeadlineInterval: 40 * time.Millisecond}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		conn.pingLoop(stop)
+		close(done)
+	}()
+
+	// Several ping periods elapse with the write lock held; each WriteControl
+	// times out and the loop must keep going.
+	select {
+	case <-done:
+		t.Fatal("pingLoop stopped while the write lock was held; write timeouts must be tolerated")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Tear down: closing the server unblocks the pending write with an error
+	// and lets the ping loop exit through either the stop or the error path.
+	_ = server.Close()
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("pingLoop did not exit after teardown")
+	}
+	select {
+	case <-writeDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("blocked write did not return after the peer closed")
+	}
+}
+
+// TestSetWriteDeadlinePropagatesToWSConn mirrors the SetReadDeadline test for
+// the write side: a past deadline must make the next write fail immediately.
+func TestSetWriteDeadlinePropagatesToWSConn(t *testing.T) {
+	conn, srv := newTestWSConn(t, 0, true)
+	defer srv.Close()
+	defer conn.wsConn.Close()
+
+	if err := conn.SetWriteDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("SetWriteDeadline: %v", err)
+	}
+	if err := conn.wsConn.WriteMessage(websocket.BinaryMessage, []byte("x")); err == nil {
+		t.Fatal("expected immediate write error after past deadline; SetWriteDeadline did not propagate")
 	}
 }

--- a/pkg/viaduct/pkg/lane/ws.go
+++ b/pkg/viaduct/pkg/lane/ws.go
@@ -3,6 +3,7 @@ package lane
 import (
 	"errors"
 	"io"
+	"net"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -30,7 +31,11 @@ func NewWSLane(van interface{}) *WSLane {
 func (l *WSLane) Read(p []byte) (int, error) {
 	_, msgData, err := l.conn.ReadMessage()
 	if err != nil {
-		if !errors.Is(err, io.EOF) {
+		// A deadline expiry is the designed half-open detection path when a
+		// read deadline is armed (see conn.WSConnection.handleMessage); it
+		// is reported there, not here.
+		var netErr net.Error
+		if !errors.Is(err, io.EOF) && !(errors.As(err, &netErr) && netErr.Timeout()) {
 			klog.Errorf("read message error(%+v)", err)
 		}
 		return len(msgData), err

--- a/pkg/viaduct/pkg/lane/ws_test.go
+++ b/pkg/viaduct/pkg/lane/ws_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lane
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newWSPair returns a connected server/client websocket pair backed by an
+// httptest server; both are closed on cleanup.
+func newWSPair(t *testing.T) (server, client *websocket.Conn) {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	serverChan := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		serverChan <- c
+	}))
+	t.Cleanup(srv.Close)
+
+	c, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	select {
+	case s := <-serverChan:
+		t.Cleanup(func() { _ = s.Close() })
+		return s, c
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for the server side of the websocket")
+		return nil, nil
+	}
+}
+
+// TestWSLaneReadReturnsDeadlineTimeout verifies that an expired read deadline
+// surfaces as a net.Error timeout from Read (the designed half-open detection
+// path, reported by the caller rather than logged here).
+func TestWSLaneReadReturnsDeadlineTimeout(t *testing.T) {
+	_, client := newWSPair(t)
+	if err := client.SetReadDeadline(time.Now().Add(-time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+
+	_, err := NewWSLane(client).Read(make([]byte, 16))
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("expected a timeout net.Error, got %v", err)
+	}
+}
+
+// TestWSLaneReadPropagatesPeerClose verifies that a close initiated by the
+// peer is returned to the caller as a non-timeout error.
+func TestWSLaneReadPropagatesPeerClose(t *testing.T) {
+	server, client := newWSPair(t)
+	if err := server.Close(); err != nil {
+		t.Fatalf("server close: %v", err)
+	}
+
+	_, err := NewWSLane(client).Read(make([]byte, 16))
+	if err == nil {
+		t.Fatal("expected an error after the peer closed the connection")
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		t.Fatalf("peer close must not be reported as a timeout: %v", err)
+	}
+}
+
+// TestWSLaneReadDelivers verifies the happy path used by the tests above:
+// a frame written by the peer is returned from Read.
+func TestWSLaneReadDelivers(t *testing.T) {
+	server, client := newWSPair(t)
+	if err := server.WriteMessage(websocket.BinaryMessage, []byte("hello")); err != nil {
+		t.Fatalf("server write: %v", err)
+	}
+
+	buf := make([]byte, 16)
+	n, err := NewWSLane(client).Read(buf)
+	if err != nil || n != len("hello") {
+		t.Fatalf("Read = (%d, %v), want (%d, nil)", n, err, len("hello"))
+	}
+}

--- a/pkg/viaduct/pkg/packer/reader.go
+++ b/pkg/viaduct/pkg/packer/reader.go
@@ -4,12 +4,25 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 
 	"k8s.io/klog/v2"
 )
 
 type Reader struct {
 	reader io.Reader
+}
+
+// silentReadErr reports whether a read error is an expected disconnect path
+// that the caller handles and logs itself: EOF (legacy behavior) or a
+// deadline expiry (the designed half-open detection in
+// conn.WSConnection.handleMessage).
+func silentReadErr(err error) bool {
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func NewReader(r io.Reader) *Reader {
@@ -30,7 +43,7 @@ func (r *Reader) Read() ([]byte, error) {
 	headerBuffer := make([]byte, HeaderSize)
 	_, err := io.ReadFull(r.reader, headerBuffer)
 	if err != nil {
-		if !errors.Is(err, io.EOF) {
+		if !silentReadErr(err) {
 			klog.Error("failed to read package header from buffer")
 		}
 		return nil, err
@@ -46,7 +59,7 @@ func (r *Reader) Read() ([]byte, error) {
 	payloadBuffer := make([]byte, header.PayloadLen)
 	_, err = io.ReadFull(r.reader, payloadBuffer)
 	if err != nil {
-		if !errors.Is(err, io.EOF) {
+		if !silentReadErr(err) {
 			klog.Error("failed to read payload from buffer")
 		}
 		return nil, err

--- a/pkg/viaduct/pkg/packer/reader_err_test.go
+++ b/pkg/viaduct/pkg/packer/reader_err_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "i/o timeout" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return false }
+
+func TestSilentReadErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"EOF", io.EOF, true},
+		{"wrapped EOF", fmt.Errorf("read: %w", io.EOF), true},
+		{"deadline timeout", timeoutErr{}, true},
+		{"wrapped timeout", fmt.Errorf("read: %w", timeoutErr{}), true},
+		{"unexpected EOF", io.ErrUnexpectedEOF, false},
+		{"other", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := silentReadErr(tc.err); got != tc.want {
+				t.Fatalf("silentReadErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadReturnsTruncatedHeaderAndPayloadErrors verifies that a stream that
+// ends mid-header or mid-payload surfaces io.ErrUnexpectedEOF (a genuine
+// transport error, not a silent one) from Read.
+func TestReadReturnsTruncatedHeaderAndPayloadErrors(t *testing.T) {
+	var packed bytes.Buffer
+	if _, err := NewWriter(&packed).Write([]byte("hello")); err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	full := packed.Bytes()
+
+	t.Run("truncated header", func(t *testing.T) {
+		_, err := NewReader(bytes.NewReader(full[:1])).Read()
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("got %v, want io.ErrUnexpectedEOF", err)
+		}
+	})
+	t.Run("truncated payload", func(t *testing.T) {
+		_, err := NewReader(bytes.NewReader(full[:len(full)-2])).Read()
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("got %v, want io.ErrUnexpectedEOF", err)
+		}
+	})
+	t.Run("clean EOF before header", func(t *testing.T) {
+		_, err := NewReader(bytes.NewReader(nil)).Read()
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("got %v, want io.EOF", err)
+		}
+	})
+	t.Run("intact", func(t *testing.T) {
+		got, err := NewReader(bytes.NewReader(full)).Read()
+		if err != nil || string(got) != "hello" {
+			t.Fatalf("got (%q, %v), want (\"hello\", nil)", got, err)
+		}
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes two related defects in the WebSocket transport (`viaduct`) that cause an edge node to remain `NotReady` for ~15-20 minutes after a network change (WiFi switchover, link flap, IP change):

1. `WSConnection.SetReadDeadline` stored the deadline in a struct field but never propagated it to the underlying `gorilla/websocket` connection, and `handleMessage` never applied a read deadline at all. This made `modules.edgeHub.websocket.readDeadline` (default `15`) a silent no-op: a half-open TCP socket blocked on `ReadMessage` until the kernel's TCP retransmission timeout (`net.ipv4.tcp_retries2=15`, ~15 minutes on Linux).

2. When a read error caused `handleMessage` to return, the `messageFifo` was not closed. Callers blocked on `ReadMessage()` / `Get()` (notably EdgeHub's `routeToEdge`) only learned about the disconnection when the next keepalive `Send` failed, delaying the reconnect by up to one heartbeat period.

The fix wires `WebSocketConfig.ReadDeadline` through `wsclient.Options.ReadDeadline` to `ConnectionOptions.ReadDeadlineInterval` and into `WSConnection`, then applies it on every `handleMessage` iteration, and closes the FIFO on a read error so the failure is observable immediately.

**Why the deadline is safe on idle connections (ping/pong keepalive)**: a read deadline alone would tear down idle-but-healthy connections, because nothing guarantees cloud-to-edge traffic within the interval (EdgeHub's application-level keepalive is one-way; CloudHub sends no response to it). To make deadline expiry mean "genuinely stalled" rather than "quiet", `pingLoop` sends WebSocket protocol pings every `readDeadlineInterval/2` and a pong handler extends the read deadline on every pong. The peer answers pings automatically (gorilla's default ping handler) as long as its read loop is running, so **no CloudHub change is needed** and the mechanism is backward-compatible with existing CloudHub deployments. A transient `WriteControl` timeout (write lock held by a large in-flight message on a slow link) does not stop the ping loop; only a genuine connection error does.

Timeout-related read errors are logged at `V(2)` consistently across the three layers that observe them (`WSConnection.handleMessage`, `WSLane.Read`, `packer.Reader.Read`); genuine transport errors still surface as `Errorf`.

`SetReadDeadline` / `SetWriteDeadline` now also propagate to the underlying connection (previously both returned `nil` without applying the deadline).

**Which issue(s) this PR fixes**:

Part of #6965

_Not using `Fixes` on purpose: #6965 is addressed together with a companion enhancement PR; please keep the issue open until both are merged._

**Special notes for your reviewer**:

- This PR is intentionally scoped to the `viaduct` layer. A companion PR (#6967) addresses the EdgeHub-level reconnect backoff and reconnect-signal coalescing. The two PRs are independent (each builds and tests on its own); the maximum reduction in `NotReady` time is achieved when both are applied.
- QUIC has the same defect (`QuicConnection.SetReadDeadline` is also a no-op) and will be addressed in a separate PR; `Options.ReadDeadline` is documented as WebSocket-only for now.
- Added `pkg/viaduct/pkg/conn/ws_test.go` covering `SetReadDeadline` propagation, deadline-driven `handleMessage` exit on a stalled peer (TCP alive, no WebSocket-level processing), ping/pong keeping an idle connection alive, and the legacy zero-deadline behavior.
- Compared to TCP keepalive / `TCP_USER_TIMEOUT`: WebSocket-level ping/pong works identically across platforms, requires no socket options plumbing through the dialer, and verifies liveness end-to-end through the TLS session rather than only at the TCP layer.

Measured on a Raspberry Pi 5 edge node (Debian 12, WebSocket transport, `heartbeat: 120`, `readDeadline: 60`):
- Before: node `NotReady` for ~20 minutes after the network path broke, most of it spent in kernel TCP retransmission inside the read path.
- With this fix: after a wired-to-Wi-Fi interface switchover, the read deadline fired **59.7s** after the switchover (matching the configured bound; the default 15s bounds detection even tighter) and the connection was re-established ~66s after the switchover. An idle connection showed **no spurious reconnects over 7+ minutes** — the ping/pong keepalive kept the deadline extended.

**Does this PR introduce a user-facing change?**:

```release-note
fix(viaduct): WSConnection now applies the configured read deadline to the underlying WebSocket connection and keeps idle connections alive with WebSocket protocol ping/pong. Edge nodes detect half-open TCP connections within `modules.edgeHub.websocket.readDeadline` (default 15s) instead of waiting for the kernel TCP retransmission timeout (~15 minutes on Linux); idle-but-healthy connections are unaffected. Read errors caused by a deadline expiry are logged at V(2), as they are the expected reconnect path.
```
