### PR TITLE
cloud/devicecontroller: guard deviceUpdated cached-device assertion

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -265,7 +265,15 @@ func (dc *DownstreamController) deviceUpdated(device *v1beta1.Device) {
 	value, ok := dc.deviceManager.Device.Load(deviceID)
 	dc.deviceManager.Device.Store(deviceID, device)
 	if ok {
-		cachedDevice := value.(*v1beta1.Device)
+		cachedDevice, ok := value.(*v1beta1.Device)
+		if !ok {
+			// The cached value is corrupted, so there is no valid previous state
+			// to diff against. Treat it as a new device addition to keep the edge
+			// node in sync, mirroring the not-cached branch below.
+			klog.Warningf("Invalid cached device object for device %s/%s", device.Namespace, device.Name)
+			dc.deviceAdded(device)
+			return
+		}
 		if isDeviceUpdated(cachedDevice, device) {
 			// if NodeName changed, delete from old node and create in new node
 			if cachedDevice.Spec.NodeName != device.Spec.NodeName {

--- a/cloud/pkg/devicecontroller/controller/downstream_test.go
+++ b/cloud/pkg/devicecontroller/controller/downstream_test.go
@@ -20,9 +20,102 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeedge/api/apis/devices/v1beta1"
+	crdfake "github.com/kubeedge/api/client/clientset/versioned/fake"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager"
+	"github.com/kubeedge/kubeedge/pkg/util"
 )
+
+// fakeMessageLayer is a minimal MessageLayer that records sent messages.
+type fakeMessageLayer struct {
+	sent []model.Message
+}
+
+func (f *fakeMessageLayer) Send(message model.Message) error {
+	f.sent = append(f.sent, message)
+	return nil
+}
+
+func (f *fakeMessageLayer) Receive() (model.Message, error) {
+	return model.Message{}, nil
+}
+
+func (f *fakeMessageLayer) Response(message model.Message) error {
+	return nil
+}
+
+func TestDeviceUpdatedInvalidCachedType(t *testing.T) {
+	t.Run("corrupted cache entry is replaced with new device (no NodeName)", func(t *testing.T) {
+		dc := &DownstreamController{
+			deviceManager:       &manager.DeviceManager{},
+			deviceStatusManager: &manager.DeviceStatusManager{},
+			crdClient:           crdfake.NewSimpleClientset(),
+		}
+		device := &v1beta1.Device{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "dev1",
+			},
+		}
+		deviceID := util.GetResourceID(device.Namespace, device.Name)
+		// Simulate a corrupted cache entry of the wrong type.
+		dc.deviceManager.Device.Store(deviceID, "not-a-device")
+
+		assert.NotPanics(t, func() {
+			dc.deviceUpdated(device)
+		})
+
+		// After recovery, the cache must hold the correct *v1beta1.Device.
+		val, ok := dc.deviceManager.Device.Load(deviceID)
+		assert.True(t, ok, "device should be present in cache after recovery")
+		_, isDevice := val.(*v1beta1.Device)
+		assert.True(t, isDevice, "cached value should be a *v1beta1.Device after recovery")
+	})
+
+	t.Run("corrupted cache entry triggers deviceAdded downlink when NodeName is set", func(t *testing.T) {
+		fml := &fakeMessageLayer{}
+		dc := &DownstreamController{
+			deviceManager:       &manager.DeviceManager{},
+			deviceModelManager:  &manager.DeviceModelManager{},
+			deviceStatusManager: &manager.DeviceStatusManager{},
+			crdClient:           crdfake.NewSimpleClientset(),
+			messageLayer:        fml,
+		}
+		device := &v1beta1.Device{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "dev2",
+			},
+			Spec: v1beta1.DeviceSpec{
+				NodeName: "edge-node-1",
+				DeviceModelRef: &corev1.LocalObjectReference{
+					Name: "test-model",
+				},
+			},
+		}
+		deviceID := util.GetResourceID(device.Namespace, device.Name)
+		// Simulate a corrupted cache entry.
+		dc.deviceManager.Device.Store(deviceID, "not-a-device")
+
+		assert.NotPanics(t, func() {
+			dc.deviceUpdated(device)
+		})
+
+		// The corrupted entry triggers deviceAdded which sends a membership message
+		// to the edge node — verify the downlink path was not silently skipped.
+		assert.NotEmpty(t, fml.sent, "deviceAdded should have sent at least one message to the edge node")
+
+		// Cache must hold the new device.
+		val, ok := dc.deviceManager.Device.Load(deviceID)
+		assert.True(t, ok)
+		_, isDevice := val.(*v1beta1.Device)
+		assert.True(t, isDevice)
+	})
+}
 
 func TestRemoveTwinWithNameChanged(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`deviceUpdated` in `cloud/pkg/devicecontroller/controller/downstream.go` loaded the cached device from the `deviceManager` `sync.Map` and asserted its type with the single-value form:

    cachedDevice := value.(*v1beta1.Device)

If the stored value is ever not a `*v1beta1.Device`, that assertion panics and takes down the whole DeviceController. Every other place in the same file that reads a value back out of these maps (`syncDevice`, `isExistModel`, `deviceStatusUpdated`) already uses the safe two-value form and logs-and-returns on failure. `deviceUpdated` was the one caller that trusted the type unconditionally.

This change switches it to the two-value form. On an unexpected cached type, instead of only logging and returning, it calls `dc.deviceAdded(device)` to treat the event as a new device addition - since there is no valid previous device state to diff against. This avoids a silent gap where the new device has already been stored in the cache but no downlink message is sent to the edge node.

**Which issue(s) this PR fixes**:

Fixes #7017

**Special notes for your reviewer**:

- Behaviour-preserving on the happy path; only adds a guard on the wrong-type path, mirroring the defensive style used in other `sync.Map` reads throughout the file.
- Added `TestDeviceUpdatedInvalidCachedType` with two sub-tests:
  - Asserts the corrupted cache entry is replaced with the correct `*v1beta1.Device` after recovery.
  - Covers the `Spec.NodeName != ""` case using a `fakeMessageLayer` to verify the downlink path is not silently skipped.
- Verified locally: `make verify`, `make lint`, `make test`, and `make integrationtest` all pass.

**Does this PR introduce a user-facing change?**:

```release-note
Fix a potential DeviceController panic when a cached device entry has an unexpected type during device update handling.
```