### PR TITLE
refactor(cloud/dynamiccontroller): replace context.TODO with context.Background

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application.go
+++ b/cloud/pkg/dynamiccontroller/application/application.go
@@ -107,7 +107,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.OptionTo(option); err != nil {
 			return nil, err
 		}
-		list, err := c.dynamicClient.Resource(gvr).Namespace(ns).List(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), *option)
+		list, err := c.dynamicClient.Resource(gvr).Namespace(ns).List(utilcontext.WithEdgeNode(context.Background(), app.Nodename), *option)
 		if err != nil {
 			return nil, fmt.Errorf("get current list error: %v", err)
 		}
@@ -130,7 +130,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.OptionTo(option); err != nil {
 			return nil, err
 		}
-		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Get(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), name, *option)
+		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Get(utilcontext.WithEdgeNode(context.Background(), app.Nodename), name, *option)
 		if err != nil {
 			return nil, err
 		}
@@ -147,9 +147,9 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		var retObj interface{}
 		var err error
 		if app.Subresource == "" {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), obj, *option)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option)
 		} else {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), obj, *option, app.Subresource)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option, app.Subresource)
 		}
 		if err != nil {
 			return nil, err
@@ -160,7 +160,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.OptionTo(&option); err != nil {
 			return nil, err
 		}
-		if err := c.dynamicClient.Resource(gvr).Namespace(ns).Delete(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), name, *option); err != nil {
+		if err := c.dynamicClient.Resource(gvr).Namespace(ns).Delete(utilcontext.WithEdgeNode(context.Background(), app.Nodename), name, *option); err != nil {
 			return nil, err
 		}
 		return nil, nil
@@ -176,9 +176,9 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		var retObj interface{}
 		var err error
 		if app.Subresource == "" {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), obj, *option)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option)
 		} else {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), obj, *option, app.Subresource)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option, app.Subresource)
 		}
 		if err != nil {
 			return nil, err
@@ -193,7 +193,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.ReqBodyTo(obj); err != nil {
 			return nil, err
 		}
-		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).UpdateStatus(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), obj, *option)
+		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).UpdateStatus(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option)
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +203,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.OptionTo(pi); err != nil {
 			return nil, err
 		}
-		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Patch(utilcontext.WithEdgeNode(context.TODO(), app.Nodename), pi.Name, pi.PatchType, pi.Data, pi.Options, pi.Subresources...)
+		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Patch(utilcontext.WithEdgeNode(context.Background(), app.Nodename), pi.Name, pi.PatchType, pi.Data, pi.Options, pi.Subresources...)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +219,7 @@ func (c *Center) passThroughRequest(app *metaserver.Application) (interface{}, e
 		return nil, fmt.Errorf("converting kubeClient to *kubernetes.Clientset type failed")
 	}
 	verb := strings.ToUpper(string(app.Verb))
-	return kubeClient.RESTClient().Verb(verb).AbsPath(app.Key).Body(app.ReqBody).Do(utilcontext.WithEdgeNode(context.TODO(), app.Nodename)).Raw()
+	return kubeClient.RESTClient().Verb(verb).AbsPath(app.Key).Body(app.ReqBody).Do(utilcontext.WithEdgeNode(context.Background(), app.Nodename)).Raw()
 }
 
 // Response update application, generate and send resp message to edge
@@ -370,7 +370,7 @@ func (c *Center) checkNodePermission(app *metaserver.Application) error {
 			Groups: []string{constants.NodesGroup},
 		},
 	}
-	ret, err := c.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), subjectAccessReview, metav1.CreateOptions{})
+	ret, err := c.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(context.Background(), subjectAccessReview, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("node %s permission check failed: %v", app.Nodename, err)
 	}

