### PR TITLE
feat(edgehub): exponential backoff & coalesce reconnect signals

### DIFF
--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -1,9 +1,11 @@
 package edgehub
 
 import (
+	"math"
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 
@@ -18,14 +20,40 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/features"
 )
 
+// reconnectBackoff returns the backoff used between reconnect attempts.
+// It starts small and grows exponentially with jitter, capped at 30s, so
+// that a quickly-recovered network surfaces a NotReady node back to Ready
+// within seconds instead of waiting heartbeat*2 (up to 4 minutes when
+// heartbeat is configured to 120s).
+func reconnectBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.2,
+		Cap:      30 * time.Second,
+		// Steps only bounds how many times Duration may grow — it never
+		// stops Step() from returning values: once Cap is reached, Step()
+		// keeps returning a jittered value in [Cap, Cap*(1+Jitter))
+		// indefinitely. MaxInt32 just ensures growth is never cut short.
+		Steps: math.MaxInt32,
+	}
+}
+
 // EdgeHub defines edgehub object structure
 type EdgeHub struct {
-	certManager   certificate.CertManager
-	chClient      clients.Adapter
+	certManager certificate.CertManager
+	chClient    clients.Adapter
+	// reconnectChan is buffered(1); the transport-error senders
+	// (routeToEdge / routeToCloud / keepalive) deliver through the
+	// non-blocking triggerReconnect, so signals for one outage coalesce.
 	reconnectChan chan struct{}
-	rateLimiter   flowcontrol.RateLimiter
-	keeperLock    sync.RWMutex
-	enable        bool
+	// rotateChan carries certificate-rotation signals separately from
+	// reconnectChan so they are never coalesced or drained away: a rotation
+	// must always be followed by a reconnect that reloads the certificate.
+	rotateChan  chan struct{}
+	rateLimiter flowcontrol.RateLimiter
+	keeperLock  sync.RWMutex
+	enable      bool
 }
 
 var _ core.Module = (*EdgeHub)(nil)
@@ -46,11 +74,42 @@ func newEdgeHub(enable bool) *EdgeHub {
 	NewCertSyncChannel()
 	return &EdgeHub{
 		enable:        enable,
-		reconnectChan: make(chan struct{}),
+		reconnectChan: make(chan struct{}, 1),
+		rotateChan:    make(chan struct{}, 1),
 		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(
 			float32(config.Config.EdgeHub.MessageQPS),
 			int(config.Config.EdgeHub.MessageBurst)),
 	}
+}
+
+// triggerReconnect requests a reconnect without blocking. If a reconnect
+// signal is already pending, the call is a no-op since one signal is
+// sufficient to drive the reconnect loop.
+func (eh *EdgeHub) triggerReconnect() {
+	select {
+	case eh.reconnectChan <- struct{}{}:
+	default:
+	}
+}
+
+// drainReconnect discards a pending transport reconnect signal, if any.
+// It deliberately does not touch rotateChan: dropping a rotation signal
+// could leave a connection running on a stale certificate until the next
+// natural disconnect.
+func (eh *EdgeHub) drainReconnect() {
+	select {
+	case <-eh.reconnectChan:
+	default:
+	}
+}
+
+// shouldResetBackoff reports whether the connection stayed up long enough to
+// consider the previous outage over. Resetting on every successful handshake
+// would let a connect-then-die loop (e.g. an overloaded CloudHub or a broken
+// LB) retry at the initial ~2s interval forever — a connection storm across
+// a large fleet. Surviving longer than the backoff cap is taken as healthy.
+func shouldResetBackoff(connectedAt time.Time, b wait.Backoff) bool {
+	return time.Since(connectedAt) > b.Cap
 }
 
 // Register register edgehub
