### PR TITLE
workflows: remove hardcoded FOSSA API key

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -21,7 +21,6 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     env:
-      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       TRUSTED_FOSSA_EVENT: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +30,8 @@ jobs:
       - run: go version
       - name: require FOSSA secret on trusted events
         if: env.TRUSTED_FOSSA_EVENT == 'true'
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
           if [ -z "${FOSSA_API_KEY}" ]; then
             echo "FOSSA_API_KEY must be configured for trusted FOSSA workflow runs." >&2
@@ -38,7 +39,7 @@ jobs:
           fi
       # Runs a set of commands to initialize and analyze with FOSSA
       - name: run FOSSA analysis
-        if: env.FOSSA_API_KEY != ''
+        if: env.TRUSTED_FOSSA_EVENT == 'true'
         uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
-          api-key: ${{ env.FOSSA_API_KEY }}
+          api-key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,15 +20,25 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    env:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      TRUSTED_FOSSA_EVENT: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
           go-version: "^1.23.x"
       - run: go version
+      - name: require FOSSA secret on trusted events
+        if: env.TRUSTED_FOSSA_EVENT == 'true'
+        run: |
+          if [ -z "${FOSSA_API_KEY}" ]; then
+            echo "FOSSA_API_KEY must be configured for trusted FOSSA workflow runs." >&2
+            exit 1
+          fi
       # Runs a set of commands to initialize and analyze with FOSSA
       - name: run FOSSA analysis
-        uses: fossas/fossa-action@main
+        if: env.FOSSA_API_KEY != ''
+        uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2.0.0
         with:
-          # FOSSA Push-Only API Token
-          api-key: '87a9c35cbed49f802657f98b60134ee8'
+          api-key: ${{ env.FOSSA_API_KEY }}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removes the hardcoded FOSSA API key from the workflow, loads the token from GitHub Actions secrets, fails trusted events clearly if the secret is missing, skips authenticated FOSSA execution on untrusted events where secrets are not available, scopes the FOSSA secret only to the steps that require it, and pins the third-party FOSSA action to an immutable full-length commit SHA.

**Which issue(s) this PR fixes**:
Refs #6977

**Special notes for your reviewer**:
Workflow behavior after this change:
- trusted events are `push` to `master` and same-repository pull requests excluding `dependabot[bot]`
- trusted events fail fast if `FOSSA_API_KEY` is not configured
- untrusted fork pull requests and Dependabot-triggered pull requests do not receive the secret and skip the authenticated FOSSA step
- `FOSSA_API_KEY` is only present on the trusted-secret check step and the FOSSA action step, not at job scope
- the FOSSA action is pinned to `29693cc50323968e039056be419b32989fc5880c` (`v2.0.0`)

Validation performed:
- local workflow diff verified that the secret is no longer job-scoped and the authenticated FOSSA step is keyed directly on the trusted-event policy
- the updated fork PR triggered an upstream FOSSA workflow run: `28785442061`
- that run is `action_required` at `0s`, which shows GitHub's fork-PR approval gate blocked execution before any workflow job could start or receive secrets
- this confirms the platform-level untrusted-event protection, but the in-workflow skip path still requires maintainer approval of that run before it can be observed directly

Operational follow-up still required from a maintainer:
- revoke the previously exposed FOSSA token
- create and store the replacement `FOSSA_API_KEY` secret
- confirm a trusted upstream run authenticates successfully with the replacement token
- approve and observe the existing fork workflow run to confirm the untrusted path skips both the trusted-secret check and the authenticated FOSSA action while leaving the workflow successful

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