--- a/cloud/pkg/dynamiccontroller/application/application.go
+++ b/cloud/pkg/dynamiccontroller/application/application.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -101,13 +102,16 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 	app.Status = metaserver.InProcessing
 	gvr, ns, name := metaserver.ParseKey(app.Key)
 
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	switch app.Verb {
 	case metaserver.List:
 		var option = new(metav1.ListOptions)
 		if err := app.OptionTo(option); err != nil {
 			return nil, err
 		}
-		list, err := c.dynamicClient.Resource(gvr).Namespace(ns).List(utilcontext.WithEdgeNode(context.Background(), app.Nodename), *option)
+		list, err := c.dynamicClient.Resource(gvr).Namespace(ns).List(utilcontext.WithEdgeNode(ctx, app.Nodename), *option)
 		if err != nil {
 			return nil, fmt.Errorf("get current list error: %v", err)
 		}
@@ -130,7 +134,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.OptionTo(option); err != nil {
 			return nil, err
 		}
-		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Get(utilcontext.WithEdgeNode(context.Background(), app.Nodename), name, *option)
+		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Get(utilcontext.WithEdgeNode(ctx, app.Nodename), name, *option)
 		if err != nil {
 			return nil, err
 		}
@@ -147,9 +151,9 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		var retObj interface{}
 		var err error
 		if app.Subresource == "" {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(ctx, app.Nodename), obj, *option)
 		} else {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option, app.Subresource)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Create(utilcontext.WithEdgeNode(ctx, app.Nodename), obj, *option, app.Subresource)
 		}
 		if err != nil {
 			return nil, err
@@ -160,7 +164,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.OptionTo(&option); err != nil {
 			return nil, err
 		}
-		if err := c.dynamicClient.Resource(gvr).Namespace(ns).Delete(utilcontext.WithEdgeNode(context.Background(), app.Nodename), name, *option); err != nil {
+		if err := c.dynamicClient.Resource(gvr).Namespace(ns).Delete(utilcontext.WithEdgeNode(ctx, app.Nodename), name, *option); err != nil {
 			return nil, err
 		}
 		return nil, nil
@@ -176,9 +180,9 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		var retObj interface{}
 		var err error
 		if app.Subresource == "" {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(ctx, app.Nodename), obj, *option)
 		} else {
-			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option, app.Subresource)
+			retObj, err = c.dynamicClient.Resource(gvr).Namespace(ns).Update(utilcontext.WithEdgeNode(ctx, app.Nodename), obj, *option, app.Subresource)
 		}
 		if err != nil {
 			return nil, err
@@ -193,7 +197,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.ReqBodyTo(obj); err != nil {
 			return nil, err
 		}
-		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).UpdateStatus(utilcontext.WithEdgeNode(context.Background(), app.Nodename), obj, *option)
+		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).UpdateStatus(utilcontext.WithEdgeNode(ctx, app.Nodename), obj, *option)
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +207,7 @@ func (c *Center) ProcessApplication(app *metaserver.Application) (interface{}, e
 		if err := app.OptionTo(pi); err != nil {
 			return nil, err
 		}
-		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Patch(utilcontext.WithEdgeNode(context.Background(), app.Nodename), pi.Name, pi.PatchType, pi.Data, pi.Options, pi.Subresources...)
+		retObj, err := c.dynamicClient.Resource(gvr).Namespace(ns).Patch(utilcontext.WithEdgeNode(ctx, app.Nodename), pi.Name, pi.PatchType, pi.Data, pi.Options, pi.Subresources...)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +223,9 @@ func (c *Center) passThroughRequest(app *metaserver.Application) (interface{}, e
 		return nil, fmt.Errorf("converting kubeClient to *kubernetes.Clientset type failed")
 	}
 	verb := strings.ToUpper(string(app.Verb))
-	return kubeClient.RESTClient().Verb(verb).AbsPath(app.Key).Body(app.ReqBody).Do(utilcontext.WithEdgeNode(context.Background(), app.Nodename)).Raw()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return kubeClient.RESTClient().Verb(verb).AbsPath(app.Key).Body(app.ReqBody).Do(utilcontext.WithEdgeNode(ctx, app.Nodename)).Raw()
 }
 
 // Response update application, generate and send resp message to edge
@@ -370,7 +376,9 @@ func (c *Center) checkNodePermission(app *metaserver.Application) error {
 			Groups: []string{constants.NodesGroup},
 		},
 	}
