### PR TITLE
cloud/devicecontroller: fix detached pointer for newly created twin

### DIFF
--- a/cloud/pkg/devicecontroller/controller/upstream.go
+++ b/cloud/pkg/devicecontroller/controller/upstream.go
@@ -353,11 +353,10 @@ func findOrCreateTwinByName(twinName string, properties []v1beta1.DeviceProperty
 			if twin != nil {
 				return twin
 			}
-			twin = &v1beta1.Twin{
+			deviceStatus.Status.Twins = append(deviceStatus.Status.Twins, v1beta1.Twin{
 				PropertyName: twinName,
-			}
-			deviceStatus.Status.Twins = append(deviceStatus.Status.Twins, *twin)
-			return twin
+			})
+			return &deviceStatus.Status.Twins[len(deviceStatus.Status.Twins)-1]
 		}
 	}
 	return nil

--- a/cloud/pkg/devicecontroller/controller/upstream_test.go
+++ b/cloud/pkg/devicecontroller/controller/upstream_test.go
@@ -165,6 +165,31 @@ func TestFindOrCreateTwinByName(t *testing.T) {
 	}
 }
 
+func TestFindOrCreateTwinByNameNewTwinIsMutable(t *testing.T) {
+	assert := assert.New(t)
+
+	status := &DeviceStatus{
+		Status: v1beta1.DeviceStatusStatus{
+			Twins: []v1beta1.Twin{},
+		},
+	}
+	properties := []v1beta1.DeviceProperty{
+		{
+			Name: "humidity",
+		},
+	}
+
+	// The returned pointer must reference the twin stored in the slice, so that
+	// updates made through it (as updateDeviceStatus does) reach the DeviceStatus
+	// that is later marshalled into the CRD patch.
+	twin := findOrCreateTwinByName("humidity", properties, status)
+	assert.NotNil(twin)
+	twin.Reported = v1beta1.TwinProperty{Value: "60"}
+
+	assert.Len(status.Status.Twins, 1)
+	assert.Equal("60", status.Status.Twins[0].Reported.Value)
+}
+
 func TestFindTwinByName(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`findOrCreateTwinByName` in `cloud/pkg/devicecontroller/controller/upstream.go` is meant to return a pointer that the caller (`updateDeviceStatus`) mutates in place. For an existing twin it correctly returns `&deviceStatus.Status.Twins[i]` (via `findTwinByName`). For a *newly created* twin, however, it appended a copy of the twin to the slice (`append(..., *twin)`) and then returned the original local `twin` pointer — which is detached from the slice.

As a result, the `Reported` / `ObservedDesired` values that `updateDeviceStatus` writes through the returned pointer land on a throwaway local, while the slice element that actually gets marshalled into the `DeviceStatus` CRD patch keeps its zero value. The first status update for any newly reported device property is therefore silently lost. Subsequent updates work because the (empty) twin now exists in the slice and `findTwinByName` returns a proper slice-backed pointer.

The fix appends the twin and returns `&deviceStatus.Status.Twins[len-1]`, so the returned pointer references the element stored in the slice.

**Which issue(s) this PR fixes**:

Fixes #7014 

**Special notes for your reviewer**:

- One-line behavioural fix; `findTwinByName` (same file) already demonstrates the intended pointer-into-slice pattern.
- Added `TestFindOrCreateTwinByNameNewTwinIsMutable`, which mutates the returned pointer and asserts the change is visible on the stored twin. The pre-existing `TestFindOrCreateTwinByName` passed even with the bug because it never mutated the returned pointer.
- Verified locally: `make verify`, `make lint`, `make test`, and `make integrationtest` all pass.

**Does this PR introduce a user-facing change?**:

```release-note
Fix device twin reported/observedDesired values being dropped on the first device status update for a newly reported property.
```
