### PR TITLE
[release-1.21] Backport security hardening fixes for v1.21.2

### DIFF
--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
@@ -22,14 +22,13 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"strings"
 
-	"github.com/blang/semver"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/operations/v1alpha1"
+	"github.com/kubeedge/kubeedge/pkg/util/validation"
 )
 
 func serveNodeUpgradeJob(w http.ResponseWriter, r *http.Request) {
@@ -49,7 +48,6 @@ func admitNodeUpgradeJob(review admissionv1.AdmissionReview) *admissionv1.Admiss
 		if _, _, err := deserializer.Decode(raw, nil, &upgrade); err != nil {
 			return admissionResponse(fmt.Errorf("validation failed with error: %v", err))
 		}
-
 		return admissionResponse(validateNodeUpgradeJob(&upgrade))
 
 	case admissionv1.Update:
@@ -58,7 +56,6 @@ func admitNodeUpgradeJob(review admissionv1.AdmissionReview) *admissionv1.Admiss
 		if _, _, err := deserializer.Decode(review.Request.Object.Raw, nil, &newUpgrade); err != nil {
 			return admissionResponse(fmt.Errorf("validation failed with error: %v", err))
 		}
-
 		oldUpgrade := v1alpha1.NodeUpgradeJob{}
 		if _, _, err := deserializer.Decode(review.Request.OldObject.Raw, nil, &oldUpgrade); err != nil {
 			return admissionResponse(fmt.Errorf("validation failed with error: %v", err))
@@ -82,16 +79,13 @@ func admitNodeUpgradeJob(review admissionv1.AdmissionReview) *admissionv1.Admiss
 }
 
 func validateNodeUpgradeJob(upgrade *v1alpha1.NodeUpgradeJob) error {
-	// version must be valid
-	if !strings.HasPrefix(upgrade.Spec.Version, "v") {
-		return fmt.Errorf("version must begin with prefix 'v'")
+	if !validation.ValidateVersion(upgrade.Spec.Version) {
+		return fmt.Errorf("invalid version %s", upgrade.Spec.Version)
 	}
-
-	_, err := semver.Parse(strings.TrimPrefix(upgrade.Spec.Version, "v"))
-	if err != nil {
-		return fmt.Errorf("version is not a semver compatible version: %v", err)
+	// Image is a optional field.
+	if upgrade.Spec.Image != "" && !validation.ValidateImageRepo(upgrade.Spec.Image) {
+		return fmt.Errorf("invalid image repo %s", upgrade.Spec.Image)
 	}
-
 	// we must specify NodeNames or LabelSelector, and we can only specify only one
 	if len(upgrade.Spec.NodeNames) == 0 && upgrade.Spec.LabelSelector == nil {
 		return fmt.Errorf("both NodeNames and LabelSelctor are NOT specified")

--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
@@ -88,10 +88,10 @@ func validateNodeUpgradeJob(upgrade *v1alpha1.NodeUpgradeJob) error {
 	}
 	// we must specify NodeNames or LabelSelector, and we can only specify only one
 	if len(upgrade.Spec.NodeNames) == 0 && upgrade.Spec.LabelSelector == nil {
-		return fmt.Errorf("both NodeNames and LabelSelctor are NOT specified")
+		return fmt.Errorf("both NodeNames and LabelSelector are NOT specified")
 	}
 	if len(upgrade.Spec.NodeNames) != 0 && upgrade.Spec.LabelSelector != nil {
-		return fmt.Errorf("both NodeNames and LabelSelctor are specified")
+		return fmt.Errorf("both NodeNames and LabelSelector are specified")
 	}
 
 	return nil
@@ -145,7 +145,7 @@ func generateNodeUpgradeJobPatch(spec v1alpha1.NodeUpgradeJobSpec) []patchValue 
 	// mutate .spec.concurrency to default value 1 if not specified
 	if spec.Concurrency == 0 {
 		patch = append(patch, patchValue{
-			Op:    "replace",
+			Op:    "add",
 			Path:  "/spec/concurrency",
 			Value: 1,
 		})
@@ -154,7 +154,7 @@ func generateNodeUpgradeJobPatch(spec v1alpha1.NodeUpgradeJobSpec) []patchValue 
 	if spec.TimeoutSeconds == nil {
 		var defaultTimeoutSeconds uint32 = 300
 		patch = append(patch, patchValue{
-			Op:    "replace",
+			Op:    "add",
 			Path:  "/spec/timeoutSeconds",
 			Value: &defaultTimeoutSeconds,
 		})

--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
@@ -96,7 +96,7 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 				},
 			},
 			expectedAllowed: false,
-			expectedError:   "both NodeNames and LabelSelctor are NOT specified",
+			expectedError:   "both NodeNames and LabelSelector are NOT specified",
 		},
 		{
 			name:      "Both NodeNames and LabelSelector",
@@ -109,7 +109,7 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 				},
 			},
 			expectedAllowed: false,
-			expectedError:   "both NodeNames and LabelSelctor are specified",
+			expectedError:   "both NodeNames and LabelSelector are specified",
 		},
 		{
 			name:      "Valid Update",
@@ -238,7 +238,7 @@ func TestValidateNodeUpgradeJob(t *testing.T) {
 					Version: "v1.0.0",
 				},
 			},
-			expectedErr: "both NodeNames and LabelSelctor are NOT specified",
+			expectedErr: "both NodeNames and LabelSelector are NOT specified",
 		},
 		{
 			name: "Both NodeNames and LabelSelector specified",
@@ -249,7 +249,7 @@ func TestValidateNodeUpgradeJob(t *testing.T) {
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
-			expectedErr: "both NodeNames and LabelSelctor are specified",
+			expectedErr: "both NodeNames and LabelSelector are specified",
 		},
 		{
 			name: "Valid upgrade job",
@@ -344,10 +344,10 @@ func TestMutatingNodeUpgradeJob(t *testing.T) {
 	err = json.Unmarshal(response.Patch, &patch)
 	assert.NoError(err)
 	assert.Len(patch, 2)
-	assert.Equal("replace", patch[0]["op"])
+	assert.Equal("add", patch[0]["op"])
 	assert.Equal("/spec/concurrency", patch[0]["path"])
 	assert.Equal(float64(1), patch[0]["value"])
-	assert.Equal("replace", patch[1]["op"])
+	assert.Equal("add", patch[1]["op"])
 	assert.Equal("/spec/timeoutSeconds", patch[1]["path"])
 	assert.Equal(float64(300), patch[1]["value"])
 }
@@ -378,12 +378,12 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 			expectedPatch: []patchValue{
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/concurrency",
 					Value: 1,
 				},
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/timeoutSeconds",
 					Value: func() *uint32 { v := uint32(300); return &v }(),
 				},
@@ -398,7 +398,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 			expectedPatch: []patchValue{
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/concurrency",
 					Value: 1,
 				},
@@ -413,7 +413,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			},
 			expectedPatch: []patchValue{
 				{
-					Op:    "replace",
+					Op:    "add",
 					Path:  "/spec/timeoutSeconds",
 					Value: func() *uint32 { v := uint32(300); return &v }(),
 				},
@@ -426,5 +426,54 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 			patch := generateNodeUpgradeJobPatch(tc.spec)
 			assert.Equal(tc.expectedPatch, patch)
 		})
