### PR TITLE
cloudhub: preserve ObjectSync specs for CRDs

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -24,6 +24,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -295,10 +296,20 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 	}
 
 	clusterObjectSyncName := synccontroller.BuildObjectSyncName(nodeID, resourceUID)
+	desiredSpec := objectSyncSpecFromMessage(msg, resourceName)
 	clusterObjectSync, err := md.clusterObjectSyncLister.Get(clusterObjectSyncName)
 
 	switch {
 	case err == nil && clusterObjectSync.Status.ObjectResourceVersion != "":
+		if objectSyncSpecNeedsBackfill(clusterObjectSync.Spec, desiredSpec) {
+			clusterObjectSync, err = md.backfillClusterObjectSyncSpec(clusterObjectSync.Name, desiredSpec)
+			if err != nil {
+				klog.ErrorS(err, "Failed to backfill clusterObjectSync spec",
+					"clusterObjectSyncName", clusterObjectSyncName,
+					"resourceName", resourceName)
+				return false
+			}
+		}
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
@@ -310,11 +321,7 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterObjectSyncName,
 			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
+			Spec: desiredSpec,
 		}
 
 		clusterObjectSync, err := md.reliableClient.
@@ -359,10 +366,21 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 	}
 
 	objectSyncName := synccontroller.BuildObjectSyncName(nodeID, resourceUID)
+	desiredSpec := objectSyncSpecFromMessage(msg, resourceName)
 	objectSync, err := md.objectSyncLister.ObjectSyncs(resourceNamespace).Get(objectSyncName)
 
 	switch {
 	case err == nil && objectSync.Status.ObjectResourceVersion != "":
+		if objectSyncSpecNeedsBackfill(objectSync.Spec, desiredSpec) {
+			objectSync, err = md.backfillObjectSyncSpec(resourceNamespace, objectSync.Name, desiredSpec)
+			if err != nil {
+				klog.ErrorS(err, "Failed to backfill objectSync spec",
+					"objectSyncName", objectSyncName,
+					"resourceNamespace", resourceNamespace,
+					"resourceName", resourceName)
+				return false
+			}
+		}
 		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0 {
 			return true
 		}
@@ -375,11 +393,7 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 				Name:      objectSyncName,
 				Namespace: resourceNamespace,
 			},
-			Spec: v1alpha1.ObjectSyncSpec{
-				ObjectAPIVersion: util.GetMessageAPIVersion(msg),
-				ObjectKind:       util.GetMessageResourceType(msg),
-				ObjectName:       resourceName,
-			},
+			Spec: desiredSpec,
 		}
 
 		objectSyncStatus, err := md.reliableClient.
@@ -414,6 +428,85 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 	}
 
 	return false
