### PR TITLE
fix(taskmanager): resolve shadowed error variables in task loop

### DIFF
--- a/cloud/pkg/taskmanager/downstream/config_update.go
+++ b/cloud/pkg/taskmanager/downstream/config_update.go
@@ -128,5 +128,5 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 			}
 		},
 	}
-	status.GetConfigeUpdateJobStatusUpdater().UpdateStatus(opts)
+	status.GetConfigUpdateJobStatusUpdater().UpdateStatus(opts)
 }

--- a/cloud/pkg/taskmanager/status/init.go
+++ b/cloud/pkg/taskmanager/status/init.go
@@ -47,6 +47,6 @@ func GetNodeUpgradeJobStatusUpdater() *StatusUpdater {
 	return nodeUpgradeJobStatusUpdater
 }
 
-func GetConfigeUpdateJobStatusUpdater() *StatusUpdater {
+func GetConfigUpdateJobStatusUpdater() *StatusUpdater {
 	return configUpdateJobStatusUpdater
 }

--- a/cloud/pkg/taskmanager/upstream/config_update.go
+++ b/cloud/pkg/taskmanager/upstream/config_update.go
@@ -66,7 +66,7 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 ) error {
 	var (
 		actoinStatus operationsv1alpha2.ConfigUpdateJobActionStatus
-		err          error
+		retErr       error
 		wg           sync.WaitGroup
 	)
 
@@ -97,14 +97,14 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 			ExtendInfo:   upmsg.Extend,
 			ActionStatus: &actoinStatus,
 		},
-		Callback: func(err error) {
-			if err != nil {
-				err = fmt.Errorf("failed to update image prepull job status, err: %v", err)
+		Callback: func(cbErr error) {
+			if cbErr != nil {
+				retErr = fmt.Errorf("failed to update config update job status: %w", cbErr)
 			}
 			wg.Done()
 		},
 	}
 	status.GetConfigeUpdateJobStatusUpdater().UpdateStatus(opts)
 	wg.Wait()
-	return err
+	return retErr
 }

--- a/cloud/pkg/taskmanager/upstream/config_update.go
+++ b/cloud/pkg/taskmanager/upstream/config_update.go
@@ -65,19 +65,19 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 	upmsg taskmsg.UpstreamMessage,
 ) error {
 	var (
-		actoinStatus operationsv1alpha2.ConfigUpdateJobActionStatus
+		actionStatus operationsv1alpha2.ConfigUpdateJobActionStatus
 		retErr       error
 		wg           sync.WaitGroup
 	)
 
-	actoinStatus.Action = operationsv1alpha2.ConfigUpdateJobAction(upmsg.Action)
+	actionStatus.Action = operationsv1alpha2.ConfigUpdateJobAction(upmsg.Action)
 	if upmsg.Succ {
-		actoinStatus.Status = metav1.ConditionTrue
+		actionStatus.Status = metav1.ConditionTrue
 	} else {
-		actoinStatus.Status = metav1.ConditionFalse
-		actoinStatus.Reason = upmsg.Reason
+		actionStatus.Status = metav1.ConditionFalse
+		actionStatus.Reason = upmsg.Reason
 	}
-	actoinStatus.Time = upmsg.FinishTime
+	actionStatus.Time = upmsg.FinishTime
 
 	phase := operationsv1alpha2.NodeTaskPhaseInProgress
 	if isFinalAction {
@@ -95,7 +95,7 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 			NodeName:     nodeName,
 			Phase:        phase,
 			ExtendInfo:   upmsg.Extend,
-			ActionStatus: &actoinStatus,
+			ActionStatus: &actionStatus,
 		},
 		Callback: func(cbErr error) {
 			if cbErr != nil {
@@ -104,7 +104,7 @@ func (h *ConfigUpdateJobHandler) UpdateNodeTaskStatus(
 			wg.Done()
 		},
 	}
-	status.GetConfigeUpdateJobStatusUpdater().UpdateStatus(opts)
+	status.GetConfigUpdateJobStatusUpdater().UpdateStatus(opts)
 	wg.Wait()
 	return retErr
 }

--- a/cloud/pkg/taskmanager/upstream/config_update_test.go
+++ b/cloud/pkg/taskmanager/upstream/config_update_test.go
@@ -29,7 +29,7 @@ import (
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
 )
 
-func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
+func TestConfigUpdateJobUpdateNodeTaskStatus(t *testing.T) {
 	var (
 		jobName  = "test-job"
 		nodeName = "node1"
@@ -38,14 +38,14 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+		gomonkey.ApplyFunc(status.GetConfigUpdateJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
 		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
-				act, ok := opts.ActionStatus.(*operationsv1alpha2.NodeUpgradeJobActionStatus)
+				act, ok := opts.ActionStatus.(*operationsv1alpha2.ConfigUpdateJobActionStatus)
 				require.True(t, ok)
-				assert.Equal(t, operationsv1alpha2.NodeUpgradeJobActionUpgrade, act.Action)
+				assert.Equal(t, operationsv1alpha2.ConfigUpdateJobActionUpdate, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseSuccessful, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
 				assert.Equal(t, nodeName, opts.NodeName)
@@ -53,9 +53,9 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 				opts.Callback(nil)
 			})
 
-		handler := &NodeUpgradeJobHandler{}
+		handler := &ConfigUpdateJobHandler{}
 		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
-			Action: string(operationsv1alpha2.NodeUpgradeJobActionUpgrade),
+			Action: string(operationsv1alpha2.ConfigUpdateJobActionUpdate),
 			Succ:   true,
 		})
 		require.NoError(t, err)
@@ -65,14 +65,14 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+		gomonkey.ApplyFunc(status.GetConfigUpdateJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
 		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
 			func(opts status.UpdateStatusOptions) {
-				act, ok := opts.ActionStatus.(*operationsv1alpha2.NodeUpgradeJobActionStatus)
+				act, ok := opts.ActionStatus.(*operationsv1alpha2.ConfigUpdateJobActionStatus)
 				require.True(t, ok)
-				assert.Equal(t, operationsv1alpha2.NodeUpgradeJobActionRollBack, act.Action)
+				assert.Equal(t, operationsv1alpha2.ConfigUpdateJobActionUpdate, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseFailure, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
 				assert.Equal(t, nodeName, opts.NodeName)
@@ -80,9 +80,9 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 				opts.Callback(nil)
 			})
 
-		handler := &NodeUpgradeJobHandler{}
+		handler := &ConfigUpdateJobHandler{}
 		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
-			Action: string(operationsv1alpha2.NodeUpgradeJobActionRollBack),
+			Action: string(operationsv1alpha2.ConfigUpdateJobActionUpdate),
 			Succ:   false,
 		})
 		require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()
 
