### PR TITLE
metaserver: emit watch BOOKMARK after initial list sync

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
@@ -234,6 +235,20 @@ func (wc *watchChan) startWatching(watchClosedCh chan struct{}) {
 			wc.sendError(err)
 			return
 		}
+		// Synthesise a BOOKMARK so modern client-go informers using
+		// AllowWatchBookmarks (e.g. Cilium >= 1.18) see the initial list
+		// sync as complete and HasSynced returns true.  MetaServer has no
+		// upstream BOOKMARK source, so we emit one after the local cache
+		// is fully drained into the event pipeline.
+		wc.sendEvent(&watch.Event{
+			Type: watch.Bookmark,
+			Object: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: fmt.Sprintf("%d", wc.initialRev),
+					Annotations:     map[string]string{"k8s.io/initial-events-end": "true"},
+				},
+			},
+		})
 	}
 	wch := wc.watcher.client.Watch(wc.ctx, wc.key, uint64(wc.initialRev+1))
 	for wres := range wch {
@@ -250,6 +265,16 @@ func (wc *watchChan) processEvent(wg *sync.WaitGroup) {
 	for {
 		select {
 		case e := <-wc.incomingEventChan:
+			// BOOKMARK events have no object key; pass straight to resultChan.
+			// The key-lookup below would log an error and drop them.
+			if e.Type == watch.Bookmark {
+				select {
+				case wc.resultChan <- *e:
+				case <-wc.ctx.Done():
+					return
+				}
+				continue
+			}
 			var res = e
 			key, err := metaserver.KeyFuncObj(e.Object)
 			if err != nil {

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/watcher_test.go
@@ -1,0 +1,164 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator"
+	fakeclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake"
+)
+
+func podJSON(name string) string {
+	return fmt.Sprintf(`{"apiVersion":"v1","kind":"Pod","metadata":{"name":%q,"namespace":"default"}}`, name)
+}
+
+// neverWatch returns a watch channel that stays open until ctx is cancelled.
+func neverWatch(ctx context.Context) <-chan watch.Event {
+	ch := make(chan watch.Event)
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch
+}
+
+func makeTestWatcher(kvs []models.MetaV2, revision uint64) *watcher {
+	resp := imitator.Resp{
+		Kvs:      &kvs,
+		Revision: revision,
+	}
+	fc := fakeclient.Client{
+		ListF: func(_ context.Context, _ string) (imitator.Resp, error) {
+			return resp, nil
+		},
+		WatchF: func(c context.Context, _ string, _ uint64) <-chan watch.Event {
+			return neverWatch(c)
+		},
+	}
+	return newWatcher(fc, unstructured.UnstructuredJSONScheme)
+}
+
+// collectEvents reads up to maxEvents from ch or until timeout, stopping after the first BOOKMARK.
+func collectEvents(ch <-chan watch.Event, maxEvents int, timeout time.Duration) []watch.Event {
+	var events []watch.Event
+	deadline := time.After(timeout)
+	for {
+		select {
+		case e, ok := <-ch:
+			if !ok {
+				return events
+			}
+			events = append(events, e)
+			if e.Type == watch.Bookmark || len(events) >= maxEvents {
+				return events
+			}
+		case <-deadline:
+			return events
+		}
+	}
+}
+
+// TestWatchBookmarkAfterInitialSync verifies that after sync(), all Added events arrive
+// before the synthesised BOOKMARK, and that the BOOKMARK carries the correct ResourceVersion
+// and the k8s.io/initial-events-end annotation used by modern client-go informers.
+func TestWatchBookmarkAfterInitialSync(t *testing.T) {
+	kvs := []models.MetaV2{
+		{Value: podJSON("pod-1")},
+		{Value: podJSON("pod-2")},
+	}
+	const rev uint64 = 42
+
+	w := makeTestWatcher(kvs, rev)
+
+	wi, err := w.Watch(context.Background(), "/core/v1/pods/default/", 0, true, storage.Everything)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer wi.Stop()
+
+	events := collectEvents(wi.ResultChan(), 10, 3*time.Second)
+
+	var addedCount int
+	var bookmarkIdx = -1
+	for i, e := range events {
+		switch e.Type {
+		case watch.Added:
+			if bookmarkIdx != -1 {
+				t.Errorf("Added event at index %d appeared after BOOKMARK at index %d", i, bookmarkIdx)
+			}
+			addedCount++
+		case watch.Bookmark:
+			bookmarkIdx = i
+		}
+	}
+
+	if addedCount != len(kvs) {
+		t.Errorf("want %d Added events, got %d", len(kvs), addedCount)
+	}
+	if bookmarkIdx == -1 {
+		t.Fatal("no BOOKMARK event received")
+	}
+
+	bm := events[bookmarkIdx]
+	accessor, ok := bm.Object.(*metav1.PartialObjectMetadata)
+	if !ok {
+		t.Fatalf("BOOKMARK object is %T, want *metav1.PartialObjectMetadata", bm.Object)
+	}
+	if accessor.ResourceVersion != fmt.Sprintf("%d", rev) {
+		t.Errorf("BOOKMARK ResourceVersion = %q, want %q", accessor.ResourceVersion, fmt.Sprintf("%d", rev))
+	}
+	if accessor.Annotations["k8s.io/initial-events-end"] != "true" {
+		t.Errorf("BOOKMARK missing k8s.io/initial-events-end annotation, got %v", accessor.Annotations)
+	}
+}
+
+// TestProcessEventBookmarkBypass verifies that processEvent forwards watch.Bookmark events
+// directly to resultChan without attempting KeyFuncObj (which would error and drop them).
+func TestProcessEventBookmarkBypass(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wc := &watchChan{
+		watcher:           &watcher{},
+		internalPred:      storage.Everything,
+		incomingEventChan: make(chan *watch.Event, incomingBufSize),
+		resultChan:        make(chan watch.Event, outgoingBufSize),
+		errChan:           make(chan error, 1),
+		added:             make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go wc.processEvent(&wg)
+
+	bm := &watch.Event{
+		Type: watch.Bookmark,
+		Object: &metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "99",
+				Annotations:     map[string]string{"k8s.io/initial-events-end": "true"},
+			},
+		},
+	}
+	wc.incomingEventChan <- bm
+
+	select {
+	case got := <-wc.resultChan:
+		if got.Type != watch.Bookmark {
+			t.Errorf("resultChan event type = %v, want Bookmark", got.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for BOOKMARK in resultChan")
+	}
+}


### PR DESCRIPTION
/kind bug

## Problem

Cilium >= 1.18 uses modern client-go informers that require a `BOOKMARK` watch event to signal end of the initial list-watch cycle before `HasSynced` returns `true`. MetaServer's SQLite watcher never emits `BOOKMARK` events, so `cilium-agent` on edge nodes blocks indefinitely at:

```
Still waiting for Cilium Operator to register CRDs...
```

After `--crd-wait-timeout` (default 5 minutes) the agent fatally exits. This affects any Cilium version >= 1.18 running on KubeEdge edge nodes via `cilium-kubeedge` DaemonSet pointed at MetaServer (`--k8s-api-server-urls=http://127.0.0.1:10550`).

**What this PR does / why we need it**: Emit a synthetic `BOOKMARK` event after the initial list sync in MetaServer's SQLite watcher so that modern client-go informers using `AllowWatchBookmarks` (required by Cilium >= 1.18) see `HasSynced` return `true`.

**Which issue(s) this PR fixes**: Fixes #6301

## Root cause

`startWatching()` calls `sync()` to drain the local SQLite cache as `Added` events, then starts a live watch — but never sends a `BOOKMARK`. The `processEvent` loop would also silently drop any `BOOKMARK` event via the `KeyFuncObj` error path.

## Fix

Two changes in `watcher.go`:

1. **`startWatching`**: after `sync()` succeeds, synthesise a `BOOKMARK` event carrying the current revision and enqueue it through `incomingEventChan`. Using the same channel preserves ordering — all `Added` events from the initial sync arrive before the `BOOKMARK`.

2. **`processEvent`**: detect `watch.Bookmark` type and forward directly to `resultChan`, bypassing the object key-lookup that would log an error and drop it.

## Testing

- Verified `cilium-kubeedge` agent on edge node no longer stalls at CRD registration with Cilium 1.19.4
- Unit tests added: ordering (Added before BOOKMARK), BOOKMARK content (ResourceVersion + `k8s.io/initial-events-end: true`), and processEvent bypass
- Existing unit tests pass: `go test ./edge/pkg/metamanager/...`
- Package compiles cleanly against KubeEdge v1.23.0 module graph

## Related

- Fixes #6301 — cilium-agent stuck waiting for Cilium Operator to register CRDs
- KubeEdge Cilium integration docs tested with Cilium 1.17.2 (pre-bookmark requirement); this fix enables Cilium 1.18+ support

**Special notes for your reviewer**: The `BOOKMARK` object type is `*metav1.PartialObjectMetadata` — this is the same type used by the Kubernetes apiserver's etcd3 watcher for synthesised bookmarks.

**Does this PR introduce a user-facing change?**:
```release-note
MetaServer's SQLite watcher now emits a BOOKMARK event after the initial list sync, enabling Cilium >= 1.18 (and any other modern client-go informer using AllowWatchBookmarks) to complete HasSynced on edge nodes.
```
