### PR TITLE
docs: fix outdated test commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,8 @@ After that, run these local verifications before submitting pull request to pred
 fail of continuous integration.
 
 * Run and pass `make verify`
-* Run and pass `make edge_test` or `make cloud_test`
-* Run and pass `make edge_integration_test`
+* Run and pass `make test` (or `make test WHAT=cloud` / `make test WHAT=edge`)
+* Run and pass `make integrationtest`
 
 In addition to the above process, a bot will begin applying structured labels to your PR.
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

CONTRIBUTING.md (lines 97-99) instructs contributors to run `make edge_test`, `make cloud_test`, and `make edge_integration_test` as part of local verification before submitting a PR. None of these targets exist in the Makefile, so contributors following the doc hit `make: *** No rule to make target 'edge_test'.  Stop.`

This PR updates CONTRIBUTING.md to reference the current working Makefile targets: `make test` (with optional `WHAT=cloud` or `WHAT=edge`) and `make integrationtest`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6995

**Special notes for your reviewer**:

This is a doc-only change with no code impact. Verified locally that `make edge_test` etc. fail on current master, and that `make test WHAT=edge`, `make test WHAT=cloud`, and `make integrationtest` are valid targets in the Makefile.

**Does this PR introduce a user-facing change?**: 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
