### PR TITLE
taskmanager: remove shell interpolation from node upgrade

### DIFF
--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
@@ -17,13 +17,18 @@ limitations under the License.
 package taskexecutor
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -39,8 +44,26 @@ import (
 )
 
 const (
-	TaskUpgrade = "upgrade"
+	TaskUpgrade                = "upgrade"
+	keadmUpgradeLogName        = "keadm-upgrade.log"
+	keadmUpgradeLogDirPerm     = 0o750
+	keadmUpgradeLogFilePerm    = 0o600
+	keadmUpgradeUnitPrefix     = "kubeedge-keadm-upgrade"
+	keadmUpgradeUnitMaxNameLen = 255 - len(".service")
+	keadmUpgradeUnitHashLen    = 12
+	systemdRunSetenvFlag       = "--setenv"
+	systemdRunCollectFlag      = "--collect"
+	systemdRunUpgradeScript    = `exec "$KUBEEDGE_KEADM_PATH" upgrade edge --upgradeID "$KUBEEDGE_UPGRADE_ID" --historyID "$KUBEEDGE_HISTORY_ID" --fromVersion "$KUBEEDGE_FROM_VERSION" --toVersion "$KUBEEDGE_TO_VERSION" --config "$KUBEEDGE_CONFIG" --image "$KUBEEDGE_IMAGE"`
+	systemdRunEnvKeadmPath     = "KUBEEDGE_KEADM_PATH"
+	systemdRunEnvUpgradeID     = "KUBEEDGE_UPGRADE_ID"
+	systemdRunEnvHistoryID     = "KUBEEDGE_HISTORY_ID"
+	systemdRunEnvFromVersion   = "KUBEEDGE_FROM_VERSION"
+	systemdRunEnvToVersion     = "KUBEEDGE_TO_VERSION"
+	systemdRunEnvConfig        = "KUBEEDGE_CONFIG"
+	systemdRunEnvImage         = "KUBEEDGE_IMAGE"
 )
