### PR TITLE
edge/devicetwin: fix index out of range in dealMetaDeviceOperation

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -192,7 +192,7 @@ func (dw *DMIWorker) dealMetaDeviceOperation(_ *dtcontext.DTContext, _ string, m
 		}
 
 	default:
-		klog.Warningf("unsupported resource type %s", resources[3])
+		klog.Warningf("unsupported resource type %s", resources[1])
 	}
 
 	return nil

--- a/edge/pkg/devicetwin/dtmanager/dmiworker_test.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dtmanager
+
+import (
+	"testing"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+)
+
+// TestDealMetaDeviceOperation tests dealMetaDeviceOperation for the input
+// validation paths that do not require a DMI client or cache.
+func TestDealMetaDeviceOperation(t *testing.T) {
+	dw := &DMIWorker{}
+
+	tests := []struct {
+		name     string
+		msg      interface{}
+		wantErr  bool
+		errValue string
+	}{
+		{
+			name:     "MsgNotMessageType",
+			msg:      "not a message",
+			wantErr:  true,
+			errValue: "msg not Message type",
+		},
+		{
+			name: "WrongResourceSegmentCount",
+			msg: &model.Message{
+				Router: model.MessageRoute{Resource: "ns/device"},
+			},
+			wantErr:  true,
+			errValue: "wrong resources ns/device",
+		},
+		{
+			name: "UnsupportedResourceType",
+			msg: &model.Message{
+				Router: model.MessageRoute{Resource: "ns/unknowntype/name"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "DeviceWithInvalidContent",
+			msg: &model.Message{
+				Router:  model.MessageRoute{Resource: "ns/device/dev1"},
+				Content: []byte("invalid-json"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "DeviceModelWithInvalidContent",
+			msg: &model.Message{
+				Router:  model.MessageRoute{Resource: "ns/devicemodel/dm1"},
+				Content: []byte("invalid-json"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := dw.dealMetaDeviceOperation(nil, "", test.msg)
+			if (err != nil) != test.wantErr {
+				t.Errorf("dealMetaDeviceOperation() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if test.errValue != "" {
+				if err == nil {
+					t.Errorf("dealMetaDeviceOperation() expected error %q, got nil", test.errValue)
+				} else if err.Error() != test.errValue {
+					t.Errorf("dealMetaDeviceOperation() error = %q, want %q", err.Error(), test.errValue)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`dealMetaDeviceOperation` in `edge/pkg/devicetwin/dtmanager/dmiworker.go` validates that `message.Router.Resource` splits into exactly 3`/`-separated segments (valid indices 0-2), but the `default` branch of
the subsequent resource-type switch logged `resources[3]`, which is always out of range at that point. Any DMI message whose middle resource segment was neither `device` nor `devicemodel` (e.g.
`"ns/somethingelse/name"`) panicked the DMIWorker goroutine, crashing edgecore instead of logging an "unsupported resource type" warning and continuing.

The fix changes `resources[3]` to `resources[1]` (the type segment), matching the code's evident intent. Also adds `dealMetaDeviceOperation` unit test coverage, including the previously-panicking default branch, since the package had none.

**Which issue(s) this PR fixes**:

Fixes #6999 

**Special notes for your reviewer**:

One-line fix; the bulk of the diff is the new test file. Verified the panic reproduces on `master` before the fix and is gone after, via the new `TestDealMetaDeviceOperation/UnsupportedResourceType` subtest.

**Does this PR introduce a user-facing change?**:

```release-note
Fix a panic in edgecore's DMIWorker when it receives a device metadata message with an unsupported resource type.
```
