### PR TITLE
router: fix goroutine leak and hang in Rest.Forward on timeout

### DIFF
--- a/cloud/pkg/router/provider/rest/rest.go
+++ b/cloud/pkg/router/provider/rest/rest.go
@@ -115,8 +115,11 @@ func (r *Rest) Forward(target provider.Target, data interface{}) (interface{}, e
 	res["header"] = request.Header
 	res["method"] = request.Method
 	stop := make(chan struct{})
-	respch := make(chan interface{})
-	errch := make(chan error)
+	// respch and errch are buffered so the worker goroutine can always deliver
+	// its result and exit, even after Forward has returned on timeout or client
+	// disconnect; with unbuffered channels it would block forever and leak.
+	respch := make(chan interface{}, 1)
+	errch := make(chan error, 1)
 	go func() {
 		resp, err := target.GoToTarget(res, stop)
 		if err != nil {
@@ -175,7 +178,7 @@ func (r *Rest) Forward(target provider.Target, data interface{}) (interface{}, e
 		if !ok {
 			return nil, errors.New("failed to get timer channel")
 		}
-		stop <- struct{}{}
+		signalStop(stop)
 		httpResponse.StatusCode = http.StatusRequestTimeout
 		httpResponse.Body = io.NopCloser(strings.NewReader("wait to get response time out"))
 		klog.Warningf("operation timeout, msg id: %s, write result: get response timeout", messageID)
@@ -185,10 +188,20 @@ func (r *Rest) Forward(target provider.Target, data interface{}) (interface{}, e
 		}
 		timer.Stop()
 		klog.Warningf("Client disconnected for handling resource, msg id: %s", messageID)
-		stop <- struct{}{}
+		signalStop(stop)
 		return nil, errors.New("client disconnected for handling resource")
 	}
 	return httpResponse, nil
+}
+
+// signalStop notifies the target to stop without blocking. The rest and eventbus
+// targets ignore the stop channel, so a plain blocking send would hang Forward
+// forever; the non-blocking send still reaches a target that is waiting on stop.
+func signalStop(stop chan struct{}) {
+	select {
+	case stop <- struct{}{}:
+	default:
+	}
 }
 
 func (r *Rest) GoToTarget(data map[string]interface{}, _ chan struct{}) (interface{}, error) {

--- a/cloud/pkg/router/provider/rest/rest.go
+++ b/cloud/pkg/router/provider/rest/rest.go
@@ -182,10 +182,9 @@ func (r *Rest) Forward(target provider.Target, data interface{}) (interface{}, e
 		httpResponse.StatusCode = http.StatusRequestTimeout
 		httpResponse.Body = io.NopCloser(strings.NewReader("wait to get response time out"))
 		klog.Warningf("operation timeout, msg id: %s, write result: get response timeout", messageID)
-	case _, ok := <-request.Context().Done():
-		if !ok {
-			return nil, errors.New("failed to get request close channel")
-		}
+	case <-request.Context().Done():
+		// Done() is closed on cancellation, so a two-value receive here always
+		// reports the channel as closed; handle the disconnect directly.
 		timer.Stop()
 		klog.Warningf("Client disconnected for handling resource, msg id: %s", messageID)
 		signalStop(stop)

--- a/cloud/pkg/router/provider/rest/rest_test.go
+++ b/cloud/pkg/router/provider/rest/rest_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -27,18 +28,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// blockingTarget simulates a target (like the rest and eventbus targets) that
-// ignores the stop channel and stays busy until it is released.
+// blockingTarget simulates a slow target. By default it ignores the stop
+// channel (like the rest and eventbus targets); when readStop is set it waits on
+// stop as well (like the servicebus target) and reports when it received it.
 type blockingTarget struct {
-	entered chan struct{}
-	release chan struct{}
+	entered  chan struct{}
+	release  chan struct{}
+	readStop bool
+	gotStop  chan struct{}
 }
 
 func (b *blockingTarget) Name() string { return "blocking-target" }
 
-func (b *blockingTarget) GoToTarget(_ map[string]interface{}, _ chan struct{}) (interface{}, error) {
+func (b *blockingTarget) GoToTarget(_ map[string]interface{}, stop chan struct{}) (interface{}, error) {
 	close(b.entered)
-	<-b.release
+	if b.readStop {
+		select {
+		case <-stop:
+			close(b.gotStop)
+		case <-b.release:
+		}
+	} else {
+		<-b.release
+	}
 	return nil, nil
 }
 
@@ -88,4 +100,72 @@ func TestForwardTimeoutDoesNotHangOrLeak(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	assert.Falsef(t, leaked, "worker goroutine leaked after timeout: before=%d after=%d", before, after)
+}
+
+// TestForwardClientDisconnect verifies that when the client disconnects while a
+// slow target is still running, Forward returns the disconnect error without
+// blocking on the stop send.
+func TestForwardClientDisconnect(t *testing.T) {
+	r := &Rest{Path: "rest"}
+	target := &blockingTarget{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	// release the worker at the end so it does not leak past the test.
+	defer close(target.release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/default/node1/rest/foo", nil).WithContext(ctx)
+	data := map[string]interface{}{
+		"request":   req,
+		"timeout":   5 * time.Second,
+		"data":      []byte("payload"),
+		"messageID": "msg-1",
+	}
+
+	// cancel the request once the worker has started so the client-disconnect
+	// branch runs before the timeout.
+	go func() {
+		<-target.entered
+		cancel()
+	}()
+
+	resp, err := r.Forward(target, data)
+	assert.Nil(t, resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client disconnected")
+}
+
+// TestForwardStopSignalReachesTarget verifies that on timeout the stop signal is
+// delivered to a target that waits on it (the non-blocking send still reaches a
+// waiting receiver).
+func TestForwardStopSignalReachesTarget(t *testing.T) {
+	r := &Rest{Path: "rest"}
+	target := &blockingTarget{
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+		readStop: true,
+		gotStop:  make(chan struct{}),
+	}
+	defer close(target.release)
+
+	req := httptest.NewRequest(http.MethodGet, "/default/node1/rest/foo", nil)
+	data := map[string]interface{}{
+		"request":   req,
+		"timeout":   50 * time.Millisecond,
+		"data":      []byte("payload"),
+		"messageID": "msg-1",
+	}
+
+	resp, err := r.Forward(target, data)
+	require.NoError(t, err)
+	httpResp, ok := resp.(*http.Response)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusRequestTimeout, httpResp.StatusCode)
+
+	select {
+	case <-target.gotStop:
+	case <-time.After(time.Second):
+		t.Fatal("target did not receive the stop signal")
+	}
 }

--- a/cloud/pkg/router/provider/rest/rest_test.go
+++ b/cloud/pkg/router/provider/rest/rest_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingTarget simulates a target (like the rest and eventbus targets) that
+// ignores the stop channel and stays busy until it is released.
+type blockingTarget struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingTarget) Name() string { return "blocking-target" }
+
+func (b *blockingTarget) GoToTarget(_ map[string]interface{}, _ chan struct{}) (interface{}, error) {
+	close(b.entered)
+	<-b.release
+	return nil, nil
+}
+
+// TestForwardTimeoutDoesNotHangOrLeak verifies that when the target is slow and
+// ignores the stop channel, Forward still returns on timeout (it does not block
+// forever on the stop send), and the worker goroutine exits instead of blocking
+// forever on the result channel.
+func TestForwardTimeoutDoesNotHangOrLeak(t *testing.T) {
+	r := &Rest{Path: "rest"}
+	target := &blockingTarget{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/default/node1/rest/foo", nil)
+	data := map[string]interface{}{
+		"request":   req,
+		"timeout":   50 * time.Millisecond,
+		"data":      []byte("payload"),
+		"messageID": "msg-1",
+	}
+
+	before := runtime.NumGoroutine()
+
+	// Forward must return on timeout even though the target ignores stop; before
+	// the fix, the stop send blocked here forever.
+	resp, err := r.Forward(target, data)
+	require.NoError(t, err)
+	httpResp, ok := resp.(*http.Response)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusRequestTimeout, httpResp.StatusCode)
+
+	// The worker goroutine is still running the target; release it and confirm it
+	// exits instead of blocking forever on the result channel. Poll from this
+	// goroutine so the check itself does not inflate the goroutine count.
+	<-target.entered
+	close(target.release)
+
+	after := before
+	leaked := true
+	for i := 0; i < 200; i++ {
+		after = runtime.NumGoroutine()
+		if after <= before {
+			leaked = false
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Falsef(t, leaked, "worker goroutine leaked after timeout: before=%d after=%d", before, after)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

`Rest.Forward` in the cloud router spawns a worker goroutine that reports its
result on unbuffered `respch`/`errch` channels and signals cancellation with a
blocking send on `stop`. On timeout or client disconnect, `Forward` returns
without draining `respch`/`errch`, so the worker blocks forever when it finishes
and leaks a goroutine per request. The `stop` send also blocks `Forward` itself,
because the rest and eventbus targets ignore the stop channel (only servicebus
reads it). Slow/unreachable targets and client disconnects are the normal case
at the edge, so this leaks goroutines and can wedge the request handler under
routine conditions.

This buffers `respch`/`errch` so the worker can always deliver its result and
exit, and makes the `stop` send non-blocking so `Forward` no longer hangs when
the target does not consume it. A non-blocking send is used rather than closing
the channel because the servicebus target sends on `stop` in its reply callback,
so closing it could cause a send-on-closed-channel panic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7006 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a goroutine leak and request hang in the cloud router when a REST-sourced message times out or the client disconnects.
```
