### PR TITLE
Add v1.21.2, v1.22.2 and v1.23.1 security patch release notes

### DIFF
--- a/CHANGELOG/CHANGELOG-1.21.md
+++ b/CHANGELOG/CHANGELOG-1.21.md
@@ -1,3 +1,8 @@
+* [v1.21.2](#v1212)
+    * [Downloads for v1.21.2](#downloads-for-v1212)
+    * [KubeEdge v1.21.2 Release Notes](#kubeedge-v1212-release-notes)
+        * [Security Fixes](#security-fixes)
+        * [Other Changes](#other-changes)
 * [v1.21.1](#v1211)
     * [Downloads for v1.21.1](#downloads-for-v1211)
     * [KubeEdge v1.21.1 Release Notes](#kubeedge-v1211-release-notes)
@@ -7,6 +12,27 @@
     * [KubeEdge v1.21 Release Notes](#kubeedge-v121-release-notes)
         * [1.21 What's New](#121-whats-new)
         * [Important Steps before Upgrading](#important-steps-before-upgrading)
+
+# v1.21.2
+
+## Downloads for v1.21.2
+
+Download v1.21.2 in the [v1.21.2 release page](https://github.com/kubeedge/kubeedge/releases/tag/v1.21.2).
+
+## KubeEdge v1.21.2 Release Notes
+
+> This release contains security fixes. Upgrading is strongly recommended for all users on affected versions.
+
+### Security Fixes
+
+- **NodeUpgradeJob command injection (RCE on edge nodes).** The v1alpha2 NodeUpgradeJob handler built the `keadm upgrade edge` command by concatenating the user-controlled `spec.version` and `spec.image` fields into a shell command. An authenticated user able to create or update NodeUpgradeJob resources could inject shell metacharacters and execute arbitrary commands on targeted edge nodes. ([CVE-2026-62371](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-5jpj-293f-rhvj), [#7030](https://github.com/kubeedge/kubeedge/pull/7030))
+- **ConfigUpdateJob command injection (RCE on edge nodes).** ConfigUpdateJob `updateFields` values were concatenated into a shell command. An authenticated user able to create or update ConfigUpdateJob resources could execute arbitrary commands on targeted edge nodes. ([CVE-2026-62182](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-m3c6-2p7h-cfr3), [#7030](https://github.com/kubeedge/kubeedge/pull/7030))
+- **keadm archive path traversal (arbitrary file write on Windows).** The `DecompressTarGz` function joined archive entry names to the destination directory without validation, allowing a crafted archive to write files outside the intended directory during `keadm join` on Windows edge nodes. ([CVE-2026-62369](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-9vm9-pqxx-x83v), [#7030](https://github.com/kubeedge/kubeedge/pull/7030))
+- **viaduct packer unbounded allocation (CloudHub DoS).** The packer allocated a buffer sized by an attacker-declared payload length with no upper bound. An authenticated edge node could send crafted headers to exhaust CloudHub memory. A 32 MiB payload limit is now enforced. ([CVE-2026-62370](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-gfw4-49f9-cp25), [#7030](https://github.com/kubeedge/kubeedge/pull/7030))
+
+### Other Changes
+
+- Fix keadm config-update not working with numeric types like int32. ([#6586](https://github.com/kubeedge/kubeedge/pull/6586), [@Abirdcfly](https://github.com/Abirdcfly))
 
 # v1.21.1
 

--- a/CHANGELOG/CHANGELOG-1.22.md
+++ b/CHANGELOG/CHANGELOG-1.22.md
@@ -1,3 +1,8 @@
+* [v1.22.2](#v1222)
+    * [Downloads for v1.22.2](#downloads-for-v1222)
+    * [KubeEdge v1.22.2 Release Notes](#kubeedge-v1222-release-notes)
+        * [Security Fixes](#security-fixes)
+        * [Other Changes](#other-changes)
 * [v1.22.1](#v1221)
     * [Downloads for v1.22.1](#downloads-for-v1221)
     * [KubeEdge v1.22.1 Release Notes](#kubeedge-v1221-release-notes)
@@ -8,6 +13,27 @@
         * [1.22 What's New](#122-whats-new)
         * [Important Steps before Upgrading](#important-steps-before-upgrading)
 
+
+# v1.22.2
+
+## Downloads for v1.22.2
+
+Download v1.22.2 in the [v1.22.2 release page](https://github.com/kubeedge/kubeedge/releases/tag/v1.22.2).
+
+## KubeEdge v1.22.2 Release Notes
+
+> This release contains security fixes. Upgrading is strongly recommended for all users on affected versions.
+
+### Security Fixes
+
+- **NodeUpgradeJob command injection (RCE on edge nodes).** The v1alpha2 NodeUpgradeJob handler built the `keadm upgrade edge` command by concatenating the user-controlled `spec.version` and `spec.image` fields into a shell command. An authenticated user able to create or update NodeUpgradeJob resources could inject shell metacharacters and execute arbitrary commands on targeted edge nodes. ([CVE-2026-62371](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-5jpj-293f-rhvj), [#7029](https://github.com/kubeedge/kubeedge/pull/7029))
+- **ConfigUpdateJob command injection (RCE on edge nodes).** ConfigUpdateJob `updateFields` values were concatenated into a shell command. An authenticated user able to create or update ConfigUpdateJob resources could execute arbitrary commands on targeted edge nodes. ([CVE-2026-62182](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-m3c6-2p7h-cfr3), [#7029](https://github.com/kubeedge/kubeedge/pull/7029))
+- **keadm archive path traversal (arbitrary file write on Windows).** The `DecompressTarGz` function joined archive entry names to the destination directory without validation, allowing a crafted archive to write files outside the intended directory during `keadm join` on Windows edge nodes. ([CVE-2026-62369](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-9vm9-pqxx-x83v), [#7029](https://github.com/kubeedge/kubeedge/pull/7029))
+- **viaduct packer unbounded allocation (CloudHub DoS).** The packer allocated a buffer sized by an attacker-declared payload length with no upper bound. An authenticated edge node could send crafted headers to exhaust CloudHub memory. A 32 MiB payload limit is now enforced. ([CVE-2026-62370](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-gfw4-49f9-cp25), [#7029](https://github.com/kubeedge/kubeedge/pull/7029))
+
+### Other Changes
+
+- Fix keadm config-update not working with numeric types like int32. ([#6586](https://github.com/kubeedge/kubeedge/pull/6586), [@Abirdcfly](https://github.com/Abirdcfly))
 
 # v1.22.1
 

--- a/CHANGELOG/CHANGELOG-1.23.md
+++ b/CHANGELOG/CHANGELOG-1.23.md
@@ -1,8 +1,29 @@
+* [v1.23.1](#v1231)
+    * [Downloads for v1.23.1](#downloads-for-v1231)
+    * [KubeEdge v1.23.1 Release Notes](#kubeedge-v1231-release-notes)
+        * [Security Fixes](#security-fixes)
 * [v1.23.0](#v1230)
     * [Downloads for v1.23.0](#downloads-for-v1230)
     * [KubeEdge v1.23 Release Notes](#kubeedge-v123-release-notes)
         * [1.23 What's New](#123-whats-new)
         * [Important Steps before Upgrading](#important-steps-before-upgrading)
+
+# v1.23.1
+
+## Downloads for v1.23.1
+
+Download v1.23.1 in the [v1.23.1 release page](https://github.com/kubeedge/kubeedge/releases/tag/v1.23.1).
+
+## KubeEdge v1.23.1 Release Notes
+
+> This release contains security fixes. Upgrading is strongly recommended for all users on affected versions.
+
+### Security Fixes
+
+- **NodeUpgradeJob command injection (RCE on edge nodes).** The v1alpha2 NodeUpgradeJob handler built the `keadm upgrade edge` command by concatenating the user-controlled `spec.version` and `spec.image` fields into a shell command. An authenticated user able to create or update NodeUpgradeJob resources could inject shell metacharacters and execute arbitrary commands on targeted edge nodes. ([CVE-2026-62371](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-5jpj-293f-rhvj), [#7028](https://github.com/kubeedge/kubeedge/pull/7028))
+- **ConfigUpdateJob command injection (RCE on edge nodes).** ConfigUpdateJob `updateFields` values were concatenated into a shell command. An authenticated user able to create or update ConfigUpdateJob resources could execute arbitrary commands on targeted edge nodes. ([CVE-2026-62182](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-m3c6-2p7h-cfr3), [#7028](https://github.com/kubeedge/kubeedge/pull/7028))
+- **keadm archive path traversal (arbitrary file write on Windows).** The `DecompressTarGz` function joined archive entry names to the destination directory without validation, allowing a crafted archive to write files outside the intended directory during `keadm join` on Windows edge nodes. ([CVE-2026-62369](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-9vm9-pqxx-x83v), [#7028](https://github.com/kubeedge/kubeedge/pull/7028))
+- **viaduct packer unbounded allocation (CloudHub DoS).** The packer allocated a buffer sized by an attacker-declared payload length with no upper bound. An authenticated edge node could send crafted headers to exhaust CloudHub memory. A 32 MiB payload limit is now enforced. ([CVE-2026-62370](https://github.com/kubeedge/kubeedge/security/advisories/GHSA-gfw4-49f9-cp25), [#7028](https://github.com/kubeedge/kubeedge/pull/7028))
 
 # v1.23.0
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add changelog entries for the upcoming security patch releases v1.21.2,
v1.22.2 and v1.23.1.

These releases address the following vulnerabilities:

- CVE-2026-62371 — command injection in NodeUpgradeJob (v1alpha2), RCE on edge nodes
- CVE-2026-62182 — command injection in ConfigUpdateJob `updateFields`, RCE on edge nodes
- CVE-2026-62369 — path traversal in keadm `DecompressTarGz`, arbitrary file write on Windows edge nodes
- CVE-2026-62370 — unbounded allocation in the viaduct packer, CloudHub DoS

The security fixes themselves are tracked in #7028 (release-1.23),
#7029 (release-1.22) and #7030 (release-1.21). This PR only updates the
changelog files under `CHANGELOG/`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- The advisory links in the changelog point to the corresponding GitHub
  Security Advisories, which are published as part of the coordinated
  disclosure. This PR should be merged once the patch releases are cut
  and the advisories are public, so the links resolve.
- v1.21.2 and v1.22.2 also include the earlier fix for keadm config-update
  numeric type handling (#6586); v1.23.1 contains security fixes only.

#### Does this PR introduce a user-facing change?

```release-note
NONE
