### PR TITLE
edgehub: recover quickly from half-open cloud connections

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -78,6 +78,7 @@ func (wsc *WebSocketClient) Init() error {
 		Addr:             wsc.config.URL,
 		AutoRoute:        false,
 		ConnUse:          api.UseTypeMessage,
+		ReadDeadline:     wsc.config.ReadDeadline,
 	}
 	exOpts := api.WSClientOption{Header: make(http.Header)}
 	exOpts.Header.Set("node_id", wsc.config.NodeID)

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -40,17 +40,26 @@ const (
 	// reconnectJitter randomizes each wait so that many edge nodes losing the
 	// connection to the same cloudcore at once do not reconnect in lockstep.
 	reconnectJitter = 0.2
+	// defaultHeartbeat mirrors the config default and is used as a fallback when
+	// the configured heartbeat is non-positive, so the backoff cap stays valid.
+	defaultHeartbeat = 15
 )
 
 // newReconnectBackoff builds the exponential backoff used between reconnect
 // attempts. It is capped at the previous fixed wait (Heartbeat*2), so the
-// longest wait never regresses while early attempts happen much sooner.
+// longest wait never regresses while early attempts happen much sooner. A
+// non-positive heartbeat falls back to the default, otherwise the cap would be
+// zero and the backoff would grow without limit.
 func newReconnectBackoff() wait.Backoff {
+	heartbeat := config.Config.Heartbeat
+	if heartbeat <= 0 {
+		heartbeat = defaultHeartbeat
+	}
 	return wait.Backoff{
 		Duration: reconnectBaseDelay,
 		Factor:   reconnectFactor,
 		Jitter:   reconnectJitter,
-		Cap:      time.Duration(config.Config.Heartbeat) * time.Second * 2,
+		Cap:      time.Duration(heartbeat) * time.Second * 2,
 		Steps:    math.MaxInt32,
 	}
 }

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -1,9 +1,11 @@
 package edgehub
 
 import (
+	"math"
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 
@@ -29,6 +31,29 @@ type EdgeHub struct {
 }
 
 var _ core.Module = (*EdgeHub)(nil)
+
+const (
+	// reconnectBaseDelay is the initial wait before the first reconnect attempt.
+	reconnectBaseDelay = time.Second
+	// reconnectFactor is the exponential growth factor between attempts.
+	reconnectFactor = 2.0
+	// reconnectJitter randomizes each wait so that many edge nodes losing the
+	// connection to the same cloudcore at once do not reconnect in lockstep.
+	reconnectJitter = 0.2
+)
+
+// newReconnectBackoff builds the exponential backoff used between reconnect
+// attempts. It is capped at the previous fixed wait (Heartbeat*2), so the
+// longest wait never regresses while early attempts happen much sooner.
+func newReconnectBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: reconnectBaseDelay,
+		Factor:   reconnectFactor,
+		Jitter:   reconnectJitter,
+		Cap:      time.Duration(config.Config.Heartbeat) * time.Second * 2,
+		Steps:    math.MaxInt32,
+	}
+}
 
 var certSync map[string]chan bool
 
