### PR TITLE
eventbus: fix data race on MQTT client during broker reconnect

### DIFF
--- a/edge/pkg/eventbus/eventbus.go
+++ b/edge/pkg/eventbus/eventbus.go
@@ -102,7 +102,7 @@ func (eb *eventbus) Start() {
 }
 
 func pubMQTT(topic string, payload []byte) {
-	token := mqttBus.MQTTHub.PubCli().Publish(topic, 1, false, payload)
+	token := mqttBus.MQTTHub.Publish(topic, 1, false, payload)
 	if token.WaitTimeout(util.TokenWaitTime) && token.Error() != nil {
 		klog.Errorf("Error in pubMQTT with topic: %s, %v", topic, token.Error())
 	} else {
@@ -201,7 +201,7 @@ func (eb *eventbus) subscribe(topic string) {
 
 	if eventconfig.Config.MqttMode >= v1alpha2.MqttModeBoth {
 		// subscribe topic to external mqtt broker.
-		token := mqttBus.MQTTHub.SubCli().Subscribe(topic, 1, mqttBus.OnSubMessageReceived)
+		token := mqttBus.MQTTHub.Subscribe(topic, 1, mqttBus.OnSubMessageReceived)
 		if rs, err := util.CheckClientToken(token); !rs {
 			klog.Errorf("Edge-hub-cli subscribe topic: %s, %v", topic, err)
 			return
@@ -220,7 +220,7 @@ func (eb *eventbus) unsubscribe(topic string) {
 	}
 
 	if eventconfig.Config.MqttMode >= v1alpha2.MqttModeBoth {
-		token := mqttBus.MQTTHub.SubCli().Unsubscribe(topic)
+		token := mqttBus.MQTTHub.Unsubscribe(topic)
 		if rs, err := util.CheckClientToken(token); !rs {
 			klog.Errorf("Edge-hub-cli unsubscribe topic: %s, %v", topic, err)
 			return

--- a/edge/pkg/eventbus/eventbus.go
+++ b/edge/pkg/eventbus/eventbus.go
@@ -102,7 +102,7 @@ func (eb *eventbus) Start() {
 }
 
 func pubMQTT(topic string, payload []byte) {
-	token := mqttBus.MQTTHub.PubCli.Publish(topic, 1, false, payload)
+	token := mqttBus.MQTTHub.PubCli().Publish(topic, 1, false, payload)
 	if token.WaitTimeout(util.TokenWaitTime) && token.Error() != nil {
 		klog.Errorf("Error in pubMQTT with topic: %s, %v", topic, token.Error())
 	} else {
@@ -201,7 +201,7 @@ func (eb *eventbus) subscribe(topic string) {
 
 	if eventconfig.Config.MqttMode >= v1alpha2.MqttModeBoth {
 		// subscribe topic to external mqtt broker.
-		token := mqttBus.MQTTHub.SubCli.Subscribe(topic, 1, mqttBus.OnSubMessageReceived)
+		token := mqttBus.MQTTHub.SubCli().Subscribe(topic, 1, mqttBus.OnSubMessageReceived)
 		if rs, err := util.CheckClientToken(token); !rs {
 			klog.Errorf("Edge-hub-cli subscribe topic: %s, %v", topic, err)
 			return
@@ -220,7 +220,7 @@ func (eb *eventbus) unsubscribe(topic string) {
 	}
 
 	if eventconfig.Config.MqttMode >= v1alpha2.MqttModeBoth {
-		token := mqttBus.MQTTHub.SubCli.Unsubscribe(topic)
+		token := mqttBus.MQTTHub.SubCli().Unsubscribe(topic)
 		if rs, err := util.CheckClientToken(token); !rs {
 			klog.Errorf("Edge-hub-cli unsubscribe topic: %s, %v", topic, err)
 			return

--- a/edge/pkg/eventbus/mqtt/client.go
+++ b/edge/pkg/eventbus/mqtt/client.go
@@ -103,13 +103,27 @@ type AccessInfo struct {
 	Content []byte `json:"content"`
 }
 
-func onPubConnectionLost(_ MQTT.Client, err error) {
+func onPubConnectionLost(client MQTT.Client, err error) {
 	klog.Errorf("onPubConnectionLost with error: %v", err)
+	// Ignore the event when it comes from a client that has already been
+	// replaced; otherwise a superseded client would reconnect and displace the
+	// current active one, starting an extra connection loop.
+	if MQTTHub == nil || client != MQTTHub.PubCli() {
+		klog.Warning("ignore connection lost event from a superseded pub client")
+		return
+	}
 	go MQTTHub.InitPubClient()
 }
 
-func onSubConnectionLost(_ MQTT.Client, err error) {
+func onSubConnectionLost(client MQTT.Client, err error) {
 	klog.Errorf("onSubConnectionLost with error: %v", err)
+	// Ignore the event when it comes from a client that has already been
+	// replaced; otherwise a superseded client would reconnect and displace the
+	// current active one, starting an extra connection loop.
+	if MQTTHub == nil || client != MQTTHub.SubCli() {
+		klog.Warning("ignore connection lost event from a superseded sub client")
+		return
+	}
 	go MQTTHub.InitSubClient()
 }
 

--- a/edge/pkg/eventbus/mqtt/client.go
+++ b/edge/pkg/eventbus/mqtt/client.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
@@ -11,6 +12,10 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/eventbus/common/util"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
 )
+
+// disconnectQuiesce is the milliseconds paho waits to finish in-flight work
+// when disconnecting a client that is being replaced on reconnect.
+const disconnectQuiesce = 250
 
 const UploadTopic = "SYS/dis/upload_records"
 
@@ -66,8 +71,28 @@ type Client struct {
 	SubClientID string
 	Username    string
 	Password    string
-	PubCli      MQTT.Client
-	SubCli      MQTT.Client
+
+	// cliLock guards pubCli and subCli, which are reassigned from the
+	// connection-lost callbacks while the eventbus loop reads them.
+	cliLock sync.RWMutex
+	pubCli  MQTT.Client
+	subCli  MQTT.Client
+}
+
+// PubCli returns the publish client. It is safe to call concurrently with the
+// reconnect path that reassigns the client.
+func (mq *Client) PubCli() MQTT.Client {
+	mq.cliLock.RLock()
+	defer mq.cliLock.RUnlock()
+	return mq.pubCli
+}
+
+// SubCli returns the subscribe client. It is safe to call concurrently with the
+// reconnect path that reassigns the client.
+func (mq *Client) SubCli() MQTT.Client {
+	mq.cliLock.RLock()
+	defer mq.cliLock.RUnlock()
+	return mq.subCli
 }
 
 // AccessInfo that deliver between edge-hub and cloud-hub
@@ -138,8 +163,19 @@ func (mq *Client) InitSubClient() {
 	subOpts.OnConnect = onSubConnect
 	subOpts.AutoReconnect = false
 	subOpts.OnConnectionLost = onSubConnectionLost
-	mq.SubCli = MQTT.NewClient(subOpts)
-	util.LoopConnect(mq.SubClientID, mq.SubCli)
+	cli := MQTT.NewClient(subOpts)
+
+	mq.cliLock.Lock()
+	old := mq.subCli
+	mq.subCli = cli
+	mq.cliLock.Unlock()
+	// release the client being replaced, otherwise its goroutines leak on every
+	// broker reconnect.
+	if old != nil {
+		old.Disconnect(disconnectQuiesce)
+	}
+
+	util.LoopConnect(mq.SubClientID, cli)
 	klog.Info("finish hub-client sub")
 }
 
@@ -157,7 +193,18 @@ func (mq *Client) InitPubClient() {
 	pubOpts := util.HubClientInit(mq.MQTTUrl, mq.PubClientID, mq.Username, mq.Password)
 	pubOpts.OnConnectionLost = onPubConnectionLost
 	pubOpts.AutoReconnect = false
-	mq.PubCli = MQTT.NewClient(pubOpts)
-	util.LoopConnect(mq.PubClientID, mq.PubCli)
+	cli := MQTT.NewClient(pubOpts)
+
+	mq.cliLock.Lock()
+	old := mq.pubCli
+	mq.pubCli = cli
+	mq.cliLock.Unlock()
+	// release the client being replaced, otherwise its goroutines leak on every
+	// broker reconnect.
+	if old != nil {
+		old.Disconnect(disconnectQuiesce)
+	}
+
+	util.LoopConnect(mq.PubClientID, cli)
 	klog.Info("finish hub-client pub")
 }

--- a/edge/pkg/eventbus/mqtt/client.go
+++ b/edge/pkg/eventbus/mqtt/client.go
@@ -73,26 +73,56 @@ type Client struct {
 	Password    string
 
 	// cliLock guards pubCli and subCli, which are reassigned from the
-	// connection-lost callbacks while the eventbus loop reads them.
+	// connection-lost callbacks while the eventbus loop uses them.
 	cliLock sync.RWMutex
 	pubCli  MQTT.Client
 	subCli  MQTT.Client
+
+	// pubInitLock and subInitLock serialize the full reconnect lifecycle
+	// (build, swap, disconnect the replaced client, connect) so concurrent
+	// connection-lost callbacks cannot interleave and reconnect a client that
+	// has already been replaced.
+	pubInitLock sync.Mutex
+	subInitLock sync.Mutex
 }
 
-// PubCli returns the publish client. It is safe to call concurrently with the
-// reconnect path that reassigns the client.
-func (mq *Client) PubCli() MQTT.Client {
+// Publish publishes on the current publish client while holding the read lock,
+// so the reconnect path cannot replace and disconnect the client during the
+// call.
+func (mq *Client) Publish(topic string, qos byte, retained bool, payload interface{}) MQTT.Token {
 	mq.cliLock.RLock()
 	defer mq.cliLock.RUnlock()
-	return mq.pubCli
+	return mq.pubCli.Publish(topic, qos, retained, payload)
 }
 
-// SubCli returns the subscribe client. It is safe to call concurrently with the
-// reconnect path that reassigns the client.
-func (mq *Client) SubCli() MQTT.Client {
+// Subscribe subscribes on the current subscribe client while holding the read
+// lock; see Publish for the rationale.
+func (mq *Client) Subscribe(topic string, qos byte, callback MQTT.MessageHandler) MQTT.Token {
 	mq.cliLock.RLock()
 	defer mq.cliLock.RUnlock()
-	return mq.subCli
+	return mq.subCli.Subscribe(topic, qos, callback)
+}
+
+// Unsubscribe unsubscribes on the current subscribe client while holding the
+// read lock; see Publish for the rationale.
+func (mq *Client) Unsubscribe(topics ...string) MQTT.Token {
+	mq.cliLock.RLock()
+	defer mq.cliLock.RUnlock()
+	return mq.subCli.Unsubscribe(topics...)
+}
+
+// isActivePubClient reports whether client is the current publish client.
+func (mq *Client) isActivePubClient(client MQTT.Client) bool {
+	mq.cliLock.RLock()
+	defer mq.cliLock.RUnlock()
+	return mq.pubCli == client
+}
+
+// isActiveSubClient reports whether client is the current subscribe client.
+func (mq *Client) isActiveSubClient(client MQTT.Client) bool {
+	mq.cliLock.RLock()
+	defer mq.cliLock.RUnlock()
+	return mq.subCli == client
 }
 
 // AccessInfo that deliver between edge-hub and cloud-hub
@@ -108,7 +138,7 @@ func onPubConnectionLost(client MQTT.Client, err error) {
 	// Ignore the event when it comes from a client that has already been
 	// replaced; otherwise a superseded client would reconnect and displace the
 	// current active one, starting an extra connection loop.
-	if MQTTHub == nil || client != MQTTHub.PubCli() {
+	if MQTTHub == nil || !MQTTHub.isActivePubClient(client) {
 		klog.Warning("ignore connection lost event from a superseded pub client")
 		return
 	}
@@ -120,7 +150,7 @@ func onSubConnectionLost(client MQTT.Client, err error) {
 	// Ignore the event when it comes from a client that has already been
 	// replaced; otherwise a superseded client would reconnect and displace the
 	// current active one, starting an extra connection loop.
-	if MQTTHub == nil || client != MQTTHub.SubCli() {
+	if MQTTHub == nil || !MQTTHub.isActiveSubClient(client) {
 		klog.Warning("ignore connection lost event from a superseded sub client")
 		return
 	}
@@ -164,6 +194,10 @@ func OnSubMessageReceived(_ MQTT.Client, msg MQTT.Message) {
 
 // InitSubClient init sub client
 func (mq *Client) InitSubClient() {
+	// Serialize the whole lifecycle so concurrent connection-lost callbacks
+	// cannot interleave and reconnect a client that has already been replaced.
+	mq.subInitLock.Lock()
+	defer mq.subInitLock.Unlock()
 	timeStr := strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
 	right := len(timeStr)
 	if right > 10 {
@@ -195,6 +229,10 @@ func (mq *Client) InitSubClient() {
 
 // InitPubClient init pub client
 func (mq *Client) InitPubClient() {
+	// Serialize the whole lifecycle so concurrent connection-lost callbacks
+	// cannot interleave and reconnect a client that has already been replaced.
+	mq.pubInitLock.Lock()
+	defer mq.pubInitLock.Unlock()
 	timeStr := strconv.FormatInt(time.Now().UnixNano()/1e6, 10)
 	right := len(timeStr)
 	if right > 10 {

--- a/edge/pkg/eventbus/mqtt/client_test.go
+++ b/edge/pkg/eventbus/mqtt/client_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -485,4 +486,61 @@ func TestAccessInfoStruct(t *testing.T) {
 	assert.Equal(t, "test-type", info.Type)
 	assert.Equal(t, "test/topic", info.Topic)
 	assert.Equal(t, []byte("test-content"), info.Content)
+}
+
+// TestClientReassignRace runs the reconnect path (which reassigns pubCli/subCli)
+// concurrently with the accessors that the eventbus loop uses to read them. It
+// must be run under -race: before the fix, reading PubCli/SubCli while the
+// connection-lost callback reassigned them was a data race.
+func TestClientReassignRace(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(MQTT.NewClient, func(_ *MQTT.ClientOptions) MQTT.Client {
+		return NewTestMQTTClient()
+	})
+	patches.ApplyFunc(util.HubClientInit, func(_, _, _, _ string) *MQTT.ClientOptions {
+		return &MQTT.ClientOptions{}
+	})
+	patches.ApplyFunc(util.LoopConnect, func(_ string, _ MQTT.Client) {})
+
+	mq := &Client{
+		MQTTUrl:     "tcp://localhost:1883",
+		PubClientID: "pub-id",
+		SubClientID: "sub-id",
+	}
+	mq.InitPubClient()
+	mq.InitSubClient()
+
+	stop := make(chan struct{})
+	var readers, writers sync.WaitGroup
+
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = mq.PubCli()
+					_ = mq.SubCli()
+				}
+			}
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for j := 0; j < 50; j++ {
+				mq.InitPubClient()
+				mq.InitSubClient()
+			}
+		}()
+	}
+
+	writers.Wait()
+	close(stop)
+	readers.Wait()
 }

--- a/edge/pkg/eventbus/mqtt/client_test.go
+++ b/edge/pkg/eventbus/mqtt/client_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -543,4 +544,40 @@ func TestClientReassignRace(t *testing.T) {
 	writers.Wait()
 	close(stop)
 	readers.Wait()
+}
+
+// TestOnConnectionLostSupersededClient verifies that a connection-lost event from
+// a client that has already been replaced does not trigger another reconnect,
+// while an event from the current active client does.
+func TestOnConnectionLostSupersededClient(t *testing.T) {
+	origMQTTHub := MQTTHub
+	defer func() { MQTTHub = origMQTTHub }()
+
+	active := NewTestMQTTClient()
+	superseded := NewTestMQTTClient()
+	MQTTHub = &Client{pubCli: active, subCli: active}
+
+	var pubReconnects, subReconnects int32
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethod(reflect.TypeOf(MQTTHub), "InitPubClient", func(_ *Client) {
+		atomic.AddInt32(&pubReconnects, 1)
+	})
+	patches.ApplyMethod(reflect.TypeOf(MQTTHub), "InitSubClient", func(_ *Client) {
+		atomic.AddInt32(&subReconnects, 1)
+	})
+
+	// a superseded client is ignored: no reconnect goroutine is started, so the
+	// counters stay at zero.
+	onPubConnectionLost(superseded, errors.New("connection lost"))
+	onSubConnectionLost(superseded, errors.New("connection lost"))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&pubReconnects))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&subReconnects))
+
+	// the active client triggers exactly one reconnect for each direction.
+	onPubConnectionLost(active, errors.New("connection lost"))
+	onSubConnectionLost(active, errors.New("connection lost"))
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt32(&pubReconnects) == 1 && atomic.LoadInt32(&subReconnects) == 1
+	}, time.Second, 10*time.Millisecond)
 }

--- a/edge/pkg/eventbus/mqtt/client_test.go
+++ b/edge/pkg/eventbus/mqtt/client_test.go
@@ -583,3 +583,22 @@ func TestOnConnectionLostSupersededClient(t *testing.T) {
 		return atomic.LoadInt32(&pubReconnects) == 1 && atomic.LoadInt32(&subReconnects) == 1
 	}, time.Second, 10*time.Millisecond)
 }
+
+// TestClientOperations verifies the lock-guarded Publish/Subscribe/Unsubscribe
+// wrappers delegate to the current pub/sub client.
+func TestClientOperations(t *testing.T) {
+	pub := NewTestMQTTClient()
+	sub := NewTestMQTTClient()
+	mq := &Client{pubCli: pub, subCli: sub}
+
+	pubToken := mq.Publish("topic/pub", 1, false, []byte("payload"))
+	assert.NotNil(t, pubToken)
+	assert.Equal(t, []byte("payload"), pub.publishTopics["topic/pub"])
+
+	subToken := mq.Subscribe("topic/sub", 1, nil)
+	assert.NotNil(t, subToken)
+	assert.True(t, sub.subscribeTopics["topic/sub"])
+
+	unsubToken := mq.Unsubscribe("topic/sub")
+	assert.NotNil(t, unsubToken)
+}

--- a/edge/pkg/eventbus/mqtt/client_test.go
+++ b/edge/pkg/eventbus/mqtt/client_test.go
@@ -296,12 +296,12 @@ func TestOnPubConnectionLost(t *testing.T) {
 	origMQTTHub := MQTTHub
 	defer func() { MQTTHub = origMQTTHub }()
 
-	initCalled := false
+	var initCalled atomic.Bool
 	MQTTHub = &Client{}
 
 	patch := gomonkey.ApplyMethod(reflect.TypeOf(MQTTHub), "InitPubClient",
 		func(_ *Client) {
-			initCalled = true
+			initCalled.Store(true)
 		})
 	defer patch.Reset()
 
@@ -309,19 +309,19 @@ func TestOnPubConnectionLost(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	assert.True(t, initCalled, "InitPubClient should be called")
+	assert.True(t, initCalled.Load(), "InitPubClient should be called")
 }
 
 func TestOnSubConnectionLost(t *testing.T) {
 	origMQTTHub := MQTTHub
 	defer func() { MQTTHub = origMQTTHub }()
 
-	initCalled := false
+	var initCalled atomic.Bool
 	MQTTHub = &Client{}
 
 	patch := gomonkey.ApplyMethod(reflect.TypeOf(MQTTHub), "InitSubClient",
 		func(_ *Client) {
-			initCalled = true
+			initCalled.Store(true)
 		})
 	defer patch.Reset()
 
@@ -329,7 +329,7 @@ func TestOnSubConnectionLost(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	assert.True(t, initCalled, "InitSubClient should be called")
+	assert.True(t, initCalled.Load(), "InitSubClient should be called")
 }
 
 func TestOnSubConnect(t *testing.T) {
@@ -524,8 +524,10 @@ func TestClientReassignRace(t *testing.T) {
 				case <-stop:
 					return
 				default:
-					_ = mq.PubCli()
-					_ = mq.SubCli()
+					// exercise the lock-guarded reads of pubCli/subCli
+					// concurrently with the writers reassigning them.
+					_ = mq.isActivePubClient(nil)
+					_ = mq.isActiveSubClient(nil)
 				}
 			}
 		}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:


The eventbus MQTT client handles (`PubCli`/`SubCli`) were read by the eventbus
loop (publish/subscribe/unsubscribe) while the paho connection lost callbacks
reassigned them from a separate goroutine, with no synchronization. Since the
handles are interface values, a broker disconnect (common on an edge node) could
race a concurrent read against the reassignment, producing a torn read and a
publish/subscribe on a half constructed client. `AutoReconnect` is disabled, so
this reassign on reconnect path is the normal one, not an edge case.

This unexports the two handles and guards them with a `RWMutex`, exposing them
through `PubCli()`/`SubCli()` accessors, so every read and the reassignment are
serialized. It also `Disconnect()`s the client being replaced, which otherwise
leaks its goroutines on every broker reconnect.

A related follow up (left out to keep this focused): `util.LoopConnect` does not
honor `beehiveContext.Done()`, so an in flight connect loop can't be reaped on
module shutdown. That change touches a shared util's signature and its tests, so
it is better as its own PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7000

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a data race on the eventbus MQTT client when the connection to the broker is lost and re-established.
```