+}
+
+func objectSyncSpecFromMessage(msg *beehivemodel.Message, resourceName string) v1alpha1.ObjectSyncSpec {
+	return v1alpha1.ObjectSyncSpec{
+		ObjectAPIVersion: util.GetMessageAPIVersion(msg),
+		ObjectKind:       util.GetMessageResourceType(msg),
+		ObjectName:       resourceName,
+	}
+}
+
+func objectSyncSpecNeedsBackfill(current, desired v1alpha1.ObjectSyncSpec) bool {
+	return (current.ObjectAPIVersion == "" && desired.ObjectAPIVersion != "") ||
+		(current.ObjectKind == "" && desired.ObjectKind != "") ||
+		(current.ObjectName == "" && desired.ObjectName != "")
+}
+
+func fillMissingObjectSyncSpec(current *v1alpha1.ObjectSyncSpec, desired v1alpha1.ObjectSyncSpec) bool {
+	updated := false
+	if current.ObjectAPIVersion == "" && desired.ObjectAPIVersion != "" {
+		current.ObjectAPIVersion = desired.ObjectAPIVersion
+		updated = true
+	}
+	if current.ObjectKind == "" && desired.ObjectKind != "" {
+		current.ObjectKind = desired.ObjectKind
+		updated = true
+	}
+	if current.ObjectName == "" && desired.ObjectName != "" {
+		current.ObjectName = desired.ObjectName
+		updated = true
+	}
+	return updated
+}
+
+func (md *messageDispatcher) backfillObjectSyncSpec(namespace, name string, desiredSpec v1alpha1.ObjectSyncSpec) (*v1alpha1.ObjectSync, error) {
+	var objectSync *v1alpha1.ObjectSync
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(namespace).
+			Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		latest = latest.DeepCopy()
+		if !fillMissingObjectSyncSpec(&latest.Spec, desiredSpec) {
+			objectSync = latest
+			return nil
+		}
+		objectSync, err = md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ObjectSyncs(namespace).
+			Update(context.Background(), latest, metav1.UpdateOptions{})
+		return err
+	})
+	return objectSync, err
+}
+
+func (md *messageDispatcher) backfillClusterObjectSyncSpec(name string, desiredSpec v1alpha1.ObjectSyncSpec) (*v1alpha1.ClusterObjectSync, error) {
+	var clusterObjectSync *v1alpha1.ClusterObjectSync
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, err := md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			Get(context.Background(), name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		latest = latest.DeepCopy()
+		if !fillMissingObjectSyncSpec(&latest.Spec, desiredSpec) {
+			clusterObjectSync = latest
+			return nil
+		}
+		clusterObjectSync, err = md.reliableClient.
+			ReliablesyncsV1alpha1().
+			ClusterObjectSyncs().
+			Update(context.Background(), latest, metav1.UpdateOptions{})
+		return err
+	})
+	return clusterObjectSync, err
 }
 
 func isDeleteMessage(msg *beehivemodel.Message) bool {

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -22,9 +22,15 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	policyv1alpha1 "github.com/kubeedge/api/apis/policy/v1alpha1"
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
 	"github.com/kubeedge/api/client/clientset/versioned/fake"
 	syncinformer "github.com/kubeedge/api/client/informers/externalversions"
@@ -33,6 +39,9 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common"
 	tf "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/testing"
 	"github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/session"
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
+	"github.com/kubeedge/kubeedge/cloud/pkg/synccontroller"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
 	mockcon "github.com/kubeedge/kubeedge/pkg/viaduct/pkg/conn/testing"
 )
 
@@ -358,6 +367,182 @@ func TestEnqueueAckMessage(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			executeTest(t, test)
 		})
