### PR TITLE
cloud/synccontroller: guard nil message in sendEvents

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -97,8 +97,9 @@ func sendEvents(nodeName string, sync *v1alpha1.ObjectSync, resourceType string,
 	if CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
 		// trigger the update event
 		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
-		msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
-		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
+		if msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj); msg != nil {
+			beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
+		}
 	}
 }
 

--- a/cloud/pkg/synccontroller/objectsync_test.go
+++ b/cloud/pkg/synccontroller/objectsync_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,6 +176,19 @@ func TestSendEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestSendEventsNilMessage(t *testing.T) {
+	// buildEdgeControllerMessage returns nil when BuildResource fails (here an
+	// empty node name). sendEvents must skip the send instead of dereferencing
+	// the nil message.
+	sync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod")
+	// resourceVersion "2" > status "1" forces the update branch; the empty node
+	// name makes buildEdgeControllerMessage return nil.
+	assert.NotPanics(t, func() {
+		sendEvents("", sync, "pod", "2", sync.DeepCopy())
+	}, "sendEvents() must not panic when buildEdgeControllerMessage returns nil")
+}
+
 func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`sendEvents` in `cloud/pkg/synccontroller/objectsync.go` built an edge message and sent it unconditionally:

    msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
    beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)

`buildEdgeControllerMessage` returns `nil` when `messagelayer.BuildResource` fails (empty node id / namespace / resource type). Dereferencing `*msg` on that nil then panics. `sendEvents` is reached from `reconcileObjectSync`, which runs on a `wait.Until(..., 5*time.Second, ...)` goroutine, so the panic tears down the SyncController reconcile loop.

This change guards the send with a nil check, exactly like the sibling `gcOrphanedObjectSync` in the same file already does.

**Which issue(s) this PR fixes**:

Fixes #7022

**Special notes for your reviewer**:

- Behaviour-preserving on the happy path; only adds a nil guard on the message before dereferencing, mirroring the existing `gcOrphanedObjectSync` pattern.
- Added `TestSendEventsNilMessage`: forces the update branch with an empty node name so message construction returns nil, then uses `assert.NotPanics` to verify `sendEvents` does not panic.
- Verified locally: `make verify`, `make lint`, `make test`, and `make integrationtest` all pass.

**Does this PR introduce a user-facing change?**:

```release-note
Fix a SyncController panic when an object-sync update event cannot build its message resource.
```