### PR TITLE
cloudstream: Support kubectl port-forward feature for container running on edge

### DIFF
--- a/cloud/pkg/cloudstream/containerportforward_connection.go
+++ b/cloud/pkg/cloudstream/containerportforward_connection.go
@@ -1,0 +1,140 @@
+package cloudstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/emicklei/go-restful"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/kubeedge/common/constants"
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+// ContainerPortForwardConnection indicates the container port-forward request initiated by kube-apiserver
+type ContainerPortForwardConnection struct {
+	MessageID    uint64
+	ctx          context.Context
+	r            *restful.Request
+	Conn         net.Conn
+	session      *Session
+	edgePeerStop chan struct{}
+	closeChan    chan bool
+}
+
+func (c *ContainerPortForwardConnection) String() string {
+	return fmt.Sprintf("APIServer_PortForwardConnection MessageID %v", c.MessageID)
+}
+
+func (c *ContainerPortForwardConnection) WriteToAPIServer(p []byte) (n int, err error) {
+	return c.Conn.Write(p)
+}
+
+func (c *ContainerPortForwardConnection) SetMessageID(id uint64) {
+	c.MessageID = id
+}
+
+func (c *ContainerPortForwardConnection) GetMessageID() uint64 {
+	return c.MessageID
+}
+
+func (c *ContainerPortForwardConnection) SetEdgePeerDone() {
+	select {
+	case <-c.closeChan:
+		return
+	case c.EdgePeerDone() <- struct{}{}:
+		klog.V(6).Infof("success send channel deleting connection with messageID %v", c.MessageID)
+	}
+}
+
+func (c *ContainerPortForwardConnection) EdgePeerDone() chan struct{} {
+	return c.edgePeerStop
+}
+
+func (c *ContainerPortForwardConnection) WriteToTunnel(m *stream.Message) error {
+	return c.session.WriteMessageToTunnel(m)
+}
+
+func (c *ContainerPortForwardConnection) SendConnection() (stream.EdgedConnection, error) {
+	connector := &stream.EdgedPortForwardConnection{
+		MessID: c.MessageID,
+		Method: c.r.Request.Method,
+		URL:    *c.r.Request.URL,
+		Header: c.r.Request.Header,
+	}
+	connector.URL.Scheme = httpScheme
+	connector.URL.Host = net.JoinHostPort(defaultServerHost, fmt.Sprintf("%v", constants.ServerPort))
+
+	m, err := connector.CreateConnectMessage()
+	if err != nil {
+		return nil, err
+	}
+	if err := c.WriteToTunnel(m); err != nil {
+		klog.Errorf("%s failed to create portForward connection: %s, err: %v", c.String(), connector.String(), err)
+		return nil, err
+	}
+	return connector, nil
+}
+
+func (c *ContainerPortForwardConnection) Serve() error {
+	defer func() {
+		close(c.closeChan)
+		klog.V(6).Infof("%s stop successfully", c.String())
+	}()
+
+	connector, err := c.SendConnection()
+	if err != nil {
+		klog.Errorf("%s send %s info error %v", c.String(), stream.MessageTypePortForwardConnect, err)
+		return err
+	}
+
+	sendCloseMessage := func() {
+		msg := stream.NewMessage(c.MessageID, stream.MessageTypeRemoveConnect, nil)
+		for retry := 0; retry < 3; retry++ {
+			if err := c.WriteToTunnel(msg); err == nil {
+				klog.V(6).Infof("%s send close message to edge successfully", c.String())
+				return
+			}
+			klog.Warningf("%v failed send %s message to edge, err: %v", c, msg.MessageType, err)
+		}
+		klog.Errorf("max retry count reached when send %s message to edge", msg.MessageType)
+	}
+
+	var data [256]byte
+	for {
+		select {
+		case <-c.ctx.Done():
+			sendCloseMessage()
+			return nil
+		case <-c.EdgePeerDone():
+			klog.V(6).Infof("%s find edge peer done, so stop this connection", c.String())
+			return fmt.Errorf("%s find edge peer done, so stop this connection", c.String())
+		default:
+		}
+
+		n, err := c.Conn.Read(data[:])
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				klog.Errorf("%s failed to read from client: %v", c.String(), err)
+				return err
+			}
+			klog.V(6).Infof("%s read EOF from client", c.String())
+			sendCloseMessage()
+			return nil
+		}
+		if n <= 0 {
+			continue
+		}
+
+		msg := stream.NewMessage(connector.GetMessageID(), stream.MessageTypeData, data[:n])
+		if err := c.WriteToTunnel(msg); err != nil {
+			klog.Errorf("%s failed to write to tunnel server, err: %v", c.String(), err)
+			return err
+		}
+	}
+}
+
+var _ APIServerConnection = &ContainerPortForwardConnection{}

