### PR TITLE
dynamiccontroller: handle optional EndpointSlice port fields

### DIFF
--- a/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster.go
+++ b/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster.go
@@ -80,13 +80,14 @@ func (f *FilterImpl) FilterResource(_ string, obj runtime.Object) {
 			if eps.Ports[i].Name == nil || *eps.Ports[i].Name != defaultEndpointSlicePortName {
 				continue
 			}
-			eps.Ports[i].Port = &f.port
-			unstrRaw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&eps)
-			if err != nil {
-				klog.Errorf("default endpointslice %v convert to unstructure error: %v", eps.Name, err)
-				return
-			}
-			unstruct.SetUnstructuredContent(unstrRaw)
+			port := f.port
+			eps.Ports[i].Port = &port
 		}
+		unstrRaw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&eps)
+		if err != nil {
+			klog.Errorf("default endpointslice %v convert to unstructure error: %v", eps.Name, err)
+			return
+		}
+		unstruct.SetUnstructuredContent(unstrRaw)
 	}
 }

--- a/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster.go
+++ b/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster.go
@@ -77,10 +77,10 @@ func (f *FilterImpl) FilterResource(_ string, obj runtime.Object) {
 		eps.Endpoints[0].Addresses = eps.Endpoints[0].Addresses[:1]
 		eps.Endpoints[0].Addresses[0] = defaultMetaServerIP
 		for i := range eps.Ports {
-			if *(eps.Ports[i].Name) != defaultEndpointSlicePortName {
+			if eps.Ports[i].Name == nil || *eps.Ports[i].Name != defaultEndpointSlicePortName {
 				continue
 			}
-			*(eps.Ports[i].Port) = defaultMetaServerPort
+			eps.Ports[i].Port = &f.port
 			unstrRaw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&eps)
 			if err != nil {
 				klog.Errorf("default endpointslice %v convert to unstructure error: %v", eps.Name, err)

--- a/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster_test.go
@@ -175,6 +175,7 @@ func TestFilterResourceOptionalEndpointPortFields(t *testing.T) {
 			var filteredEndpointSlice discovery.EndpointSlice
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &filteredEndpointSlice)
 			assert.NoError(t, err)
+			assert.Equal(t, defaultMetaServerIP, filteredEndpointSlice.Endpoints[0].Addresses[0])
 			for i := range tt.wantPorts {
 				assert.Equal(t, tt.wantPorts[i], filteredEndpointSlice.Ports[i].Port)
 			}

--- a/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/defaultmaster/defaultmaster_test.go
@@ -126,3 +126,58 @@ func TestFilterResource(t *testing.T) {
 	assert.Equal(int32(defaultMetaServerPort), *filteredEndpointSlice.Ports[0].Port)
 	assert.Equal(defaultEndpointSlicePortName, *filteredEndpointSlice.Ports[0].Name)
 }
+
+func TestFilterResourceOptionalEndpointPortFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		ports     []discovery.EndpointPort
+		wantPorts []*int32
+	}{
+		{
+			name: "unnamed port is ignored",
+			ports: []discovery.EndpointPort{{
+				Port: func(i int32) *int32 { return &i }(443),
+			}},
+			wantPorts: []*int32{func(i int32) *int32 { return &i }(443)},
+		},
+		{
+			name: "https port without number is rewritten",
+			ports: []discovery.EndpointPort{{
+				Name: func(s string) *string { return &s }(defaultEndpointSlicePortName),
+			}},
+			wantPorts: []*int32{func(i int32) *int32 { return &i }(defaultMetaServerPort)},
+		},
+		{
+			name: "unnamed port does not block https port rewrite",
+			ports: []discovery.EndpointPort{
+				{Port: func(i int32) *int32 { return &i }(443)},
+				{Name: func(s string) *string { return &s }(defaultEndpointSlicePortName)},
+			},
+			wantPorts: []*int32{
+				func(i int32) *int32 { return &i }(443),
+				func(i int32) *int32 { return &i }(defaultMetaServerPort),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpointSlice := &discovery.EndpointSlice{
+				Endpoints: []discovery.Endpoint{{Addresses: []string{"192.168.1.1"}}},
+				Ports:     tt.ports,
+			}
+			unstr, err := runtime.DefaultUnstructuredConverter.ToUnstructured(endpointSlice)
+			assert.NoError(t, err)
+			unstructuredObj := &unstructured.Unstructured{Object: unstr}
+
+			newDefaultMasterFilter().FilterResource("", unstructuredObj)
+
+			var filteredEndpointSlice discovery.EndpointSlice
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &filteredEndpointSlice)
+			assert.NoError(t, err)
+			for i := range tt.wantPorts {
+				assert.Equal(t, tt.wantPorts[i], filteredEndpointSlice.Ports[i].Port)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The dynamic controller's default-master EndpointSlice filter dereferenced the optional `EndpointPort.Name` and `EndpointPort.Port` fields without nil checks.

This change:

- ignores unnamed EndpointSlice ports instead of panicking;
- assigns the metaserver port pointer for a matching `https` entry, including when its original port is omitted;
- adds regression tests for nil name, nil port, and mixed port entries.

Both reported panic paths were reproduced independently before applying the fix:

- nil `Name` panicked at `defaultmaster.go:80`;
- nil `Port` panicked at `defaultmaster.go:83`.

**Which issue(s) this PR fixes**:

Fixes #7003

**Special notes for your reviewer**:

Verified with:

```text
go test ./cloud/pkg/dynamiccontroller/filter/defaultmaster -count=1
go test ./cloud/pkg/dynamiccontroller/filter/... -count=1
go test -race ./cloud/pkg/dynamiccontroller/filter/defaultmaster -count=1
```

The focused package suite was also run twice after the initial fix.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a CloudCore panic when the dynamic controller processes EndpointSlice ports with omitted optional fields.
```