### PR TITLE
Add resourceclaims/binding RBAC for DRA granular status authorization

### DIFF
--- a/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/vendor/k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -603,6 +603,10 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			rbacv1helpers.NewRule(Read...).Groups(resourceGroup).Resources("deviceclasses").RuleOrDie(),
 			rbacv1helpers.NewRule(ReadUpdate...).Groups(resourceGroup).Resources("resourceclaims").RuleOrDie(),
 			rbacv1helpers.NewRule(ReadUpdate...).Groups(resourceGroup).Resources("resourceclaims/status").RuleOrDie(),
+			// Needed for DRAResourceClaimGranularStatusAuthorization (beta in k8s v1.36, on by default).
+			// The resourceclaims/binding subresource is inert on clusters older than v1.33 but safe to add in preparation.
+			// Ref: kubernetes/kubernetes#138149
+			rbacv1helpers.NewRule("update", "patch").Groups(resourceGroup).Resources("resourceclaims/binding").RuleOrDie(),
 			rbacv1helpers.NewRule(ReadUpdate...).Groups(legacyGroup).Resources("pods/finalizers").RuleOrDie(),
 			rbacv1helpers.NewRule(Read...).Groups(resourceGroup).Resources("resourceslices").RuleOrDie(),
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Adds `update` and `patch` permissions on `resource.k8s.io/resourceclaims/binding`
to the `system:kube-scheduler` ClusterRole in the vendored bootstrap RBAC policy.

In Kubernetes v1.36, the `DRAResourceClaimGranularStatusAuthorization` feature gate
is beta and on by default. It introduces a dedicated `resourceclaims/binding`
subresource to separate scheduler binding authorization from `resourceclaims/status`.
Without this permission, the scheduler cannot perform ResourceClaim binding operations
on v1.36+ clusters with DynamicResourceAllocation enabled.

The permission is inert on clusters older than v1.33 where the subresource does not
exist, so it is safe to add now in preparation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
 https://github.com/kubernetes/kubernetes/issues/138149https://github.com/kubernetes/kubernetes/issues/138149

**Special notes for your reviewer**:

The `DRAResourceClaimGranularStatusAuthorization` feature gate constant does not exist
in the vendored Kubernetes v1.32. The rule is therefore placed flat inside the existing
`DynamicResourceAllocation` block, which is the correct outer guard. When the vendored
Kubernetes is bumped to v1.33+, this can be moved under its own feature gate check.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add resourceclaims/binding RBAC for DRA granular status authorization to the
system:kube-scheduler ClusterRole. Required for Kubernetes v1.36 clusters with
DynamicResourceAllocation enabled.
```