+	}
+}
+
+func TestEnqueueNamespacedResourceSkipsAPIForInitializedObjectSync(t *testing.T) {
+	msg, objectSync := newNamespacedObjectSyncSpecTestData(t, true)
+	client, dispatcher := newObjectSyncSpecTestDispatcher(t, objectSync, nil)
+
+	if !dispatcher.enqueueNamespacedResource(tf.TestNodeID, msg) {
+		t.Fatal("expected newer message to be enqueued")
+	}
+	if actions := client.Actions(); len(actions) != 0 {
+		t.Fatalf("expected initialized hot path to avoid API calls, got %v", actions)
+	}
+}
+
+func TestEnqueueNonNamespacedResourceSkipsAPIForInitializedClusterObjectSync(t *testing.T) {
+	msg, clusterObjectSync := newClusterObjectSyncSpecTestData(t, true)
+	client, dispatcher := newObjectSyncSpecTestDispatcher(t, nil, clusterObjectSync)
+
+	if !dispatcher.enqueueNonNamespacedResource(tf.TestNodeID, msg) {
+		t.Fatal("expected newer message to be enqueued")
+	}
+	if actions := client.Actions(); len(actions) != 0 {
+		t.Fatalf("expected initialized hot path to avoid API calls, got %v", actions)
+	}
+}
+
+func TestEnqueueNamespacedResourceBackfillsMissingObjectSyncSpec(t *testing.T) {
+	msg, objectSync := newNamespacedObjectSyncSpecTestData(t, false)
+	client, dispatcher := newObjectSyncSpecTestDispatcher(t, objectSync, nil)
+
+	if !dispatcher.enqueueNamespacedResource(tf.TestNodeID, msg) {
+		t.Fatal("expected newer message to be enqueued after spec backfill")
+	}
+	assertBackfillActions(t, client.Actions())
+
+	got, err := client.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).
+		Get(t.Context(), objectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get objectSync: %v", err)
+	}
+	assertObjectSyncSpec(t, got.Spec, "policy.kubeedge.io/v1alpha1", "ServiceAccountAccess", "orangepi-agent")
+}
+
+func TestEnqueueNonNamespacedResourceBackfillsMissingClusterObjectSyncSpec(t *testing.T) {
+	msg, clusterObjectSync := newClusterObjectSyncSpecTestData(t, false)
+	client, dispatcher := newObjectSyncSpecTestDispatcher(t, nil, clusterObjectSync)
+
+	if !dispatcher.enqueueNonNamespacedResource(tf.TestNodeID, msg) {
+		t.Fatal("expected newer message to be enqueued after spec backfill")
+	}
+	assertBackfillActions(t, client.Actions())
+
+	got, err := client.ReliablesyncsV1alpha1().ClusterObjectSyncs().
+		Get(t.Context(), clusterObjectSync.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get clusterObjectSync: %v", err)
+	}
+	assertObjectSyncSpec(t, got.Spec, "v1", "Node", "test-resource-node")
+}
+
+func newNamespacedObjectSyncSpecTestData(t *testing.T, completeSpec bool) (*beehivemodel.Message, *v1alpha1.ObjectSync) {
+	t.Helper()
+	resource := &policyv1alpha1.ServiceAccountAccess{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "orangepi-agent",
+			Namespace:       tf.TestNamespace,
+			UID:             types.UID("service-account-access-uid"),
+			ResourceVersion: "3",
+		},
+	}
+	messageResource, err := messagelayer.BuildResource(
+		tf.TestNodeID, resource.Namespace, "serviceaccountaccess", resource.Name)
+	if err != nil {
+		t.Fatalf("failed to build message resource: %v", err)
+	}
+	msg := beehivemodel.NewMessage("").
+		SetResourceVersion(resource.ResourceVersion).
+		FillBody(resource).
+		BuildRouter("policycontroller", "resource", messageResource, "update")
+
+	spec := v1alpha1.ObjectSyncSpec{ObjectName: resource.Name}
+	if completeSpec {
+		spec.ObjectAPIVersion = "policy.kubeedge.io/v1alpha1"
+		spec.ObjectKind = "ServiceAccountAccess"
+	}
+	return msg, &v1alpha1.ObjectSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      synccontroller.BuildObjectSyncName(tf.TestNodeID, string(resource.UID)),
+			Namespace: resource.Namespace,
+		},
+		Spec: spec,
+		Status: v1alpha1.ObjectSyncStatus{
+			ObjectResourceVersion: "2",
+		},
+	}
+}
+
+func newClusterObjectSyncSpecTestData(t *testing.T, completeSpec bool) (*beehivemodel.Message, *v1alpha1.ClusterObjectSync) {
+	t.Helper()
+	resource := &corev1.Node{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Node"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-resource-node",
+			UID:             types.UID("node-uid"),
+			ResourceVersion: "3",
+		},
+	}
+	messageResource, err := messagelayer.BuildResource(
+		tf.TestNodeID, models.NullNamespace, "node", resource.Name)
+	if err != nil {
+		t.Fatalf("failed to build message resource: %v", err)
+	}
+	msg := beehivemodel.NewMessage("").
+		SetResourceVersion(resource.ResourceVersion).
+		FillBody(resource).
+		BuildRouter("edgecontroller", "resource", messageResource, "update")
+
+	spec := v1alpha1.ObjectSyncSpec{ObjectName: resource.Name}
+	if completeSpec {
+		spec.ObjectAPIVersion = "v1"
+		spec.ObjectKind = "Node"
+	}
+	return msg, &v1alpha1.ClusterObjectSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: synccontroller.BuildObjectSyncName(tf.TestNodeID, string(resource.UID)),
+		},
+		Spec: spec,
+		Status: v1alpha1.ObjectSyncStatus{
+			ObjectResourceVersion: "2",
+		},
+	}
+}
+
+func newObjectSyncSpecTestDispatcher(
+	t *testing.T,
+	objectSync *v1alpha1.ObjectSync,
+	clusterObjectSync *v1alpha1.ClusterObjectSync,
+) (*fake.Clientset, *messageDispatcher) {
+	t.Helper()
+	objects := make([]runtime.Object, 0, 2)
+	objectSyncIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	clusterObjectSyncIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if objectSync != nil {
+		objects = append(objects, objectSync.DeepCopy())
+		if err := objectSyncIndexer.Add(objectSync); err != nil {
+			t.Fatalf("failed to seed objectSync lister: %v", err)
+		}
+	}
+	if clusterObjectSync != nil {
+		objects = append(objects, clusterObjectSync.DeepCopy())
+		if err := clusterObjectSyncIndexer.Add(clusterObjectSync); err != nil {
+			t.Fatalf("failed to seed clusterObjectSync lister: %v", err)
+		}
+	}
+
+	client := fake.NewSimpleClientset(objects...)
+	client.ClearActions()
+	return client, &messageDispatcher{
+		reliableClient:          client,
+		objectSyncLister:        synclisters.NewObjectSyncLister(objectSyncIndexer),
+		clusterObjectSyncLister: synclisters.NewClusterObjectSyncLister(clusterObjectSyncIndexer),
+	}
+}
+
+func assertBackfillActions(t *testing.T, actions []ktesting.Action) {
+	t.Helper()
+	if len(actions) != 2 || actions[0].GetVerb() != "get" || actions[1].GetVerb() != "update" {
+		t.Fatalf("expected get and update backfill actions, got %v", actions)
+	}
+}
+
+func assertObjectSyncSpec(t *testing.T, spec v1alpha1.ObjectSyncSpec, apiVersion, kind, name string) {
+	t.Helper()
+	if spec.ObjectAPIVersion != apiVersion || spec.ObjectKind != kind || spec.ObjectName != name {
+		t.Fatalf("unexpected objectSync spec: %#v", spec)
 	}
 }
 

