### PR TITLE
test(cloudcore): add comprehensive unit tests for cloudcore app and fix nil map panic

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -208,6 +208,13 @@ func NegotiateTunnelPort() (*int, error) {
 			return nil, err
 		}
 
+		if record.IPTunnelPort == nil {
+			record.IPTunnelPort = make(map[string]int)
+		}
+		if record.Port == nil {
+			record.Port = make(map[int]bool)
+		}
+
 		port, found := record.IPTunnelPort[localIP]
 		if found {
 			return &port, nil
@@ -292,10 +299,13 @@ func updateCloudCoreConfigMap(c *v1alpha1.CloudCoreConfig) {
 		return
 	}
 
+	if cloudCoreCM.Data == nil {
+		cloudCoreCM.Data = make(map[string]string)
+	}
 	cloudCoreCM.Data["cloudcore.yaml"] = string(configBytes)
 
 	_, err = kubeClient.CoreV1().ConfigMaps(constants.SystemNamespace).Update(context.TODO(), cloudCoreCM, metav1.UpdateOptions{})
 	if err != nil {
-		klog.Errorf("Failed to marshal cloudcore config: %v", err)
+		klog.Errorf("Failed to update CloudCore configMap: %v", err)
 	}
 }

--- a/cloud/cmd/cloudcore/app/server_test.go
+++ b/cloud/cmd/cloudcore/app/server_test.go
@@ -1,15 +1,38 @@
+/*
+Copyright 2019 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package app
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	fakekube "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/yaml"
 
+	"github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/common/constants"
@@ -22,31 +45,6 @@ func TestNegotiateTunnelPort(t *testing.T) {
 		isPortExist   bool
 		isPortUsed    bool
 	}
-	cases := testCase{}
-	var cm = v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        modules.TunnelPort,
-			Namespace:   constants.SystemNamespace,
-			Annotations: map[string]string{},
-		},
-	}
-	hostnameOverride := util.GetHostname()
-	localIP, _ := util.GetLocalIP(hostnameOverride)
-	patch := gomonkey.NewPatches()
-	defer patch.Reset()
-	patch.ApplyFunc(client.GetKubeClient, func() kubernetes.Interface {
-		if cases.isConfigExits {
-			record := "{}"
-			if cases.isPortExist {
-				record = "{\"ipTunnelPort\":{\"" + localIP + "\":10351},\"port\":{\"10351\":true}}"
-			} else if cases.isPortUsed {
-				record = "{\"ipTunnelPort\":{\"127.0.0.1\":10351},\"port\":{\"10351\":true}}"
-			}
-			cm.ObjectMeta.Annotations[modules.TunnelPortRecordAnnotationKey] = record
-			return fakekube.NewSimpleClientset(&cm)
-		}
-		return fakekube.NewSimpleClientset()
-	})
 
 	tests := []struct {
 		name    string
@@ -72,9 +70,42 @@ func TestNegotiateTunnelPort(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
+	hostnameOverride := util.GetHostname()
+	localIP, _ := util.GetLocalIP(hostnameOverride)
+
 	for _, tt := range tests {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
-			cases = tt.cases
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyFunc(client.CreateNamespaceIfNeeded, func(ctx context.Context, namespace string) error {
+				return nil
+			})
+
+			patches.ApplyFunc(client.GetKubeClient, func() kubernetes.Interface {
+				if tt.cases.isConfigExits {
+					record := "{}"
+					if tt.cases.isPortExist {
+						record = "{\"ipTunnelPort\":{\"" + localIP + "\":10351},\"port\":{\"10351\":true}}"
+					} else if tt.cases.isPortUsed {
+						record = "{\"ipTunnelPort\":{\"127.0.0.1\":10351},\"port\":{\"10351\":true}}"
+					}
+					cm := v1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      modules.TunnelPort,
+							Namespace: constants.SystemNamespace,
+							Annotations: map[string]string{
+								modules.TunnelPortRecordAnnotationKey: record,
+							},
+						},
+					}
+					return fakekube.NewSimpleClientset(&cm)
+				}
+				return fakekube.NewSimpleClientset()
+			})
+
 			got, err := NegotiateTunnelPort()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NegotiateTunnelPort() error = %v, wantErr %v", err, tt.wantErr)
@@ -85,4 +116,288 @@ func TestNegotiateTunnelPort(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNegotiateTunnelPort_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name         string
+		mockNS       func() error
+		setupClient  func() kubernetes.Interface
+		expectErr    bool
+		expectErrStr string
+	}{
+		{
+			name: "CreateNamespaceIfNeeded fails",
+			mockNS: func() error {
+				return errors.New("simulated namespace error")
+			},
+			setupClient:  func() kubernetes.Interface { return fakekube.NewSimpleClientset() },
+			expectErr:    true,
+			expectErrStr: "failed to create system namespace: simulated namespace error",
+		},
+		{
+			name:   "ConfigMap missing annotation",
+			mockNS: func() error { return nil },
+			setupClient: func() kubernetes.Interface {
+				return fakekube.NewSimpleClientset(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      modules.TunnelPort,
+						Namespace: constants.SystemNamespace,
+					},
+				})
+			},
+			expectErr:    true,
+			expectErrStr: "failed to get tunnel port record",
+		},
+		{
+			name:   "JSON unmarshal error",
+			mockNS: func() error { return nil },
+			setupClient: func() kubernetes.Interface {
+				return fakekube.NewSimpleClientset(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      modules.TunnelPort,
+						Namespace: constants.SystemNamespace,
+						Annotations: map[string]string{
+							modules.TunnelPortRecordAnnotationKey: "invalid-json-format",
+						},
+					},
+				})
+			},
+			expectErr: true,
+		},
+		{
+			name:   "JSON unmarshal empty record {}",
+			mockNS: func() error { return nil },
+			setupClient: func() kubernetes.Interface {
+				return fakekube.NewSimpleClientset(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      modules.TunnelPort,
+						Namespace: constants.SystemNamespace,
+						Annotations: map[string]string{
+							modules.TunnelPortRecordAnnotationKey: "{}",
+						},
+					},
+				})
+			},
+			expectErr: false,
+		},
+		{
+			name:   "JSON unmarshal missing ipTunnelPort map",
+			mockNS: func() error { return nil },
+			setupClient: func() kubernetes.Interface {
+				return fakekube.NewSimpleClientset(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      modules.TunnelPort,
+						Namespace: constants.SystemNamespace,
+						Annotations: map[string]string{
+							modules.TunnelPortRecordAnnotationKey: "{\"port\":{}}",
+						},
+					},
+				})
+			},
+			expectErr: false,
+		},
+		{
+			name:   "JSON unmarshal missing port map",
+			mockNS: func() error { return nil },
+			setupClient: func() kubernetes.Interface {
+				return fakekube.NewSimpleClientset(&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      modules.TunnelPort,
+						Namespace: constants.SystemNamespace,
+						Annotations: map[string]string{
+							modules.TunnelPortRecordAnnotationKey: "{\"ipTunnelPort\":{}}",
+						},
+					},
+				})
+			},
+			expectErr: false,
+		},
+		{
+			name:   "ConfigMap Update fails",
+			mockNS: func() error { return nil },
+			setupClient: func() kubernetes.Interface {
+				cm := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      modules.TunnelPort,
+						Namespace: constants.SystemNamespace,
+						Annotations: map[string]string{
+							modules.TunnelPortRecordAnnotationKey: "{\"ipTunnelPort\":{},\"port\":{}}",
+						},
+					},
+				}
+				cs := fakekube.NewSimpleClientset(cm)
+				cs.PrependReactor("update", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("simulated update error")
+				})
+				return cs
+			},
+			expectErr: true,
+		},
+		{
+			name:   "ConfigMap Create fails (Not Found branch)",
+			mockNS: func() error { return nil },
+			setupClient: func() kubernetes.Interface {
+				cs := fakekube.NewSimpleClientset() // Empty client causes IsNotFound
+				cs.PrependReactor("create", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, errors.New("simulated create error")
+				})
+				return cs
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyFunc(client.CreateNamespaceIfNeeded, func(ctx context.Context, namespace string) error {
+				return tt.mockNS()
+			})
+			patches.ApplyFunc(client.GetKubeClient, tt.setupClient)
+
+			port, err := NegotiateTunnelPort()
+			if tt.expectErr {
+				assert.Error(t, err)
+				if tt.expectErrStr != "" {
+					assert.EqualError(t, err, tt.expectErrStr)
+				}
+				assert.Nil(t, port)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, port)
+			}
+		})
+	}
+}
+
+func TestNegotiatePort(t *testing.T) {
+	record := map[int]bool{
+		constants.ServerPort + 1: true,
+		constants.ServerPort + 2: true,
+	}
+	port := negotiatePort(record)
+	assert.Equal(t, constants.ServerPort+3, port)
+}
+
+func TestUpdateCloudCoreConfigMap(t *testing.T) {
+	t.Run("Successfully updates config map", func(t *testing.T) {
+		fakeClient := fakekube.NewSimpleClientset(&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.CloudConfigMapName,
+				Namespace: constants.SystemNamespace,
+			},
+			Data: map[string]string{},
+		})
+
+		patches := gomonkey.ApplyFunc(client.GetKubeClient, func() kubernetes.Interface {
+			return fakeClient
+		})
+		defer patches.Reset()
+
+		config := &v1alpha1.CloudCoreConfig{
+			CommonConfig: &v1alpha1.CommonConfig{
+				TunnelPort: 12345,
+			},
+		}
+		updateCloudCoreConfigMap(config)
+
+		// Assert exactly one get followed by one update action was executed
+		actions := fakeClient.Actions()
+		assert.Len(t, actions, 2)
+		assert.Equal(t, "get", actions[0].GetVerb())
+		assert.Equal(t, "update", actions[1].GetVerb())
+
+		cm, err := fakeClient.CoreV1().ConfigMaps(constants.SystemNamespace).Get(context.TODO(), constants.CloudConfigMapName, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Contains(t, cm.Data, "cloudcore.yaml")
+
+		// Verify serialized YAML config value
+		expectedBytes, err := yaml.Marshal(config)
+		assert.NoError(t, err)
+		assert.Equal(t, string(expectedBytes), cm.Data["cloudcore.yaml"])
+	})
+
+	t.Run("Fails to get ConfigMap", func(t *testing.T) {
+		fakeClient := fakekube.NewSimpleClientset()
+		patches := gomonkey.ApplyFunc(client.GetKubeClient, func() kubernetes.Interface {
+			return fakeClient
+		})
+		defer patches.Reset()
+
+		config := &v1alpha1.CloudCoreConfig{}
+		assert.NotPanics(t, func() {
+			updateCloudCoreConfigMap(config)
+		})
+
+		// Assert that get was attempted but no update action was initiated
+		actions := fakeClient.Actions()
+		assert.Len(t, actions, 1)
+		assert.Equal(t, "get", actions[0].GetVerb())
+	})
+
+	t.Run("Fails to update ConfigMap", func(t *testing.T) {
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.CloudConfigMapName,
+				Namespace: constants.SystemNamespace,
+			},
+			Data: map[string]string{},
+		}
+		fakeClient := fakekube.NewSimpleClientset(cm)
+		fakeClient.PrependReactor("update", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, nil, errors.New("simulated update error")
+		})
+
+		patches := gomonkey.ApplyFunc(client.GetKubeClient, func() kubernetes.Interface {
+			return fakeClient
+		})
+		defer patches.Reset()
+
+		config := &v1alpha1.CloudCoreConfig{}
+		assert.NotPanics(t, func() {
+			updateCloudCoreConfigMap(config)
+		})
+
+		// Assert both get and update actions were attempted
+		actions := fakeClient.Actions()
+		assert.Len(t, actions, 2)
+		assert.Equal(t, "get", actions[0].GetVerb())
+		assert.Equal(t, "update", actions[1].GetVerb())
+	})
+
+	t.Run("Successfully updates config map when Data is nil", func(t *testing.T) {
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.CloudConfigMapName,
+				Namespace: constants.SystemNamespace,
+			},
+			Data: nil,
+		}
+		fakeClient := fakekube.NewSimpleClientset(cm)
+
+		patches := gomonkey.ApplyFunc(client.GetKubeClient, func() kubernetes.Interface {
+			return fakeClient
+		})
+		defer patches.Reset()
+
+		config := &v1alpha1.CloudCoreConfig{}
+		assert.NotPanics(t, func() {
+			updateCloudCoreConfigMap(config)
+		})
+
+		// Assert both get and update actions were executed
+		actions := fakeClient.Actions()
+		assert.Len(t, actions, 2)
+		assert.Equal(t, "get", actions[0].GetVerb())
+		assert.Equal(t, "update", actions[1].GetVerb())
+
+		updatedCM, err := fakeClient.CoreV1().ConfigMaps(constants.SystemNamespace).Get(context.TODO(), constants.CloudConfigMapName, metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.NotNil(t, updatedCM.Data)
+		assert.Contains(t, updatedCM.Data, "cloudcore.yaml")
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind test
/kind bug

**What this PR does / why we need it**:
1. Covers edge cases in the CloudCore app lifecycle.
2. Resolves a `nil` map initialization panic found during testing.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Added the `kind/bug` label due to the production fix included alongside the tests.

**Does this PR introduce a user-facing change?**:
```release-note
Fix nil map panic and incomplete tunnel-port record handling in CloudCore.
```

