### PR TITLE
servicebus: serve traffic over TLS

### DIFF
--- a/edge/pkg/servicebus/servicebus.go
+++ b/edge/pkg/servicebus/servicebus.go
@@ -2,11 +2,16 @@ package servicebus
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -24,11 +29,14 @@ import (
 	servicebusConfig "github.com/kubeedge/kubeedge/edge/pkg/servicebus/config"
 	"github.com/kubeedge/kubeedge/edge/pkg/servicebus/util"
 	"github.com/kubeedge/kubeedge/pkg/features"
+	utilvalidation "github.com/kubeedge/kubeedge/pkg/util/validation"
 )
 
 var (
 	inited int32
-	c      = make(chan struct{})
+
+	serverMu sync.Mutex
+	active   *http.Server
 )
 
 const (
@@ -36,10 +44,8 @@ const (
 	maxBodySize = 5 * 1e6
 )
 
-// servicebus struct
 type servicebus struct {
-	enable bool
-	// default 127.0.0.1
+	enable  bool
 	server  string
 	port    int
 	timeout int
@@ -71,7 +77,6 @@ func newServicebus(enable bool, server string, port, timeout int) *servicebus {
 	}
 }
 
-// Register register servicebus
 func Register(s *v1alpha2.ServiceBus) {
 	servicebusConfig.InitConfigure(s)
 	core.Register(newServicebus(s.Enable, s.Server, s.Port, s.Timeout))
@@ -100,19 +105,16 @@ func (sb *servicebus) RestartPolicy() *core.ModuleRestartPolicy {
 }
 
 func (sb *servicebus) Start() {
-	// no need to call TopicInit now, we have fixed topic
 	htc.Timeout = time.Second * 10
 	uc.Client = htc
 	if !sb.sbs.IsTableEmpty() {
-		if atomic.CompareAndSwapInt32(&inited, 0, 1) {
-			go server(c)
-		}
+		startServer()
 	}
-	//Get message from channel
 	for {
 		select {
 		case <-beehiveContext.Done():
 			klog.Warning("servicebus stop")
+			stopServer()
 			return
 		default:
 		}
@@ -122,7 +124,6 @@ func (sb *servicebus) Start() {
 			continue
 		}
 
-		// build new message with required field & send message to servicebus
 		klog.V(4).Info("servicebus receive msg")
 		go processMessage(&msg)
 	}
@@ -138,20 +139,16 @@ func processMessage(msg *beehiveModel.Message) {
 	switch msg.GetOperation() {
 	case message.OperationStart:
 		if err := dbc.InsertUrls(resource); err != nil {
-			// TODO: handle err
 			klog.Error(err)
 		}
-		if atomic.CompareAndSwapInt32(&inited, 0, 1) {
-			go server(c)
-		}
+		startServer()
 	case message.OperationStop:
 		if err := dbc.DeleteUrlsByKey(resource); err != nil {
-			// TODO: handle err
 			klog.Error(err)
 		}
 
 		if dbc.IsTableEmpty() {
-			c <- struct{}{}
+			stopServer()
 		}
 	default:
 		r := strings.Split(resource, ":")
@@ -186,7 +183,6 @@ func processMessage(msg *beehiveModel.Message) {
 			return
 		}
 
-		//send message with resource to the edge part
 		operation := httpRequest.Method
 		targetURL := "http://127.0.0.1:" + r[0] + r[1]
 		resp, err := uc.HTTPDo(operation, targetURL, httpRequest.Header, httpRequest.Body)
@@ -221,34 +217,128 @@ func processMessage(msg *beehiveModel.Message) {
 	}
 }
 
-func server(stopChan <-chan struct{}) {
-	var (
-		timeout time.Duration
-		err     error
-	)
-	if timeout, err = time.ParseDuration(fmt.Sprintf("%vs", servicebusConfig.Config.Timeout)); err != nil {
-		klog.Errorf("can't format timeout and the default value will be set")
-		timeout, _ = time.ParseDuration("10s")
+func startServer() {
+	serverMu.Lock()
+	if active != nil {
+		serverMu.Unlock()
+		return
 	}
 
-	h := buildBasicHandler(timeout)
-	// TODO we should add tls for servicebus http server later
-	s := http.Server{
-		Addr:    fmt.Sprintf("%s:%d", servicebusConfig.Config.Server, servicebusConfig.Config.Port),
-		Handler: h,
+	srv, listener, err := newTLSServer(servicebusConfig.Config.ServiceBus)
+	if err != nil {
+		serverMu.Unlock()
+		atomic.StoreInt32(&inited, 0)
+		utilruntime.HandleError(err)
+		return
 	}
-	go func() {
-		<-stopChan
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := s.Shutdown(ctx); err != nil {
-			klog.Errorf("Server shutdown failed: %s", err)
+	active = srv
+	atomic.StoreInt32(&inited, 1)
+	serverMu.Unlock()
+
+	go serveTLS(srv, listener)
+}
+
+func stopServer() {
+	serverMu.Lock()
+	srv := active
+	active = nil
+	atomic.StoreInt32(&inited, 0)
+	serverMu.Unlock()
+
+	if srv == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		klog.Errorf("Server shutdown failed: %s", err)
+	}
+}
+
+func serveTLS(srv *http.Server, listener net.Listener) {
+	defer func() {
+		_ = listener.Close()
+		serverMu.Lock()
+		if active == srv {
+			active = nil
 		}
 		atomic.StoreInt32(&inited, 0)
+		serverMu.Unlock()
 	}()
 
-	klog.Infof("[servicebus]start to listen and server at %v", s.Addr)
-	utilruntime.HandleError(s.ListenAndServe())
+	klog.Infof("[servicebus] start to listen and serve at %v", srv.Addr)
+	if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		utilruntime.HandleError(err)
+	}
+}
+
+func newTLSServer(cfg v1alpha2.ServiceBus) (*http.Server, net.Listener, error) {
+	timeout, err := time.ParseDuration(fmt.Sprintf("%vs", cfg.Timeout))
+	if err != nil {
+		klog.Errorf("can't format timeout and the default value will be set")
+		timeout = 10 * time.Second
+	}
+
+	address := fmt.Sprintf("%s:%d", cfg.Server, cfg.Port)
+	if !utilvalidation.IsLoopbackHost(cfg.Server) {
+		return nil, nil, fmt.Errorf("servicebus without client authentication must bind to a loopback address")
+	}
+	tlsConfig, err := loadTLSConfig(cfg.TLSCertFile, cfg.TLSPrivateKeyFile, cfg.Server)
+	if err != nil {
+		return nil, nil, err
+	}
+	srv := &http.Server{
+		Addr:              address,
+		Handler:           buildBasicHandler(timeout),
+		ReadHeaderTimeout: 10 * time.Second,
+		TLSConfig:         tlsConfig,
+	}
+	rawListener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, nil, err
+	}
+	return srv, tls.NewListener(rawListener, tlsConfig), nil
+}
+
+func loadTLSConfig(certFile, keyFile, server string) (*tls.Config, error) {
+	if _, err := loadCertificate(certFile, keyFile, server); err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := loadCertificate(certFile, keyFile, server)
+			if err != nil {
+				return nil, err
+			}
+			return cert, nil
+		},
+	}, nil
+}
+
+func loadCertificate(certFile, keyFile, server string) (*tls.Certificate, error) {
+	host := server
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	if errs := utilvalidation.ValidateServerTLSFiles(certFile, keyFile, host, time.Now()); len(errs) > 0 {
+		return nil, fmt.Errorf("invalid servicebus tls files: %s", strings.Join(errs, "; "))
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	if cert.Leaf == nil && len(cert.Certificate) > 0 {
+		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &cert, nil
 }
 
 func buildBasicHandler(timeout time.Duration) http.Handler {
@@ -261,7 +351,6 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 			sResp.Code = http.StatusBadRequest
 			sResp.Msg = "can't read data from body of the http's request"
 			if _, err := w.Write(marshalResult(sResp)); err != nil {
-				// TODO: handle err
 				klog.Error(err)
 			}
 			return
@@ -270,7 +359,6 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 			sResp.Code = http.StatusBadRequest
 			sResp.Msg = "invalid params"
 			if _, err := w.Write(marshalResult(sResp)); err != nil {
-				// TODO: handle err
 				klog.Error(err)
 			}
 			return
@@ -279,7 +367,6 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 			sResp.Code = http.StatusBadRequest
 			sResp.Msg = fmt.Sprintf("url %s is not allowed and please make a rule for this url in the cloud", sReq.TargetURL)
 			if _, err := w.Write(marshalResult(sResp)); err != nil {
-				// TODO: handle err
 				klog.Error(err)
 			}
 			return
@@ -291,7 +378,6 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 			sResp.Code = http.StatusBadRequest
 			sResp.Msg = err.Error()
 			if _, err := w.Write(marshalResult(sResp)); err != nil {
-				// TODO: handle err
 				klog.Error(err)
 			}
 			return
@@ -301,7 +387,6 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 			sResp.Code = http.StatusInternalServerError
 			sResp.Msg = err.Error()
 			if _, err := w.Write(marshalResult(sResp)); err != nil {
-				// TODO: handle err
 				klog.Error(err)
 			}
 			return
@@ -311,7 +396,6 @@ func buildBasicHandler(timeout time.Duration) http.Handler {
 		sResp.Msg = "receive response from cloud successfully"
 		sResp.Body = string(resp)
 		if _, err := w.Write(marshalResult(sResp)); err != nil {
-			// TODO: handle err
 			klog.Error(err)
 		}
 	})

--- a/edge/pkg/servicebus/servicebus_test.go
+++ b/edge/pkg/servicebus/servicebus_test.go
@@ -1,0 +1,196 @@
+package servicebus
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	servicebusConfig "github.com/kubeedge/kubeedge/edge/pkg/servicebus/config"
+)
+
+func TestStartServerCanRetryAfterStartupFailure(t *testing.T) {
+	resetServerState()
+	port := freePort(t)
+	servicebusConfig.Config = servicebusConfig.Configure{
+		ServiceBus: v1alpha2.ServiceBus{
+			Enable:            true,
+			Server:            "127.0.0.1",
+			Port:              port,
+			Timeout:           1,
+			TLSCertFile:       filepath.Join(t.TempDir(), "missing.crt"),
+			TLSPrivateKeyFile: filepath.Join(t.TempDir(), "missing.key"),
+		},
+	}
+
+	startServer()
+	require.Equal(t, int32(0), atomic.LoadInt32(&inited))
+
+	dir := t.TempDir()
+	caCert, caKey, caPool := newCertificateAuthority(t)
+	certPath, keyPath, _ := writeServerCertificate(t, dir, "127.0.0.1", 1, caCert, caKey)
+	servicebusConfig.Config.ServiceBus.TLSCertFile = certPath
+	servicebusConfig.Config.ServiceBus.TLSPrivateKeyFile = keyPath
+
+	startServer()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&inited) == 1
+	}, 3*time.Second, 50*time.Millisecond)
+
+	resp, err := httpsClient(caPool, "").Get("https://127.0.0.1:" + strconv.Itoa(port))
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	stopServer()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&inited) == 0
+	}, 3*time.Second, 50*time.Millisecond)
+}
+
+func TestTLSServerLifecycleAndRotation(t *testing.T) {
+	resetServerState()
+	dir := t.TempDir()
+	caCert, caKey, caPool := newCertificateAuthority(t)
+	certPath, keyPath, serial1 := writeServerCertificate(t, dir, "127.0.0.1", 1, caCert, caKey)
+	cfg := v1alpha2.ServiceBus{
+		Enable:            true,
+		Server:            "127.0.0.1",
+		Port:              0,
+		Timeout:           1,
+		TLSCertFile:       certPath,
+		TLSPrivateKeyFile: keyPath,
+	}
+	servicebusConfig.Config = servicebusConfig.Configure{ServiceBus: cfg}
+
+	srv, listener, err := newTLSServer(cfg)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		serveTLS(srv, listener)
+	}()
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(stopCtx)
+		<-done
+	})
+
+	addr := listener.Addr().String()
+	resp, err := httpsClient(caPool, "").Get("https://" + addr)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Contains(t, string(body), "invalid params")
+	require.Equal(t, serial1.String(), resp.TLS.PeerCertificates[0].SerialNumber.String())
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	require.NoError(t, err)
+	_, err = conn.Write([]byte("GET / HTTP/1.1\r\nHost: " + addr + "\r\n\r\n"))
+	require.NoError(t, err)
+	buf := make([]byte, 64)
+	n, readErr := conn.Read(buf)
+	_ = conn.Close()
+	plainResponse := string(buf[:n])
+	require.True(t, readErr != nil || !strings.Contains(plainResponse, "invalid params"))
+
+	_, err = httpsClient(x509.NewCertPool(), "").Get("https://" + addr)
+	require.Error(t, err)
+	_, err = httpsClient(caPool, "wrong-host").Get("https://" + addr)
+	require.Error(t, err)
+
+	_, _, serial2 := writeServerCertificate(t, dir, "127.0.0.1", 2, caCert, caKey)
+	resp, err = httpsClient(caPool, "").Get("https://" + addr)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, serial2.String(), resp.TLS.PeerCertificates[0].SerialNumber.String())
+}
+
+func httpsClient(pool *x509.CertPool, serverName string) *http.Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:    pool,
+			ServerName: serverName,
+		},
+	}
+	return &http.Client{Transport: transport, Timeout: 3 * time.Second}
+}
+
+func resetServerState() {
+	serverMu.Lock()
+	active = nil
+	serverMu.Unlock()
+	atomic.StoreInt32(&inited, 0)
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func newCertificateAuthority(t *testing.T) (*x509.Certificate, *rsa.PrivateKey, *x509.CertPool) {
+	t.Helper()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1000),
+		Subject:               pkix.Name{CommonName: "servicebus-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}))
+	return caCert, caKey, pool
+}
+
+func writeServerCertificate(t *testing.T, dir, host string, serial int64, caCert *x509.Certificate, caKey *rsa.PrivateKey) (string, string, *big.Int) {
+	t.Helper()
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: "servicebus"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		IPAddresses:  []net.IP{net.ParseIP(host)},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	certPath := filepath.Join(dir, "servicebus.crt")
+	keyPath := filepath.Join(dir, "servicebus.key")
+	require.NoError(t, os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER}), 0o644))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)}), 0o600))
+	return certPath, keyPath, serverTemplate.SerialNumber
+}

