### PR TITLE
dynamiccontroller: skip EndpointSlices without node names

### DIFF
--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
@@ -89,6 +89,9 @@ func filterEndpointSlice(targetNode string, obj runtime.Object) {
 	}
 	var epsTmp []discovery.Endpoint
 	for _, ep := range epSlice.Endpoints {
+		if ep.NodeName == nil {
+			continue
+		}
 		if filter.IsBelongToSameGroup(targetNode, *ep.NodeName) {
 			epsTmp = append(epsTmp, ep)
 		}

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
@@ -191,6 +191,9 @@ func TestFilterEndpointSlice(t *testing.T) {
 		},
 		Endpoints: []discovery.Endpoint{
 			{
+				Addresses: []string{"192.168.1.0"},
+			},
+			{
 				Addresses: []string{"192.168.1.1"},
 				NodeName:  &n1,
 			},
@@ -213,6 +216,7 @@ func TestFilterEndpointSlice(t *testing.T) {
 
 	assert.Len(t, result.Endpoints, 1, "Should only include endpoints from node1")
 	assert.Equal(t, nodeName1, *result.Endpoints[0].NodeName)
+	assert.Equal(t, []string{"192.168.1.1"}, result.Endpoints[0].Addresses)
 }
 
 // func TestFilterEndpoints(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The dynamic-controller EndpointSlice filter dereferenced the optional `Endpoint.NodeName` field while filtering endpoints by node group. A valid EndpointSlice may omit this field, which caused a CloudCore nil-pointer panic.

This change skips endpoints without a node name, matching the existing behavior of the legacy `Endpoints` filtering path.

The existing EndpointSlice test now includes an endpoint without a node name and verifies that it is skipped while the target-node endpoint remains.

**Which issue(s) this PR fixes**:

Fixes #7007

**Special notes for your reviewer**:

Before this change, the updated focused test reproducibly panicked at the `*ep.NodeName` dereference in `filterEndpointSlice`.

Verified with:

```text
go test ./cloud/pkg/dynamiccontroller/filter/endpointresource -run TestFilterEndpointSlice -count=1
go test ./cloud/pkg/dynamiccontroller/filter/endpointresource -count=1
go test ./cloud/pkg/dynamiccontroller/filter/... -count=1
go test -race ./cloud/pkg/dynamiccontroller/filter/endpointresource -count=1
go vet ./cloud/pkg/dynamiccontroller/filter/endpointresource
```

**Does this PR introduce a user-facing change?**

```release-note
Fixed a CloudCore panic when dynamic-controller filters an EndpointSlice with an endpoint that has no node name.
```