--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -11,10 +12,12 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage"
-	"k8s.io/client-go/kubernetes/scheme"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 
+	kubeedgescheme "github.com/kubeedge/api/client/clientset/versioned/scheme"
 	beehiveModel "github.com/kubeedge/beehive/pkg/core/model"
 )
 
@@ -23,18 +26,15 @@ import (
 // apiVersion: apps/v1
 // kind: Deployments
 // }
-// TODO: support crd
 func SetMetaType(obj runtime.Object) error {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err
 	}
-	//gvr,_,_ := apiserverlite.ParseKey(accessor.GetSelfLink())
-	kinds, _, err := scheme.Scheme.ObjectKinds(obj)
+	gvk, err := getObjectKind(obj)
 	if err != nil {
 		return err
 	}
-	gvk := kinds[0]
 	obj.GetObjectKind().SetGroupVersionKind(gvk)
 	klog.V(6).Infof("[metaserver]successfully set MetaType for obj %v, %+v", obj.GetObjectKind(), accessor.GetName())
 	return nil
@@ -128,22 +128,50 @@ func UnstructuredAttr(obj runtime.Object) (labels.Set, fields.Set, error) {
 	}
 }
 
-// GetMessageUID returns the UID of the object in message
+// GetMessageAPIVersion returns the API version of the object in message.
 func GetMessageAPIVersion(msg *beehiveModel.Message) string {
 	obj, ok := msg.Content.(runtime.Object)
 	if ok {
-		return obj.GetObjectKind().GroupVersionKind().GroupVersion().String()
+		gvk, err := getObjectKind(obj)
+		if err != nil {
+			return ""
+		}
+		return gvk.GroupVersion().String()
 	}
 	return ""
 }
 
