### PR TITLE
devicecontroller: tolerate DeviceStatus create races

### DIFF
--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -210,7 +210,11 @@ func (dc *DownstreamController) getOrCreateDeviceStatusForDevice(device *v1beta1
 		return nil, err
 	}
 
-	return dc.crdClient.DevicesV1beta1().DeviceStatuses(device.Namespace).Create(context.Background(), deviceStatus, metav1.CreateOptions{})
+	deviceStatus, err = dc.crdClient.DevicesV1beta1().DeviceStatuses(device.Namespace).Create(context.Background(), deviceStatus, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return dc.crdClient.DevicesV1beta1().DeviceStatuses(device.Namespace).Get(context.Background(), device.Name, metav1.GetOptions{})
+	}
+	return deviceStatus, err
 }
 
 // createDevice creates a device from CRD

--- a/cloud/pkg/devicecontroller/controller/downstream_test.go
+++ b/cloud/pkg/devicecontroller/controller/downstream_test.go
@@ -17,11 +17,20 @@ limitations under the License.
 package controller
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kubeedge/api/apis/devices/v1beta1"
+	crdfake "github.com/kubeedge/api/client/clientset/versioned/fake"
+	"github.com/kubeedge/kubeedge/cloud/pkg/devicecontroller/manager"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ktesting "k8s.io/client-go/testing"
 )
 
 func TestRemoveTwinWithNameChanged(t *testing.T) {
@@ -124,4 +133,55 @@ func TestRemoveTwinWithNameChanged(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.deviceStatus.Status.Twins)
 		})
 	}
+}
+
+func TestGetOrCreateDeviceStatusForDeviceHandlesAlreadyExistsRace(t *testing.T) {
+	device := &v1beta1.Device{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       "Device",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lite-node",
+			Namespace: "led",
+			UID:       types.UID("device-uid"),
+		},
+	}
+	existingStatus := &v1beta1.DeviceStatus{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       "DeviceStatus",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      device.Name,
+			Namespace: device.Namespace,
+		},
+	}
+
+	deviceStatuses := schema.GroupResource{Group: v1beta1.GroupName, Resource: "devicestatuses"}
+	getCalls := 0
+	crdClient := crdfake.NewSimpleClientset()
+	crdClient.Fake.PrependReactor("get", "devicestatuses", func(action ktesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 1 {
+			return true, nil, apierrors.NewNotFound(deviceStatuses, action.(ktesting.GetAction).GetName())
+		}
+		return true, existingStatus.DeepCopy(), nil
+	})
+	crdClient.Fake.PrependReactor("create", "devicestatuses", func(action ktesting.Action) (bool, runtime.Object, error) {
+		deviceStatus := action.(ktesting.CreateAction).GetObject().(*v1beta1.DeviceStatus)
+		return true, nil, apierrors.NewAlreadyExists(deviceStatuses, deviceStatus.Name)
+	})
+
+	dc := &DownstreamController{
+		crdClient: crdClient,
+		deviceStatusManager: &manager.DeviceStatusManager{
+			DeviceStatus: sync.Map{},
+		},
+	}
+
+	status, err := dc.getOrCreateDeviceStatusForDevice(device)
+	assert.NoError(t, err)
+	assert.Equal(t, existingStatus.Name, status.Name)
+	assert.Equal(t, 2, getCalls)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR makes DeviceStatus creation idempotent when CloudCore runs with multiple replicas.

All devicecontroller replicas can receive the same Device add event. They may all observe that the DeviceStatus is absent, then race to create it. The first create succeeds and the remaining creates return `AlreadyExists`.

Previously, `deviceAdded()` treated that expected race as a fatal error and returned before sending the DeviceModel and Device messages to the edge node. The API server could therefore contain both Device and DeviceStatus objects while the edge node never received the corresponding Device ObjectSync.

The create path now handles `AlreadyExists` by fetching the DeviceStatus created by the winning replica and continuing the normal Device/DeviceModel downlink path.

**Special notes for your reviewer**:

Validation performed:

- Verified the regression test fails against the old logic with `devicestatuses.devices.kubeedge.io "lite-node" already exists`.
- `go test ./cloud/pkg/devicecontroller/... -count=1`
- `git diff --check upstream/master...HEAD`

**Does this PR introduce a user-facing change?**:

```release-note
CloudCore devicecontroller now tolerates concurrent DeviceStatus create races so Device and DeviceModel downlink continues in HA deployments.
```