@@ -99,6 +158,7 @@ func (eh *EdgeHub) Start() {
 
 	go eh.ifRotationDone()
 
+	backoff := reconnectBackoff()
 	for {
 		select {
 		case <-beehiveContext.Done():
@@ -112,14 +172,37 @@ func (eh *EdgeHub) Start() {
 			return
 		}
 
-		waitTime := time.Duration(config.Config.Heartbeat) * time.Second * 2
-
+		// A rotation that completed while we were disconnected is already
+		// satisfied by the upcoming Init(), which reads the newest
+		// certificate from disk (certManager writes the files before
+		// signaling). Discard such a stale signal now — while still
+		// disconnected — so it does not trigger a redundant reconnect right
+		// after the connection is established. A rotation completing after
+		// this point sends a fresh signal that survives to the wait below.
+		select {
+		case <-eh.rotateChan:
+		default:
+		}
 		err = eh.chClient.Init()
 		if err != nil {
-			klog.Errorf("connection failed: %v, will reconnect after %s", err, waitTime.String())
-			time.Sleep(waitTime)
+			sleep := backoff.Step()
+			klog.Errorf("connection failed: %v, will reconnect after %s", err, sleep.String())
+			select {
+			case <-beehiveContext.Done():
+				klog.Warning("EdgeHub stop")
+				return
+			case <-time.After(sleep):
+			}
 			continue
 		}
+		// Drain any stale transport-error signal queued by the previous
+		// generation of goroutines while Init was in flight. Without this,
+		// the stale signal would be received immediately by the wait below,
+		// triggering an unnecessary reconnect cycle right after a successful
+		// connect. Certificate-rotation signals are deliberately not
+		// drained (see rotateChan).
+		eh.drainReconnect()
+		connectedAt := time.Now()
 		// execute hook func after connect
 		eh.pubConnectInfo(true)
 		go eh.routeToEdge()
@@ -128,24 +211,53 @@ func (eh *EdgeHub) Start() {
 
 		// wait the stop signal
 		// stop authinfo manager/websocket connection
-		<-eh.reconnectChan
+		rotated := false
+		select {
+		case <-beehiveContext.Done():
+			// Module shutdown: clean up like the reconnect/rotation paths
+			// below instead of relying on process teardown.
+			eh.chClient.UnInit()
+			eh.pubConnectInfo(false)
+			klog.Warning("EdgeHub stop")
+			return
+		case <-eh.reconnectChan:
+		case <-eh.rotateChan:
+			// The certificate was rotated (possibly while the connect above
+			// was in flight). Re-establish the connection so chClient.Init()
+			// reloads the new certificate from disk.
+			rotated = true
+		}
 		eh.chClient.UnInit()
 
 		// execute hook fun after disconnect
 		eh.pubConnectInfo(false)
 
-		// sleep one period of heartbeat, then try to connect cloud hub again
-		klog.Warningf("connection is broken, will reconnect after %s", waitTime.String())
-		time.Sleep(waitTime)
-
-		// clean channel
-	clean:
-		for {
-			select {
-			case <-eh.reconnectChan:
-			default:
-				break clean
-			}
+		if rotated {
+			// A certificate rotation is an intentional, healthy reconnect,
+			// not a transport failure, so reconnect immediately without a
+			// backoff wait.
+			klog.Info("certificate rotated, reconnecting to reload it")
+			continue
 		}
+
+		// Reset the backoff only after the connection proved healthy for a
+		// while, so a connect-then-die loop keeps backing off instead of
+		// hammering the cloud at the initial interval.
+		if shouldResetBackoff(connectedAt, backoff) {
+			backoff = reconnectBackoff()
+		}
+		sleep := backoff.Step()
+		klog.Warningf("connection is broken, will reconnect after %s", sleep.String())
+		select {
+		case <-beehiveContext.Done():
+			klog.Warning("EdgeHub stop")
+			return
+		case <-time.After(sleep):
+		}
+
+		// reconnectChan is buffered(1) and triggerReconnect is non-blocking,
+		// so at most one queued signal can remain. A single non-blocking
+		// receive is sufficient to start the next cycle from a clean state.
+		eh.drainReconnect()
 	}
 }

--- a/edge/pkg/edgehub/edgehub_test.go
+++ b/edge/pkg/edgehub/edgehub_test.go
@@ -18,8 +18,10 @@ package edgehub
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 )
 
@@ -89,6 +91,158 @@ func TestGroup(t *testing.T) {
 			t.Errorf("EdgeHub.Group() returned unexpected result. got = %s, want = hub", got)
 		}
 	})
