### PR TITLE
test(devicecontroller): add unit test for devicecontroller config

### DIFF
--- a/cloud/pkg/devicecontroller/config/config_test.go
+++ b/cloud/pkg/devicecontroller/config/config_test.go
@@ -32,9 +32,6 @@ func TestInitConfigure(t *testing.T) {
 		Config = Configure{}
 	})
 
-	// Reset the sync.Once and Config just in case for clean test
-	once = sync.Once{}
-	Config = Configure{}
 
 	dc := &v1alpha1.DeviceController{
 		Enable: true,

--- a/cloud/pkg/devicecontroller/config/config_test.go
+++ b/cloud/pkg/devicecontroller/config/config_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+func TestInitConfigure(t *testing.T) {
+	// Reset the sync.Once and Config just in case for clean test
+	once = sync.Once{}
+	Config = Configure{}
+
+	dc := &v1alpha1.DeviceController{
+		Enable: true,
+	}
+
+	InitConfigure(dc)
+
+	require.Equal(t, true, Config.Enable)
+	require.Equal(t, *dc, Config.DeviceController)
+
+	// Test sync.Once works, subsequent calls should not overwrite
+	dc2 := &v1alpha1.DeviceController{
+		Enable: false,
+	}
+	InitConfigure(dc2)
+
+	require.Equal(t, true, Config.Enable, "Config should not be overwritten after first initialization")
+}

--- a/cloud/pkg/devicecontroller/config/config_test.go
+++ b/cloud/pkg/devicecontroller/config/config_test.go
@@ -26,6 +26,12 @@ import (
 )
 
 func TestInitConfigure(t *testing.T) {
+	// Use t.Cleanup to restore global state after the test execution
+	t.Cleanup(func() {
+		once = sync.Once{}
+		Config = Configure{}
+	})
+
 	// Reset the sync.Once and Config just in case for clean test
 	once = sync.Once{}
 	Config = Configure{}
@@ -39,11 +45,14 @@ func TestInitConfigure(t *testing.T) {
 	require.Equal(t, true, Config.Enable)
 	require.Equal(t, *dc, Config.DeviceController)
 
+	// Save the initialized Config state
+	expectedConfig := Config
+
 	// Test sync.Once works, subsequent calls should not overwrite
 	dc2 := &v1alpha1.DeviceController{
 		Enable: false,
 	}
 	InitConfigure(dc2)
 
-	require.Equal(t, true, Config.Enable, "Config should not be overwritten after first initialization")
+	require.Equal(t, expectedConfig, Config, "Entire config should remain unchanged after first initialization")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Adds unit tests for `cloud/pkg/devicecontroller/config/config.go` to achieve 100% test coverage. It asserts the `sync.Once` singleton initialization pattern is functioning correctly to ensure robust configuration parsing.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This is a focused, isolated PR strictly aimed at increasing codebase test coverage. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
