### PR TITLE
refactor(pkg/image): replace context.TODO in image runtime tests

### DIFF
--- a/pkg/image/image_runtime_test.go
+++ b/pkg/image/image_runtime_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestGetImageDigest(t *testing.T) {
-	ctx := context.TODO()
+	ctx := context.Background()
 	image := "docker.io/kubeedge/installation-package:v1.20.0"
 
 	t.Run("failed to get image status", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://docs.kubeedge.io/community/contributing/contributing
2. Ensure you have added or ran the appropriate tests for your PR
3. If the PR is unfinished, add '<IN PROGRESS>' in your PR title, e.g., '<IN PROGRESS>pr title'
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Refactors leftover `context.TODO()` instances to `context.Background()` within the `pkg/image` runtime tests, ensuring proper context lifecycle propagation and eliminating technical debt.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