+
+var keadmExecutablePath = filepath.Join(constants.KubeEdgeUsrBinPath, constants.KeadmBinaryName)
 
 type Upgrade struct {
 	*BaseExecutor
@@ -192,33 +215,122 @@ func upgrade(taskReq types.NodeTaskRequest) (event fsm.Event) {
 
 func keadmUpgrade(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) error {
 	klog.Infof("Begin to run upgrade command")
-
-	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	launcher, err := newKeadmUpgradeLauncher(upgradeReq, opts)
 	if err != nil {
-		return fmt.Errorf("failed to open keadm log file: %w", err)
+		return err
 	}
-	defer logFile.Close()
-
-	args := buildKeadmUpgradeArgs(upgradeReq, opts)
-
-	cmd := exec.Command("nohup", append([]string{"keadm"}, args...)...)
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start keadm upgrade command: %w", err)
-	}
-	if err := cmd.Process.Release(); err != nil {
-		return fmt.Errorf("failed to release keadm upgrade process: %w", err)
+	if launcher.systemdManaged {
+		output, err := launcher.cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("start systemd upgrade command %v failed: %w, %s", launcher.cmd.Args, err, output)
+		}
+		klog.Infof("Started transient systemd unit for upgrade command %v", launcher.cmd.Args)
+	} else {
+		if err := launcher.cmd.Start(); err != nil {
+			if cerr := launcher.logFile.Close(); cerr != nil {
+				klog.Warningf("failed to close upgrade log file %s: %v", launcher.logFile.Name(), cerr)
+			}
+			return fmt.Errorf("start upgrade command %v failed: %w", launcher.cmd.Args, err)
+		}
+		go waitForUpgradeCommand(launcher.cmd, launcher.logFile)
 	}
 
 	klog.Infof("Started keadm upgrade from Version %s to %s ...", version.Get().String(), upgradeReq.Version)
 	return nil
 }
 
+type keadmUpgradeLauncher struct {
+	cmd            *exec.Cmd
+	logFile        *os.File
+	systemdManaged bool
+}
+
+type systemdRunCapabilities struct {
+	path            string
+	supportsSetenv  bool
+	supportsCollect bool
+}
+
+func waitForUpgradeCommand(cmd *exec.Cmd, logFile *os.File) {
+	defer func() {
+		if cerr := logFile.Close(); cerr != nil {
+			klog.Warningf("failed to close upgrade log file %s: %v", logFile.Name(), cerr)
+		}
+	}()
+	if err := cmd.Wait(); err != nil {
+		klog.Errorf("upgrade command %v failed: %v", cmd.Args, err)
+	}
+}
+
+func newKeadmUpgradeLauncher(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) (*keadmUpgradeLauncher, error) {
+	logPath := keadmUpgradeLogPath()
+	caps, useSystemdRun, err := detectSystemdRunCapabilities()
+	if err != nil {
+		return nil, err
+	}
+	if useSystemdRun {
+		cmd, err := newSystemdRunUpgradeCommand(caps, upgradeReq, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &keadmUpgradeLauncher{
+			cmd:            cmd,
+			systemdManaged: true,
+		}, nil
+	}
+
+	cmd, logFile, err := newKeadmUpgradeCommand(upgradeReq, opts, logPath)
+	if err != nil {
+		return nil, err
+	}
+	return &keadmUpgradeLauncher{
+		cmd:     cmd,
+		logFile: logFile,
+	}, nil
+}
+
+func newKeadmUpgradeCommand(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions, logPath string) (*exec.Cmd, *os.File, error) {
+	logFile, err := openUpgradeLogFile(logPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cmd := exec.Command(keadmExecutablePath, buildKeadmUpgradeArgs(upgradeReq, opts)...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	return cmd, logFile, nil
+}
+
+func newSystemdRunUpgradeCommand(caps systemdRunCapabilities, upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) (*exec.Cmd, error) {
+	args := []string{
+		"--unit", buildKeadmUpgradeUnitName(upgradeReq.UpgradeID, upgradeReq.HistoryID),
+		"--description", "KubeEdge node upgrade",
+		buildSystemdRunSetenvArg(systemdRunEnvKeadmPath, keadmExecutablePath),
+		buildSystemdRunSetenvArg(systemdRunEnvUpgradeID, upgradeReq.UpgradeID),
+		buildSystemdRunSetenvArg(systemdRunEnvHistoryID, upgradeReq.HistoryID),
+		buildSystemdRunSetenvArg(systemdRunEnvFromVersion, version.Get().String()),
+		buildSystemdRunSetenvArg(systemdRunEnvToVersion, upgradeReq.Version),
+		buildSystemdRunSetenvArg(systemdRunEnvConfig, opts.ConfigFile),
+		buildSystemdRunSetenvArg(systemdRunEnvImage, upgradeReq.Image),
+		"/bin/sh",
+		"-c",
+		systemdRunUpgradeScript,
+	}
+	if caps.supportsCollect {
+		args = append([]string{systemdRunCollectFlag}, args...)
+	}
+	return exec.Command(caps.path, args...), nil
+}
+
+func buildSystemdRunSetenvArg(name, value string) string {
+	return systemdRunSetenvFlag + "=" + name + "=" + value
+}
+
 func buildKeadmUpgradeArgs(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) []string {
 	return []string{
-		"upgrade", "edge",
+		"upgrade",
+		"edge",
 		"--upgradeID", upgradeReq.UpgradeID,
 		"--historyID", upgradeReq.HistoryID,
 		"--fromVersion", version.Get().String(),
@@ -226,6 +338,144 @@ func buildKeadmUpgradeArgs(upgradeReq commontypes.NodeUpgradeJobRequest, opts *o
 		"--config", opts.ConfigFile,
 		"--image", upgradeReq.Image,
 	}
+}
+
+func keadmUpgradeLogPath() string {
+	return filepath.Join(constants.KubeEdgeLogPath, keadmUpgradeLogName)
+}
+
+func detectSystemdRunCapabilities() (systemdRunCapabilities, bool, error) {
+	if runtime.GOOS != "linux" {
+		return systemdRunCapabilities{}, false, nil
+	}
+	if _, err := os.Stat("/run/systemd/system"); err != nil {
+		return systemdRunCapabilities{}, false, nil
+	}
+	systemdRunPath, err := exec.LookPath("systemd-run")
+	if err != nil {
+		return systemdRunCapabilities{}, false, fmt.Errorf("systemd-managed upgrade requires systemd-run: %w", err)
+	}
+	caps, err := inspectSystemdRunCapabilities(systemdRunPath)
+	if err != nil {
+		return systemdRunCapabilities{}, false, err
+	}
+	if !caps.supportsSetenv {
+		return systemdRunCapabilities{}, false, fmt.Errorf("systemd-managed upgrade requires systemd-run support for %s", systemdRunSetenvFlag)
+	}
+	return caps, true, nil
+}
+
+func inspectSystemdRunCapabilities(systemdRunPath string) (systemdRunCapabilities, error) {
+	output, err := exec.Command(systemdRunPath, "--help").CombinedOutput()
+	if err != nil {
+		return systemdRunCapabilities{}, fmt.Errorf("inspect systemd-run capabilities failed: %w, %s", err, output)
+	}
+	return systemdRunCapabilities{
+		path:            systemdRunPath,
+		supportsSetenv:  bytes.Contains(output, []byte(systemdRunSetenvFlag)),
+		supportsCollect: bytes.Contains(output, []byte(systemdRunCollectFlag)),
+	}, nil
+}
+
+func buildKeadmUpgradeUnitName(upgradeID, historyID string) string {
+	identity := buildKeadmUpgradeUnitIdentity(upgradeID, historyID)
+	if identity == "" {
+		return keadmUpgradeUnitPrefix
+	}
+	sanitizedID := sanitizeSystemdUnitComponent(identity)
+	hashBytes := sha256.Sum256([]byte(identity))
+	hashSuffix := hex.EncodeToString(hashBytes[:])[:keadmUpgradeUnitHashLen]
+	maxReadableLen := keadmUpgradeUnitMaxNameLen - len(keadmUpgradeUnitPrefix) - len(hashSuffix) - 2
+	if maxReadableLen < 0 {
+		maxReadableLen = 0
+	}
+	if len(sanitizedID) > maxReadableLen {
+		sanitizedID = sanitizedID[:maxReadableLen]
+	}
+	if sanitizedID == "" {
+		return keadmUpgradeUnitPrefix + "-" + hashSuffix
+	}
+	return keadmUpgradeUnitPrefix + "-" + sanitizedID + "-" + hashSuffix
+}
+
+func buildKeadmUpgradeUnitIdentity(upgradeID, historyID string) string {
+	switch {
+	case upgradeID == "" && historyID == "":
+		return ""
+	case historyID == "":
+		return upgradeID
+	case upgradeID == "":
+		return historyID
+	default:
+		return upgradeID + "-" + historyID
+	}
+}
+
+func sanitizeSystemdUnitComponent(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+func ensureSecureLogDir(logDir string) error {
+	if info, err := os.Lstat(logDir); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("upgrade log directory %s must not be a symlink", logDir)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("upgrade log directory %s is not a directory", logDir)
+		}
+	} else if os.IsNotExist(err) {
+		if err := os.MkdirAll(logDir, keadmUpgradeLogDirPerm); err != nil {
+			return fmt.Errorf("create upgrade log directory %s failed: %w", logDir, err)
+		}
+	} else {
+		return fmt.Errorf("inspect upgrade log directory %s failed: %w", logDir, err)
+	}
+
+	if err := ensureOwnedByCurrentUser(infoOwner(logDir)); err != nil {
+		return fmt.Errorf("upgrade log directory %s %w", logDir, err)
+	}
+	if err := os.Chmod(logDir, keadmUpgradeLogDirPerm); err != nil {
+		return fmt.Errorf("set upgrade log directory permissions on %s failed: %w", logDir, err)
+	}
+	return nil
+}
+
+func openUpgradeLogFile(logPath string) (*os.File, error) {
+	if err := ensureSecureLogDir(filepath.Dir(logPath)); err != nil {
+		return nil, err
+	}
+	logFile, err := openAndValidateUpgradeLogFile(logPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := logFile.Truncate(0); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("truncate upgrade log file %s failed: %w", logPath, err)
+	}
+	if _, err := logFile.Seek(0, 0); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("rewind upgrade log file %s failed: %w", logPath, err)
+	}
+	if err := logFile.Chmod(keadmUpgradeLogFilePerm); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("set upgrade log file permissions on %s failed: %w", logPath, err)
+	}
+	return logFile, nil
 }
 
 func prepareKeadm(upgradeReq *commontypes.NodeUpgradeJobRequest) error {

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_log_unix.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_log_unix.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskexecutor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func openAndValidateUpgradeLogFile(logPath string) (*os.File, error) {
+	fd, err := unix.Open(logPath, unix.O_CREAT|unix.O_WRONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, uint32(keadmUpgradeLogFilePerm))
+	if err != nil {
+		return nil, fmt.Errorf("open upgrade log file %s failed: %w", logPath, err)
+	}
+	logFile := os.NewFile(uintptr(fd), logPath)
+	if logFile == nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("open upgrade log file %s failed: create file handle", logPath)
+	}
+	if err := ensureRegularOwnedFile(logFile); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("upgrade log file %s %w", logPath, err)
+	}
+	return logFile, nil
+}
+
+func ensureRegularOwnedFile(logFile *os.File) error {
+	info, err := logFile.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect file failed: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("must be a regular file")
+	}
+	return ensureOwnedByCurrentUser(info.Sys())
+}
+
+func ensureOwnedByCurrentUser(stat any) error {
+	statT, ok := stat.(*syscall.Stat_t)
+	if !ok {
+		return errors.New("owner could not be determined")
+	}
+	if statT.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("must be owned by uid %d", os.Geteuid())
+	}
+	return nil
+}
+
+func infoOwner(path string) any {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil
+	}
+	return info.Sys()
+}

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_log_windows.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_log_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskexecutor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func openAndValidateUpgradeLogFile(logPath string) (*os.File, error) {
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY, keadmUpgradeLogFilePerm)
+	if err != nil {
+		return nil, fmt.Errorf("open upgrade log file %s failed: %w", logPath, err)
+	}
+	if err := ensureRegularOwnedFile(logFile); err != nil {
+		_ = logFile.Close()
+		return nil, fmt.Errorf("upgrade log file %s %w", logPath, err)
+	}
+	return logFile, nil
+}
+
+func ensureRegularOwnedFile(logFile *os.File) error {
+	info, err := logFile.Stat()
+	if err != nil {
+		return fmt.Errorf("inspect file failed: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("must be a regular file")
+	}
+	return nil
+}
+
+func ensureOwnedByCurrentUser(_ any) error {
+	return nil
+}
+
+func infoOwner(path string) any {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil
+	}
+	return info.Sys()
+}

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
@@ -17,59 +17,222 @@ limitations under the License.
 package taskexecutor
 
 import (
-	"reflect"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	commontypes "github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
 	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
-func TestBuildKeadmUpgradeArgsDoesNotUseShell(t *testing.T) {
-	upgradeReq := commontypes.NodeUpgradeJobRequest{
-		UpgradeID: "upgrade-1; touch /tmp/pwned",
-		HistoryID: "history-1$(touch /tmp/pwned)",
-		Version:   "v1.23.1; rm -rf /",
-		Image:     "kubeedge/installation-package; touch /tmp/pwned",
+func TestBuildKeadmUpgradeArgsTreatsShellMetacharactersAsLiteralArgs(t *testing.T) {
+	req := commontypes.NodeUpgradeJobRequest{
+		UpgradeID: "upgrade;touch /tmp/pwned",
+		HistoryID: "history && whoami",
+		Version:   "v1.17.0 $(uname -a)",
+		Image:     "example.com/keadm:latest;echo owned",
 	}
-	opts := &options.EdgeCoreOptions{
-		ConfigFile: "/etc/kubeedge/config/edgecore.yaml; touch /tmp/pwned",
-	}
+	opts := &options.EdgeCoreOptions{ConfigFile: "/etc/kubeedge/edgecore.yaml"}
 
-	args := buildKeadmUpgradeArgs(upgradeReq, opts)
+	args := buildKeadmUpgradeArgs(req, opts)
 
-	want := []string{
-		"upgrade", "edge",
-		"--upgradeID", upgradeReq.UpgradeID,
-		"--historyID", upgradeReq.HistoryID,
+	require.Equal(t, []string{
+		"upgrade",
+		"edge",
+		"--upgradeID", req.UpgradeID,
+		"--historyID", req.HistoryID,
 		"--fromVersion", version.Get().String(),
-		"--toVersion", upgradeReq.Version,
+		"--toVersion", req.Version,
 		"--config", opts.ConfigFile,
-		"--image", upgradeReq.Image,
-	}
-
-	if !reflect.DeepEqual(args, want) {
-		t.Fatalf("unexpected args: got %v, want %v", args, want)
-	}
+		"--image", req.Image,
+	}, args)
 }
 
-func TestKeadmUpgradeReturnsErrorWhenCommandMissing(t *testing.T) {
-	t.Setenv("PATH", t.TempDir())
+func TestNewKeadmUpgradeCommandBuildsDirectExecCommand(t *testing.T) {
+	req := commontypes.NodeUpgradeJobRequest{
+		UpgradeID: "upgrade-id",
+		HistoryID: "history-id",
+		Version:   "v1.17.0",
+		Image:     "example.com/installation-package:v1.17.0",
+	}
+	opts := &options.EdgeCoreOptions{ConfigFile: "/etc/kubeedge/edgecore.yaml"}
+	logPath := filepath.Join(t.TempDir(), "keadm.log")
 
-	err := keadmUpgrade(commontypes.NodeUpgradeJobRequest{
-		UpgradeID: "upgrade-1",
-		HistoryID: "history-1",
-		Version:   "v1.23.1",
-		Image:     "kubeedge/installation-package:v1.23.1",
-	}, &options.EdgeCoreOptions{
-		ConfigFile: "/etc/kubeedge/config/edgecore.yaml",
+	cmd, logFile, err := newKeadmUpgradeCommand(req, opts, logPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = logFile.Close()
 	})
 
-	if err == nil {
-		t.Fatal("expected error when keadm command cannot be started")
+	require.Equal(t, keadmExecutablePath, cmd.Path)
+	require.Equal(t, append([]string{cmd.Path}, buildKeadmUpgradeArgs(req, opts)...), cmd.Args)
+	require.Same(t, logFile, cmd.Stdout)
+	require.Same(t, logFile, cmd.Stderr)
+
+	info, err := os.Stat(logPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestOpenUpgradeLogFileRejectsSymlink(t *testing.T) {
+	logDir := t.TempDir()
+	target := filepath.Join(logDir, "target.log")
+	logPath := filepath.Join(logDir, "keadm-upgrade.log")
+
+	require.NoError(t, os.WriteFile(target, []byte("target"), 0o600))
+	require.NoError(t, os.Symlink(target, logPath))
+
+	_, err := openUpgradeLogFile(logPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many levels of symbolic links")
+
+	data, readErr := os.ReadFile(target)
+	require.NoError(t, readErr)
+	require.Equal(t, "target", string(data))
+}
+
+func TestOpenUpgradeLogFileTruncatesExistingContent(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "keadm-upgrade.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("stale-output"), 0o644))
+
+	logFile, err := openUpgradeLogFile(logPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = logFile.Close()
+	})
+
+	_, err = logFile.WriteString("fresh-output")
+	require.NoError(t, err)
+	require.NoError(t, logFile.Close())
+
+	data, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Equal(t, "fresh-output", string(data))
+
+	info, err := os.Stat(logPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestOpenUpgradeLogFileCreatesProtectedDirectoryAndFile(t *testing.T) {
+	logDir := filepath.Join(t.TempDir(), "var", "log", "kubeedge")
+	logPath := filepath.Join(logDir, keadmUpgradeLogName)
+
+	logFile, err := openUpgradeLogFile(logPath)
+	require.NoError(t, err)
+	require.NoError(t, logFile.Close())
+
+	dirInfo, err := os.Stat(logDir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o750), dirInfo.Mode().Perm())
+
+	fileInfo, err := os.Stat(logPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
+}
+
+func TestNewSystemdRunUpgradeCommandPreservesLiteralArgs(t *testing.T) {
+	req := commontypes.NodeUpgradeJobRequest{
+		UpgradeID: "upgrade ${KUBEEDGE_TEST_VALUE}",
+		HistoryID: "history ${KUBEEDGE_TEST_VALUE}",
+		Version:   "v1.17.0 ${KUBEEDGE_TEST_VALUE}",
+		Image:     "example.com/package:${KUBEEDGE_TEST_VALUE}",
 	}
-	if !strings.Contains(err.Error(), "failed to start keadm upgrade command") {
-		t.Fatalf("unexpected error: %v", err)
+	opts := &options.EdgeCoreOptions{ConfigFile: "/etc/kubeedge/${KUBEEDGE_TEST_VALUE}.yaml"}
+
+	binDir := t.TempDir()
+	capturedArgsPath := filepath.Join(t.TempDir(), "argv.txt")
+	helperPath := filepath.Join(binDir, "keadm-helper.sh")
+	systemdRunPath := filepath.Join(binDir, "systemd-run")
+
+	require.NoError(t, os.WriteFile(helperPath, []byte(fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$@" > %q
+`, capturedArgsPath)), 0o755))
+	require.NoError(t, os.WriteFile(systemdRunPath, []byte(`#!/bin/sh
+if [ "$1" = "--help" ]; then
+	printf '%s\n' '--setenv'
+	exit 0
+fi
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--unit|--description)
+			shift 2
+			;;
+		--setenv=*)
+			export "${1#--setenv=}"
+			shift
+			;;
+		*)
+			break
+			;;
+	esac
+done
+exec "$@"
+`), 0o755))
+
+	originalKeadmPath := keadmExecutablePath
+	keadmExecutablePath = helperPath
+	t.Cleanup(func() {
+		keadmExecutablePath = originalKeadmPath
+	})
+
+	cmd, err := newSystemdRunUpgradeCommand(systemdRunCapabilities{
+		path:           systemdRunPath,
+		supportsSetenv: true,
+	}, req, opts)
+	require.NoError(t, err)
+	require.NoError(t, cmd.Run())
+
+	data, err := os.ReadFile(capturedArgsPath)
+	require.NoError(t, err)
+	require.Equal(t, strings.Join(buildKeadmUpgradeArgs(req, opts), "\n")+"\n", string(data))
+}
+
+func TestNewSystemdRunUpgradeCommandAddsCollectWhenSupported(t *testing.T) {
+	req := commontypes.NodeUpgradeJobRequest{
+		UpgradeID: "upgrade-id",
+		HistoryID: "history-id",
+		Version:   "v1.17.0",
+		Image:     "example.com/package:v1.17.0",
 	}
+	opts := &options.EdgeCoreOptions{ConfigFile: "/etc/kubeedge/edgecore.yaml"}
+
+	cmd, err := newSystemdRunUpgradeCommand(systemdRunCapabilities{
+		path:            "/usr/bin/systemd-run",
+		supportsSetenv:  true,
+		supportsCollect: true,
+	}, req, opts)
+	require.NoError(t, err)
+	require.Contains(t, cmd.Args, systemdRunCollectFlag)
+}
+
+func TestBuildKeadmUpgradeUnitNameEmptyIDUsesPrefix(t *testing.T) {
+	require.Equal(t, keadmUpgradeUnitPrefix, buildKeadmUpgradeUnitName("", ""))
+}
+
+func TestBuildKeadmUpgradeUnitNameBoundsLengthAndHashes(t *testing.T) {
+	longID := strings.Repeat("very-long-upgrade-id-", 32)
+	unitName := buildKeadmUpgradeUnitName(longID, "history-id")
+
+	require.LessOrEqual(t, len(unitName), keadmUpgradeUnitMaxNameLen)
+	require.True(t, strings.HasPrefix(unitName, keadmUpgradeUnitPrefix+"-"))
+}
+
+func TestBuildKeadmUpgradeUnitNameKeepsSamePrefixIDsDistinct(t *testing.T) {
+	id1 := strings.Repeat("same-prefix-", 20) + "one"
+	id2 := strings.Repeat("same-prefix-", 20) + "two"
+
+	require.NotEqual(t, buildKeadmUpgradeUnitName(id1, "history"), buildKeadmUpgradeUnitName(id2, "history"))
+}
+
+func TestBuildKeadmUpgradeUnitNameKeepsSameUpgradeIDDifferentHistoryIDsDistinct(t *testing.T) {
+	require.NotEqual(t,
+		buildKeadmUpgradeUnitName("upgrade-id", "history-1"),
+		buildKeadmUpgradeUnitName("upgrade-id", "history-2"),
+	)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Removes the untrusted `bash -c` interpolation from the v1alpha1 edge node upgrade executor and replaces the non-systemd path with an explicit `keadm` argv invocation. On systemd-managed nodes, the upgrade is launched through a transient `systemd-run` unit and a fixed shell wrapper that reconstructs the final `keadm` argv from environment variables, so request fields are not interpolated into shell source and the upgrade survives the EdgeCore service stop during self-upgrade. The patch also hardens the non-systemd log-file path under `/var/log/kubeedge`, restores truncating log behavior for each upgrade attempt, and uses journald as the default logging destination for the transient systemd unit.

**Which issue(s) this PR fixes**:
Fixes #6979

**Special notes for your reviewer**:
Added focused unit coverage for argv construction, transient systemd launch construction, secure log creation, symlink rejection, log truncation behavior, transient unit identity uniqueness, and conditional `systemd-run` capability handling.

Verified locally following `CONTRIBUTING.md` with:
- `GOCACHE=/Users/rootp1/Documents/repos/kubeedge/.worktrees/pr6980-vm/.cache/go-build go test ./edge/pkg/taskmanager/v1alpha1/taskexecutor`
- `GOCACHE=/Users/rootp1/Documents/repos/kubeedge/.worktrees/pr6980-vm/.cache/go-build go test -race ./edge/pkg/taskmanager/v1alpha1/taskexecutor`
- `GOOS=windows GOARCH=amd64 go build ./edge/cmd/edgecore`
- `PATH="/opt/homebrew/opt/md5sha1sum/bin:/opt/homebrew/bin:$PATH" make verify`

Verified the systemd lifecycle in a real Linux systemd VM:
- Ubuntu 24.04.4 LTS guest
- repository `build/tools/edgecore.service`
- upgrade launched through the v1alpha1 `keadmUpgrade(...)` path
- confirmed the upgrade process survived `systemctl stop edgecore.service`
- confirmed binary replacement completed
- confirmed `edgecore.service` restarted successfully on the replaced binary

Verified additional real-systemd regressions in the same VM:
- exact hostile argv values reached `keadm` literally through the real systemd manager
- a failed transient unit did not block a retry with the same `UpgradeID` and a new `HistoryID`

Evidence from the lifecycle run:
- `systemd-run` launched the transient unit and the helper `keadm` process survived `systemctl stop edgecore.service`
- `/var/log/kubeedge/lifecycle.log` recorded `before-stop`, `survived-stop`, and `restart-complete`
- `/var/log/kubeedge/edgecore-lifecycle.log` recorded `edgecore-v1-start`, `edgecore-v1-stop`, and `edgecore-v2-start`
- final `systemctl status edgecore.service` showed the restarted service active on the replaced binary

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a command injection risk in the v1alpha1 edge node upgrade flow by removing untrusted shell interpolation from the upgrade launch path. Non-systemd nodes now invoke `keadm` with explicit argv values, while systemd-managed nodes launch the upgrade in a transient systemd unit using a fixed shell wrapper with environment-provided arguments. Non-systemd upgrade logs are written safely under `/var/log/kubeedge`.
```
