### PR TITLE
metaserver: close watch channel when hook registration fails

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
@@ -201,13 +201,21 @@ func (s *imitator) SetRevision(version interface{}) {
 	}
 }
 
+// registerWatchHook registers the watch hook and can be replaced in tests
+// to exercise the registration-failure path.
+var registerWatchHook = watchhook.NewWatchHook
+
 func (s *imitator) Watch(ctx context.Context, key string, rev uint64) <-chan watch.Event {
 	wch := make(chan watch.Event)
 	receiver := watchhook.NewChanReceiver(wch)
-	wh, err := watchhook.NewWatchHook(key, rev, receiver)
+	wh, err := registerWatchHook(key, rev, receiver)
 	if err != nil {
+		// The detailed error is only logged because this interface cannot
+		// return it. Return a closed non-nil channel so the caller observes
+		// a clean watch termination instead of blocking forever.
 		klog.Errorf("add hook for %s failed, %v", key, err)
-		return nil
+		close(wch)
+		return wch
 	}
 
 	go func() {

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watch_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watch_test.go
@@ -1,0 +1,33 @@
+package imitator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook"
+)
+
+func TestWatchReturnsClosedChannelOnRegistrationFailure(t *testing.T) {
+	original := registerWatchHook
+	registerWatchHook = func(key string, rev uint64, receiver watchhook.Receiver) (*watchhook.WatchHook, error) {
+		return nil, errors.New("hook registration failed")
+	}
+	defer func() { registerWatchHook = original }()
+
+	s := &imitator{}
+	ch := s.Watch(context.TODO(), "/core/v1/pods/default/foo", 1)
+	if ch == nil {
+		t.Fatal("Watch returned a nil channel on registration failure")
+	}
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Fatal("expected the returned channel to be closed without events")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("receive from the returned channel did not complete immediately")
+	}
+}

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher.go
@@ -23,7 +23,6 @@ package sqlite
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -239,7 +238,10 @@ func (wc *watchChan) startWatching(watchClosedCh chan struct{}) {
 	for wres := range wch {
 		wc.sendEvent(&wres)
 	}
-	wc.sendError(fmt.Errorf("stop to watch sqlite/meta_v2"))
+	// The source channel closing is a clean watch termination, so only signal
+	// watchClosedCh. Sending an error here as well would make the result
+	// nondeterministic: run selects between errChan and watchClosedCh, so the
+	// client could see either a watch.Error event or a clean ResultChan close.
 	close(watchClosedCh)
 }
 

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher_test.go
@@ -1,0 +1,54 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake"
+)
+
+// TestWatchClosedSourceChannelTerminatesCleanly verifies that when the
+// underlying client returns a pre-closed channel, as imitator.Watch does when
+// hook registration fails, the watch terminates within a bounded time with a
+// clean ResultChan close and no watch.Error event.
+func TestWatchClosedSourceChannelTerminatesCleanly(t *testing.T) {
+	closedCh := make(chan watch.Event)
+	close(closedCh)
+	kvs := []models.MetaV2{}
+	client := fake.Client{
+		ListF: func(ctx context.Context, key string) (imitator.Resp, error) {
+			return imitator.Resp{Kvs: &kvs, Revision: 0}, nil
+		},
+		WatchF: func(ctx context.Context, key string, rv uint64) <-chan watch.Event {
+			return closedCh
+		},
+	}
+
+	w := newWatcher(client, nil)
+	wi, err := w.Watch(context.TODO(), "/core/v1/pods/default", 0, true, storage.Everything)
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case e, ok := <-wi.ResultChan():
+			if !ok {
+				return
+			}
+			if e.Type == watch.Error {
+				t.Fatalf("expected clean close, got error event: %v", e)
+			}
+			t.Fatalf("expected no events, got: %v", e)
+		case <-timeout:
+			t.Fatal("watch did not terminate within bounded time")
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When `watchhook.NewWatchHook` fails in `imitator.Watch`, the function returned `nil`. The caller in `watcher.go` ranges over that channel with `for wres := range wch`, which blocks forever on a nil channel in Go.

This PR closes the channel and returns it on registration failure, so the watch loop exits instead of hanging silently. The upper watcher then terminates with a deterministic clean `ResultChan` close.

**Which issue(s) this PR fixes**:

Fixes #6975

**Special notes for your reviewer**:

Registration-failure returns a closed non-nil channel. `startWatching` signals only `watchClosedCh` when the source channel closes, so callers see a clean close rather than a race with `watch.Error`. Regression tests cover both the imitator failure path and the upper watcher closed-source path.

**Does this PR introduce a user-facing change?**:

```release-note
Fix metaserver watch hang when hook registration fails by returning a closed channel and terminating the watch cleanly.
```
