### PR TITLE
upgrade: require digest verification before executing artifacts

### DIFF
--- a/edge/pkg/taskmanager/actions/nodeupgradejob.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob.go
@@ -19,6 +19,7 @@ package actions
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -30,11 +31,13 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/common/constants"
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
 	"github.com/kubeedge/kubeedge/pkg/containers"
+	keimage "github.com/kubeedge/kubeedge/pkg/image"
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
 	upgradeedge "github.com/kubeedge/kubeedge/pkg/upgrade/edge"
@@ -132,6 +135,20 @@ func (nodeUpgradeJobActionHandler) checkItems(
 			return resp
 		}
 	}
+	expectedDigest, err := expectedUpgradeImageDigest(spec.ImageDigestGetter)
+	if err != nil {
+		resp.err = err
+		return resp
+	}
+
+	if !validation.ValidateVersion(spec.Version) {
+		resp.err = fmt.Errorf("invalid version %s", spec.Version)
+		return resp
+	}
+	if spec.Image != "" && !validation.ValidateImageRepo(spec.Image) {
+		resp.err = fmt.Errorf("invalid image repo %s", spec.Image)
+		return resp
+	}
 
 	if !validation.ValidateVersion(spec.Version) {
 		resp.err = fmt.Errorf("invalid version %s", spec.Version)
@@ -144,9 +161,10 @@ func (nodeUpgradeJobActionHandler) checkItems(
 
 	// Pull installation-package image.
 	cfg := options.GetEdgeCoreConfig()
+	endpoint, cgroupDriver := getNodeUpgradeRuntimeSettings(cfg)
 	ctrcli, err := containers.NewContainerRuntime(
-		cfg.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint,
-		cfg.Modules.Edged.TailoredKubeletConfig.CgroupDriver)
+		endpoint,
+		cgroupDriver)
 	if err != nil {
 		resp.err = fmt.Errorf("failed to new container runtime, err: %v", err)
 		return resp
@@ -157,39 +175,56 @@ func (nodeUpgradeJobActionHandler) checkItems(
 		return resp
 	}
 
-	// If the ImageDigestGetter is not empty, verify the image digest.
-	if getter := spec.ImageDigestGetter; getter != nil {
-		var expectedDigest string
-		switch {
-		case runtime.GOARCH == "arm64" && getter.ARM64 != "":
-			expectedDigest = getter.ARM64
-		case runtime.GOARCH == "amd64" && getter.AMD64 != "":
-			expectedDigest = getter.AMD64
-		default:
-			resp.err = fmt.Errorf("unsupported the arch %s to verify the image digest", runtime.GOARCH)
-			return resp
-		}
-		local, err := ctrcli.GetImageDigest(ctx, image)
-		if err != nil {
-			resp.err = fmt.Errorf("failed to get image digest of %s, err: %v", image, err)
-		}
-		if local != expectedDigest {
-			resp.err = fmt.Errorf("image digest of %s is not correct, local: %s, expected: %s",
-				image, local, expectedDigest)
-			return resp
-		}
+	local, err := ctrcli.GetImageDigest(ctx, image)
+	if err != nil {
+		resp.err = fmt.Errorf("failed to get image digest of %s, err: %v", image, err)
+		return resp
+	}
+	if local != expectedDigest {
+		resp.err = fmt.Errorf("image digest of %s is not correct, local: %s, expected: %s",
+			image, local, expectedDigest)
+		return resp
+	}
+	immutableImage, err := keimage.ImmutableImageRef(image, expectedDigest)
+	if err != nil {
+		resp.err = fmt.Errorf("failed to build immutable image ref for %s, err: %v", image, err)
+		return resp
 	}
 
 	// Copy new keadm bainnary from the image to /usr/local/bin.
 	containerPath := filepath.Join(constants.KubeEdgeUsrBinPath, constants.KeadmBinaryName)
 	hostPath := filepath.Join(constants.KubeEdgeUsrBinPath, constants.KeadmBinaryName)
 	files := map[string]string{containerPath: hostPath}
-	if err := ctrcli.CopyResources(ctx, image, files); err != nil {
+	if err := ctrcli.CopyResources(ctx, immutableImage, files); err != nil {
 		resp.err = fmt.Errorf("failed to copy keadm from %s in the image %s to the host path %s, err: %v",
-			containerPath, image, hostPath, err)
+			containerPath, immutableImage, hostPath, err)
 		return resp
 	}
 	return resp
+}
+
+func expectedUpgradeImageDigest(getter *operationsv1alpha2.ImageDigestGetter) (string, error) {
+	if getter == nil {
+		return "", errors.New("imageDigestGetter is required for node upgrade jobs")
+	}
+	var value string
+	switch {
+	case runtime.GOARCH == "arm64" && getter.ARM64 != "":
+		value = getter.ARM64
+	case runtime.GOARCH == "amd64" && getter.AMD64 != "":
+		value = getter.AMD64
+	default:
+		return "", fmt.Errorf("image digest is required for arch %s", runtime.GOARCH)
+	}
+	return keimage.NormalizeDigest(value)
+}
+
+func getNodeUpgradeRuntimeSettings(config *cfgv1alpha2.EdgeCoreConfig) (string, string) {
+	if config == nil || config.Modules == nil || config.Modules.Edged == nil || config.Modules.Edged.TailoredKubeletConfig == nil {
+		return "", ""
+	}
+	return config.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint,
+		config.Modules.Edged.TailoredKubeletConfig.CgroupDriver
 }
 
 func (nodeUpgradeJobActionHandler) waitingConfirmation(
@@ -263,6 +298,13 @@ func (h *nodeUpgradeJobActionHandler) upgrade(
 		return resp
 	}
 
+	args, err := buildNodeUpgradeJobCommandArgs(spec)
+	if err != nil {
+		resp.err = err
+		resp.interrupt = true // No upgrade yet, no need to roll back.
+		return resp
+	}
+
 	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		resp.err = fmt.Errorf("failed to open keadm log file: %w", err)
@@ -270,8 +312,6 @@ func (h *nodeUpgradeJobActionHandler) upgrade(
 		return resp
 	}
 	defer logFile.Close()
-
-	args := buildNodeUpgradeJobCommandArgs(spec)
 
 	cmd := exec.Command("keadm", args...)
 	cmd.Stdout = logFile
@@ -281,12 +321,19 @@ func (h *nodeUpgradeJobActionHandler) upgrade(
 	return resp
 }
 
-func buildNodeUpgradeJobCommandArgs(spec *operationsv1alpha2.NodeUpgradeJobSpec) []string {
+func buildNodeUpgradeJobCommandArgs(spec *operationsv1alpha2.NodeUpgradeJobSpec) ([]string, error) {
 	args := []string{"upgrade", "edge", "--force", "--toVersion", spec.Version}
 	if spec.Image != "" {
 		args = append(args, "--image", spec.Image)
 	}
-	return args
+	if spec.ImageDigestGetter != nil {
+		expectedDigest, err := expectedUpgradeImageDigest(spec.ImageDigestGetter)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "--image-digest", expectedDigest)
+	}
+	return args, nil
 }
 
 func (h *nodeUpgradeJobActionHandler) rollback(

--- a/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -89,13 +90,7 @@ func TestNodeUpgradeJobPostRun(t *testing.T) {
 
 func TestNodeUpgradeJobCheckItems(t *testing.T) {
 	ctx := context.TODO()
-	specser := &cachedSpecSerializer{
-		spec: &operationsv1alpha2.NodeUpgradeJobSpec{
-			CheckItems: []string{"cpu", "mem", "disk"},
-			Image:      "kubeedge/installation-package",
-			Version:    "v1.21.0",
-		},
-	}
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
 	cfg := &cfgv1alpha2.EdgeCoreConfig{
 		Modules: &cfgv1alpha2.Modules{
 			Edged: &cfgv1alpha2.Edged{
@@ -111,6 +106,13 @@ func TestNodeUpgradeJobCheckItems(t *testing.T) {
 	}
 
 	t.Run("check items failed", func(t *testing.T) {
+		specser := &cachedSpecSerializer{
+			spec: &operationsv1alpha2.NodeUpgradeJobSpec{
+				CheckItems: []string{"cpu", "mem", "disk"},
+				Image:      "kubeedge/installation-package",
+				Version:    "v1.21.0",
+			},
+		}
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
@@ -122,8 +124,14 @@ func TestNodeUpgradeJobCheckItems(t *testing.T) {
 		assert.EqualError(t, resp.Error(), "test error")
 	})
 
-	t.Run("check items success", func(t *testing.T) {
-		var pullImageCalled, copyResourcesCalled bool
+	t.Run("check items requires image digest getter", func(t *testing.T) {
+		specser := &cachedSpecSerializer{
+			spec: &operationsv1alpha2.NodeUpgradeJobSpec{
+				CheckItems: []string{"cpu", "mem", "disk"},
+				Image:      "kubeedge/installation-package",
+				Version:    "v1.21.0",
+			},
+		}
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
@@ -141,24 +149,84 @@ func TestNodeUpgradeJobCheckItems(t *testing.T) {
 		})
 		patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "PullImage",
 			func(_ctx context.Context, image string, _authConfig *runtimeapi.AuthConfig, _sandboxConfig *runtimeapi.PodSandboxConfig) error {
-				pullImageCalled = true
 				assert.Equal(t, "kubeedge/installation-package:v1.21.0", image)
 				return nil
 			})
+
+		resp := h.checkItems(ctx, "", "", specser)
+		require.EqualError(t, resp.Error(), "imageDigestGetter is required for node upgrade jobs")
+	})
+
+	t.Run("copies keadm from immutable image reference", func(t *testing.T) {
+		specser := &cachedSpecSerializer{
+			spec: &operationsv1alpha2.NodeUpgradeJobSpec{
+				Image:   "kubeedge/installation-package",
+				Version: "v1.21.0",
+				ImageDigestGetter: &operationsv1alpha2.ImageDigestGetter{
+					AMD64: validDigest,
+					ARM64: validDigest,
+				},
+			},
+		}
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFunc(options.GetEdgeCoreConfig, func() *cfgv1alpha2.EdgeCoreConfig {
+			return cfg
+		})
+		patches.ApplyFunc(containers.NewContainerRuntime, func(endpoint, cgroupDriver string,
+		) (containers.ContainerRuntime, error) {
+			return &containers.ContainerRuntimeImpl{}, nil
+		})
+		patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "PullImage",
+			func(_ctx context.Context, image string, _authConfig *runtimeapi.AuthConfig, _sandboxConfig *runtimeapi.PodSandboxConfig) error {
+				assert.Equal(t, "kubeedge/installation-package:v1.21.0", image)
+				return nil
+			})
+		patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "GetImageDigest",
+			func(_ctx context.Context, image string) (string, error) {
+				assert.Equal(t, "kubeedge/installation-package:v1.21.0", image)
+				return validDigest, nil
+			})
 		patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "CopyResources",
-			func(_ctx context.Context, edgeImage string, files map[string]string) error {
-				copyResourcesCalled = true
-				assert.Equal(t, "kubeedge/installation-package:v1.21.0", edgeImage)
-				hostpath, ok := files["/usr/local/bin/keadm"]
-				assert.True(t, ok)
-				assert.Equal(t, "/usr/local/bin/keadm", hostpath)
+			func(_ctx context.Context, image string, files map[string]string) error {
+				assert.Equal(t, "docker.io/kubeedge/installation-package@"+validDigest, image)
+				assert.Equal(t, "/usr/local/bin/keadm", files["/usr/local/bin/keadm"])
 				return nil
 			})
 
 		resp := h.checkItems(ctx, "", "", specser)
 		require.NoError(t, resp.Error())
-		assert.True(t, pullImageCalled)
-		assert.True(t, copyResourcesCalled)
+	})
+}
+
+func TestExpectedUpgradeImageDigest(t *testing.T) {
+	t.Run("requires digest getter", func(t *testing.T) {
+		digest, err := expectedUpgradeImageDigest(nil)
+		require.EqualError(t, err, "imageDigestGetter is required for node upgrade jobs")
+		assert.Empty(t, digest)
+	})
+
+	t.Run("returns digest for current architecture", func(t *testing.T) {
+		const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
+		digest, err := expectedUpgradeImageDigest(&operationsv1alpha2.ImageDigestGetter{
+			AMD64: validDigest,
+			ARM64: validDigest,
+		})
+		require.NoError(t, err)
+		if runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64" {
+			assert.Equal(t, validDigest, digest)
+		} else {
+			assert.NotEmpty(t, digest)
+		}
+	})
+
+	t.Run("rejects malformed digest", func(t *testing.T) {
+		_, err := expectedUpgradeImageDigest(&operationsv1alpha2.ImageDigestGetter{
+			AMD64: "sha256:not-a-real-digest",
+			ARM64: "sha256:not-a-real-digest",
+		})
+		require.ErrorContains(t, err, "invalid image digest")
 	})
 }
 
@@ -264,7 +332,8 @@ func TestNodeUpgradeJobUpgrade(t *testing.T) {
 			Version: "v1.21.0",
 		}
 
-		args := buildNodeUpgradeJobCommandArgs(spec)
+args, err := buildNodeUpgradeJobCommandArgs(spec)
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{
 			"upgrade", "edge",
@@ -279,7 +348,8 @@ func TestNodeUpgradeJobUpgrade(t *testing.T) {
 			Image:   "custom.com/kubeedge/installation-package",
 		}
 
-		args := buildNodeUpgradeJobCommandArgs(spec)
+args, err := buildNodeUpgradeJobCommandArgs(spec)
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{
 			"upgrade", "edge",
@@ -295,7 +365,8 @@ func TestNodeUpgradeJobUpgrade(t *testing.T) {
 			Image:   "custom.com/kubeedge/installation-package$(touch /tmp/pwned)",
 		}
 
-		args := buildNodeUpgradeJobCommandArgs(spec)
+args, err := buildNodeUpgradeJobCommandArgs(spec)
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{
 			"upgrade", "edge",
@@ -303,6 +374,37 @@ func TestNodeUpgradeJobUpgrade(t *testing.T) {
 			"--toVersion", "v1.21.0; touch /tmp/pwned",
 			"--image", "custom.com/kubeedge/installation-package$(touch /tmp/pwned)",
 		}, args)
+})
+
+	t.Run("upgrade command includes image digest", func(t *testing.T) {
+		const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
+		spec := &operationsv1alpha2.NodeUpgradeJobSpec{
+			Version: "v1.21.0",
+			ImageDigestGetter: &operationsv1alpha2.ImageDigestGetter{
+				AMD64: validDigest,
+				ARM64: validDigest,
+			},
+		}
+
+		args, err := buildNodeUpgradeJobCommandArgs(spec)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{
+			"upgrade", "edge",
+			"--force",
+			"--toVersion", "v1.21.0",
+			"--image-digest", validDigest,
+		}, args)
+	})
+
+	t.Run("missing image digest returns error", func(t *testing.T) {
+		spec := &operationsv1alpha2.NodeUpgradeJobSpec{
+			Version:           "v1.21.0",
+			ImageDigestGetter: &operationsv1alpha2.ImageDigestGetter{},
+		}
+
+		_, err := buildNodeUpgradeJobCommandArgs(spec)
+		require.Error(t, err)
 	})
 }
 

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
@@ -28,12 +28,14 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/common/constants"
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	api "github.com/kubeedge/api/apis/fsm/v1alpha1"
 	"github.com/kubeedge/kubeedge/common/types"
 	commontypes "github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
 	"github.com/kubeedge/kubeedge/pkg/containers"
+	keimage "github.com/kubeedge/kubeedge/pkg/image"
 	"github.com/kubeedge/kubeedge/pkg/util/fsm"
 	"github.com/kubeedge/kubeedge/pkg/version"
 )
@@ -193,13 +195,16 @@ func upgrade(taskReq types.NodeTaskRequest) (event fsm.Event) {
 func keadmUpgrade(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) error {
 	klog.Infof("Begin to run upgrade command")
 
+	args, err := buildKeadmUpgradeArgs(upgradeReq, opts)
+	if err != nil {
+		return err
+	}
+
 	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to open keadm log file: %w", err)
 	}
 	defer logFile.Close()
-
-	args := buildKeadmUpgradeArgs(upgradeReq, opts)
 
 	cmd := exec.Command("nohup", append([]string{"keadm"}, args...)...)
 	cmd.Stdout = logFile
@@ -216,7 +221,11 @@ func keadmUpgrade(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.Ed
 	return nil
 }
 
-func buildKeadmUpgradeArgs(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) []string {
+func buildKeadmUpgradeArgs(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) ([]string, error) {
+	expectedDigest, err := keimage.NormalizeDigest(upgradeReq.ImageDigest)
+	if err != nil {
+		return nil, err
+	}
 	return []string{
 		"upgrade", "edge",
 		"--upgradeID", upgradeReq.UpgradeID,
@@ -225,16 +234,25 @@ func buildKeadmUpgradeArgs(upgradeReq commontypes.NodeUpgradeJobRequest, opts *o
 		"--toVersion", upgradeReq.Version,
 		"--config", opts.ConfigFile,
 		"--image", upgradeReq.Image,
-	}
+		"--image-digest", expectedDigest,
+	}, nil
 }
 
 func prepareKeadm(upgradeReq *commontypes.NodeUpgradeJobRequest) error {
 	ctx := context.Background()
 	config := options.GetEdgeCoreConfig()
+	if upgradeReq.ImageDigest == "" {
+		return errors.New("imageDigest is required for node upgrade jobs")
+	}
+	expectedDigest, err := keimage.NormalizeDigest(upgradeReq.ImageDigest)
+	if err != nil {
+		return err
+	}
 
 	// install the requested installer keadm from docker image
 	klog.Infof("Begin to download version %s keadm", upgradeReq.Version)
-	ctrcli, err := containers.NewContainerRuntime(config.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint, config.Modules.Edged.TailoredKubeletConfig.CgroupDriver)
+	endpoint, cgroupDriver := containerRuntimeSettings(config)
+	ctrcli, err := containers.NewContainerRuntime(endpoint, cgroupDriver)
 	if err != nil {
 		return fmt.Errorf("failed to new container runtime: %v", err)
 	}
@@ -247,22 +265,32 @@ func prepareKeadm(upgradeReq *commontypes.NodeUpgradeJobRequest) error {
 		return fmt.Errorf("pull image failed: %v", err)
 	}
 	// Check installation-package image digest
-	if upgradeReq.ImageDigest != "" {
-		var local string
-		local, err = ctrcli.GetImageDigest(ctx, image)
-		if err != nil {
-			return err
-		}
-		if upgradeReq.ImageDigest != local {
-			return fmt.Errorf("invalid installation-package image digest value: %s", local)
-		}
+	var local string
+	local, err = ctrcli.GetImageDigest(ctx, image)
+	if err != nil {
+		return err
+	}
+	if expectedDigest != local {
+		return fmt.Errorf("invalid installation-package image digest value: %s", local)
+	}
+	immutableImage, err := keimage.ImmutableImageRef(image, expectedDigest)
+	if err != nil {
+		return err
 	}
 	containerPath := filepath.Join(constants.KubeEdgeUsrBinPath, constants.KeadmBinaryName)
 	hostPath := filepath.Join(constants.KubeEdgeUsrBinPath, constants.KeadmBinaryName)
 	files := map[string]string{containerPath: hostPath}
-	err = ctrcli.CopyResources(ctx, image, files)
+	err = ctrcli.CopyResources(ctx, immutableImage, files)
 	if err != nil {
 		return fmt.Errorf("failed to cp file from image to host: %v", err)
 	}
 	return nil
+}
+
+func containerRuntimeSettings(config *cfgv1alpha2.EdgeCoreConfig) (string, string) {
+	if config == nil || config.Modules == nil || config.Modules.Edged == nil || config.Modules.Edged.TailoredKubeletConfig == nil {
+		return "", ""
+	}
+	return config.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint,
+		config.Modules.Edged.TailoredKubeletConfig.CgroupDriver
 }

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,27 +17,94 @@ limitations under the License.
 package taskexecutor
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/require"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+
+	cfgv1alpha2 "github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	commontypes "github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
+	"github.com/kubeedge/kubeedge/pkg/containers"
 	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
+func TestPrepareKeadmRequiresImageDigest(t *testing.T) {
+	err := prepareKeadm(&commontypes.NodeUpgradeJobRequest{
+		Version: "v1.21.0",
+		Image:   "kubeedge/installation-package:v1.21.0",
+	})
+
+	require.EqualError(t, err, "imageDigest is required for node upgrade jobs")
+}
+
+func TestPrepareKeadmCopiesFromImmutableImage(t *testing.T) {
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
+	cfg := &cfgv1alpha2.EdgeCoreConfig{
+		Modules: &cfgv1alpha2.Modules{
+			Edged: &cfgv1alpha2.Edged{
+				TailoredKubeletConfig: &cfgv1alpha2.TailoredKubeletConfiguration{
+					ContainerRuntimeEndpoint: "unix:///var/run/containerd/containerd.sock",
+					CgroupDriver:             "systemd",
+				},
+			},
+		},
+	}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(options.GetEdgeCoreConfig, func() *cfgv1alpha2.EdgeCoreConfig {
+		return cfg
+	})
+	patches.ApplyFunc(containers.NewContainerRuntime, func(endpoint, cgroupDriver string,
+	) (containers.ContainerRuntime, error) {
+		return &containers.ContainerRuntimeImpl{}, nil
+	})
+	patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "PullImages",
+		func(_ctx context.Context, images []string, _authConfig *runtimeapi.AuthConfig) error {
+			require.Equal(t, []string{"kubeedge/installation-package:v1.21.0"}, images)
+			return nil
+		})
+	patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "GetImageDigest",
+		func(_ctx context.Context, image string) (string, error) {
+			require.Equal(t, "kubeedge/installation-package:v1.21.0", image)
+			return validDigest, nil
+		})
+	patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "CopyResources",
+		func(_ctx context.Context, image string, files map[string]string) error {
+			require.Equal(t, "docker.io/kubeedge/installation-package@"+validDigest, image)
+			require.Equal(t, "/usr/local/bin/keadm", files["/usr/local/bin/keadm"])
+			return nil
+		})
+
+	err := prepareKeadm(&commontypes.NodeUpgradeJobRequest{
+		Version:     "v1.21.0",
+		Image:       "kubeedge/installation-package:v1.21.0",
+		ImageDigest: validDigest,
+	})
+	require.NoError(t, err)
+}
+
 func TestBuildKeadmUpgradeArgsDoesNotUseShell(t *testing.T) {
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
 	upgradeReq := commontypes.NodeUpgradeJobRequest{
-		UpgradeID: "upgrade-1; touch /tmp/pwned",
-		HistoryID: "history-1$(touch /tmp/pwned)",
-		Version:   "v1.23.1; rm -rf /",
-		Image:     "kubeedge/installation-package; touch /tmp/pwned",
+		UpgradeID:   "upgrade-1; touch /tmp/pwned",
+		HistoryID:   "history-1$(touch /tmp/pwned)",
+		Version:     "v1.23.1; rm -rf /",
+		Image:       "kubeedge/installation-package; touch /tmp/pwned",
+		ImageDigest: validDigest,
 	}
 	opts := &options.EdgeCoreOptions{
 		ConfigFile: "/etc/kubeedge/config/edgecore.yaml; touch /tmp/pwned",
 	}
 
-	args := buildKeadmUpgradeArgs(upgradeReq, opts)
+	args, err := buildKeadmUpgradeArgs(upgradeReq, opts)
+	require.NoError(t, err)
 
 	want := []string{
 		"upgrade", "edge",
@@ -47,6 +114,7 @@ func TestBuildKeadmUpgradeArgsDoesNotUseShell(t *testing.T) {
 		"--toVersion", upgradeReq.Version,
 		"--config", opts.ConfigFile,
 		"--image", upgradeReq.Image,
+		"--image-digest", validDigest,
 	}
 
 	if !reflect.DeepEqual(args, want) {
@@ -54,14 +122,31 @@ func TestBuildKeadmUpgradeArgsDoesNotUseShell(t *testing.T) {
 	}
 }
 
-func TestKeadmUpgradeReturnsErrorWhenCommandMissing(t *testing.T) {
-	t.Setenv("PATH", t.TempDir())
-
-	err := keadmUpgrade(commontypes.NodeUpgradeJobRequest{
+func TestBuildKeadmUpgradeArgsRequiresValidDigest(t *testing.T) {
+	upgradeReq := commontypes.NodeUpgradeJobRequest{
 		UpgradeID: "upgrade-1",
 		HistoryID: "history-1",
 		Version:   "v1.23.1",
 		Image:     "kubeedge/installation-package:v1.23.1",
+	}
+	opts := &options.EdgeCoreOptions{
+		ConfigFile: "/etc/kubeedge/config/edgecore.yaml",
+	}
+
+	_, err := buildKeadmUpgradeArgs(upgradeReq, opts)
+	require.Error(t, err)
+}
+
+func TestKeadmUpgradeReturnsErrorWhenCommandMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
+
+	err := keadmUpgrade(commontypes.NodeUpgradeJobRequest{
+		UpgradeID:   "upgrade-1",
+		HistoryID:   "history-1",
+		Version:     "v1.23.1",
+		Image:       "kubeedge/installation-package:v1.23.1",
+		ImageDigest: validDigest,
 	}, &options.EdgeCoreOptions{
 		ConfigFile: "/etc/kubeedge/config/edgecore.yaml",
 	})

--- a/keadm/cmd/keadm/app/cmd/edge/options.go
+++ b/keadm/cmd/keadm/app/cmd/edge/options.go
@@ -44,8 +44,8 @@ type UpgradeOptions struct {
 	// Force is a flag to force upgrade.
 	// If set to true, the upgrade command will not prompt for confirmation.
 	Force bool
-	// ImageDigest defines the correct image digest to verify the local image.
-	// When this value is set, the image digest is verified.
+	// ImageDigest defines the required OCI digest for the installation-package image.
+	// The upgrade command verifies the pulled image against this digest before copying binaries.
 	ImageDigest string
 
 	BaseOptions
@@ -108,7 +108,7 @@ func AddUpgradeFlags(cmd *cobra.Command, opts *UpgradeOptions) {
 	cmd.Flags().BoolVar(&opts.Force, "force", opts.Force,
 		"Upgrade the node without prompting for confirmation")
 	cmd.Flags().StringVar(&opts.ImageDigest, "image-digest", opts.ImageDigest,
-		"Use this key to specify the correct image digest to verify the local image.")
+		"Use this key to specify the required OCI image digest for the installation-package image.")
 
 	// TODO: remove these flags in v1.23
 	const deprecatedMessage = "For compatibility with historical versions, It will be removed in v1.23"

--- a/keadm/cmd/keadm/app/cmd/edge/upgrade.go
+++ b/keadm/cmd/keadm/app/cmd/edge/upgrade.go
@@ -19,6 +19,7 @@ package edge
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	"github.com/kubeedge/kubeedge/pkg/containers"
+	keimage "github.com/kubeedge/kubeedge/pkg/image"
 	upgrdeedge "github.com/kubeedge/kubeedge/pkg/upgrade/edge"
 	"github.com/kubeedge/kubeedge/pkg/util/files"
 )
@@ -156,6 +158,14 @@ func (executor *upgradeExecutor) newReporter(upgradeID, toVersion string) upgrde
 // getEdgeCoreBinary pulls the installation-package image and obtains the edgecore binary from it.
 // The edgecore binary is copied to the upgrade path, and the filepath is returned.
 func getEdgeCoreBinary(ctx context.Context, opts UpgradeOptions, config *cfgv1alpha2.EdgeCoreConfig) (string, error) {
+	expectedDigest, err := keimage.NormalizeDigest(opts.ImageDigest)
+	if err != nil {
+		if opts.ImageDigest == "" {
+			return "", errors.New("image-digest is required for edge upgrade")
+		}
+		return "", err
+	}
+
 	ctrcli, err := containers.NewContainerRuntime(
 		config.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint,
 		config.Modules.Edged.TailoredKubeletConfig.CgroupDriver)
@@ -167,24 +177,25 @@ func getEdgeCoreBinary(ctx context.Context, opts UpgradeOptions, config *cfgv1al
 	if err := ctrcli.PullImage(ctx, image, nil, nil); err != nil {
 		return "", fmt.Errorf("failed to pull image %s, err: %v", image, err)
 	}
-	// If the ImageDigest is not empty, verify the image.
-	if opts.ImageDigest != "" {
-		local, err := ctrcli.GetImageDigest(ctx, image)
-		if err != nil {
-			return "", fmt.Errorf("failed to get image digest of %s, err: %v", image, err)
-		}
-		if local != opts.ImageDigest {
-			return "", fmt.Errorf("image digest of %s is not correct, local: %s, expected: %s",
-				image, local, opts.ImageDigest)
-		}
+	local, err := ctrcli.GetImageDigest(ctx, image)
+	if err != nil {
+		return "", fmt.Errorf("failed to get image digest of %s, err: %v", image, err)
+	}
+	if local != expectedDigest {
+		return "", fmt.Errorf("image digest of %s is not correct, local: %s, expected: %s",
+			image, local, expectedDigest)
+	}
+	immutableImage, err := keimage.ImmutableImageRef(image, expectedDigest)
+	if err != nil {
+		return "", err
 	}
 	// Copy edgecore binary from the image to the upgrade path.
 	containerFilePath := filepath.Join(constants.KubeEdgeUsrBinPath, constants.KubeEdgeBinaryName)
 	hostPath := filepath.Join(upgradePath(opts.ToVersion), constants.KubeEdgeBinaryName)
 	files := map[string]string{containerFilePath: hostPath}
-	if err := ctrcli.CopyResources(ctx, image, files); err != nil {
+	if err := ctrcli.CopyResources(ctx, immutableImage, files); err != nil {
 		return "", fmt.Errorf("failed to copy edgecore from %s in the image %s to host %s, err: %v",
-			containerFilePath, image, hostPath, err)
+			containerFilePath, immutableImage, hostPath, err)
 	}
 	return hostPath, nil
 }

--- a/keadm/cmd/keadm/app/cmd/edge/upgrade_test.go
+++ b/keadm/cmd/keadm/app/cmd/edge/upgrade_test.go
@@ -309,15 +309,7 @@ func TestUpgradeExecutorUpgrade(t *testing.T) {
 
 func TestGetEdgeCoreBinary(t *testing.T) {
 	const wantHostPath = "/etc/kubeedge/upgrade/v1.1.0/edgecore"
-	var checked int
-
-	opts := UpgradeOptions{
-		Image:     "kubeedge/installation-package",
-		ToVersion: "v1.1.0",
-		BaseOptions: BaseOptions{
-			Config: constants.EdgecoreConfigPath,
-		},
-	}
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
 	cfg := &cfgv1alpha2.EdgeCoreConfig{
 		Modules: &cfgv1alpha2.Modules{
 			Edged: &cfgv1alpha2.Edged{
@@ -329,34 +321,81 @@ func TestGetEdgeCoreBinary(t *testing.T) {
 		},
 	}
 
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
+	t.Run("requires image digest", func(t *testing.T) {
+		opts := UpgradeOptions{
+			Image:     "kubeedge/installation-package",
+			ToVersion: "v1.1.0",
+			BaseOptions: BaseOptions{
+				Config: constants.EdgecoreConfigPath,
+			},
+		}
 
-	patches.ApplyFunc(containers.NewContainerRuntime, func(endpoint, cgroupDriver string,
-	) (containers.ContainerRuntime, error) {
-		assert.Equal(t, cfg.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint, endpoint)
-		assert.Equal(t, cfg.Modules.Edged.TailoredKubeletConfig.CgroupDriver, cgroupDriver)
-		checked++
-		return &containers.ContainerRuntimeImpl{}, nil
+		path, err := getEdgeCoreBinary(context.TODO(), opts, cfg)
+		assert.EqualError(t, err, "image-digest is required for edge upgrade")
+		assert.Empty(t, path)
 	})
-	patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "PullImage",
-		func(_ctx context.Context, image string, _authConfig *runtimeapi.AuthConfig, _sandboxConfig *runtimeapi.PodSandboxConfig) error {
-			assert.Equal(t, opts.Image+":"+opts.ToVersion, image)
-			checked++
-			return nil
-		})
-	patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "CopyResources",
-		func(_ctx context.Context, edgeImage string, files map[string]string) error {
-			assert.Equal(t, opts.Image+":"+opts.ToVersion, edgeImage)
-			hostpath, ok := files["/usr/local/bin/edgecore"]
-			assert.True(t, ok)
-			assert.Equal(t, wantHostPath, hostpath)
-			checked++
-			return nil
-		})
 
-	path, err := getEdgeCoreBinary(context.TODO(), opts, cfg)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, checked)
-	assert.Equal(t, wantHostPath, path)
+	t.Run("copies verified binary", func(t *testing.T) {
+		var checked int
+		opts := UpgradeOptions{
+			Image:       "kubeedge/installation-package",
+			ImageDigest: validDigest,
+			ToVersion:   "v1.1.0",
+			BaseOptions: BaseOptions{
+				Config: constants.EdgecoreConfigPath,
+			},
+		}
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFunc(containers.NewContainerRuntime, func(endpoint, cgroupDriver string,
+		) (containers.ContainerRuntime, error) {
+			assert.Equal(t, cfg.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint, endpoint)
+			assert.Equal(t, cfg.Modules.Edged.TailoredKubeletConfig.CgroupDriver, cgroupDriver)
+			checked++
+			return &containers.ContainerRuntimeImpl{}, nil
+		})
+		patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "PullImage",
+			func(_ctx context.Context, image string, _authConfig *runtimeapi.AuthConfig, _sandboxConfig *runtimeapi.PodSandboxConfig) error {
+				assert.Equal(t, opts.Image+":"+opts.ToVersion, image)
+				checked++
+				return nil
+			})
+		patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "GetImageDigest",
+			func(_ctx context.Context, image string) (string, error) {
+				assert.Equal(t, opts.Image+":"+opts.ToVersion, image)
+				checked++
+				return opts.ImageDigest, nil
+			})
+		patches.ApplyMethodFunc(reflect.TypeOf(&containers.ContainerRuntimeImpl{}), "CopyResources",
+			func(_ctx context.Context, edgeImage string, files map[string]string) error {
+				assert.Equal(t, "docker.io/kubeedge/installation-package@"+validDigest, edgeImage)
+				hostpath, ok := files["/usr/local/bin/edgecore"]
+				assert.True(t, ok)
+				assert.Equal(t, wantHostPath, hostpath)
+				checked++
+				return nil
+			})
+
+		path, err := getEdgeCoreBinary(context.TODO(), opts, cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, 4, checked)
+		assert.Equal(t, wantHostPath, path)
+	})
+
+	t.Run("rejects malformed digest", func(t *testing.T) {
+		opts := UpgradeOptions{
+			Image:       "kubeedge/installation-package",
+			ImageDigest: "sha256:not-a-real-digest",
+			ToVersion:   "v1.1.0",
+			BaseOptions: BaseOptions{
+				Config: constants.EdgecoreConfigPath,
+			},
+		}
+
+		path, err := getEdgeCoreBinary(context.TODO(), opts, cfg)
+		assert.ErrorContains(t, err, "invalid image digest")
+		assert.Empty(t, path)
+	})
 }

--- a/pkg/image/image_runtime.go
+++ b/pkg/image/image_runtime.go
@@ -19,10 +19,10 @@ package image
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/distribution/reference"
+	digest "github.com/opencontainers/go-digest"
 	"go.opentelemetry.io/otel/trace/noop"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
@@ -80,17 +80,24 @@ func (runtime *RuntimeImpl) GetImageDigest(ctx context.Context, image string) (s
 		return "", err
 	}
 	if resp.Image == nil {
-		return "", nil
+		return "", fmt.Errorf("image %s not found in local runtime", image)
 	}
-	for i := range resp.Image.RepoTags {
-		tag := resp.Image.RepoTags[i]
-		if tag == image {
-			repoDigest := resp.Image.RepoDigests[i]
-			digestIndex := strings.LastIndex(repoDigest, "@sha256:")
-			return repoDigest[digestIndex+1:], nil
+
+	repository, err := imageRepository(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image %s: %v", image, err)
+	}
+	for _, repoDigest := range resp.Image.RepoDigests {
+		repoDigest = ConvToCRIImage(repoDigest)
+		repo, dgst, err := parseRepositoryDigest(repoDigest)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse repo digest %s for image %s: %v", repoDigest, image, err)
+		}
+		if repo == repository {
+			return dgst, nil
 		}
 	}
-	return "", nil
+	return "", fmt.Errorf("image digest for repository %s not found in local runtime", repository)
 }
 
 func (runtime *RuntimeImpl) PullImage(
@@ -119,4 +126,55 @@ func ConvToCRIImage(image string) string {
 		return image
 	}
 	return ref.String()
+}
+
+func NormalizeDigest(value string) (string, error) {
+	dgst, err := digest.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("invalid image digest %q: %v", value, err)
+	}
+	if err := dgst.Validate(); err != nil {
+		return "", fmt.Errorf("invalid image digest %q: %v", value, err)
+	}
+	return dgst.String(), nil
+}
+
+func ImmutableImageRef(image, dgst string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse image %s: %v", image, err)
+	}
+	normalizedDigest, err := NormalizeDigest(dgst)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := reference.WithDigest(reference.TrimNamed(named), digest.Digest(normalizedDigest))
+	if err != nil {
+		return "", fmt.Errorf("failed to build immutable image ref for %s: %v", image, err)
+	}
+	return canonical.String(), nil
+}
+
+func imageRepository(image string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", err
+	}
+	return reference.TrimNamed(named).Name(), nil
+}
+
+func parseRepositoryDigest(repoDigest string) (string, string, error) {
+	ref, err := reference.ParseNormalizedNamed(repoDigest)
+	if err != nil {
+		return "", "", err
+	}
+	digested, ok := ref.(reference.Digested)
+	if !ok {
+		return "", "", fmt.Errorf("reference %s does not include a digest", repoDigest)
+	}
+	normalizedDigest, err := NormalizeDigest(digested.Digest().String())
+	if err != nil {
+		return "", "", err
+	}
+	return reference.TrimNamed(ref).Name(), normalizedDigest, nil
 }

--- a/pkg/image/image_runtime_test.go
+++ b/pkg/image/image_runtime_test.go
@@ -29,6 +29,7 @@ import (
 func TestGetImageDigest(t *testing.T) {
 	ctx := context.TODO()
 	image := "docker.io/kubeedge/installation-package:v1.20.0"
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
 
 	t.Run("failed to get image status", func(t *testing.T) {
 		fakeImgSvc := criapitesting.NewFakeImageService()
@@ -47,30 +48,15 @@ func TestGetImageDigest(t *testing.T) {
 			imgsvc: fakeImgSvc,
 		}
 		digest, err := imgrt.GetImageDigest(ctx, image)
-		require.NoError(t, err)
+		require.EqualError(t, err, "image docker.io/kubeedge/installation-package:v1.20.0 not found in local runtime")
 		require.Equal(t, "", digest)
 	})
 
-	t.Run("match repo tags", func(t *testing.T) {
-		fakeImgSvc := criapitesting.NewFakeImageService()
-		fakeImgSvc.Images[image] = &runtimeapi.Image{
-			RepoTags:    []string{image},
-			RepoDigests: []string{"docker.io/kubeedge/installation-package@sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"},
-		}
-
-		imgrt := &RuntimeImpl{
-			imgsvc: fakeImgSvc,
-		}
-		digest, err := imgrt.GetImageDigest(ctx, image)
-		require.NoError(t, err)
-		require.Equal(t, "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695", digest)
-	})
-
-	t.Run("not match repo tags", func(t *testing.T) {
+	t.Run("matches repo digest by repository name", func(t *testing.T) {
 		fakeImgSvc := criapitesting.NewFakeImageService()
 		fakeImgSvc.Images[image] = &runtimeapi.Image{
 			RepoTags:    []string{"kubeedge/installation-package:v1.20.0"},
-			RepoDigests: []string{"kubeedge/installation-package@sha256:12345"},
+			RepoDigests: []string{"kubeedge/installation-package@" + validDigest},
 		}
 
 		imgrt := &RuntimeImpl{
@@ -78,8 +64,56 @@ func TestGetImageDigest(t *testing.T) {
 		}
 		digest, err := imgrt.GetImageDigest(ctx, image)
 		require.NoError(t, err)
+		require.Equal(t, validDigest, digest)
+	})
+
+	t.Run("returns error when repo digest missing for repository", func(t *testing.T) {
+		fakeImgSvc := criapitesting.NewFakeImageService()
+		fakeImgSvc.Images[image] = &runtimeapi.Image{
+			RepoDigests: []string{"docker.io/kubeedge/edgecore@" + validDigest},
+		}
+
+		imgrt := &RuntimeImpl{
+			imgsvc: fakeImgSvc,
+		}
+		digest, err := imgrt.GetImageDigest(ctx, image)
+		require.EqualError(t, err, "image digest for repository docker.io/kubeedge/installation-package not found in local runtime")
 		require.Empty(t, digest)
 	})
+
+	t.Run("returns error when repo digest malformed", func(t *testing.T) {
+		fakeImgSvc := criapitesting.NewFakeImageService()
+		fakeImgSvc.Images[image] = &runtimeapi.Image{
+			RepoDigests: []string{"docker.io/kubeedge/installation-package@sha256:not-a-real-digest"},
+		}
+
+		imgrt := &RuntimeImpl{
+			imgsvc: fakeImgSvc,
+		}
+		digest, err := imgrt.GetImageDigest(ctx, image)
+		require.ErrorContains(t, err, "failed to parse repo digest")
+		require.Empty(t, digest)
+	})
+}
+
+func TestNormalizeDigest(t *testing.T) {
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
+
+	normalized, err := NormalizeDigest(validDigest)
+	require.NoError(t, err)
+	require.Equal(t, validDigest, normalized)
+
+	normalized, err = NormalizeDigest("sha256:not-a-real-digest")
+	require.EqualError(t, err, "invalid image digest \"sha256:not-a-real-digest\": invalid checksum digest length")
+	require.Empty(t, normalized)
+}
+
+func TestImmutableImageRef(t *testing.T) {
+	const validDigest = "sha256:e47afdf2746ad10ee76dd64289eae01895000327c0f23c5b498959eca6953695"
+
+	ref, err := ImmutableImageRef("kubeedge/installation-package:v1.20.0", validDigest)
+	require.NoError(t, err)
+	require.Equal(t, "docker.io/kubeedge/installation-package@"+validDigest, ref)
 }
 
 func TestConvToCRIImage(t *testing.T) {

--- a/staging/src/github.com/kubeedge/api/apis/operations/v1alpha2/types_nodeupgrade.go
+++ b/staging/src/github.com/kubeedge/api/apis/operations/v1alpha2/types_nodeupgrade.go
@@ -97,9 +97,8 @@ type NodeUpgradeJobSpec struct {
 	// +optional
 	Image string `json:"image,omitempty"`
 
-	// ImageDigestGetter define registry v2 interface access configuration.
-	// As a transition, it is not required at first, and the image digest is checked when this field is set.
-	// +optional
+	// ImageDigestGetter defines the expected installation-package image digests for each platform.
+	// Node upgrade jobs require the digest for the current platform and verify the pulled image before copying binaries.
 	ImageDigestGetter *ImageDigestGetter `json:"imageDigestGatter"`
 
 	// Concurrency specifies the maximum number of concurrent that edge nodes associated with
@@ -124,21 +123,21 @@ type NodeUpgradeJobSpec struct {
 	RequireConfirmation bool `json:"requireConfirmation,omitempty"`
 }
 
-// ImageDigestGetter used to define a method for getting the image digest.
+// ImageDigestGetter defines the expected installation-package image digests used during node upgrades.
 type ImageDigestGetter struct {
-	// ARM64 indicates the image digest of the arm64 platform for verification.
+	// ARM64 indicates the required image digest of the arm64 platform for verification.
 	// E.g., sha256:0738039541234567890123456789012345678901234567890123456789012345
-	// +optional
+	// +required
 	ARM64 string `json:"arm64,omitempty"`
 
-	// AMD64 indicates the image digest of the amd64 platform for verification.
+	// AMD64 indicates the required image digest of the amd64 platform for verification.
 	// E.g., sha256:0738039541234567890123456789012345678901234567890123456789012345
-	// +optional
+	// +required
 	AMD64 string `json:"amd64,omitempty"`
 
 	// RegistryAPI define registry v2 interface access configuration.
-	// Used to automatically gets multiple platform image digests from a remote registry
-	// to set values into ARM64 and AMD64 fields.
+	// Used to automatically fetch multiple platform image digests from a remote registry
+	// and populate the ARM64 and AMD64 fields before the upgrade is dispatched.
 	// +optional
 	RegistryAPI *RegistryAPI `json:"registryAPI,omitempty"`
 }


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:
Requires upgrade artifact digests across the edge upgrade paths so KubeEdge fails closed before copying or executing binaries from installation-package images.

Which issue(s) this PR fixes:
Fixes #6983

Special notes for your reviewer:
Verified with:
- `go test ./edge/pkg/taskmanager/v1alpha1/taskexecutor -run ^'TestPrepareKeadmRequiresImageDigest$' -count=1`
- `go test ./edge/pkg/taskmanager/actions -run '^(TestNodeUpgradeJobCheckItems|TestExpectedUpgradeImageDigest)$' -count=1`
- `go test ./keadm/cmd/keadm/app/cmd/edge -run ^'TestGetEdgeCoreBinary$' -count=1`
- `make verify`

Does this PR introduce a user-facing change?:

```release-note
Edge upgrade flows now require and verify installation-package image digests before copying or executing upgrade artifacts.
```