--- a/cloud/pkg/cloudstream/containerportforward_connection_test.go
+++ b/cloud/pkg/cloudstream/containerportforward_connection_test.go
@@ -1,0 +1,150 @@
+package cloudstream
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/emicklei/go-restful"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/pkg/stream"
+)
+
+func TestPortForward_String(t *testing.T) {
+	assert := assert.New(t)
+	portForwardConn := &ContainerPortForwardConnection{
+		MessageID: 100,
+	}
+
+	stdResult := "APIServer_PortForwardConnection MessageID 100"
+	assert.Equal(stdResult, portForwardConn.String())
+}
+
+func TestPortForward_WriteToAPIServer(t *testing.T) {
+	assert := assert.New(t)
+	mockConn := &MockConn{}
+	portForwardConn := &ContainerPortForwardConnection{
+		Conn: mockConn,
+	}
+
+	data := []byte("test data")
+	dataLength, err := portForwardConn.WriteToAPIServer(data)
+	assert.NoError(err)
+	assert.Equal(9, dataLength)
+	assert.Equal(data, mockConn.writeBuffer.Bytes())
+}
+
+func TestPortForward_SetMessageID(t *testing.T) {
+	assert := assert.New(t)
+	portForwardConn := &ContainerPortForwardConnection{}
+
+	portForwardConn.SetMessageID(uint64(100))
+
+	stdResult := uint64(100)
+	assert.Equal(stdResult, portForwardConn.MessageID)
+}
+
+func TestPortForward_GetMessageID(t *testing.T) {
+	assert := assert.New(t)
+
+	portForwardConn := &ContainerPortForwardConnection{
+		MessageID: 200,
+	}
+
+	stdResult := uint64(200)
+	assert.Equal(stdResult, portForwardConn.GetMessageID())
+}
+
+func TestPortForward_SetEdgePeerDone(t *testing.T) {
+	assert := assert.New(t)
+
+	portForwardConn := &ContainerPortForwardConnection{
+		MessageID:    1,
+		edgePeerStop: make(chan struct{}),
+		closeChan:    make(chan bool),
+	}
+
+	go func() {
+		portForwardConn.SetEdgePeerDone()
+	}()
+
+	select {
+	case <-portForwardConn.edgePeerStop:
+		assert.True(true)
+	case <-portForwardConn.closeChan:
+		assert.Fail("Expected edgePeerStop to receive but got closeChan")
+	}
+}
+
+func TestPortForward_EdgePeerDone(t *testing.T) {
+	assert := assert.New(t)
+
+	edgePeerStop := make(chan struct{})
+	portForwardConn := &ContainerPortForwardConnection{
+		edgePeerStop: edgePeerStop,
+	}
+
+	assert.Equal(edgePeerStop, portForwardConn.EdgePeerDone())
+}
+
+func TestPortForward_WriteToTunnel(t *testing.T) {
+	assert := assert.New(t)
+
+	mockTunneler := &MockTunneler{}
+	session := &Session{
+		tunnel: mockTunneler,
+	}
+	portForwardConn := &ContainerPortForwardConnection{
+		MessageID: 1,
+		session:   session,
+	}
+
+	message := stream.NewMessage(portForwardConn.MessageID, stream.MessageTypeData, []byte("test data"))
+
+	err := portForwardConn.WriteToTunnel(message)
+	assert.NoError(err)
+	assert.Equal(mockTunneler.lastMessage, message)
+}
+
+func TestPortForward_SendConnection(t *testing.T) {
+	assert := assert.New(t)
+
+	mockConn := &MockConn{}
+	mockTunneler := &MockTunneler{}
+	session := &Session{
+		tunnel: mockTunneler,
+	}
+	r := &restful.Request{
+		Request: &http.Request{
+			Method: "GET",
+			URL:    &url.URL{},
+			Header: http.Header{},
+		},
+	}
+
+	portForwardConn := &ContainerPortForwardConnection{
+		MessageID: 1,
+		r:         r,
+		Conn:      mockConn,
+		session:   session,
+	}
+
+	connector, err := portForwardConn.SendConnection()
+	assert.NoError(err)
+
+	edgedConnector, ok := connector.(*stream.EdgedPortForwardConnection)
+	assert.True(ok, "Expected connector should be of type *stream.EdgedPortForwardConnection")
+	assert.Equal(portForwardConn.MessageID, edgedConnector.MessID)
+	assert.Equal(r.Request.Method, edgedConnector.Method)
+	expectedURL := url.URL{
+		Scheme: "http",
+		Host:   "127.0.0.1:10350",
+	}
+	assert.Equal(expectedURL, edgedConnector.URL)
+	assert.Equal(r.Request.Header, edgedConnector.Header)
+
+	assert.Equal(mockTunneler.lastMessage.MessageType, stream.MessageTypePortForwardConnect)
+	expectedData, _ := edgedConnector.CreateConnectMessage()
+	assert.Equal(mockTunneler.lastMessage.Data, expectedData.Data)
+}

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -60,6 +60,14 @@ func (s *StreamServer) installDebugHandler() {
 	s.container.Add(ws)
 
 	ws = new(restful.WebService)
+	ws.Path("/portForward")
+	ws.Route(ws.GET("/{podNamespace}/{podID}").
+		To(s.getPortForward))
+	ws.Route(ws.POST("/{podNamespace}/{podID}").
+		To(s.getPortForward))
+	s.container.Add(ws)
+
+	ws = new(restful.WebService)
 	ws.Path("/exec")
 
 	ws.Route(ws.GET("/{podNamespace}/{podID}/{containerName}").
@@ -355,6 +363,73 @@ func (s *StreamServer) getAttach(request *restful.Request, response *restful.Res
 	if err = attachConnection.Serve(); err != nil {
 		err = fmt.Errorf("apiconnection Serve %s in %s error %v",
 			attachConnection.String(), session.String(), err)
+		return
+	}
+}
+
+func (s *StreamServer) getPortForward(request *restful.Request, response *restful.Response) {
+	var err error
+	defer func() {
+		if err != nil {
+			response.WriteHeader(http.StatusInternalServerError)
+			klog.Errorf("Failed to get portForward, err: %v", err)
+		}
+	}()
+
+	sessionKey, err := s.getSessionKey(request.Request.URL.Path)
+	if err != nil {
+		err = fmt.Errorf("can not get session key: %v", err)
+		return
+	}
+	session, ok := s.tunnel.getSession(sessionKey)
+	if !ok {
+		err = fmt.Errorf("portForward: can not find %v session ", sessionKey)
+		return
+	}
+
+	if !httpstream.IsUpgradeRequest(request.Request) {
+		err = fmt.Errorf("request was not an upgrade")
+		return
+	}
+
+	requestHijacker, ok := response.ResponseWriter.(http.Hijacker)
+	if !ok {
+		klog.V(6).Infof("Unable to hijack response writer: %T", response.ResponseWriter)
+		err = fmt.Errorf("request connection cannot be hijacked: %T", response.ResponseWriter)
+		return
+	}
+
+	requestHijackedConn, _, err := requestHijacker.Hijack()
+	if err != nil {
+		klog.V(6).Infof("Unable to hijack response: %v", err)
+		err = fmt.Errorf("error hijacking connection: %v", err)
+		return
+	}
+	defer requestHijackedConn.Close()
+
+	portForwardConnection, err := session.AddAPIServerConnection(s, &ContainerPortForwardConnection{
+		r:            request,
+		Conn:         requestHijackedConn,
+		session:      session,
+		ctx:          request.Request.Context(),
+		edgePeerStop: make(chan struct{}, 2),
+		closeChan:    make(chan bool),
+	})
+	if err != nil {
+		err = fmt.Errorf("add apiServer portForward connection into %s error %v", session.String(), err)
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			session.DeleteAPIServerConnection(portForwardConnection)
+			klog.Infof("Delete %s from %s", portForwardConnection.String(), session.String())
+		}
+	}()
+
+	if err = portForwardConnection.Serve(); err != nil {
+		err = fmt.Errorf("apiconnection Serve %s in %s error %v",
+			portForwardConnection.String(), session.String(), err)
 		return
 	}
 }

--- a/edge/pkg/edgestream/tunnel.go
+++ b/edge/pkg/edgestream/tunnel.go
@@ -91,6 +91,21 @@ func (s *TunnelSession) serveContainerAttachConnection(m *stream.Message) error 
 	return attachCon.Serve(s.Tunnel)
 }
 
