### PR TITLE
cloudhub: guard empty Organization in verifyCertSubject

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
@@ -98,6 +98,9 @@ func verifyCert(cert *x509.Certificate, nodeName string) error {
 
 // verifyCertSubject ...
 func verifyCertSubject(cert *x509.Certificate, nodeName string) error {
+	if len(cert.Subject.Organization) == 0 {
+		return errors.New("certificate subject organization is empty")
+	}
 	if cert.Subject.Organization[0] == "KubeEdge" && cert.Subject.CommonName == "kubeedge.io" {
 		// In order to maintain compatibility with older versions of certificates
 		// this condition will be removed in KubeEdge v1.18.

--- a/cloud/pkg/cloudhub/servers/httpserver/certificate/certs_test.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/certificate/certs_test.go
@@ -50,6 +50,43 @@ func TestVerifyCert(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestVerifyCertEmptyOrganization(t *testing.T) {
+	cahandler := certs.GetCAHandler(certs.CAHandlerTypeX509)
+	pk, err := cahandler.GenPrivateKey()
+	require.NoError(t, err)
+
+	caPem, err := cahandler.NewSelfSigned(pk)
+	require.NoError(t, err)
+
+	certshandler := certs.GetHandler(certs.HandlerTypeX509)
+	csrPem, err := certshandler.CreateCSR(pkix.Name{
+		Country:    []string{"CN"},
+		Locality:   []string{"Hangzhou"},
+		Province:   []string{"Zhejiang"},
+		CommonName: "system:node:testnode",
+	}, pk, nil)
+	require.NoError(t, err)
+
+	certPem, err := certshandler.SignCerts(certs.SignCertsOptionsWithCSR(
+		csrPem.Bytes,
+		caPem.Bytes,
+		pk.DER(),
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		time.Hour,
+	))
+	require.NoError(t, err)
+
+	origCA := hubconfig.Config.Ca
+	hubconfig.Config.Ca = caPem.Bytes
+	t.Cleanup(func() { hubconfig.Config.Ca = origCA })
+
+	parsed, err := x509.ParseCertificate(certPem.Bytes)
+	require.NoError(t, err)
+
+	err = verifyCert(parsed, "testnode")
+	require.ErrorContains(t, err, "organization is empty")
+}
+
 func TestVerifyAuthorization(t *testing.T) {
 	const cakey = `MHcCAQEEIJQgy45Hw91mXm3pRXwxwDg4BgR4DY1UvHlzm/JXr9K6oAoGCCqGSM49AwEHoUQDQgAEq4Rd11aJ/FXEYBE2YCUMjRZVpqytxDBq2anuzokPculGaTrSDiRy1IKukPhlg34bq7J6wqkF0cmFUvcTjtReqw==`
 	cakeyDer, err := base64.StdEncoding.DecodeString(cakey)
@@ -117,4 +154,14 @@ func TestVerifyAuthorization(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifyCertSubjectEmptyOrganization(t *testing.T) {
+	cert := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "system:node:testnode",
+		},
+	}
+	err := verifyCertSubject(cert, "testnode")
+	require.ErrorContains(t, err, "organization is empty")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

verifyCertSubject reads cert.Subject.Organization[0] without checking the slice length. When Organization is empty during edge certificate rotation, CloudCore panics with index out of range [0] with length 0 instead of rejecting the certificate.

This PR returns an error when Subject.Organization is empty, so CloudHub rejects the cert and CloudCore stays up.

**Which issue(s) this PR fixes**:

Fixes #6973

**Special notes for your reviewer**:

Change is limited to cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go and certs_test.go. Added TestVerifyCertSubjectEmptyOrganization and TestVerifyCertEmptyOrganization as regression coverage.

**Does this PR introduce a user-facing change?**:

```release-note
Fix CloudHub panic during edge certificate rotation when the client certificate Subject.Organization is empty.
```