--- a/pkg/util/validation/tls.go
+++ b/pkg/util/validation/tls.go
@@ -1,0 +1,81 @@
+package validation
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func ValidateServerTLSFiles(certFile, keyFile, host string, now time.Time) []string {
+	var errs []string
+
+	certInfo, err := os.Stat(certFile)
+	if err != nil {
+		return []string{fmt.Sprintf("tlsCertFile not accessible: %v", err)}
+	}
+	if !certInfo.Mode().IsRegular() {
+		return []string{"tlsCertFile must be a regular file"}
+	}
+
+	keyInfo, err := os.Stat(keyFile)
+	if err != nil {
+		return []string{fmt.Sprintf("tlsPrivateKeyFile not accessible: %v", err)}
+	}
+	if !keyInfo.Mode().IsRegular() {
+		return []string{"tlsPrivateKeyFile must be a regular file"}
+	}
+	if keyInfo.Mode().Perm()&0o077 != 0 {
+		errs = append(errs, "tlsPrivateKeyFile must not be readable or writable by group or others")
+	}
+
+	keyPair, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("invalid tls key pair: %v", err))
+		return errs
+	}
+	if len(keyPair.Certificate) == 0 {
+		errs = append(errs, "tlsCertFile does not contain a certificate")
+		return errs
+	}
+
+	leaf, err := x509.ParseCertificate(keyPair.Certificate[0])
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("failed to parse tls certificate: %v", err))
+		return errs
+	}
+	if now.Before(leaf.NotBefore) || now.After(leaf.NotAfter) {
+		errs = append(errs, "tls certificate is not currently valid")
+	}
+
+	var serverAuth bool
+	for _, usage := range leaf.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageServerAuth {
+			serverAuth = true
+			break
+		}
+	}
+	if !serverAuth {
+		errs = append(errs, "tls certificate must support server auth")
+	}
+
+	if err := leaf.VerifyHostname(host); err != nil {
+		if net.ParseIP(host) != nil {
+			errs = append(errs, fmt.Sprintf("tls certificate must include IP SAN %s", host))
+		} else {
+			errs = append(errs, fmt.Sprintf("tls certificate must match hostname %s", host))
+		}
+	}
+
+	return errs
+}
+
+func IsLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/default.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/default.go
@@ -147,10 +147,12 @@ func NewDefaultEdgeCoreConfig() *EdgeCoreConfig {
 				},
 			},
 			ServiceBus: &ServiceBus{
-				Enable:  false,
-				Server:  "127.0.0.1",
-				Port:    9060,
-				Timeout: 60,
+				Enable:            false,
+				Server:            "127.0.0.1",
+				Port:              9060,
+				Timeout:           60,
+				TLSCertFile:       "",
+				TLSPrivateKeyFile: "",
 			},
 			DeviceTwin: &DeviceTwin{
 				Enable: true,

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/types.go
@@ -412,12 +412,17 @@ type ServiceBus struct {
 	// if set to false (for debugging etc.), skip checking other ServiceBus configs.
 	// default false
 	Enable bool `json:"enable"`
-	// Address indicates address for http server
+	// Address indicates the address for the local HTTPS servicebus listener.
 	Server string `json:"server"`
-	// Port indicates port for http server
+	// Port indicates the port for the local HTTPS servicebus listener.
 	Port int `json:"port"`
 	// Timeout indicates timeout for servicebus receive message
 	Timeout int `json:"timeout"`
+	// TLSCertFile indicates the file containing the dedicated x509 server certificate for ServiceBus HTTPS.
+	// The certificate must support ServerAuth and match the configured ServiceBus address.
+	TLSCertFile string `json:"tlsCertFile,omitempty"`
+	// TLSPrivateKeyFile indicates the file containing the private key matching tlsCertFile.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty"`
 }
 
 // DeviceTwin indicates the DeviceTwin module config

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/validation/validation.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/validation/validation.go
@@ -18,8 +18,11 @@ package validation
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path"
+	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
@@ -123,6 +126,46 @@ func ValidateModuleServiceBus(s v1alpha1.ServiceBus) field.ErrorList {
 		return field.ErrorList{}
 	}
 	allErrs := field.ErrorList{}
+	if s.TLSCertFile == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("tlsCertFile"), "tlsCertFile is required when servicebus is enabled"))
+	}
+	if s.TLSPrivateKeyFile == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("tlsPrivateKeyFile"), "tlsPrivateKeyFile is required when servicebus is enabled"))
+	}
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	if !utilvalidation.FileIsExist(s.TLSCertFile) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("tlsCertFile"), s.TLSCertFile, "tlsCertFile not exist"))
+	}
+	if !utilvalidation.FileIsExist(s.TLSPrivateKeyFile) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("tlsPrivateKeyFile"), s.TLSPrivateKeyFile, "tlsPrivateKeyFile not exist"))
+	}
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+
+	host := s.Server
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	if !utilvalidation.IsLoopbackHost(host) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("server"), s.Server, "servicebus without client authentication must bind to a loopback address"))
+		return allErrs
+	}
+	for _, errMsg := range utilvalidation.ValidateServerTLSFiles(s.TLSCertFile, s.TLSPrivateKeyFile, host, time.Now()) {
+		switch {
+		case strings.HasPrefix(errMsg, "tlsCertFile"):
+			allErrs = append(allErrs, field.Invalid(field.NewPath("tlsCertFile"), s.TLSCertFile, errMsg))
+		case strings.HasPrefix(errMsg, "tlsPrivateKeyFile"):
+			allErrs = append(allErrs, field.Invalid(field.NewPath("tlsPrivateKeyFile"), s.TLSPrivateKeyFile, errMsg))
+		default:
+			allErrs = append(allErrs, field.Invalid(field.NewPath("tlsCertFile"), s.TLSCertFile, errMsg))
+		}
+	}
 	return allErrs
 }
 

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/validation/validation_test.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/validation/validation_test.go
@@ -17,11 +17,19 @@ limitations under the License.
 package validation
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -241,31 +249,175 @@ func TestValidateModuleMetaManager(t *testing.T) {
 
 func TestValidateModuleServiceBus(t *testing.T) {
 	cases := []struct {
-		name     string
-		input    v1alpha1.ServiceBus
-		expected field.ErrorList
+		name        string
+		input       v1alpha1.ServiceBus
+		expectedLen int
 	}{
 		{
 			name: "case1 not enabled",
 			input: v1alpha1.ServiceBus{
 				Enable: false,
 			},
-			expected: field.ErrorList{},
+			expectedLen: 0,
 		},
 		{
-			name: "case2 enabled",
+			name: "case2 enabled with missing tls files",
 			input: v1alpha1.ServiceBus{
-				Enable: true,
+				Enable:            true,
+				Server:            "127.0.0.1",
+				TLSCertFile:       "/not/exist.crt",
+				TLSPrivateKeyFile: "/not/exist.key",
 			},
-			expected: field.ErrorList{},
+			expectedLen: 2,
+		},
+		{
+			name: "case3 enabled with valid tls files",
+			input: func() v1alpha1.ServiceBus {
+				dir := t.TempDir()
+				certFile, keyFile := writeServerKeyPairV1Alpha1(t, dir, "127.0.0.1")
+				return v1alpha1.ServiceBus{
+					Enable:            true,
+					Server:            "127.0.0.1",
+					TLSCertFile:       certFile.Name(),
+					TLSPrivateKeyFile: keyFile.Name(),
+				}
+			}(),
+			expectedLen: 0,
+		},
+		{
+			name: "case4 rejects client auth cert without san",
+			input: func() v1alpha1.ServiceBus {
+				dir := t.TempDir()
+				certFile, keyFile := writeClientOnlyKeyPairV1Alpha1(t, dir)
+				return v1alpha1.ServiceBus{
+					Enable:            true,
+					Server:            "127.0.0.1",
+					TLSCertFile:       certFile.Name(),
+					TLSPrivateKeyFile: keyFile.Name(),
+				}
+			}(),
+			expectedLen: 2,
 		},
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleServiceBus(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
+		if result := ValidateModuleServiceBus(c.input); len(result) != c.expectedLen {
+			t.Errorf("%v: expected %d errors, but got %v", c.name, c.expectedLen, result)
 		}
 	}
+}
+
+func writeServerKeyPairV1Alpha1(t *testing.T, dir, host string) (*os.File, *os.File) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key failed: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "servicebus"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		template.IPAddresses = []net.IP{ip}
+	} else {
+		template.DNSNames = []string{host}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert failed: %v", err)
+	}
+
+	certFile, err := os.CreateTemp(dir, "cert-*.crt")
+	if err != nil {
+		t.Fatalf("create temp cert file failed: %v", err)
+	}
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("write cert failed: %v", err)
+	}
+	if err := certFile.Close(); err != nil {
+		t.Fatalf("close cert failed: %v", err)
+	}
+	certFile, err = os.Open(certFile.Name())
+	if err != nil {
+		t.Fatalf("reopen cert failed: %v", err)
+	}
+
+	keyFile, err := os.CreateTemp(dir, "key-*.key")
+	if err != nil {
+		t.Fatalf("create temp key file failed: %v", err)
+	}
+	if err := keyFile.Chmod(0o600); err != nil {
+		t.Fatalf("chmod key failed: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		t.Fatalf("write key failed: %v", err)
+	}
+	if err := keyFile.Close(); err != nil {
+		t.Fatalf("close key failed: %v", err)
+	}
+	keyFile, err = os.Open(keyFile.Name())
+	if err != nil {
+		t.Fatalf("reopen key failed: %v", err)
+	}
+	return certFile, keyFile
+}
+
+func writeClientOnlyKeyPairV1Alpha1(t *testing.T, dir string) (*os.File, *os.File) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key failed: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "system:node:test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert failed: %v", err)
+	}
+
+	certFile, err := os.CreateTemp(dir, "cert-*.crt")
+	if err != nil {
+		t.Fatalf("create temp cert file failed: %v", err)
+	}
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("write cert failed: %v", err)
+	}
+	if err := certFile.Close(); err != nil {
+		t.Fatalf("close cert failed: %v", err)
+	}
+	certFile, err = os.Open(certFile.Name())
+	if err != nil {
+		t.Fatalf("reopen cert failed: %v", err)
+	}
+
+	keyFile, err := os.CreateTemp(dir, "key-*.key")
+	if err != nil {
+		t.Fatalf("create temp key file failed: %v", err)
+	}
+	if err := keyFile.Chmod(0o600); err != nil {
+		t.Fatalf("chmod key failed: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		t.Fatalf("write key failed: %v", err)
+	}
+	if err := keyFile.Close(); err != nil {
+		t.Fatalf("close key failed: %v", err)
+	}
+	keyFile, err = os.Open(keyFile.Name())
+	if err != nil {
+		t.Fatalf("reopen key failed: %v", err)
+	}
+	return certFile, keyFile
 }
 
 func TestValidateModuleDeviceTwin(t *testing.T) {

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -134,10 +134,12 @@ func NewDefaultEdgeCoreConfig() (config *EdgeCoreConfig) {
 				},
 			},
 			ServiceBus: &ServiceBus{
-				Enable:  false,
-				Server:  "127.0.0.1",
-				Port:    9060,
-				Timeout: 60,
+				Enable:            false,
+				Server:            "127.0.0.1",
+				Port:              9060,
+				Timeout:           60,
+				TLSCertFile:       "",
+				TLSPrivateKeyFile: "",
 			},
 			DeviceTwin: &DeviceTwin{
 				Enable:      true,

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/types.go
@@ -1043,12 +1043,17 @@ type ServiceBus struct {
 	// if set to false (for debugging etc.), skip checking other ServiceBus configs.
 	// default false
 	Enable bool `json:"enable"`
-	// Address indicates address for http server
+	// Address indicates the address for the local HTTPS servicebus listener.
 	Server string `json:"server"`
-	// Port indicates port for http server
+	// Port indicates the port for the local HTTPS servicebus listener.
 	Port int `json:"port"`
 	// Timeout indicates timeout for servicebus receive mseeage
 	Timeout int `json:"timeout"`
+	// TLSCertFile indicates the file containing the dedicated x509 server certificate for ServiceBus HTTPS.
+	// The certificate must support ServerAuth and match the configured ServiceBus address.
+	TLSCertFile string `json:"tlsCertFile,omitempty"`
+	// TLSPrivateKeyFile indicates the file containing the private key matching tlsCertFile.
+	TLSPrivateKeyFile string `json:"tlsPrivateKeyFile,omitempty"`
 }
 
 // DeviceTwin indicates the DeviceTwin module config

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation/validation.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation/validation.go
@@ -18,8 +18,11 @@ package validation
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path"
+	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
@@ -130,6 +133,46 @@ func ValidateModuleServiceBus(s v1alpha2.ServiceBus) field.ErrorList {
 		return field.ErrorList{}
 	}
 	allErrs := field.ErrorList{}
+	if s.TLSCertFile == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("tlsCertFile"), "tlsCertFile is required when servicebus is enabled"))
+	}
+	if s.TLSPrivateKeyFile == "" {
+		allErrs = append(allErrs, field.Required(field.NewPath("tlsPrivateKeyFile"), "tlsPrivateKeyFile is required when servicebus is enabled"))
+	}
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+	if !utilvalidation.FileIsExist(s.TLSCertFile) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("tlsCertFile"), s.TLSCertFile, "tlsCertFile not exist"))
+	}
+	if !utilvalidation.FileIsExist(s.TLSPrivateKeyFile) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("tlsPrivateKeyFile"), s.TLSPrivateKeyFile, "tlsPrivateKeyFile not exist"))
+	}
+	if len(allErrs) > 0 {
+		return allErrs
+	}
+
+	host := s.Server
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		host = parsedHost
+	}
+	if !utilvalidation.IsLoopbackHost(host) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("server"), s.Server, "servicebus without client authentication must bind to a loopback address"))
+		return allErrs
+	}
+	for _, errMsg := range utilvalidation.ValidateServerTLSFiles(s.TLSCertFile, s.TLSPrivateKeyFile, host, time.Now()) {
+		switch {
+		case strings.HasPrefix(errMsg, "tlsCertFile"):
+			allErrs = append(allErrs, field.Invalid(field.NewPath("tlsCertFile"), s.TLSCertFile, errMsg))
+		case strings.HasPrefix(errMsg, "tlsPrivateKeyFile"):
+			allErrs = append(allErrs, field.Invalid(field.NewPath("tlsPrivateKeyFile"), s.TLSPrivateKeyFile, errMsg))
+		default:
+			allErrs = append(allErrs, field.Invalid(field.NewPath("tlsCertFile"), s.TLSCertFile, errMsg))
+		}
+	}
 	return allErrs
 }
 

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation/validation_test.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation/validation_test.go
@@ -17,11 +17,19 @@ limitations under the License.
 package validation
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -283,31 +291,175 @@ func TestValidateModuleMetaManager(t *testing.T) {
 
 func TestValidateModuleServiceBus(t *testing.T) {
 	cases := []struct {
-		name     string
-		input    v1alpha2.ServiceBus
-		expected field.ErrorList
+		name        string
+		input       v1alpha2.ServiceBus
+		expectedLen int
 	}{
 		{
 			name: "case1 not enabled",
 			input: v1alpha2.ServiceBus{
 				Enable: false,
 			},
-			expected: field.ErrorList{},
+			expectedLen: 0,
 		},
 		{
-			name: "case2 enabled",
+			name: "case2 enabled with missing tls files",
 			input: v1alpha2.ServiceBus{
-				Enable: true,
+				Enable:            true,
+				Server:            "127.0.0.1",
+				TLSCertFile:       "/not/exist.crt",
+				TLSPrivateKeyFile: "/not/exist.key",
 			},
-			expected: field.ErrorList{},
+			expectedLen: 2,
+		},
+		{
+			name: "case3 enabled with valid tls files",
+			input: func() v1alpha2.ServiceBus {
+				dir := t.TempDir()
+				certFile, keyFile := writeServerKeyPair(t, dir, "127.0.0.1")
+				return v1alpha2.ServiceBus{
+					Enable:            true,
+					Server:            "127.0.0.1",
+					TLSCertFile:       certFile.Name(),
+					TLSPrivateKeyFile: keyFile.Name(),
+				}
+			}(),
+			expectedLen: 0,
+		},
+		{
+			name: "case4 rejects client auth cert without san",
+			input: func() v1alpha2.ServiceBus {
+				dir := t.TempDir()
+				certFile, keyFile := writeClientOnlyKeyPair(t, dir)
+				return v1alpha2.ServiceBus{
+					Enable:            true,
+					Server:            "127.0.0.1",
+					TLSCertFile:       certFile.Name(),
+					TLSPrivateKeyFile: keyFile.Name(),
+				}
+			}(),
+			expectedLen: 2,
 		},
 	}
 
 	for _, c := range cases {
-		if result := ValidateModuleServiceBus(c.input); !reflect.DeepEqual(result, c.expected) {
-			t.Errorf("%v: expected %v, but got %v", c.name, c.expected, result)
+		if result := ValidateModuleServiceBus(c.input); len(result) != c.expectedLen {
+			t.Errorf("%v: expected %d errors, but got %v", c.name, c.expectedLen, result)
 		}
 	}
+}
+
+func writeServerKeyPair(t *testing.T, dir, host string) (*os.File, *os.File) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key failed: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "servicebus"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		template.IPAddresses = []net.IP{ip}
+	} else {
+		template.DNSNames = []string{host}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert failed: %v", err)
+	}
+
+	certFile, err := os.CreateTemp(dir, "cert-*.crt")
+	if err != nil {
+		t.Fatalf("create temp cert file failed: %v", err)
+	}
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("write cert failed: %v", err)
+	}
+	if err := certFile.Close(); err != nil {
+		t.Fatalf("close cert failed: %v", err)
+	}
+	certFile, err = os.Open(certFile.Name())
+	if err != nil {
+		t.Fatalf("reopen cert failed: %v", err)
+	}
+
+	keyFile, err := os.CreateTemp(dir, "key-*.key")
+	if err != nil {
+		t.Fatalf("create temp key file failed: %v", err)
+	}
+	if err := keyFile.Chmod(0o600); err != nil {
+		t.Fatalf("chmod key failed: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		t.Fatalf("write key failed: %v", err)
+	}
+	if err := keyFile.Close(); err != nil {
+		t.Fatalf("close key failed: %v", err)
+	}
+	keyFile, err = os.Open(keyFile.Name())
+	if err != nil {
+		t.Fatalf("reopen key failed: %v", err)
+	}
+	return certFile, keyFile
+}
+
+func writeClientOnlyKeyPair(t *testing.T, dir string) (*os.File, *os.File) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key failed: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "system:node:test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert failed: %v", err)
+	}
+
+	certFile, err := os.CreateTemp(dir, "cert-*.crt")
+	if err != nil {
+		t.Fatalf("create temp cert file failed: %v", err)
+	}
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("write cert failed: %v", err)
+	}
+	if err := certFile.Close(); err != nil {
+		t.Fatalf("close cert failed: %v", err)
+	}
+	certFile, err = os.Open(certFile.Name())
+	if err != nil {
+		t.Fatalf("reopen cert failed: %v", err)
+	}
+
+	keyFile, err := os.CreateTemp(dir, "key-*.key")
+	if err != nil {
+		t.Fatalf("create temp key file failed: %v", err)
+	}
+	if err := keyFile.Chmod(0o600); err != nil {
+		t.Fatalf("chmod key failed: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		t.Fatalf("write key failed: %v", err)
+	}
+	if err := keyFile.Close(); err != nil {
+		t.Fatalf("close key failed: %v", err)
+	}
+	keyFile, err = os.Open(keyFile.Name())
+	if err != nil {
+		t.Fatalf("reopen key failed: %v", err)
+	}
+	return certFile, keyFile
 }
 
 func TestValidateModuleDeviceTwin(t *testing.T) {

--- a/staging/src/github.com/kubeedge/api/apis/util/validation/tls.go
+++ b/staging/src/github.com/kubeedge/api/apis/util/validation/tls.go
@@ -1,0 +1,81 @@
+package validation
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func ValidateServerTLSFiles(certFile, keyFile, host string, now time.Time) []string {
+	var errs []string
+
+	certInfo, err := os.Stat(certFile)
+	if err != nil {
+		return []string{fmt.Sprintf("tlsCertFile not accessible: %v", err)}
+	}
+	if !certInfo.Mode().IsRegular() {
+		return []string{"tlsCertFile must be a regular file"}
+	}
+
+	keyInfo, err := os.Stat(keyFile)
+	if err != nil {
+		return []string{fmt.Sprintf("tlsPrivateKeyFile not accessible: %v", err)}
+	}
+	if !keyInfo.Mode().IsRegular() {
+		return []string{"tlsPrivateKeyFile must be a regular file"}
+	}
+	if keyInfo.Mode().Perm()&0o077 != 0 {
+		errs = append(errs, "tlsPrivateKeyFile must not be readable or writable by group or others")
+	}
+
+	keyPair, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("invalid tls key pair: %v", err))
+		return errs
+	}
+	if len(keyPair.Certificate) == 0 {
+		errs = append(errs, "tlsCertFile does not contain a certificate")
+		return errs
+	}
+
+	leaf, err := x509.ParseCertificate(keyPair.Certificate[0])
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("failed to parse tls certificate: %v", err))
+		return errs
+	}
+	if now.Before(leaf.NotBefore) || now.After(leaf.NotAfter) {
+		errs = append(errs, "tls certificate is not currently valid")
+	}
+
+	var serverAuth bool
+	for _, usage := range leaf.ExtKeyUsage {
+		if usage == x509.ExtKeyUsageServerAuth {
+			serverAuth = true
+			break
+		}
+	}
+	if !serverAuth {
+		errs = append(errs, "tls certificate must support server auth")
+	}
+
+	if err := leaf.VerifyHostname(host); err != nil {
+		if net.ParseIP(host) != nil {
+			errs = append(errs, fmt.Sprintf("tls certificate must include IP SAN %s", host))
+		} else {
+			errs = append(errs, fmt.Sprintf("tls certificate must match hostname %s", host))
+		}
+	}
+
+	return errs
+}
+
+func IsLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}


### PR DESCRIPTION
/kind bug

What this PR does / why we need it:
Moves the edge ServiceBus listener off plaintext HTTP by serving with TLS and wiring certificate configuration through the edgecore ServiceBus config. The change also validates the configured cert and key paths in both edgecore config API versions so misconfigured secure listeners fail early.

Which issue(s) this PR fixes:
Fixes #6985

Special notes for your reviewer:
Verified with:
- `go test ./staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha1/validation ./staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation ./edge/pkg/servicebus`
- `make verify`

Does this PR introduce a user-facing change?:

```release-note
The edge ServiceBus listener now serves HTTPS using configured TLS certificate and key files, and edgecore validation now rejects enabled ServiceBus configs with missing TLS listener credentials.
```