+func (s *TunnelSession) servePortForwardConnection(m *stream.Message) error {
+	portForwardCon := &stream.EdgedPortForwardConnection{
+		ReadChan: make(chan *stream.Message, 128),
+		Stop:     make(chan struct{}, 2),
+	}
+	if err := json.Unmarshal(m.Data, portForwardCon); err != nil {
+		klog.Errorf("unmarshal connector data error %v", err)
+		return err
+	}
+
+	s.AddLocalConnection(m.ConnectID, portForwardCon)
+	klog.V(6).Infof("Get PortForward Connection info: %+v", *portForwardCon)
+	return portForwardCon.Serve(s.Tunnel)
+}
+
 func (s *TunnelSession) serveMetricsConnection(m *stream.Message) error {
 	metricsCon := &stream.EdgedMetricsConnection{
 		ReadChan: make(chan *stream.Message, 128),
@@ -122,6 +137,10 @@ func (s *TunnelSession) ServeConnection(m *stream.Message) {
 	case stream.MessageTypeAttachConnect:
 		if err := s.serveContainerAttachConnection(m); err != nil {
 			klog.Errorf("Serve Attach connection error %s", m.String())
+		}
+	case stream.MessageTypePortForwardConnect:
+		if err := s.servePortForwardConnection(m); err != nil {
+			klog.Errorf("Serve PortForward connection error %s", m.String())
 		}
 	default:
 		panic(fmt.Sprintf("Wrong message type %v", m.MessageType))
@@ -191,10 +210,24 @@ func (s *TunnelSession) Serve() error {
 			return fmt.Errorf("close tunnel stream connection, error:%s", string(mess.Data))
 		}
 
-		if (mess.MessageType < stream.MessageTypeData) || (mess.MessageType >= stream.MessageTypeAttachConnect) {
+		if isConnectMessageType(mess.MessageType) {
 			go s.ServeConnection(mess)
+			continue
 		}
 		s.WriteToLocalConnection(mess)
+	}
+}
+
+func isConnectMessageType(messageType stream.MessageType) bool {
+	switch messageType {
+	case stream.MessageTypeLogsConnect,
+		stream.MessageTypeExecConnect,
+		stream.MessageTypeMetricConnect,
+		stream.MessageTypeAttachConnect,
+		stream.MessageTypePortForwardConnect:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/stream/constants.go
+++ b/pkg/stream/constants.go
@@ -13,4 +13,5 @@ const (
 	MessageTypeRemoveConnect
 	MessageTypeCloseConnect
 	MessageTypeAttachConnect
+	MessageTypePortForwardConnect
 )

--- a/pkg/stream/edgedportforwardconnection.go
+++ b/pkg/stream/edgedportforwardconnection.go
@@ -1,0 +1,137 @@
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
+	"k8s.io/klog/v2"
+)
+
+type EdgedPortForwardConnection struct {
+	ReadChan chan *Message `json:"-"`
+	Stop     chan struct{} `json:"-"`
+	MessID   uint64
+	URL      url.URL     `json:"url"`
+	Header   http.Header `json:"header"`
+	Method   string      `json:"method"`
+}
+
+func (p *EdgedPortForwardConnection) CreateConnectMessage() (*Message, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+	return NewMessage(p.MessID, MessageTypePortForwardConnect, data), nil
+}
+
+func (p *EdgedPortForwardConnection) GetMessageID() uint64 {
+	return p.MessID
+}
+
+func (p *EdgedPortForwardConnection) String() string {
+	return fmt.Sprintf("EDGE_PORT_FORWARD_CONNECTOR Message MessageID %v", p.MessID)
+}
+
+func (p *EdgedPortForwardConnection) CacheTunnelMessage(msg *Message) {
+	p.ReadChan <- msg
+}
+
+func (p *EdgedPortForwardConnection) CloseReadChannel() {
+	close(p.ReadChan)
+}
+
+func (p *EdgedPortForwardConnection) CleanChannel() {
+	for {
+		select {
+		case <-p.Stop:
+		default:
+			return
+		}
+	}
+}
+
+func (p *EdgedPortForwardConnection) receiveFromCloudStream(con net.Conn, stop chan struct{}) {
+	for message := range p.ReadChan {
+		switch message.MessageType {
+		case MessageTypeRemoveConnect:
+			klog.Infof("%s receive remove client id %v", p.String(), message.ConnectID)
+			stop <- struct{}{}
+		case MessageTypeData:
+			if _, err := con.Write(message.Data); err != nil {
+				klog.Errorf("%s failed to write portForward data, err: %v", p.String(), err)
+			}
+		}
+	}
+	klog.V(0).Infof("%s read channel closed", p.String())
+}
+
+func (p *EdgedPortForwardConnection) write2CloudStream(tunnel SafeWriteTunneler, con net.Conn, stop chan struct{}) {
+	defer func() {
+		stop <- struct{}{}
+	}()
+
+	var data [256]byte
+	for {
+		n, err := con.Read(data[:])
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				klog.Errorf("%v failed to read portForward data, err:%v", p.String(), err)
+			}
+			return
+		}
+		msg := NewMessage(p.MessID, MessageTypeData, data[:n])
+		if err := tunnel.WriteMessage(msg); err != nil {
+			klog.Errorf("%v failed to write to tunnel, msg: %+v, err: %v", p.String(), msg, err)
+			return
+		}
+	}
+}
+
+func (p *EdgedPortForwardConnection) Serve(tunnel SafeWriteTunneler) error {
+	tripper, err := spdy.NewRoundTripper(nil)
+	if err != nil {
+		return fmt.Errorf("failed to create a new tripper, err: %v", err)
+	}
+
+	req, err := http.NewRequest(p.Method, p.URL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create portForward request, err: %v", err)
+	}
+	req.Header = p.Header
+
+	con, err := tripper.Dial(req)
+	if err != nil {
+		klog.Errorf("failed to dial portForward, err: %v", err)
+		return err
+	}
+	defer con.Close()
+
+	klog.Infof("successfully connected local portForward endpoint: %s", req.URL.String())
+
+	go p.receiveFromCloudStream(con, p.Stop)
+
+	defer func() {
+		for retry := 0; retry < 3; retry++ {
+			msg := NewMessage(p.MessID, MessageTypeRemoveConnect, nil)
+			if err := tunnel.WriteMessage(msg); err != nil {
+				klog.Errorf("%v send %s message error %v", p, msg.MessageType, err)
+			} else {
+				break
+			}
+		}
+	}()
+
+	go p.write2CloudStream(tunnel, con, p.Stop)
+
+	<-p.Stop
+	klog.Infof("receive stop signal, so stop portForward scan ...")
+	return nil
+}
+
+var _ EdgedConnection = &EdgedPortForwardConnection{}

--- a/pkg/stream/edgedportforwardconnection_test.go
+++ b/pkg/stream/edgedportforwardconnection_test.go
@@ -1,0 +1,196 @@
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPortForwardConnection_CreateConnectMessage(t *testing.T) {
+	assert := assert.New(t)
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		MessID: 1,
+	}
+
+	msg, err := edgedPortForwardConn.CreateConnectMessage()
+	assert.NoError(err)
+	expectedData, err := json.Marshal(edgedPortForwardConn)
+	assert.NoError(err)
+	expectedMessage := NewMessage(edgedPortForwardConn.MessID, MessageTypePortForwardConnect, expectedData)
+
+	assert.Equal(expectedMessage, msg)
+}
+
+func TestPortForwardConnection_GetMessageID(t *testing.T) {
+	assert := assert.New(t)
+
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		MessID: uint64(100),
+	}
+
+	messID := edgedPortForwardConn.GetMessageID()
+	stdResult := uint64(100)
+
+	assert.Equal(messID, stdResult)
+}
+
+func TestPortForwardConnection_String(t *testing.T) {
+	assert := assert.New(t)
+
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		MessID: uint64(100),
+	}
+
+	result := edgedPortForwardConn.String()
+	stdResult := "EDGE_PORT_FORWARD_CONNECTOR Message MessageID 100"
+	assert.Equal(stdResult, result)
+}
+
+func TestPortForwardConnection_CacheTunnelMessage(t *testing.T) {
+	assert := assert.New(t)
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		ReadChan: make(chan *Message, 1),
+	}
+
+	msg := &Message{ConnectID: 100, MessageType: MessageTypeData, Data: []byte("test data")}
+	edgedPortForwardConn.CacheTunnelMessage(msg)
+
+	assert.Equal(msg, <-edgedPortForwardConn.ReadChan)
+}
+
+func TestPortForwardConnection_CloseReadChannel(t *testing.T) {
+	assert := assert.New(t)
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		ReadChan: make(chan *Message),
+	}
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		edgedPortForwardConn.CloseReadChannel()
+	}()
+
+	_, ok := <-edgedPortForwardConn.ReadChan
+	assert.False(ok)
+}
+
+func TestPortForwardConnection_CleanChannel(t *testing.T) {
+	assert := assert.New(t)
+
+	forwardPortConn := &EdgedPortForwardConnection{
+		Stop: make(chan struct{}, 2),
+	}
+
+	forwardPortConn.Stop <- struct{}{}
+	forwardPortConn.Stop <- struct{}{}
+
+	forwardPortConn.CleanChannel()
+
+	assert.Equal(0, len(forwardPortConn.Stop))
+}
+
+func TestPortForwardConnection_receiveFromCloudStream(t *testing.T) {
+	assert := assert.New(t)
+
+	// reusing the MockConn from exec
+	portForwardMockConn := &execMockConn{}
+	stop := make(chan struct{}, 1)
+
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		MessID:   uint64(100),
+		ReadChan: make(chan *Message, 3),
+	}
+
+	removeConnMsg := NewMessage(edgedPortForwardConn.MessID, MessageTypeRemoveConnect, nil)
+
+	dataBytes := []byte("test data")
+	dataMsg := NewMessage(edgedPortForwardConn.MessID, MessageTypeData, dataBytes)
+
+	edgedPortForwardConn.ReadChan <- removeConnMsg
+	edgedPortForwardConn.ReadChan <- dataMsg
+
+	close(edgedPortForwardConn.ReadChan)
+
+	edgedPortForwardConn.receiveFromCloudStream(portForwardMockConn, stop)
+
+	assert.Equal(1, len(stop))
+	assert.Equal(dataBytes, portForwardMockConn.WriteData)
+}
+
+func TestPortForwardConnection_write2CloudStream(t *testing.T) {
+	assert := assert.New(t)
+
+	// reusing the MockTunneler from attach
+	mockTunneler := &MockTunneler{}
+	stop := make(chan struct{}, 1)
+
+	// reusing the MockConn from exec
+	portForwardMockConn := &execMockConn{
+		ReadData: []byte("test data for tunnel"),
+	}
+
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		MessID: uint64(100),
+	}
+
+	go edgedPortForwardConn.write2CloudStream(mockTunneler, portForwardMockConn, stop)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(1, len(mockTunneler.Messages))
+	assert.Equal(MessageTypeData, mockTunneler.Messages[0].MessageType)
+	assert.Equal([]byte("test data for tunnel"), mockTunneler.Messages[0].Data)
+
+	assert.Equal(1, len(stop))
+}
+
+func TestPortForwardConnection_write2CloudStream_ReadError(t *testing.T) {
+	assert := assert.New(t)
+
+	// reusing the MockTunneler from attach
+	mockTunneler := &MockTunneler{}
+	stop := make(chan struct{}, 1)
+
+	// reusing the MockConn from exec
+	portForwardMockConn := &execMockConn{
+		ReadErr: errors.New("read error"),
+	}
+
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		MessID: uint64(100),
+	}
+
+	go edgedPortForwardConn.write2CloudStream(mockTunneler, portForwardMockConn, stop)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(0, len(mockTunneler.Messages))
+	assert.Equal(1, len(stop))
+}
+
+func TestPortForwardConnection_write2CloudStream_WriteError(t *testing.T) {
+	assert := assert.New(t)
+
+	// reusing the MockTunneler from attach
+	mockTunneler := &MockTunneler{
+		WriteErr: errors.New("tunnel write error"),
+	}
+	stop := make(chan struct{}, 1)
+
+	// reusing the MockConn from exec
+	portForwardMockConn := &execMockConn{
+		ReadData: []byte("test data for tunnel"),
+	}
+
+	edgedPortForwardConn := &EdgedPortForwardConnection{
+		MessID: uint64(100),
+	}
+
+	go edgedPortForwardConn.write2CloudStream(mockTunneler, portForwardMockConn, stop)
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(1, len(stop))
+}