-		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+		gomonkey.ApplyFunc(status.GetConfigUpdateJobStatusUpdater, func() *status.StatusUpdater {
 			return &status.StatusUpdater{}
 		})
 		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
@@ -101,13 +101,13 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 				opts.Callback(assert.AnError)
 			})
 
-		handler := &NodeUpgradeJobHandler{}
+		handler := &ConfigUpdateJobHandler{}
 		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
-			Action: string(operationsv1alpha2.NodeUpgradeJobActionUpgrade),
+			Action: string(operationsv1alpha2.ConfigUpdateJobActionUpdate),
 			Succ:   true,
 		})
 		require.Error(t, err)
 		require.ErrorIs(t, err, assert.AnError)
-		assert.Contains(t, err.Error(), "failed to update node upgrade job status")
+		assert.Contains(t, err.Error(), "failed to update config update job status")
 	})
 }

--- a/cloud/pkg/taskmanager/upstream/image_prepull.go
+++ b/cloud/pkg/taskmanager/upstream/image_prepull.go
@@ -66,7 +66,7 @@ func (h *ImagePrePullJobHandler) UpdateNodeTaskStatus(
 ) error {
 	var (
 		actoinStatus operationsv1alpha2.ImagePrePullJobActionStatus
-		err          error
+		retErr       error
 		wg           sync.WaitGroup
 	)
 
@@ -97,14 +97,14 @@ func (h *ImagePrePullJobHandler) UpdateNodeTaskStatus(
 			ExtendInfo:   upmsg.Extend,
 			ActionStatus: &actoinStatus,
 		},
-		Callback: func(err error) {
-			if err != nil {
-				err = fmt.Errorf("failed to update image prepull job status, err: %v", err)
+		Callback: func(cbErr error) {
+			if cbErr != nil {
+				retErr = fmt.Errorf("failed to update image prepull job status: %w", cbErr)
 			}
 			wg.Done()
 		},
 	}
 	status.GetImagePrePullJobStatusUpdater().UpdateStatus(opts)
 	wg.Wait()
-	return err
+	return retErr
 }

--- a/cloud/pkg/taskmanager/upstream/image_prepull.go
+++ b/cloud/pkg/taskmanager/upstream/image_prepull.go
@@ -65,19 +65,19 @@ func (h *ImagePrePullJobHandler) UpdateNodeTaskStatus(
 	upmsg taskmsg.UpstreamMessage,
 ) error {
 	var (
-		actoinStatus operationsv1alpha2.ImagePrePullJobActionStatus
+		actionStatus operationsv1alpha2.ImagePrePullJobActionStatus
 		retErr       error
 		wg           sync.WaitGroup
 	)
 
-	actoinStatus.Action = operationsv1alpha2.ImagePrePullJobAction(upmsg.Action)
+	actionStatus.Action = operationsv1alpha2.ImagePrePullJobAction(upmsg.Action)
 	if upmsg.Succ {
-		actoinStatus.Status = metav1.ConditionTrue
+		actionStatus.Status = metav1.ConditionTrue
 	} else {
-		actoinStatus.Status = metav1.ConditionFalse
-		actoinStatus.Reason = upmsg.Reason
+		actionStatus.Status = metav1.ConditionFalse
+		actionStatus.Reason = upmsg.Reason
 	}
-	actoinStatus.Time = upmsg.FinishTime
+	actionStatus.Time = upmsg.FinishTime
 
 	phase := operationsv1alpha2.NodeTaskPhaseInProgress
 	if isFinalAction {
@@ -95,7 +95,7 @@ func (h *ImagePrePullJobHandler) UpdateNodeTaskStatus(
 			NodeName:     nodeName,
 			Phase:        phase,
 			ExtendInfo:   upmsg.Extend,
-			ActionStatus: &actoinStatus,
+			ActionStatus: &actionStatus,
 		},
 		Callback: func(cbErr error) {
 			if cbErr != nil {

--- a/cloud/pkg/taskmanager/upstream/image_prepull_test.go
+++ b/cloud/pkg/taskmanager/upstream/image_prepull_test.go
@@ -87,4 +87,26 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+
+	t.Run("callback returns error", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		gomonkey.ApplyFunc(status.GetImagePrePullJobStatusUpdater, func() *status.StatusUpdater {
+			return &status.StatusUpdater{}
+		})
+		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+			func(opts status.UpdateStatusOptions) {
+				require.NotNil(t, opts.Callback)
+				opts.Callback(assert.AnError)
+			})
+
+		handler := &ImagePrePullJobHandler{}
+		err := handler.UpdateNodeTaskStatus(jobName, nodeNmae, true, taskmsg.UpstreamMessage{
+			Action: string(operationsv1alpha2.ImagePrePullJobActionPull),
+			Succ:   true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update image prepull job status")
+	})
 }

--- a/cloud/pkg/taskmanager/upstream/image_prepull_test.go
+++ b/cloud/pkg/taskmanager/upstream/image_prepull_test.go
@@ -32,7 +32,7 @@ import (
 func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 	var (
 		jobName  = "test-job"
-		nodeNmae = "node1"
+		nodeName = "node1"
 	)
 	t.Run("final action successful", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
@@ -48,13 +48,13 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 				assert.Equal(t, operationsv1alpha2.ImagePrePullJobActionPull, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseSuccessful, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
-				assert.Equal(t, nodeNmae, opts.NodeName)
+				assert.Equal(t, nodeName, opts.NodeName)
 				require.NotNil(t, opts.Callback)
 				opts.Callback(nil)
 			})
 
 		handler := &ImagePrePullJobHandler{}
-		err := handler.UpdateNodeTaskStatus(jobName, nodeNmae, true, taskmsg.UpstreamMessage{
+		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
 			Action: string(operationsv1alpha2.ImagePrePullJobActionPull),
 			Succ:   true,
 		})
@@ -75,13 +75,13 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 				assert.Equal(t, operationsv1alpha2.ImagePrePullJobActionPull, act.Action)
 				assert.Equal(t, operationsv1alpha2.NodeTaskPhaseFailure, opts.Phase)
 				assert.Equal(t, jobName, opts.JobName)
-				assert.Equal(t, nodeNmae, opts.NodeName)
+				assert.Equal(t, nodeName, opts.NodeName)
 				require.NotNil(t, opts.Callback)
 				opts.Callback(nil)
 			})
 
 		handler := &ImagePrePullJobHandler{}
-		err := handler.UpdateNodeTaskStatus(jobName, nodeNmae, true, taskmsg.UpstreamMessage{
+		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
 			Action: string(operationsv1alpha2.ImagePrePullJobActionPull),
 			Succ:   false,
 		})
@@ -102,11 +102,12 @@ func TestImagePrePullJobUpdateNodeTaskStatus(t *testing.T) {
 			})
 
 		handler := &ImagePrePullJobHandler{}
-		err := handler.UpdateNodeTaskStatus(jobName, nodeNmae, true, taskmsg.UpstreamMessage{
+		err := handler.UpdateNodeTaskStatus(jobName, nodeName, true, taskmsg.UpstreamMessage{
 			Action: string(operationsv1alpha2.ImagePrePullJobActionPull),
 			Succ:   true,
 		})
 		require.Error(t, err)
+		require.ErrorIs(t, err, assert.AnError)
 		assert.Contains(t, err.Error(), "failed to update image prepull job status")
 	})
 }

--- a/cloud/pkg/taskmanager/upstream/node_upgrade.go
+++ b/cloud/pkg/taskmanager/upstream/node_upgrade.go
@@ -66,7 +66,7 @@ func (h *NodeUpgradeJobHandler) UpdateNodeTaskStatus(
 ) error {
 	var (
 		actoinStatus operationsv1alpha2.NodeUpgradeJobActionStatus
-		err          error
+		retErr       error
 		wg           sync.WaitGroup
 	)
 
@@ -97,16 +97,16 @@ func (h *NodeUpgradeJobHandler) UpdateNodeTaskStatus(
 			ExtendInfo:   upmsg.Extend,
 			ActionStatus: &actoinStatus,
 		},
-		Callback: func(err error) {
-			if err != nil {
-				err = fmt.Errorf("failed to update image prepull job status, err: %v", err)
+		Callback: func(cbErr error) {
+			if cbErr != nil {
+				retErr = fmt.Errorf("failed to update node upgrade job status: %w", cbErr)
 			}
 			wg.Done()
 		},
 	}
 	status.GetNodeUpgradeJobStatusUpdater().UpdateStatus(opts)
 	wg.Wait()
-	return err
+	return retErr
 }
 
 // func (h *NodeUpgradeJobHandler) FindNodeTaskStatus(ctx context.Context, res taskmsg.Resource,

--- a/cloud/pkg/taskmanager/upstream/node_upgrade.go
+++ b/cloud/pkg/taskmanager/upstream/node_upgrade.go
@@ -65,19 +65,19 @@ func (h *NodeUpgradeJobHandler) UpdateNodeTaskStatus(
 	upmsg taskmsg.UpstreamMessage,
 ) error {
 	var (
-		actoinStatus operationsv1alpha2.NodeUpgradeJobActionStatus
+		actionStatus operationsv1alpha2.NodeUpgradeJobActionStatus
 		retErr       error
 		wg           sync.WaitGroup
 	)
 
-	actoinStatus.Action = operationsv1alpha2.NodeUpgradeJobAction(upmsg.Action)
+	actionStatus.Action = operationsv1alpha2.NodeUpgradeJobAction(upmsg.Action)
 	if upmsg.Succ {
-		actoinStatus.Status = metav1.ConditionTrue
+		actionStatus.Status = metav1.ConditionTrue
 	} else {
-		actoinStatus.Status = metav1.ConditionFalse
-		actoinStatus.Reason = upmsg.Reason
+		actionStatus.Status = metav1.ConditionFalse
+		actionStatus.Reason = upmsg.Reason
 	}
-	actoinStatus.Time = upmsg.FinishTime
+	actionStatus.Time = upmsg.FinishTime
 
 	phase := operationsv1alpha2.NodeTaskPhaseInProgress
 	if isFinalAction {
@@ -95,7 +95,7 @@ func (h *NodeUpgradeJobHandler) UpdateNodeTaskStatus(
 			NodeName:     nodeName,
 			Phase:        phase,
 			ExtendInfo:   upmsg.Extend,
-			ActionStatus: &actoinStatus,
+			ActionStatus: &actionStatus,
 		},
 		Callback: func(cbErr error) {
 			if cbErr != nil {

--- a/cloud/pkg/taskmanager/upstream/node_upgrade_test.go
+++ b/cloud/pkg/taskmanager/upstream/node_upgrade_test.go
@@ -87,4 +87,26 @@ func TestNodeUpgradeJobUpdateNodeTaskStatus(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+
+	t.Run("callback returns error", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		gomonkey.ApplyFunc(status.GetNodeUpgradeJobStatusUpdater, func() *status.StatusUpdater {
+			return &status.StatusUpdater{}
+		})
+		gomonkey.ApplyMethodFunc(reflect.TypeOf(&status.StatusUpdater{}), "UpdateStatus",
+			func(opts status.UpdateStatusOptions) {
+				require.NotNil(t, opts.Callback)
+				opts.Callback(assert.AnError)
+			})
+
+		handler := &NodeUpgradeJobHandler{}
+		err := handler.UpdateNodeTaskStatus(jobName, nodeNmae, true, taskmsg.UpstreamMessage{
+			Action: string(operationsv1alpha2.NodeUpgradeJobActionUpgrade),
+			Succ:   true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update node upgrade job status")
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Several error variables in the task manager loop were unintentionally shadowed by inner scope assignments. This caused genuine failures to be ignored, leading to incorrect task state reporting. This PR resolves the variable shadowing, ensuring errors are correctly captured and propagated.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```