+}
+
+func TestTriggerReconnectNonBlocking(t *testing.T) {
+	eh := &EdgeHub{reconnectChan: make(chan struct{}, 1)}
+
+	// First call enqueues a signal.
+	eh.triggerReconnect()
+	// Second call must not block even though the channel is full.
+	done := make(chan struct{})
+	go func() {
+		eh.triggerReconnect()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("triggerReconnect blocked when channel was full")
+	}
+
+	// Exactly one signal should be receivable; the second send was coalesced.
+	select {
+	case <-eh.reconnectChan:
+	default:
+		t.Fatal("expected one reconnect signal")
+	}
+	select {
+	case <-eh.reconnectChan:
+		t.Fatal("did not expect a second reconnect signal")
+	default:
+	}
+}
+
+// TestIfRotationDoneSendsToRotateChan guards the wiring that makes the
+// rotation guarantee hold end-to-end: a certManager.Done signal must be
+// forwarded to rotateChan — never to the drainable reconnectChan, where the
+// post-connect drain could discard it.
+func TestIfRotationDoneSendsToRotateChan(t *testing.T) {
+	eh := &EdgeHub{
+		reconnectChan: make(chan struct{}, 1),
+		rotateChan:    make(chan struct{}, 1),
+		certManager: certificate.CertManager{
+			RotateCertificates: true,
+			Done:               make(chan struct{}),
+		},
+	}
+	go eh.ifRotationDone()
+
+	select {
+	case eh.certManager.Done <- struct{}{}:
+	case <-time.After(time.Second):
+		t.Fatal("ifRotationDone did not consume certManager.Done")
+	}
+
+	select {
+	case <-eh.rotateChan:
+	case <-time.After(time.Second):
+		t.Fatal("rotation signal was not forwarded to rotateChan")
+	}
+	select {
+	case <-eh.reconnectChan:
+		t.Fatal("rotation signal must not go to reconnectChan")
+	default:
+	}
+}
+
+// TestDrainReconnectLeavesRotateSignal guards the certificate-rotation
+// guarantee: the post-connect drain must only discard stale transport
+// reconnect signals, never a pending rotation signal. Dropping the latter
+// would leave a connection running on a stale certificate until the next
+// natural disconnect (certManager.Done fires only once per rotation).
+func TestDrainReconnectLeavesRotateSignal(t *testing.T) {
+	eh := &EdgeHub{
+		reconnectChan: make(chan struct{}, 1),
+		rotateChan:    make(chan struct{}, 1),
+	}
+	eh.triggerReconnect()
+	eh.rotateChan <- struct{}{}
+
+	eh.drainReconnect()
+
+	select {
+	case <-eh.reconnectChan:
+		t.Fatal("drainReconnect must discard the pending reconnect signal")
+	default:
+	}
+	select {
+	case <-eh.rotateChan:
+	default:
+		t.Fatal("drainReconnect must not consume a pending rotation signal")
+	}
+
+	// Draining with nothing pending must not block.
+	done := make(chan struct{})
+	go func() {
+		eh.drainReconnect()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("drainReconnect blocked on an empty channel")
+	}
+}
+
+// TestShouldResetBackoff guards the flapping protection: the backoff is only
+// reset once a connection survived longer than the backoff cap, so a
+// connect-then-die loop keeps backing off instead of retrying at the initial
+// interval forever.
+func TestShouldResetBackoff(t *testing.T) {
+	b := reconnectBackoff()
+	if shouldResetBackoff(time.Now().Add(-time.Second), b) {
+		t.Fatal("a connection that lived 1s must not reset the backoff")
+	}
+	if !shouldResetBackoff(time.Now().Add(-b.Cap-time.Second), b) {
+		t.Fatal("a connection that outlived the cap must reset the backoff")
+	}
+}
+
+func TestReconnectBackoffGrowsAndCaps(t *testing.T) {
+	b := reconnectBackoff()
+	// Derive bounds from the Backoff contract itself so the test keeps
+	// holding when the constants are tuned.
+	maxAllowed := b.Cap + time.Duration(float64(b.Cap)*b.Jitter)
+
+	for i := 0; i < 50; i++ {
+		got := b.Step()
+		if got <= 0 {
+			t.Fatalf("step %d: backoff must be positive, got %v", i, got)
+		}
+		if got > maxAllowed {
+			t.Fatalf("step %d: %v exceeds cap+jitter (%v)", i, got, maxAllowed)
+		}
+	}
+}
+
+func TestReconnectBackoffResetReturnsInitial(t *testing.T) {
+	b := reconnectBackoff()
+	// Exhaust until Cap is reached.
+	for i := 0; i < 10; i++ {
+		b.Step()
+	}
+	// Re-creating returns a backoff starting from the initial duration;
+	// this is the contract used to reset after a healthy connection.
+	// Bounds derive from the Backoff fields (captured before Step mutates
+	// Duration) so the test keeps holding when the constants are tuned.
+	b2 := reconnectBackoff()
+	minAllowed := b2.Duration
+	maxAllowed := b2.Duration + time.Duration(float64(b2.Duration)*b2.Jitter)
+	first := b2.Step()
+	if first < minAllowed || first > maxAllowed {
+		t.Fatalf("initial step out of [%v, %v]: got %v", minAllowed, maxAllowed, first)
+	}
 }
 
 func TestEnable(t *testing.T) {

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -50,7 +50,7 @@ func (eh *EdgeHub) routeToEdge() {
 		message, err := eh.chClient.Receive()
 		if err != nil {
 			klog.Errorf("websocket read error: %v", err)
-			eh.reconnectChan <- struct{}{}
+			eh.triggerReconnect()
 			return
 		}
 		klog.V(4).Infof("[edgehub/routeToEdge] receive msg from cloud, msg: %+v", message)
@@ -97,7 +97,7 @@ func (eh *EdgeHub) routeToCloud() {
 		err = eh.sendToCloud(message)
 		if err != nil {
 			klog.Errorf("failed to send message to cloud: %v", err)
-			eh.reconnectChan <- struct{}{}
+			eh.triggerReconnect()
 			return
 		}
 	}
@@ -119,7 +119,7 @@ func (eh *EdgeHub) keepalive() {
 		err := eh.sendToCloud(*msg)
 		if err != nil {
 			klog.Errorf("websocket write error: %v", err)
-			eh.reconnectChan <- struct{}{}
+			eh.triggerReconnect()
 			return
 		}
 
@@ -149,8 +149,25 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 func (eh *EdgeHub) ifRotationDone() {
 	if eh.certManager.RotateCertificates {
 		for {
-			<-eh.certManager.Done
-			eh.reconnectChan <- struct{}{}
+			select {
+			case <-beehiveContext.Done():
+				return
+			case <-eh.certManager.Done:
+				// Send on the dedicated rotation channel so the signal
+				// cannot be coalesced away with transport reconnects:
+				// unlike reconnectChan, rotateChan is not touched by the
+				// post-connect drain; it is consumed by the reconnect wait
+				// in Start, and dropped only while disconnected, right
+				// before an Init() that reads the newest certificate
+				// anyway. Buffered(1) + non-blocking keeps this loop from
+				// blocking when a signal is already pending — one pending
+				// rotation reconnect is enough, the newest certificate is
+				// always read from disk.
+				select {
+				case eh.rotateChan <- struct{}{}:
+				default:
+				}
+			}
 		}
 	}
 }

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -356,8 +356,12 @@ func TestKeepalive(t *testing.T) {
 		{
 			name: "Heartbeat failure Case",
 			hub: &EdgeHub{
-				chClient:      mockAdapter,
-				reconnectChan: make(chan struct{}),
+				chClient: mockAdapter,
+				// buffered(1) is the production invariant established by
+				// newEdgeHub; triggerReconnect's non-blocking send relies
+				// on it (an unbuffered channel would race with the
+				// receiver parking and could drop the signal).
+				reconnectChan: make(chan struct{}, 1),
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR replaces EdgeHub's fixed `Heartbeat * 2` reconnect wait time with an exponential backoff (initial 2s, factor 2, jitter 0.2, cap 30s, effectively unbounded steps). With the previous fixed wait, environments configuring a long heartbeat period (e.g. 120s to reduce cloudhub load on large clusters) had to wait up to 4 minutes before retrying after a transient outage, even when the network had already recovered.

**The backoff is reset only after the connection stayed up longer than the backoff cap** (`shouldResetBackoff`), not on every successful handshake. Resetting on handshake success would let a connect-then-die loop (e.g. an overloaded CloudHub or a broken LB) retry at the initial ~2s interval forever — a connection storm across a large fleet.

This PR also makes `reconnectChan` a buffered(1) channel and routes the transport-error senders (`routeToEdge` / `routeToCloud` / `keepalive`) through a non-blocking `triggerReconnect()` helper. With the previous unbuffered channel, multiple goroutines firing on the same outage could block on the send; one queued signal is sufficient to drive the reconnect loop, so coalescing is intentional. The labeled drain loop is replaced with a `drainReconnect()` helper (single non-blocking receive), and a stale signal queued during `chClient.Init()` is drained immediately after a successful connect so it does not trigger an unnecessary reconnect cycle.

**Certificate-rotation signals are deliberately NOT coalesced with transport reconnects**: they flow through a dedicated buffered(1) `rotateChan` and the reconnect wait `select`s on both channels. A rotation must always result in a connection that uses the new certificate (`chClient.Init()` reloads it from disk); routing the signal through the drainable `reconnectChan` could discard it when a rotation completes while a connect is in flight, leaving the old certificate in use until the next natural disconnect (`certManager.Done` fires only once per rotation). While connected, a rotation signal is never discarded; a stale signal is dropped only while disconnected, right before an `Init()` that reads the newest certificate from disk anyway (the certificate files are fully written before the signal is sent). Rotation-triggered reconnects are logged at Info instead of the broken-connection Warning, since the disconnect is intentional.

**Which issue(s) this PR fixes**:

Part of #6965

_Not using `Fixes` on purpose: #6965 is addressed together with a companion bug-fix PR (#6966); please keep the issue open until both are merged._

**Special notes for your reviewer**:

- This PR is intentionally scoped to the EdgeHub layer. A companion PR (#6966) addresses the related `WSConnection` read-deadline defect in the `viaduct` transport. The two PRs are independent (each builds and tests on its own); the maximum reduction in `NotReady` time is achieved when both are applied.
- Tests cover the coalescing semantics of `triggerReconnect`, `drainReconnect` never consuming rotation signals, the `ifRotationDone` → `rotateChan` wiring, the `shouldResetBackoff` gating, and the value range of `reconnectBackoff` (positive, capped, jittered, resettable).
- The backoff constants (initial 2s, cap 30s) are chosen to recover quickly while staying well below the previous default wait (`heartbeat*2` = 30s with the default heartbeat). If maintainers prefer, exposing them through the EdgeHub config is a straightforward follow-up; kept out of this PR to avoid an API change.

Measured on a Raspberry Pi 5 edge node (Debian 12, WebSocket transport, `heartbeat: 120`, `readDeadline: 60`), with the companion read-deadline fix applied:
- `NotReady` time after an interface switchover dropped from ~20 minutes to **1-2 minutes**; the reconnect wait observed at recovery was **~2s** (vs. the previous fixed 4 minutes at `heartbeat: 120`).
- When the first reconnect attempt landed on a load-balancer instance still holding the stale session and was closed immediately, the backoff grew 2.0s → 4.3s and the second attempt succeeded — and after the connection stayed healthy well past the cap, the next outage started from the initial ~2s again (`shouldResetBackoff` behaving as designed).

**Does this PR introduce a user-facing change?**:

```release-note
feat(edgehub): EdgeHub now uses exponential backoff with jitter (initial 2s, cap 30s) between reconnect attempts instead of a fixed `Heartbeat * 2` wait, so edge nodes recover from transient cloud outages within seconds even when `heartbeat` is configured to a long period. The backoff resets only after a connection stays healthy for longer than the cap, preventing connection storms from connect-then-die loops. Reconnect signals from concurrent senders are coalesced through a buffered, non-blocking channel; certificate-rotation signals use a dedicated non-coalesced channel so a rotation always results in a connection that uses the new certificate.
```