+	}
+}
+
+func TestValidateNodeUpgradeJobAllowsOptionalAndValidImage(t *testing.T) {
+	cases := []struct {
+		name    string
+		upgrade *v1alpha1.NodeUpgradeJob
+	}{
+		{
+			name: "empty image is allowed",
+			upgrade: &v1alpha1.NodeUpgradeJob{
+				Spec: v1alpha1.NodeUpgradeJobSpec{
+					Version:   "v1.0.0",
+					NodeNames: []string{"node1"},
+				},
+			},
+		},
+		{
+			name: "valid image repo is allowed",
+			upgrade: &v1alpha1.NodeUpgradeJob{
+				Spec: v1alpha1.NodeUpgradeJobSpec{
+					Version:   "v1.0.0",
+					Image:     "kubeedge/installation-package:v1.23.1",
+					NodeNames: []string{"node1"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateNodeUpgradeJob(tt.upgrade); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestGenerateNodeUpgradeJobPatchReturnsEmptyWhenDefaultsSpecified(t *testing.T) {
+	timeoutSeconds := uint32(600)
+	patch := generateNodeUpgradeJobPatch(v1alpha1.NodeUpgradeJobSpec{
+		Version:        "v1.0.0",
+		NodeNames:      []string{"node1"},
+		Concurrency:    2,
+		TimeoutSeconds: &timeoutSeconds,
+	})
+
+	if len(patch) != 0 {
+		t.Fatalf("expected empty patch, got %#v", patch)
 	}
 }

--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
@@ -61,7 +61,7 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 				},
 			},
 			expectedAllowed: false,
-			expectedError:   "version must begin with prefix 'v'",
+			expectedError:   "invalid version 1.0.0",
 		},
 		{
 			name:      "Invalid Semver",
@@ -73,7 +73,19 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 				},
 			},
 			expectedAllowed: false,
-			expectedError:   "version is not a semver compatible version",
+			expectedError:   "invalid version v1.0",
+		},
+		{
+			name:      "Invalid image",
+			operation: admissionv1.Create,
+			upgrade: &v1alpha1.NodeUpgradeJob{
+				Spec: v1alpha1.NodeUpgradeJobSpec{
+					Version: "v1.0.0",
+					Image:   "invalid-image",
+				},
+			},
+			expectedAllowed: false,
+			expectedError:   "invalid image repo invalid-image",
 		},
 		{
 			name:      "No NodeNames and LabelSelector",
@@ -197,7 +209,17 @@ func TestValidateNodeUpgradeJob(t *testing.T) {
 					NodeNames: []string{"node1"},
 				},
 			},
-			expectedErr: "version must begin with prefix 'v'",
+			expectedErr: "invalid version 1.0.0",
+		},
+		{
+			name: "Invalid image",
+			upgrade: &v1alpha1.NodeUpgradeJob{
+				Spec: v1alpha1.NodeUpgradeJobSpec{
+					Version: "v1.0.0",
+					Image:   "invalid-image",
+				},
+			},
+			expectedErr: "invalid image repo invalid-image",
 		},
 		{
 			name: "Invalid version (not semver compatible)",
@@ -207,7 +229,7 @@ func TestValidateNodeUpgradeJob(t *testing.T) {
 					NodeNames: []string{"node1"},
 				},
 			},