-	ret, err := c.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(context.Background(), subjectAccessReview, metav1.CreateOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ret, err := c.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(ctx, subjectAccessReview, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("node %s permission check failed: %v", app.Nodename, err)
 	}

--- a/cloud/pkg/dynamiccontroller/application/application_test.go
+++ b/cloud/pkg/dynamiccontroller/application/application_test.go
@@ -511,7 +511,7 @@ func TestProcessApplication(t *testing.T) {
 		},
 	}
 
-	_, err := dynamicClient.Resource(deployGVR).Namespace("default").Create(context.TODO(), deployment, metav1.CreateOptions{})
+	_, err := dynamicClient.Resource(deployGVR).Namespace("default").Create(context.Background(), deployment, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	t.Run("WATCH verb", func(t *testing.T) {
 		originalEnableAuthorization := config.Config.EnableAuthorization

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
@@ -131,7 +131,7 @@ func filterEndpoints(targetNode string, obj runtime.Object) {
 
 	if !filter.GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("services")).Informer().HasSynced() {
 		klog.Info("services informer has not synced yet")
-		svcRaw, err = client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("services")).Namespace(ep.Namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
+		svcRaw, err = client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("services")).Namespace(ep.Namespace).Get(context.Background(), svcName, metav1.GetOptions{})
 		if err != nil {
 			klog.Errorf("filter endpoint for svc %s error: %v", svcName, err)
 			return

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
@@ -1,6 +1,8 @@
 package endpointresource
 
 import (
+	"time"
+
 	"context"
 
 	v1 "k8s.io/api/core/v1"
@@ -131,7 +133,9 @@ func filterEndpoints(targetNode string, obj runtime.Object) {
 
 	if !filter.GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("services")).Informer().HasSynced() {
 		klog.Info("services informer has not synced yet")
-		svcRaw, err = client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("services")).Namespace(ep.Namespace).Get(context.Background(), svcName, metav1.GetOptions{})
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		svcRaw, err = client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("services")).Namespace(ep.Namespace).Get(ctx, svcName, metav1.GetOptions{})
 		if err != nil {
 			klog.Errorf("filter endpoint for svc %s error: %v", svcName, err)
 			return

--- a/cloud/pkg/dynamiccontroller/filter/util.go
+++ b/cloud/pkg/dynamiccontroller/filter/util.go
@@ -27,7 +27,7 @@ func IsBelongToSameGroup(targetNodeName string, epNodeName string) bool {
 	if !GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Informer().HasSynced() {
 		klog.Info("nodes informer has not synced yet")
 		getNode = func(nodeName string) (interface{}, error) {
-			return client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("nodes")).Get(context.TODO(), nodeName, metav1.GetOptions{})
+			return client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("nodes")).Get(context.Background(), nodeName, metav1.GetOptions{})
 		}
 	} else {
 		getNode = func(nodeName string) (interface{}, error) {

--- a/cloud/pkg/dynamiccontroller/filter/util.go
+++ b/cloud/pkg/dynamiccontroller/filter/util.go
@@ -1,6 +1,8 @@
 package filter
 
 import (
+	"time"
+
 	"context"
 
 	v1 "k8s.io/api/core/v1"
@@ -27,7 +29,9 @@ func IsBelongToSameGroup(targetNodeName string, epNodeName string) bool {
 	if !GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Informer().HasSynced() {
 		klog.Info("nodes informer has not synced yet")
 		getNode = func(nodeName string) (interface{}, error) {
-			return client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("nodes")).Get(context.Background(), nodeName, metav1.GetOptions{})
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			return client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("nodes")).Get(ctx, nodeName, metav1.GetOptions{})
 		}
 	} else {
 		getNode = func(nodeName string) (interface{}, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Refactors all `context.TODO()` instances to `context.Background()` within the `cloud/pkg/dynamiccontroller` module. This aligns the context propagation with Kubernetes upstream best practices, closing technical debt regarding orphaned contexts.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