@@ -99,6 +124,7 @@ func (eh *EdgeHub) Start() {
 
 	go eh.ifRotationDone()
 
+	backoff := newReconnectBackoff()
 	for {
 		select {
 		case <-beehiveContext.Done():
@@ -112,16 +138,16 @@ func (eh *EdgeHub) Start() {
 			return
 		}
 
-		waitTime := time.Duration(config.Config.Heartbeat) * time.Second * 2
-
 		err = eh.chClient.Init()
 		if err != nil {
+			waitTime := backoff.Step()
 			klog.Errorf("connection failed: %v, will reconnect after %s", err, waitTime.String())
 			time.Sleep(waitTime)
 			continue
 		}
 		// execute hook func after connect
 		eh.pubConnectInfo(true)
+		connectedAt := time.Now()
 		go eh.routeToEdge()
 		go eh.routeToCloud()
 		go eh.keepalive()
@@ -134,7 +160,13 @@ func (eh *EdgeHub) Start() {
 		// execute hook fun after disconnect
 		eh.pubConnectInfo(false)
 
-		// sleep one period of heartbeat, then try to connect cloud hub again
+		// a connection that stayed up at least one full backoff cap is treated as
+		// healthy, so the backoff resets and the next reconnect starts quickly; a
+		// connection that keeps flapping keeps backing off to spare cloudcore.
+		if time.Since(connectedAt) >= backoff.Cap {
+			backoff = newReconnectBackoff()
+		}
+		waitTime := backoff.Step()
 		klog.Warningf("connection is broken, will reconnect after %s", waitTime.String())
 		time.Sleep(waitTime)
 

--- a/edge/pkg/edgehub/edgehub_test.go
+++ b/edge/pkg/edgehub/edgehub_test.go
@@ -18,6 +18,7 @@ package edgehub
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
@@ -115,5 +116,51 @@ func TestEnable(t *testing.T) {
 				t.Errorf("EdgeHub.Enable() returned expected results. got = %v, want = %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestNewReconnectBackoff checks the reconnect backoff grows exponentially with
+// jitter and is capped at the previous fixed wait (Heartbeat*2).
+func TestNewReconnectBackoff(t *testing.T) {
+	config.Config.Heartbeat = 15
+	cap := time.Duration(config.Config.Heartbeat) * time.Second * 2 // 30s
+
+	backoff := newReconnectBackoff()
+	if backoff.Duration != reconnectBaseDelay {
+		t.Errorf("backoff base = %s, want %s", backoff.Duration, reconnectBaseDelay)
+	}
+	if backoff.Factor != reconnectFactor {
+		t.Errorf("backoff factor = %v, want %v", backoff.Factor, reconnectFactor)
+	}
+	if backoff.Jitter != reconnectJitter {
+		t.Errorf("backoff jitter = %v, want %v", backoff.Jitter, reconnectJitter)
+	}
+	if backoff.Cap != cap {
+		t.Errorf("backoff cap = %s, want %s", backoff.Cap, cap)
+	}
+
+	// Each step lies in [base*factor^i, base*factor^i*(1+jitter)] until it caps.
+	steps := []struct {
+		low  time.Duration
+		high time.Duration
+	}{
+		{1 * time.Second, 1200 * time.Millisecond},
+		{2 * time.Second, 2400 * time.Millisecond},
+		{4 * time.Second, 4800 * time.Millisecond},
+	}
+	for i, s := range steps {
+		got := backoff.Step()
+		if got < s.low || got > s.high {
+			t.Errorf("step %d = %s, want within [%s, %s]", i, got, s.low, s.high)
+		}
+	}
+
+	// After enough steps the wait is capped at Cap (plus jitter) and never grows further.
+	var last time.Duration
+	for i := 0; i < 20; i++ {
+		last = backoff.Step()
+	}
+	if last < cap || last > time.Duration(float64(cap)*(1+reconnectJitter)) {
+		t.Errorf("capped step = %s, want within [%s, %s]", last, cap, time.Duration(float64(cap)*(1+reconnectJitter)))
 	}
 }

--- a/edge/pkg/edgehub/edgehub_test.go
+++ b/edge/pkg/edgehub/edgehub_test.go
@@ -122,6 +122,9 @@ func TestEnable(t *testing.T) {
 // TestNewReconnectBackoff checks the reconnect backoff grows exponentially with
 // jitter and is capped at the previous fixed wait (Heartbeat*2).
 func TestNewReconnectBackoff(t *testing.T) {
+	oldHeartbeat := config.Config.Heartbeat
+	defer func() { config.Config.Heartbeat = oldHeartbeat }()
+
 	config.Config.Heartbeat = 15
 	cap := time.Duration(config.Config.Heartbeat) * time.Second * 2 // 30s
 
@@ -162,5 +165,12 @@ func TestNewReconnectBackoff(t *testing.T) {
 	}
 	if last < cap || last > time.Duration(float64(cap)*(1+reconnectJitter)) {
 		t.Errorf("capped step = %s, want within [%s, %s]", last, cap, time.Duration(float64(cap)*(1+reconnectJitter)))
+	}
+
+	// a non-positive heartbeat must still yield a valid, capped backoff instead
+	// of one that grows without limit.
+	config.Config.Heartbeat = 0
+	if got := newReconnectBackoff(); got.Cap <= 0 {
+		t.Errorf("backoff cap with non-positive heartbeat = %s, want > 0", got.Cap)
 	}
 }

--- a/pkg/viaduct/pkg/client/client.go
+++ b/pkg/viaduct/pkg/client/client.go
@@ -38,6 +38,10 @@ type Options struct {
 	HandshakeTimeout time.Duration
 	// consumer for raw data
 	Consumer io.Writer
+	// ReadDeadline is the idle read timeout for the connection. When greater
+	// than zero, the websocket connection keeps it refreshed via ping/pong to
+	// detect half-open connections promptly.
+	ReadDeadline time.Duration
 }
 
 // client including common options and extend options

--- a/pkg/viaduct/pkg/client/ws.go
+++ b/pkg/viaduct/pkg/client/ws.go
@@ -55,12 +55,13 @@ func (c *WSClient) Connect() (conn.Connection, error) {
 			peerCerts = resp.TLS.PeerCertificates
 		}
 		return conn.NewConnection(&conn.ConnectionOptions{
-			ConnType: api.ProtocolTypeWS,
-			ConnUse:  c.options.ConnUse,
-			Base:     wsConn,
-			Consumer: c.options.Consumer,
-			Handler:  c.options.Handler,
-			CtrlLane: lane.NewLane(api.ProtocolTypeWS, wsConn),
+			ConnType:     api.ProtocolTypeWS,
+			ConnUse:      c.options.ConnUse,
+			Base:         wsConn,
+			Consumer:     c.options.Consumer,
+			Handler:      c.options.Handler,
+			ReadDeadline: c.options.ReadDeadline,
+			CtrlLane:     lane.NewLane(api.ProtocolTypeWS, wsConn),
 			State: &conn.ConnectionState{
 				State:            api.StatConnected,
 				Headers:          c.exOpts.Header.Clone(),

--- a/pkg/viaduct/pkg/conn/factory.go
+++ b/pkg/viaduct/pkg/conn/factory.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"io"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -30,6 +31,12 @@ type ConnectionOptions struct {
 	AutoRoute bool
 	// OnReadTransportErr
 	OnReadTransportErr func(nodeID, projectID string)
+	// ReadDeadline is the idle timeout for reading from the connection.
+	// When it is greater than zero, the websocket connection keeps the read
+	// deadline refreshed through ping/pong so a stalled (half-open) connection
+	// is detected within the deadline instead of waiting for the kernel TCP
+	// timeout. It is only honored by the websocket message connection.
+	ReadDeadline time.Duration
 }
 
 // get connection interface by ConnTye

--- a/pkg/viaduct/pkg/conn/ws.go
+++ b/pkg/viaduct/pkg/conn/ws.go
@@ -32,6 +32,10 @@ type WSConnection struct {
 	messageFifo        *fifo.MessageFifo
 	locker             sync.Mutex
 	OnReadTransportErr func(nodeID, projectID string)
+	// readTimeout is the idle read timeout. When greater than zero, the read
+	// loop keeps the underlying connection's read deadline refreshed through
+	// ping/pong so a half-open connection is detected within readTimeout.
+	readTimeout time.Duration
 }
 
 func NewWSConn(options *ConnectionOptions) *WSConnection {
@@ -44,6 +48,7 @@ func NewWSConn(options *ConnectionOptions) *WSConnection {
 		autoRoute:          options.AutoRoute,
 		messageFifo:        fifo.NewMessageFifo(),
 		OnReadTransportErr: options.OnReadTransportErr,
+		readTimeout:        options.ReadDeadline,
 	}
 }
 
@@ -100,6 +105,16 @@ func (conn *WSConnection) handleRawData() {
 }
 
 func (conn *WSConnection) handleMessage() {
+	if conn.readTimeout > 0 {
+		_ = conn.wsConn.SetReadDeadline(time.Now().Add(conn.readTimeout))
+		conn.wsConn.SetPongHandler(func(string) error {
+			return conn.wsConn.SetReadDeadline(time.Now().Add(conn.readTimeout))
+		})
+		stop := make(chan struct{})
+		defer close(stop)
+		go conn.keepalive(stop)
+	}
+
 	for {
 		msg := &model.Message{}
 		err := lane.NewLane(api.ProtocolTypeWS, conn.wsConn).ReadMessage(msg)
@@ -116,6 +131,11 @@ func (conn *WSConnection) handleMessage() {
 			}
 
 			return
+		}
+
+		// a successful read means the peer is alive, extend the read deadline
+		if conn.readTimeout > 0 {
+			_ = conn.wsConn.SetReadDeadline(time.Now().Add(conn.readTimeout))
 		}
 
 		// filter control message
@@ -149,9 +169,36 @@ func (conn *WSConnection) handleMessage() {
 	}
 }
 
+// keepalive periodically sends websocket ping control frames so the peer's
+// pong refreshes the read deadline set in handleMessage. If the connection is
+// half-open, no pong arrives, the read deadline fires and the read loop tears
+// the connection down instead of blocking until the kernel TCP timeout.
+func (conn *WSConnection) keepalive(stop <-chan struct{}) {
+	pingPeriod := conn.readTimeout * 9 / 10
+	if pingPeriod <= 0 {
+		return
+	}
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			conn.locker.Lock()
+			err := conn.wsConn.WriteControl(websocket.PingMessage, nil, time.Now().Add(conn.readTimeout))
+			conn.locker.Unlock()
+			if err != nil {
+				klog.Errorf("failed to send ping to peer, error: %+v", err)
+				return
+			}
+		}
+	}
+}
+
 func (conn *WSConnection) SetReadDeadline(t time.Time) error {
 	conn.ReadDeadline = t
-	return nil
+	return conn.wsConn.SetReadDeadline(t)
 }
 
 func (conn *WSConnection) SetWriteDeadline(t time.Time) error {

--- a/pkg/viaduct/pkg/conn/ws_test.go
+++ b/pkg/viaduct/pkg/conn/ws_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conn
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
+)
+
+// dialTestConn starts a websocket server with the given handler and returns a
+// client connection to it together with the server for cleanup.
+func dialTestConn(t *testing.T, handler http.HandlerFunc) (*websocket.Conn, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	url := "ws" + strings.TrimPrefix(server.URL, "http")
+	wsConn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		server.Close()
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	return wsConn, server
+}
+
+func newTestWSConn(base *websocket.Conn, readDeadline time.Duration, onErr func(string, string)) *WSConnection {
+	return NewWSConn(&ConnectionOptions{
+		ConnType: api.ProtocolTypeWS,
+		ConnUse:  api.UseTypeMessage,
+		Base:     base,
+		State: &ConnectionState{
+			State:   api.StatConnected,
+			Headers: http.Header{},
+		},
+		ReadDeadline:       readDeadline,
+		OnReadTransportErr: onErr,
+	})
+}
+
+// TestWSConnectionReadDeadlineHalfOpen verifies that when the peer stops
+// responding (no data and no pong), the read deadline fires and the read loop
+// tears the connection down promptly instead of blocking until the kernel TCP
+// timeout.
+func TestWSConnectionReadDeadlineHalfOpen(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	// The server upgrades and then goes silent: it never reads, so gorilla never
+	// answers the client's pings with a pong, emulating a half-open connection.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		time.Sleep(5 * time.Second)
+	}
+	wsConn, server := dialTestConn(t, handler)
+	defer server.Close()
+
+	var once sync.Once
+	fired := make(chan struct{})
+	conn := newTestWSConn(wsConn, time.Second, func(string, string) {
+		once.Do(func() { close(fired) })
+	})
+	conn.ServeConn()
+
+	select {
+	case <-fired:
+		// detected within the read deadline, as expected
+	case <-time.After(4 * time.Second):
+		t.Fatal("read deadline did not fire; half-open connection was not detected")
+	}
+	if conn.state.State != api.StatDisconnected {
+		t.Errorf("connection state = %q, want %q", conn.state.State, api.StatDisconnected)
+	}
+}
+
+// TestWSConnectionReadDeadlineHealthy verifies that a responsive peer keeps the
+// connection alive across several read-deadline windows via ping/pong, so the
+// connection is not torn down while it is healthy.
+func TestWSConnectionReadDeadlineHealthy(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	// The server keeps reading, so gorilla answers the client's pings with pongs.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		for {
+			if _, _, err := c.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}
+	wsConn, server := dialTestConn(t, handler)
+	defer server.Close()
+
+	var once sync.Once
+	fired := make(chan struct{})
+	conn := newTestWSConn(wsConn, time.Second, func(string, string) {
+		once.Do(func() { close(fired) })
+	})
+	conn.ServeConn()
+
+	select {
+	case <-fired:
+		t.Fatal("connection was torn down while the peer was responsive")
+	case <-time.After(2500 * time.Millisecond):
+		// stayed alive across multiple read-deadline windows, as expected
+	}
+	_ = conn.Close()
+}

--- a/pkg/viaduct/pkg/conn/ws_test.go
+++ b/pkg/viaduct/pkg/conn/ws_test.go
@@ -117,7 +117,9 @@ func TestWSConnectionReadDeadlineHealthy(t *testing.T) {
 
 	var once sync.Once
 	fired := make(chan struct{})
-	conn := newTestWSConn(wsConn, time.Second, func(string, string) {
+	// Use a generous read deadline so the ping/pong round-trip and goroutine
+	// scheduling have enough slack to keep this test stable under CI load.
+	conn := newTestWSConn(wsConn, 3*time.Second, func(string, string) {
 		once.Do(func() { close(fired) })
 	})
 	conn.ServeConn()
@@ -125,8 +127,8 @@ func TestWSConnectionReadDeadlineHealthy(t *testing.T) {
 	select {
 	case <-fired:
 		t.Fatal("connection was torn down while the peer was responsive")
-	case <-time.After(2500 * time.Millisecond):
-		// stayed alive across multiple read-deadline windows, as expected
+	case <-time.After(5 * time.Second):
+		// stayed alive past the read-deadline window via ping/pong, as expected
 	}
 	_ = conn.Close()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:


After a network change beneath an active edgecore->cloudcore websocket
connection (WiFi switchover, link flap, IP change), the connection goes
half open and the node stays NotReady for ~15-20 minutes before it
reconnects. Two independent issues cause the delay:

1. The read deadline is never applied to the underlying gorilla
   connection, so the read blocks until the kernel TCP timeout (~15 min).
2. EdgeHub waits a fixed Heartbeat*2 before reconnecting, adding more
   delay with longer heartbeat settings.

This wires the read deadline through to the connection and keeps it
refreshed with websocket ping/pong, so a stalled connection is detected
within the deadline instead of the kernel timeout. It also replaces the
fixed reconnect wait with capped exponential backoff and jitter. The
backoff is capped at the previous fixed wait, so the longest wait never
regresses while early attempts happen much sooner, and the jitter avoids
a reconnect storm when many nodes drop off one cloudcore at once.

The ping/pong is driven from the edge client only (gated on a non zero
read deadline); the cloud replies with pong automatically, so cloudcore,
QUIC, and the stream tunnel are unchanged.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6965

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed edgecore staying NotReady for ~15-20 minutes after a network change by detecting half open cloud connections via websocket ping/pong and using exponential backoff with jitter for reconnection.
```
