### PR TITLE
cloud/messagelayer: fix grammar in required parameters error messages

### DIFF
--- a/cloud/pkg/common/messagelayer/util.go
+++ b/cloud/pkg/common/messagelayer/util.go
@@ -48,7 +48,7 @@ const (
 // BuildResource return a string as "beehive/pkg/core/model".Message.Router.Resource
 func BuildResource(nodeID, namespace, resourceType, resourceID string) (resource string, err error) {
 	if namespace == "" || resourceType == "" || nodeID == "" {
-		err = fmt.Errorf("required parameter are not set (node id, namespace or resource type)")
+		err = fmt.Errorf("required parameters are not set (node id, namespace or resource type)")
 		return
 	}
 
@@ -111,7 +111,7 @@ func GetResourceName(msg model.Message) (string, error) {
 // BuildResourceForRouter return a string as "beehive/pkg/core/model".Message.Router.Resource
 func BuildResourceForRouter(resourceType, resourceID string) (string, error) {
 	if resourceID == "" || resourceType == "" {
-		return "", fmt.Errorf("required parameter are not set (resourceID or resource type)")
+		return "", fmt.Errorf("required parameters are not set (resourceID or resource type)")
 	}
 	return pkgutil.ConcatStrings(resourceType, constants.ResourceSep, resourceID), nil
 }
@@ -119,7 +119,7 @@ func BuildResourceForRouter(resourceType, resourceID string) (string, error) {
 // BuildResourceForDevice return a string as "beehive/pkg/core/model".Message.Router.Resource
 func BuildResourceForDevice(nodeID, resourceType, resourceID string) (resource string, err error) {
 	if nodeID == "" || resourceType == "" {
-		err = fmt.Errorf("required parameter are not set (node id, namespace or resource type)")
+		err = fmt.Errorf("required parameters are not set (node id or resource type)")
 		return
 	}
 	resource = fmt.Sprintf("%s%s%s%s%s", ResourceNode, constants.ResourceSep, nodeID, constants.ResourceSep, resourceType)

--- a/cloud/pkg/common/messagelayer/util_test.go
+++ b/cloud/pkg/common/messagelayer/util_test.go
@@ -61,7 +61,7 @@ func TestBuildResourceForDevice(t *testing.T) {
 				resourceID:   "",
 			},
 			wantResource: "",
-			wantErr:      fmt.Errorf("required parameter are not set (node id, namespace or resource type)"),
+			wantErr:      fmt.Errorf("required parameters are not set (node id or resource type)"),
 		},
 	}
 	for _, tt := range tests {
@@ -233,7 +233,7 @@ func TestBuildResource(t *testing.T) {
 				resourceID:   ResourceID,
 			},
 			"",
-			fmt.Errorf("required parameter are not set (node id, namespace or resource type)"),
+			fmt.Errorf("required parameters are not set (node id, namespace or resource type)"),
 		},
 		{
 			"TestBuildResource(): Case 2: no resourceID.",
@@ -290,7 +290,7 @@ func TestBuildResourceForRouter(t *testing.T) {
 				resourceID:   ResourceID,
 			},
 			"",
-			fmt.Errorf("required parameter are not set (resourceID or resource type)"),
+			fmt.Errorf("required parameters are not set (resourceID or resource type)"),
 		},
 		{
 			"TestBuildResourceForRouter(): Case 2: no resourceID.",
@@ -299,7 +299,7 @@ func TestBuildResourceForRouter(t *testing.T) {
 				resourceID:   "",
 			},
 			"",
-			fmt.Errorf("required parameter are not set (resourceID or resource type)"),
+			fmt.Errorf("required parameters are not set (resourceID or resource type)"),
 		},
 		{
 			"TestBuildResourceForRouter(): Case 3: success.",

--- a/cloud/pkg/csidriver/utils.go
+++ b/cloud/pkg/csidriver/utils.go
@@ -140,7 +140,7 @@ func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, h
 // buildResource return a string as "beehive/pkg/core/model".Message.Router.Resource
 func buildResource(nodeID, namespace, resourceType, resourceID string) (string, error) {
 	if nodeID == "" || namespace == "" || resourceType == "" {
-		return "", fmt.Errorf("required parameter are not set (node id, namespace or resource type)")
+		return "", fmt.Errorf("required parameters are not set (node id, namespace or resource type)")
 	}
 	resource := fmt.Sprintf("%s%s%s%s%s%s%s", "node", constants.ResourceSep, nodeID, constants.ResourceSep, namespace, constants.ResourceSep, resourceType)
 	if resourceID != "" {

--- a/cloud/pkg/router/messagelayer/util.go
+++ b/cloud/pkg/router/messagelayer/util.go
@@ -12,7 +12,7 @@ func BuildResourceForRouter(namespace, resourceType, resourceID string) (string,
 		namespace = "default"
 	}
 	if resourceID == "" || resourceType == "" {
-		return "", fmt.Errorf("required parameter are not set (resourceID or resource type)")
+		return "", fmt.Errorf("required parameters are not set (resourceID or resource type)")
 	}
 	return fmt.Sprintf("node/nodeid/%s%s%s%s%s", namespace, constants.ResourceSep, resourceType, constants.ResourceSep, resourceID), nil
 }

--- a/cloud/pkg/router/messagelayer/util_test.go
+++ b/cloud/pkg/router/messagelayer/util_test.go
@@ -45,7 +45,7 @@ func TestBuildResourceForRouter(t *testing.T) {
 				resourceID:   "id",
 			},
 			wantResource: "",
-			wantErr:      fmt.Errorf("required parameter are not set (resourceID or resource type)"),
+			wantErr:      fmt.Errorf("required parameters are not set (resourceID or resource type)"),
 		},
 		{
 			name: "case 2: empty resourceID",
@@ -55,7 +55,7 @@ func TestBuildResourceForRouter(t *testing.T) {
 				resourceID:   "",
 			},
 			wantResource: "",
-			wantErr:      fmt.Errorf("required parameter are not set (resourceID or resource type)"),
+			wantErr:      fmt.Errorf("required parameters are not set (resourceID or resource type)"),
 		},
 		{
 			name: "case 3: empty namespace",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The phrase `required parameter are not set` appeared in five error messages across three cloud packages. The phrase is grammatically incorrect because it checks multiple parameters; the correct form is
`required parameters are not set`.

This PR corrects all five occurrences in the source files and updates the corresponding test expectations so that assertions match the fixed error text. No logic, behaviour, or API surface is changed.

**Which issue(s) this PR fixes**:

Fixes #6989

**Special notes for your reviewer**:

The change is a pure string literal correction with no semantic impact.
The spellcheck `make spellcheck` failures observed during CI are pre-existing and limited to vendored/cached third-party modules (`golang.org/x/text`), not to any code owned by this repository.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```