### PR TITLE
metaserver: lock hooks map in watchhook.Trigger

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook/hooks.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook/hooks.go
@@ -46,8 +46,14 @@ func Trigger(e watch.Event) {
 		return
 	}
 	gvr, ns, name := metaserver.ParseKey(key)
-	//TODO why not lock hooks ?
+	hooksLock.Lock()
+	activeHooks := make([]*WatchHook, 0, len(hooks))
 	for _, hook := range hooks {
+		activeHooks = append(activeHooks, hook)
+	}
+	hooksLock.Unlock()
+
+	for _, hook := range activeHooks {
 		compGVR, compNS, compName, compRev := true, true, true, true
 		if !hook.GetGVR().Empty() {
 			compGVR = hook.GetGVR() == gvr

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook/watchhook.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook/watchhook.go
@@ -18,7 +18,8 @@ type WatchHook struct {
 	ResourceVersion uint64
 	id              string
 	Receiver
-	lock sync.Mutex
+	lock    sync.Mutex
+	stopped bool
 }
 
 func NewWatchHook(key string, rev uint64, receiver Receiver) (*WatchHook, error) {
@@ -39,6 +40,9 @@ func NewWatchHook(key string, rev uint64, receiver Receiver) (*WatchHook, error)
 func (h *WatchHook) Do(event watch.Event) error {
 	h.Lock()
 	defer h.UnLock()
+	if h.stopped {
+		return nil
+	}
 	return h.Receive(event)
 }
 
@@ -59,7 +63,13 @@ func (h *WatchHook) GetResourceVersion() uint64 {
 
 func (h *WatchHook) Stop() {
 	h.Lock()
-	defer h.UnLock()
+	if h.stopped {
+		h.UnLock()
+		return
+	}
+	h.stopped = true
+	h.UnLock()
+
 	if err := DeleteHook(h.id); err != nil {
 		klog.Error(err)
 	}

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook/watchhook_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook/watchhook_test.go
@@ -1,0 +1,144 @@
+package watchhook
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/kubeedge/kubeedge/pkg/metaserver"
+)
+
+type testReceiver struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *testReceiver) Receive(watch.Event) error {
+	r.calls.Add(1)
+	if r.started != nil {
+		r.once.Do(func() {
+			close(r.started)
+		})
+	}
+	if r.release != nil {
+		<-r.release
+	}
+	return nil
+}
+
+func newTestEvent(t *testing.T) (watch.Event, string) {
+	t.Helper()
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("v1")
+	obj.SetKind("Pod")
+	obj.SetNamespace("default")
+	obj.SetName("test-pod")
+	obj.SetResourceVersion("1")
+
+	key, err := metaserver.KeyFuncObj(obj)
+	require.NoError(t, err)
+	return watch.Event{Type: watch.Modified, Object: obj}, key
+}
+
+func TestWatchHookNoDeliveryAfterStop(t *testing.T) {
+	event, key := newTestEvent(t)
+	receiver := &testReceiver{}
+	hook, err := NewWatchHook(key, 0, receiver)
+	require.NoError(t, err)
+
+	hook.Stop()
+	require.NoError(t, hook.Do(event))
+	Trigger(event)
+	hook.Stop()
+
+	require.Zero(t, receiver.calls.Load())
+}
+
+func TestWatchHookStopWaitsForInFlightDelivery(t *testing.T) {
+	event, key := newTestEvent(t)
+	receiver := &testReceiver{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	hook, err := NewWatchHook(key, 0, receiver)
+	require.NoError(t, err)
+
+	doDone := make(chan struct{})
+	doErr := make(chan error, 1)
+	go func() {
+		defer close(doDone)
+		doErr <- hook.Do(event)
+	}()
+	<-receiver.started
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		hook.Stop()
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before the in-flight delivery completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(receiver.release)
+	<-doDone
+	require.NoError(t, <-doErr)
+	<-stopDone
+
+	require.NoError(t, hook.Do(event))
+	require.Equal(t, int32(1), receiver.calls.Load())
+}
+
+func TestWatchHookConcurrentTriggerAndStop(t *testing.T) {
+	event, key := newTestEvent(t)
+	const (
+		workers    = 8
+		iterations = 100
+	)
+
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers + 1)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for range workers * iterations {
+			Trigger(event)
+		}
+	}()
+
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			for range iterations {
+				hook, err := NewWatchHook(key, 0, &testReceiver{})
+				if err != nil {
+					errs <- err
+					return
+				}
+				hook.Stop()
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

watchhook.Trigger iterates the global hooks map without holding hooksLock, while AddHook and DeleteHook mutate the same map under that lock. Under concurrent metaserver watches and object updates from metamanager, this can trigger Go's fatal error: concurrent map iteration and map write and crash edgecore.

This PR snapshots active hooks under hooksLock, releases the lock, then iterates the copy to call hook.Do(e). That protects map access during registration and teardown, and avoids holding hooksLock while hook.Do runs, which could otherwise deadlock with WatchHook.Stop() (hook.lock → DeleteHook → hooksLock).

**Which issue(s) this PR fixes**:

Fixes #6971

**Special notes for your reviewer**:

Change is limited to edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook/hooks.go. The original //TODO why not lock hooks ? is removed. Hooks are copied into a local slice under hooksLock before event delivery.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a race in metaserver watch hooks that could crash edgecore during concurrent hook trigger and removal.
```
