### PR TITLE
test(pkg/metaserver): migrate test setup assertions from assert to require

### DIFF
--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -72,7 +73,7 @@ func TestNewApplication(t *testing.T) {
 
 	for _, test := range cases {
 		app, err := NewApplication(test.ctx, test.key, test.verb, test.nodename, test.subresource, test.option, test.reqBody)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, test.key, app.Key)
 		assert.Equal(t, test.verb, app.Verb)
 		assert.Equal(t, test.nodename, app.Nodename)
@@ -239,7 +240,7 @@ func TestOptionTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.OptionTo(&result)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, test.stdResult, result)
 	}
 
@@ -263,7 +264,7 @@ func TestReqBodyTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.ReqBodyTo(&result)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, result, test.stdResult)
 	}
 
@@ -288,7 +289,7 @@ func TestRespBodyTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.RespBodyTo(&result)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, test.expected, result)
 	}
 
@@ -416,7 +417,7 @@ func TestMsgToApplication(t *testing.T) {
 			if test.hasError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, test.stdResult, app)
 			}
 		})
@@ -463,7 +464,7 @@ func TestMsgToApplications(t *testing.T) {
 			if test.hasError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, test.stdResult, apps)
 			}
 		})

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -73,13 +72,9 @@ func TestNewApplication(t *testing.T) {
 
 	for _, test := range cases {
 		app, err := NewApplication(test.ctx, test.key, test.verb, test.nodename, test.subresource, test.option, test.reqBody)
-<<<<<<< Updated upstream
-		require.NoError(t, err)
-=======
 		if !assert.NoError(t, err) {
 			continue
 		}
->>>>>>> Stashed changes
 		assert.Equal(t, test.key, app.Key)
 		assert.Equal(t, test.verb, app.Verb)
 		assert.Equal(t, test.nodename, app.Nodename)
@@ -246,13 +241,9 @@ func TestOptionTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.OptionTo(&result)
-<<<<<<< Updated upstream
-		require.NoError(t, err)
-=======
 		if !assert.NoError(t, err) {
 			continue
 		}
->>>>>>> Stashed changes
 		assert.Equal(t, test.stdResult, result)
 	}
 
@@ -276,13 +267,9 @@ func TestReqBodyTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.ReqBodyTo(&result)
-<<<<<<< Updated upstream
-		require.NoError(t, err)
-=======
 		if !assert.NoError(t, err) {
 			continue
 		}
->>>>>>> Stashed changes
 		assert.Equal(t, result, test.stdResult)
 	}
 
@@ -307,13 +294,9 @@ func TestRespBodyTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.RespBodyTo(&result)
-<<<<<<< Updated upstream
-		require.NoError(t, err)
-=======
 		if !assert.NoError(t, err) {
 			continue
 		}
->>>>>>> Stashed changes
 		assert.Equal(t, test.expected, result)
 	}
 
@@ -441,7 +424,7 @@ func TestMsgToApplication(t *testing.T) {
 			if test.hasError {
 				assert.Error(t, err)
 			} else {
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, test.stdResult, app)
 			}
 		})
@@ -488,7 +471,7 @@ func TestMsgToApplications(t *testing.T) {
 			if test.hasError {
 				assert.Error(t, err)
 			} else {
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, test.stdResult, apps)
 			}
 		})

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -73,7 +73,13 @@ func TestNewApplication(t *testing.T) {
 
 	for _, test := range cases {
 		app, err := NewApplication(test.ctx, test.key, test.verb, test.nodename, test.subresource, test.option, test.reqBody)
+<<<<<<< Updated upstream
 		require.NoError(t, err)
+=======
+		if !assert.NoError(t, err) {
+			continue
+		}
+>>>>>>> Stashed changes
 		assert.Equal(t, test.key, app.Key)
 		assert.Equal(t, test.verb, app.Verb)
 		assert.Equal(t, test.nodename, app.Nodename)
@@ -240,7 +246,13 @@ func TestOptionTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.OptionTo(&result)
+<<<<<<< Updated upstream
 		require.NoError(t, err)
+=======
+		if !assert.NoError(t, err) {
+			continue
+		}
+>>>>>>> Stashed changes
 		assert.Equal(t, test.stdResult, result)
 	}
 
@@ -264,7 +276,13 @@ func TestReqBodyTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.ReqBodyTo(&result)
+<<<<<<< Updated upstream
 		require.NoError(t, err)
+=======
+		if !assert.NoError(t, err) {
+			continue
+		}
+>>>>>>> Stashed changes
 		assert.Equal(t, result, test.stdResult)
 	}
 
@@ -289,7 +307,13 @@ func TestRespBodyTo(t *testing.T) {
 	for _, test := range cases {
 		var result map[string]string
 		err := test.app.RespBodyTo(&result)
+<<<<<<< Updated upstream
 		require.NoError(t, err)
+=======
+		if !assert.NoError(t, err) {
+			continue
+		}
+>>>>>>> Stashed changes
 		assert.Equal(t, test.expected, result)
 	}
 

--- a/pkg/metaserver/key_test.go
+++ b/pkg/metaserver/key_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -59,7 +60,7 @@ func TestKeyFuncObj(t *testing.T) {
 			obj.SetName(test.attr[4])
 
 			key, err := KeyFuncObj(&obj)
-			assert.NoError(err)
+			require.NoError(t, err)
 			assert.Equal(test.stdResult, key)
 		})
 	}
@@ -157,14 +158,14 @@ func TestKeyFuncReq(t *testing.T) {
 	for k, v := range Cases {
 		t.Run("parseKey", func(t *testing.T) {
 			req, err := http.NewRequest(v.method, v.url, nil)
-			assert.NoError(err)
+			require.NoError(t, err)
 
 			apiRequestInfo, err := resolver.NewRequestInfo(req)
-			assert.NoError(err)
+			require.NoError(t, err)
 
 			ctx := request.WithRequestInfo(context.TODO(), apiRequestInfo)
 			key, err := KeyFuncReq(ctx, "")
-			assert.NoError(err)
+			require.NoError(t, err)
 			assert.Equal(stdResult[k], key)
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Migrates `assert.NoError` to `require.NoError` in the `pkg/metaserver` test suites. Using `assert` during test setup phases allows the test to continue executing when struct creation fails, which causes cascading and difficult-to-debug nil-pointer panics in CI logs. `require` immediately halts the test on failure.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