-			expectedErr: "version is not a semver compatible version",
+			expectedErr: "invalid version v1.0",
 		},
 		{
 			name: "Missing both NodeNames and LabelSelector",

--- a/cloud/test/integration/scripts/execute.sh
+++ b/cloud/test/integration/scripts/execute.sh
@@ -22,11 +22,11 @@ ENVTEST_BIN_DIR=""
 
 function do_preparation() {
     which setup-envtest &> /dev/null || {
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
+        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
         sudo cp $GOPATH/bin/setup-envtest /usr/bin/
     }
 
-    ENVTEST_BIN_DIR=$(setup-envtest use 1.22.1 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
+    ENVTEST_BIN_DIR=$(setup-envtest use 1.23.5 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
 
     which ginkgo &>/dev/null || {
         go install github.com/onsi/ginkgo/ginkgo@latest

--- a/edge/pkg/metamanager/process_test.go
+++ b/edge/pkg/metamanager/process_test.go
@@ -193,16 +193,13 @@ func TestProcessInsert(t *testing.T) {
 	})
 
 	//jsonMarshall fail
-	msg = model.NewMessage("").BuildRouter(ModuleNameEdged, GroupResource, model.ResourceTypeLease, model.InsertOperation).FillBody(make(chan int))
+	msg = model.NewMessage("").BuildRouter(ModuleNameController, GroupResource, model.ResourceTypeLease, model.InsertOperation).FillBody(make(chan int))
 	meta.processInsert(*msg)
 	message, err = beehiveContext.Receive(ModuleNameEdgeHub)
 	if err != nil {
 		t.Errorf("EdgeHub Channel not found: %v", err)
 		return
 	}
-	message.Header.ParentID = message.GetID()
-	beehiveContext.SendResp(message)
-	message, err = beehiveContext.Receive(ModuleNameEdged)
 	t.Run("MarshallFail", func(t *testing.T) {
 		if message.GetContent() != marshalError {
 			t.Errorf("Wrong Error message received : Wanted %v and Got %v", marshalError, message.GetContent())

--- a/edge/pkg/taskmanager/actions/configupdatejob.go
+++ b/edge/pkg/taskmanager/actions/configupdatejob.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -98,15 +100,11 @@ func (h *configUpdateJobActionHandler) updateConfig(
 		return resp
 	}
 
-	var setFields string
-	for updateKey, updateVal := range spec.UpdateFields {
-		setFields = setFields + fmt.Sprintf("%s=%s,", updateKey, updateVal)
-	}
-	setFields = strings.TrimSuffix(setFields, ",")
-	cmdStr := execs.NewCommand(fmt.Sprintf("keadm config-update --set %s", setFields))
-	err := cmdStr.Exec()
+	args := buildConfigUpdateArgs(spec.UpdateFields)
+	cmd := exec.Command("keadm", args...)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		resp.err = err
+		resp.err = fmt.Errorf("update config failed, err: %w, output: %s", err, out)
 		return resp
 	}
 	return resp
@@ -150,4 +148,14 @@ func (h *configUpdateJobActionHandler) reportActionStatus(jobname, nodename, act
 		body.Succ = true
 	}
 	message.ReportNodeTaskStatus(res, body)
+}
+
+func buildConfigUpdateArgs(updateFields map[string]string) []string {
+	setFields := make([]string, 0, len(updateFields))
+	for updateKey, updateVal := range updateFields {
+		setFields = append(setFields, fmt.Sprintf("%s=%s", updateKey, updateVal))
+	}
+	sort.Strings(setFields)
+
+	return []string{"config-update", "--set", strings.Join(setFields, ",")}
 }

--- a/edge/pkg/taskmanager/actions/configupdatejob_test.go
+++ b/edge/pkg/taskmanager/actions/configupdatejob_test.go
@@ -47,3 +47,36 @@ func TestBuildConfigUpdateArgsDoesNotUseShell(t *testing.T) {
 		t.Fatalf("args must not invoke a shell: %v", args)
 	}
 }
+
+func TestBuildConfigUpdateArgsSortsFields(t *testing.T) {
+	updateFields := map[string]string{
+		"z.key": "z",
+		"a.key": "a",
+	}
+
+	args := buildConfigUpdateArgs(updateFields)
+
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "config-update" {
+		t.Fatalf("expected config-update subcommand, got %q", args[0])
+	}
+	if args[1] != "--set" {
+		t.Fatalf("expected --set flag, got %q", args[1])
+	}
+	if args[2] != "a.key=a,z.key=z" {
+		t.Fatalf("unexpected --set value: %q", args[2])
+	}
+}
+
+func TestBuildConfigUpdateArgsEmptyFields(t *testing.T) {
+	args := buildConfigUpdateArgs(map[string]string{})
+
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "config-update" || args[1] != "--set" || args[2] != "" {
+		t.Fatalf("unexpected args for empty update fields: %v", args)
+	}
+}

--- a/edge/pkg/taskmanager/actions/configupdatejob_test.go
+++ b/edge/pkg/taskmanager/actions/configupdatejob_test.go
@@ -21,6 +21,11 @@ import (
 	"testing"
 )
 
+const (
+	testConfigUpdateCommand = "config-update"
+	testConfigUpdateSetFlag = "--set"
+)
+
 func TestBuildConfigUpdateArgsDoesNotUseShell(t *testing.T) {
 	updateFields := map[string]string{
 		"modules.edgehub.websocket.url":           "ws://127.0.0.1:10000/e632aba927ea4ac2b575ec1603d56f10/events",
@@ -32,10 +37,10 @@ func TestBuildConfigUpdateArgsDoesNotUseShell(t *testing.T) {
 	if len(args) != 3 {
 		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 	}
-	if args[0] != "config-update" {
+	if args[0] != testConfigUpdateCommand {
 		t.Fatalf("expected config-update subcommand, got %q", args[0])
 	}
-	if args[1] != "--set" {
+	if args[1] != testConfigUpdateSetFlag {
 		t.Fatalf("expected --set flag, got %q", args[1])
 	}
 	if !strings.Contains(args[2], "30; touch /tmp/pwned") {
@@ -59,10 +64,10 @@ func TestBuildConfigUpdateArgsSortsFields(t *testing.T) {
 	if len(args) != 3 {
 		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 	}
-	if args[0] != "config-update" {
+	if args[0] != testConfigUpdateCommand {
 		t.Fatalf("expected config-update subcommand, got %q", args[0])
 	}
-	if args[1] != "--set" {
+	if args[1] != testConfigUpdateSetFlag {
 		t.Fatalf("expected --set flag, got %q", args[1])
 	}
 	if args[2] != "a.key=a,z.key=z" {
@@ -76,7 +81,7 @@ func TestBuildConfigUpdateArgsEmptyFields(t *testing.T) {
 	if len(args) != 3 {
 		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
 	}
-	if args[0] != "config-update" || args[1] != "--set" || args[2] != "" {
+	if args[0] != testConfigUpdateCommand || args[1] != testConfigUpdateSetFlag || args[2] != "" {
 		t.Fatalf("unexpected args for empty update fields: %v", args)
 	}
 }

--- a/edge/pkg/taskmanager/actions/configupdatejob_test.go
+++ b/edge/pkg/taskmanager/actions/configupdatejob_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actions
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildConfigUpdateArgsDoesNotUseShell(t *testing.T) {
+	updateFields := map[string]string{
+		"modules.edgehub.websocket.url":           "ws://127.0.0.1:10000/e632aba927ea4ac2b575ec1603d56f10/events",
+		"modules.edgehub.websocket.writeDeadline": "30; touch /tmp/pwned",
+	}
+
+	args := buildConfigUpdateArgs(updateFields)
+
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "config-update" {
+		t.Fatalf("expected config-update subcommand, got %q", args[0])
+	}
+	if args[1] != "--set" {
+		t.Fatalf("expected --set flag, got %q", args[1])
+	}
+	if !strings.Contains(args[2], "30; touch /tmp/pwned") {
+		t.Fatalf("expected update value to remain a single argv value, got %q", args[2])
+	}
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "bash -c") || strings.Contains(joined, "sh -c") {
+		t.Fatalf("args must not invoke a shell: %v", args)
+	}
+}

--- a/edge/pkg/taskmanager/actions/nodeupgradejob.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -38,6 +39,7 @@ import (
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
 	upgradeedge "github.com/kubeedge/kubeedge/pkg/upgrade/edge"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
+	"github.com/kubeedge/kubeedge/pkg/util/validation"
 )
 
 func newNodeUpgradeJobRunner() *ActionRunner {
@@ -129,6 +131,15 @@ func (nodeUpgradeJobActionHandler) checkItems(
 			resp.err = err
 			return resp
 		}
+	}
+
+	if !validation.ValidateVersion(spec.Version) {
+		resp.err = fmt.Errorf("invalid version %s", spec.Version)
+		return resp
+	}
+	if spec.Image != "" && !validation.ValidateImageRepo(spec.Image) {
+		resp.err = fmt.Errorf("invalid image repo %s", spec.Image)
+		return resp
 	}
 
 	// Pull installation-package image.
@@ -241,16 +252,41 @@ func (h *nodeUpgradeJobActionHandler) upgrade(
 		resp.interrupt = true // No upgrade yet, no need to roll back.
 		return resp
 	}
-	var cmdline strings.Builder
-	cmdline.WriteString("keadm upgrade edge --force --toVersion " + spec.Version)
-	if spec.Image != "" {
-		cmdline.WriteString(" --image " + spec.Image)
+	if !validation.ValidateVersion(spec.Version) {
+		resp.err = fmt.Errorf("invalid version %s", spec.Version)
+		resp.interrupt = true // No upgrade yet, no need to roll back.
+		return resp
 	}
-	cmdline.WriteString(" >> /tmp/keadm.log 2>&1")
-	cmd := execs.NewCommand(cmdline.String())
-	h.logger.V(2).Info("run upgrade cmd", "cmd", cmdline.String())
-	resp.err = cmd.Exec()
+	if spec.Image != "" && !validation.ValidateImageRepo(spec.Image) {
+		resp.err = fmt.Errorf("invalid image repo %s", spec.Image)
+		resp.interrupt = true // No upgrade yet, no need to roll back.
+		return resp
+	}
+
+	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		resp.err = fmt.Errorf("failed to open keadm log file: %w", err)
+		resp.interrupt = true // No upgrade yet, no need to roll back.
+		return resp
+	}
+	defer logFile.Close()
+
+	args := buildNodeUpgradeJobCommandArgs(spec)
+
+	cmd := exec.Command("keadm", args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	h.logger.V(2).Info("run upgrade cmd", "cmd", "keadm", "args", args)
+	resp.err = cmd.Run()
 	return resp
+}
+
+func buildNodeUpgradeJobCommandArgs(spec *operationsv1alpha2.NodeUpgradeJobSpec) []string {
+	args := []string{"upgrade", "edge", "--force", "--toVersion", spec.Version}
+	if spec.Image != "" {
+		args = append(args, "--image", spec.Image)
+	}
+	return args
 }
 
 func (h *nodeUpgradeJobActionHandler) rollback(

--- a/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
@@ -259,51 +259,50 @@ func TestNodeUpgradeJobBackup(t *testing.T) {
 }
 
 func TestNodeUpgradeJobUpgrade(t *testing.T) {
-	ctx := context.TODO()
-	specser := &cachedSpecSerializer{}
-	h := nodeUpgradeJobActionHandler{
-		logger: klog.Background(),
-	}
-
-	t.Run("get spec failed", func(t *testing.T) {
-		resp := h.upgrade(ctx, "", "", specser)
-		require.ErrorContains(t, resp.Error(), "failed to conv spec to NodeUpgradeJobSpec, actual type <nil>")
-		require.True(t, resp.NeedInterrupt())
-	})
-
-	t.Run("standard upgrade command", func(t *testing.T) {
-		patches := gomonkey.NewPatches()
-		defer patches.Reset()
-
-		patches.ApplyMethod(reflect.TypeOf((*execs.Command)(nil)), "Exec",
-			func(cmd *execs.Command) error {
-				assert.Equal(t, "bash -c keadm upgrade edge --force --toVersion 1.21.0 >> /tmp/keadm.log 2>&1", cmd.GetCommand())
-				return nil
-			})
-
-		specser.spec = &operationsv1alpha2.NodeUpgradeJobSpec{
-			Version: "1.21.0",
+	t.Run("standard upgrade command args", func(t *testing.T) {
+		spec := &operationsv1alpha2.NodeUpgradeJobSpec{
+			Version: "v1.21.0",
 		}
-		resp := h.upgrade(ctx, "", "", specser)
-		require.NoError(t, resp.Error())
+
+		args := buildNodeUpgradeJobCommandArgs(spec)
+
+		assert.Equal(t, []string{
+			"upgrade", "edge",
+			"--force",
+			"--toVersion", "v1.21.0",
+		}, args)
 	})
 
-	t.Run("custom image repository upgrade command", func(t *testing.T) {
-		patches := gomonkey.NewPatches()
-		defer patches.Reset()
-
-		patches.ApplyMethod(reflect.TypeOf((*execs.Command)(nil)), "Exec",
-			func(cmd *execs.Command) error {
-				assert.Equal(t, "bash -c keadm upgrade edge --force --toVersion 1.21.0 --image custom.com/kubeedge/installation-package >> /tmp/keadm.log 2>&1", cmd.GetCommand())
-				return nil
-			})
-
-		specser.spec = &operationsv1alpha2.NodeUpgradeJobSpec{
-			Version: "1.21.0",
+	t.Run("custom image repository upgrade command args", func(t *testing.T) {
+		spec := &operationsv1alpha2.NodeUpgradeJobSpec{
+			Version: "v1.21.0",
 			Image:   "custom.com/kubeedge/installation-package",
 		}
-		resp := h.upgrade(ctx, "", "", specser)
-		require.NoError(t, resp.Error())
+
+		args := buildNodeUpgradeJobCommandArgs(spec)
+
+		assert.Equal(t, []string{
+			"upgrade", "edge",
+			"--force",
+			"--toVersion", "v1.21.0",
+			"--image", "custom.com/kubeedge/installation-package",
+		}, args)
+	})
+
+	t.Run("malicious fields are kept as argv values", func(t *testing.T) {
+		spec := &operationsv1alpha2.NodeUpgradeJobSpec{
+			Version: "v1.21.0; touch /tmp/pwned",
+			Image:   "custom.com/kubeedge/installation-package$(touch /tmp/pwned)",
+		}
+
+		args := buildNodeUpgradeJobCommandArgs(spec)
+
+		assert.Equal(t, []string{
+			"upgrade", "edge",
+			"--force",
+			"--toVersion", "v1.21.0; touch /tmp/pwned",
+			"--image", "custom.com/kubeedge/installation-package$(touch /tmp/pwned)",
+		}, args)
 	})
 }
 

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -153,19 +154,40 @@ func upgrade(taskReq types.NodeTaskRequest) (event fsm.Event) {
 
 func keadmUpgrade(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) error {
 	klog.Infof("Begin to run upgrade command")
-	upgradeCmd := fmt.Sprintf("keadm upgrade edge --upgradeID %s --historyID %s --fromVersion %s --toVersion %s --config %s --image %s > /tmp/keadm.log 2>&1",
-		upgradeReq.UpgradeID, upgradeReq.HistoryID, version.Get(), upgradeReq.Version, opts.ConfigFile, upgradeReq.Image)
 
-	// run upgrade cmd to upgrade edge node
-	// use nohup command to start a child progress
-	command := fmt.Sprintf("nohup %s &", upgradeCmd)
-	cmd := exec.Command("bash", "-c", command)
-	s, err := cmd.CombinedOutput()
+	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
-		return fmt.Errorf("run upgrade command %s failed: %v, %s", command, err, s)
+		return fmt.Errorf("failed to open keadm log file: %w", err)
 	}
-	klog.Infof("!!! Finish upgrade from Version %s to %s ...", version.Get(), upgradeReq.Version)
+	defer logFile.Close()
+
+	args := buildKeadmUpgradeArgs(upgradeReq, opts)
+
+	cmd := exec.Command("nohup", append([]string{"keadm"}, args...)...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start keadm upgrade command: %w", err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return fmt.Errorf("failed to release keadm upgrade process: %w", err)
+	}
+
+	klog.Infof("Started keadm upgrade from Version %s to %s ...", version.Get().String(), upgradeReq.Version)
 	return nil
+}
+
+func buildKeadmUpgradeArgs(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) []string {
+	return []string{
+		"upgrade", "edge",
+		"--upgradeID", upgradeReq.UpgradeID,
+		"--historyID", upgradeReq.HistoryID,
+		"--fromVersion", version.Get().String(),
+		"--toVersion", upgradeReq.Version,
+		"--config", opts.ConfigFile,
+		"--image", upgradeReq.Image,
+	}
 }
 
 func prepareKeadm(upgradeReq *commontypes.NodeUpgradeJobRequest) error {

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
@@ -18,6 +18,7 @@ package taskexecutor
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	commontypes "github.com/kubeedge/kubeedge/common/types"
@@ -50,5 +51,25 @@ func TestBuildKeadmUpgradeArgsDoesNotUseShell(t *testing.T) {
 
 	if !reflect.DeepEqual(args, want) {
 		t.Fatalf("unexpected args: got %v, want %v", args, want)
+	}
+}
+
+func TestKeadmUpgradeReturnsErrorWhenCommandMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	err := keadmUpgrade(commontypes.NodeUpgradeJobRequest{
+		UpgradeID: "upgrade-1",
+		HistoryID: "history-1",
+		Version:   "v1.23.1",
+		Image:     "kubeedge/installation-package:v1.23.1",
+	}, &options.EdgeCoreOptions{
+		ConfigFile: "/etc/kubeedge/config/edgecore.yaml",
+	})
+
+	if err == nil {
+		t.Fatal("expected error when keadm command cannot be started")
+	}
+	if !strings.Contains(err.Error(), "failed to start keadm upgrade command") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskexecutor
+
+import (
+	"reflect"
+	"testing"
+
+	commontypes "github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
+	"github.com/kubeedge/kubeedge/pkg/version"
+)
+
+func TestBuildKeadmUpgradeArgsDoesNotUseShell(t *testing.T) {
+	upgradeReq := commontypes.NodeUpgradeJobRequest{
+		UpgradeID: "upgrade-1; touch /tmp/pwned",
+		HistoryID: "history-1$(touch /tmp/pwned)",
+		Version:   "v1.23.1; rm -rf /",
+		Image:     "kubeedge/installation-package; touch /tmp/pwned",
+	}
+	opts := &options.EdgeCoreOptions{
+		ConfigFile: "/etc/kubeedge/config/edgecore.yaml; touch /tmp/pwned",
+	}
+
+	args := buildKeadmUpgradeArgs(upgradeReq, opts)
+
+	want := []string{
+		"upgrade", "edge",
+		"--upgradeID", upgradeReq.UpgradeID,
+		"--historyID", upgradeReq.HistoryID,
+		"--fromVersion", version.Get().String(),
+		"--toVersion", upgradeReq.Version,
+		"--config", opts.ConfigFile,
+		"--image", upgradeReq.Image,
+	}
+
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("unexpected args: got %v, want %v", args, want)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require github.com/davecgh/go-spew v1.1.1 // indirect
+
 require (
 	cloud.google.com/go/compute v1.24.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -106,7 +108,7 @@ require (
 	github.com/containerd/ttrpc v1.2.5 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/cyphar/filepath-securejoin v0.3.6
+	github.com/cyphar/filepath-securejoin v0.2.4
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v23.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -106,8 +106,7 @@ require (
 	github.com/containerd/ttrpc v1.2.5 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/cyphar/filepath-securejoin v0.3.6
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v23.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect

--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -24,10 +24,13 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
 
 	"github.com/blang/semver"
 	"github.com/spf13/pflag"
@@ -228,7 +231,12 @@ func DecompressTarGz(gzFilePath, dest string) error {
 	}
 	defer reader.Close()
 
-	err = os.MkdirAll(dest, os.ModePerm)
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(absDest, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -252,7 +260,23 @@ func DecompressTarGz(gzFilePath, dest string) error {
 			continue
 		}
 
-		target := filepath.Join(dest, header.Name)
+		if header.Name == "" {
+			return fmt.Errorf("tar entry name is empty")
+		}
+
+		entryName := strings.ReplaceAll(header.Name, "\\", "/")
+		entryName = path.Clean(entryName)
+		if len(entryName) >= 2 && entryName[1] == ':' && ((entryName[0] >= 'a' && entryName[0] <= 'z') || (entryName[0] >= 'A' && entryName[0] <= 'Z')) {
+			return fmt.Errorf("tar entry %q attempts path traversal outside %s", header.Name, absDest)
+		}
+		if path.IsAbs(entryName) || entryName == ".." || strings.HasPrefix(entryName, "../") {
+			return fmt.Errorf("tar entry %q attempts path traversal outside %s", header.Name, absDest)
+		}
+
+		target, err := securejoin.SecureJoin(absDest, entryName)
+		if err != nil {
+			return err
+		}
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if _, err := os.Stat(target); err != nil {

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"errors"
 	"fmt"
 	"os"
@@ -930,5 +932,128 @@ func TestCleanupCompressFile(t *testing.T) {
 
 	if err != nil {
 		t.Logf("Expected error: %v", err)
+	}
+}
+
+type testTarEntry struct {
+	name     string
+	body     string
+	typeflag byte
+}
+
+func createTestTarGz(t *testing.T, entries []testTarEntry) string {
+	t.Helper()
+
+	archivePath := filepath.Join(t.TempDir(), "test.tar.gz")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("failed to create test archive: %v", err)
+	}
+
+	gzWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	for _, entry := range entries {
+		header := &tar.Header{
+			Name:     entry.name,
+			Mode:     0644,
+			Typeflag: entry.typeflag,
+		}
+		if entry.typeflag == tar.TypeReg {
+			header.Size = int64(len(entry.body))
+		}
+		if entry.typeflag == tar.TypeDir {
+			header.Mode = 0755
+		}
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("failed to write tar header: %v", err)
+		}
+		if entry.typeflag == tar.TypeReg {
+			if _, err := tarWriter.Write([]byte(entry.body)); err != nil {
+				t.Fatalf("failed to write tar body: %v", err)
+			}
+		}
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close archive file: %v", err)
+	}
+
+	return archivePath
+}
+
+func TestDecompressTarGzAllowsSafeEntries(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "extract")
+	archivePath := createTestTarGz(t, []testTarEntry{
+		{name: "dir", typeflag: tar.TypeDir},
+		{name: "dir/file.txt", body: "SAFE", typeflag: tar.TypeReg},
+	})
+
+	err := DecompressTarGz(archivePath, dest)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(dest, "dir", "file.txt"))
+	assert.NoError(t, err)
+	assert.Equal(t, "SAFE", string(got))
+}
+
+func TestDecompressTarGzRejectsPathTraversal(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryName string
+	}{
+		{
+			name:      "parent directory traversal",
+			entryName: "../victim.txt",
+		},
+		{
+			name:      "backslash parent directory traversal",
+			entryName: `..\victim.txt`,
+		},
+		{
+			name:      "windows drive absolute path",
+			entryName: `C:\Users\Public\victim.txt`,
+		},
+		{
+			name:      "windows drive absolute path with slashes",
+			entryName: "C:/Users/Public/victim.txt",
+		},
+		{
+			name:      "absolute unix path",
+			entryName: "/tmp/victim.txt",
+		},
+		{
+			name:      "nested parent traversal",
+			entryName: "dir/../../victim.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := t.TempDir()
+			dest := filepath.Join(base, "extract")
+			victim := filepath.Join(base, "victim.txt")
+
+			err := os.WriteFile(victim, []byte("ORIGINAL"), 0644)
+			assert.NoError(t, err)
+
+			archivePath := createTestTarGz(t, []testTarEntry{
+				{name: tt.entryName, body: "OVERWRITTEN", typeflag: tar.TypeReg},
+			})
+
+			err = DecompressTarGz(archivePath, dest)
+			assert.Error(t, err)
+
+			got, err := os.ReadFile(victim)
+			assert.NoError(t, err)
+			assert.Equal(t, "ORIGINAL", string(got))
+		})
 	}
 }

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -19,6 +19,14 @@ package validation
 import (
 	"fmt"
 	"net"
+	"regexp"
+)
+
+// Regexps
+var (
+	regexpImageRepo = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]*/[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)*(@sha256:[A-Fa-f0-9]{64}|:[A-Za-z0-9_][A-Za-z0-9._-]{0,127})?$`)
+
+	regexpVersion = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-zA-Z0-9_.]+(?:-[a-zA-Z0-9_.]+)*)?$`)
 )
 
 // IsValidIP tests that the argument is a valid IP address.
@@ -41,4 +49,12 @@ func IsValidPortNum(port int) []string {
 // between" validation failure.
 func InclusiveRangeError(lo, hi int) string {
 	return fmt.Sprintf(`must be between %d and %d, inclusive`, lo, hi)
+}
+
+func ValidateImageRepo(image string) bool {
+	return regexpImageRepo.MatchString(image)
+}
+
+func ValidateVersion(version string) bool {
+	return regexpVersion.MatchString(version)
 }

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -45,7 +45,7 @@ func TestIsValidIP(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			v := IsValidIP(c.IP)
 			get := len(v) == 0
-			assert.Equal(get, c.Expect)
+			assert.Equal(c.Expect, get)
 		})
 	}
 }
@@ -83,7 +83,7 @@ func TestIsValidPortNum(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			v := IsValidPortNum(c.Port)
-			assert.Equal(v, c.Expect)
+			assert.Equal(c.Expect, v)
 		})
 	}
 }
@@ -93,5 +93,86 @@ func TestInclusiveRangeError(t *testing.T) {
 
 	result := InclusiveRangeError(1, 65535)
 	expect := "must be between 1 and 65535, inclusive"
-	assert.Equal(result, expect)
+	assert.Equal(expect, result)
+}
+
+func TestValidateImageRepo(t *testing.T) {
+	cases := []struct {
+		imageRepo string
+		want      bool
+	}{
+		{
+			imageRepo: "installation-package",
+			want:      false,
+		},
+		{
+			imageRepo: "kubeedge/installation-package",
+			want:      true,
+		},
+		{
+			imageRepo: "kubeedge/installation-package;bash",
+			want:      false,
+		},
+		{
+			imageRepo: "_kubeedge/installation-package",
+			want:      false,
+		},
+		{
+			imageRepo: "aaa.bbb.ccc/kubeedge/installation-package",
+			want:      true,
+		},
+		{
+			imageRepo: "registry.example.com:5000/kubeedge/installation-package",
+			want:      true,
+		},
+		{
+			imageRepo: "kubeedge/installation-package:v1.23.1",
+			want:      true,
+		},
+		{
+			imageRepo: "kubeedge/installation-package@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			want:      true,
+		},
+		{
+			imageRepo: "kubeedge/installation-package;touch /tmp/pwned",
+			want:      false,
+		},
+		{
+			imageRepo: "kubeedge/installation-package$(touch /tmp/pwned)",
+			want:      false,
+		},
+		{
+			imageRepo: "kubeedge/installation-package`touch /tmp/pwned`",
+			want:      false,
+		},
+		{
+			imageRepo: "kubeedge/installation-package\n touch /tmp/pwned",
+			want:      false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.imageRepo, func(t *testing.T) {
+			assert.Equal(t, c.want, ValidateImageRepo(c.imageRepo))
+		})
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{version: "v1.0.0", want: true},
+		{version: "V1.0.0", want: false},
+		{version: "1.0.0", want: false},
+		{version: "v1.0", want: false},
+		{version: "v1.0.0;bash", want: false},
+		{version: "v1.0.0-rc1", want: true},
+		{version: "v1.0.0-rc1.1", want: true},
+	}
+	for _, c := range cases {
+		t.Run(c.version, func(t *testing.T) {
+			assert.Equal(t, c.want, ValidateVersion(c.version))
+		})
+	}
 }

--- a/pkg/viaduct/pkg/packer/package.go
+++ b/pkg/viaduct/pkg/packer/package.go
@@ -16,6 +16,9 @@ const (
 	PayloadLenSize   = 4
 	HeaderSize       = VersionSize + PackageTypeSize + PackageFlagsSize + PayloadLenSize
 
+	// MaxPayloadLen limits the maximum viaduct payload size accepted by the packer.
+	MaxPayloadLen uint32 = 32 * 1024 * 1024
+
 	// filed offsets
 	VersionOffset     = 0
 	PackageTypeOffset = VersionSize

--- a/pkg/viaduct/pkg/packer/reader.go
+++ b/pkg/viaduct/pkg/packer/reader.go
@@ -39,6 +39,10 @@ func (r *Reader) Read() ([]byte, error) {
 	header := PackageHeader{}
 	header.Unpack(headerBuffer)
 
+	if header.PayloadLen > MaxPayloadLen {
+		return nil, fmt.Errorf("payload length %d exceeds maximum %d", header.PayloadLen, MaxPayloadLen)
+	}
+
 	payloadBuffer := make([]byte, header.PayloadLen)
 	_, err = io.ReadFull(r.reader, payloadBuffer)
 	if err != nil {

--- a/pkg/viaduct/pkg/packer/reader_writer_test.go
+++ b/pkg/viaduct/pkg/packer/reader_writer_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package packer
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func buildTestFrame(payload []byte) []byte {
+	header := NewPackageHeader(Message)
+	header.SetPayloadLen(uint32(len(payload)))
+
+	var headerBuffer []byte
+	header.Pack(&headerBuffer)
+
+	var frame bytes.Buffer
+	frame.Write(headerBuffer)
+	frame.Write(payload)
+	return frame.Bytes()
+}
+
+func buildTestHeaderWithPayloadLen(payloadLen uint32) []byte {
+	header := NewPackageHeader(Message)
+	header.SetPayloadLen(payloadLen)
+
+	var headerBuffer []byte
+	header.Pack(&headerBuffer)
+	return headerBuffer
+}
+
+func TestReaderReadRejectsPayloadLargerThanLimit(t *testing.T) {
+	frame := buildTestHeaderWithPayloadLen(MaxPayloadLen + 1)
+
+	_, err := NewReader(bytes.NewReader(frame)).Read()
+	if err == nil {
+		t.Fatalf("expected error for payload larger than limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("expected max payload error, got %v", err)
+	}
+}
+
+func TestReaderReadAllowsPayloadWithinLimit(t *testing.T) {
+	payload := []byte("hello")
+	frame := buildTestFrame(payload)
+
+	got, err := NewReader(bytes.NewReader(frame)).Read()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("expected payload %q, got %q", payload, got)
+	}
+}
+
+func TestWriterWriteRejectsPayloadLargerThanLimit(t *testing.T) {
+	payload := make([]byte, int(MaxPayloadLen)+1)
+
+	var buf bytes.Buffer
+	n, err := NewWriter(&buf).Write(payload)
+	if err == nil {
+		t.Fatalf("expected error for payload larger than limit")
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 bytes written, got %d", n)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected nothing written, got %d bytes", buf.Len())
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("expected max payload error, got %v", err)
+	}
+}
+
+func TestWriterWriteAllowsPayloadWithinLimit(t *testing.T) {
+	payload := []byte("hello")
+
+	var buf bytes.Buffer
+	n, err := NewWriter(&buf).Write(payload)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("expected %d bytes written, got %d", len(payload), n)
+	}
+
+	got, err := NewReader(&buf).Read()
+	if err != nil {
+		t.Fatalf("expected no error reading written frame, got %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("expected payload %q, got %q", payload, got)
+	}
+}

--- a/pkg/viaduct/pkg/packer/writer.go
+++ b/pkg/viaduct/pkg/packer/writer.go
@@ -26,6 +26,9 @@ func (w *Writer) Write(data []byte) (int, error) {
 		klog.Error("bad io writer")
 		return 0, fmt.Errorf("bad io writer")
 	}
+	if len(data) > int(MaxPayloadLen) {
+		return 0, fmt.Errorf("payload length %d exceeds maximum %d", len(data), MaxPayloadLen)
+	}
 
 	// packing header
 	header := NewPackageHeader(Message)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

This PR backports a set of security hardening fixes to the release-1.21 branch for the v1.21.2 patch release.

Included areas:
- NodeUpgradeJob command execution hardening
- ConfigUpdateJob command execution hardening
- keadm archive extraction path validation
- viaduct packer payload size validation

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

This is the release-1.21 backport of the security hardening fixes already merged into master.

Targeted validation completed locally:

```bash
go test ./pkg/util/validation -count=1

go test ./cloud/pkg/admissioncontroller \
  -run 'NodeUpgrade|ValidateNodeUpgrade|GenerateNodeUpgradeJobPatch|MutatingNodeUpgradeJob' \
  -count=1

go test ./edge/pkg/taskmanager/v1alpha1/taskexecutor \
  -run 'NodeUpgrade|BuildKeadmUpgradeArgs|KeadmUpgrade' \
  -count=1

go test -gcflags=all=-l ./edge/pkg/taskmanager/actions \
  -run 'NodeUpgrade|ConfigUpdate|BuildConfigUpdate' \
  -count=1

go test ./pkg/viaduct/pkg/packer -count=1

go test ./keadm/cmd/keadm/app/cmd/util \
  -run 'Decompress|Tar|Traversal|ZipSlip' \
  -count=1
```

Additional checks:
- conflict marker grep: no output
- git diff --check: clean
- diff scope checked, no unrelated files included

#### Does this PR introduce a user-facing change?

```release-note
Backport security hardening fixes for the v1.21.2 patch release.
```