-// GetMessageUID returns the UID of the object in message
+// GetMessageResourceType returns the kind of the object in message.
 func GetMessageResourceType(msg *beehiveModel.Message) string {
 	obj, ok := msg.Content.(runtime.Object)
 	if ok {
-		return obj.GetObjectKind().GroupVersionKind().Kind
+		gvk, err := getObjectKind(obj)
+		if err != nil {
+			return ""
+		}
+		return gvk.Kind
 	}
 	return ""
+}
+
+func getObjectKind(obj runtime.Object) (schema.GroupVersionKind, error) {
+	if obj == nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("object is nil")
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if !gvk.Empty() {
+		return gvk, nil
+	}
+
+	for _, scheme := range []*runtime.Scheme{kubescheme.Scheme, kubeedgescheme.Scheme} {
+		kinds, _, err := scheme.ObjectKinds(obj)
+		if err == nil && len(kinds) > 0 {
+			return kinds[0], nil
+		}
+	}
+
+	return schema.GroupVersionKind{}, fmt.Errorf("no kind is registered for object %T", obj)
 }
 
 type key int

--- a/pkg/metaserver/util/util_test.go
+++ b/pkg/metaserver/util/util_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	policyv1alpha1 "github.com/kubeedge/api/apis/policy/v1alpha1"
 	beehiveModel "github.com/kubeedge/beehive/pkg/core/model"
 )
 
@@ -45,6 +46,14 @@ func TestGetMessageAPIVerison(t *testing.T) {
 					Content: "content",
 				}},
 			want: "",
+		},
+		{
+			name: "TestGetMessageAPIVerison(): Case 3: KubeEdge CRD without TypeMeta",
+			args: args{
+				msg: &beehiveModel.Message{
+					Content: &policyv1alpha1.ServiceAccountAccess{},
+				}},
+			want: "policy.kubeedge.io/v1alpha1",
 		},
 	}
 	for _, tt := range tests {
@@ -85,6 +94,14 @@ func TestGetMessageResourceType(t *testing.T) {
 					Content: "content",
 				}},
 			want: "",
+		},
+		{
+			name: "TestGetMessageResourceType(): Case 3: KubeEdge CRD without TypeMeta",
+			args: args{
+				msg: &beehiveModel.Message{
+					Content: &policyv1alpha1.ServiceAccountAccess{},
+				}},
+			want: "ServiceAccountAccess",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR preserves ObjectSync and ClusterObjectSync GVK metadata for Kubernetes and KubeEdge runtime objects, including KubeEdge CRDs whose in-memory objects do not contain TypeMeta.

When a downstream `ServiceAccountAccess` object had an empty TypeMeta, `GetMessageAPIVersion` and `GetMessageResourceType` returned empty strings. CloudHub then created an ObjectSync with empty `spec.objectAPIVersion` and `spec.objectKind`, so synccontroller could not reconstruct and resend the object during compensation.

The change resolves GVK from the Kubernetes and KubeEdge runtime schemes when TypeMeta is absent. New ObjectSync records use that resolved spec, and existing records backfill only missing spec fields with conflict retries.

The backfill is guarded by the informer-cached spec. When the ObjectSync or ClusterObjectSync spec and status are already initialized, dispatch compares resource versions directly and performs no synchronous API server call. API GET/UPDATE calls only occur when a spec field is actually missing and a replacement value is available.

**Special notes for your reviewer**:

Validation performed:

- Added namespaced and cluster-scoped tests that assert the initialized dispatch hot path records zero client actions.
- Added namespaced and cluster-scoped tests that assert missing specs perform exactly GET and UPDATE before dispatch continues.
- Added KubeEdge CRD tests for API version and kind resolution without TypeMeta.
- `go test ./pkg/metaserver/util ./cloud/pkg/cloudhub/dispatcher ./cloud/pkg/cloudhub/session -count=1`
- `git diff --check upstream/master...HEAD`

The broader `go test ./cloud/pkg/cloudhub/...` command also reaches an unrelated existing panic in `cloud/pkg/cloudhub/servers/httpserver/node`; the same failure reproduces on the current upstream master without this change.

**Does this PR introduce a user-facing change?**:

```release-note
CloudHub now preserves and conditionally backfills ObjectSync GVK metadata for Kubernetes and KubeEdge runtime objects without adding API server calls to the initialized dispatch hot path.
```