--- a/pkg/stream/message.go
+++ b/pkg/stream/message.go
@@ -43,6 +43,8 @@ func (m MessageType) String() string {
 		return "DATA"
 	case MessageTypeRemoveConnect:
 		return "REMOVE_CONNECT"
+	case MessageTypePortForwardConnect:
+		return "PORT_FORWARD_CONNECT"
 	}
 	return "UNKNOWN"
 }

--- a/pkg/stream/message_test.go
+++ b/pkg/stream/message_test.go
@@ -47,6 +47,10 @@ func TestMessageType_String(t *testing.T) {
 			stdResult: "ATTACH_CONNECT",
 		},
 		{
+			msg:       MessageTypePortForwardConnect,
+			stdResult: "PORT_FORWARD_CONNECT",
+		},
+		{
 			msg:       MessageTypeMetricConnect,
 			stdResult: "METRIC_CONNECT",
 		},


### PR DESCRIPTION

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables port-forwarding with kubectl for pods running on edge nodes. 
If kubectl logs/exec/attach works for you, with this PR:
For example:
```
$ kubectl -n default port-forward pod/nginx-test-698e487c-5ccc89d5b6-zjzhm 8080:80   &                                                                                                                                                                                                                                                                  
Forwarding from 127.0.0.1:8080 -> 80

$ curl -v localhost:8080                                                                                                                                          
curl  localhost:8080
Handling connection for 8080
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, nginx is successfully installed and working.
Further configuration is required for the web server, reverse proxy, 
API gateway, load balancer, content cache, or other features.</p>

<p>For online documentation and support please refer to
<a href="https://nginx.org/">nginx.org</a>.<br/>
To engage with the community please visit
<a href="https://community.nginx.org/">community.nginx.org</a>.<br/>
For enterprise grade support, professional services, additional 
security features and capabilities please refer to
<a href="https://f5.com/nginx">f5.com/nginx</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>

...
```

Without this PR i get a "404 not found".
kubectl  port-forward nginx-test-698e487c-5ccc89d5b6-zjzhm 8080:80
error: error upgrading connection: unable to upgrade connection: 404 page not found
