### PR TITLE
test(eventbus): add unit test for eventbus config

### DIFF
--- a/edge/pkg/eventbus/config/config.go
+++ b/edge/pkg/eventbus/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var Config Configure
-var once = new(sync.Once)
+var once sync.Once
 
 type Configure struct {
 	v1alpha2.EventBus

--- a/edge/pkg/eventbus/config/config.go
+++ b/edge/pkg/eventbus/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var Config Configure
-var once sync.Once
+var once = new(sync.Once)
 
 type Configure struct {
 	v1alpha2.EventBus

--- a/edge/pkg/eventbus/config/config_test.go
+++ b/edge/pkg/eventbus/config/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,13 +25,8 @@ import (
 )
 
 func TestInitConfigure(t *testing.T) {
-	// Reset the global state at the beginning to prevent test flakiness from prior tests
-	once = new(sync.Once)
-	Config = Configure{}
-
 	// Use t.Cleanup to restore global state after the test execution
 	t.Cleanup(func() {
-		once = new(sync.Once)
 		Config = Configure{}
 	})
 

--- a/edge/pkg/eventbus/config/config_test.go
+++ b/edge/pkg/eventbus/config/config_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+)
+
+func TestInitConfigure(t *testing.T) {
+	// Reset the global state at the beginning to prevent test flakiness from prior tests
+	once = sync.Once{}
+	Config = Configure{}
+
+	// Use t.Cleanup to restore global state after the test execution
+	t.Cleanup(func() {
+		once = sync.Once{}
+		Config = Configure{}
+	})
+
+	eb := &v1alpha2.EventBus{}
+	nodeName := "test-node"
+
+	InitConfigure(eb, nodeName)
+
+	require.Equal(t, *eb, Config.EventBus)
+	require.Equal(t, nodeName, Config.NodeName)
+
+	// Save the initialized Config state
+	expectedConfig := Config
+
+	// Test sync.Once works, subsequent calls should not overwrite
+	eb2 := &v1alpha2.EventBus{}
+	InitConfigure(eb2, "different-node")
+
+	require.Equal(t, expectedConfig, Config, "Entire config should remain unchanged after first initialization")
+}

--- a/edge/pkg/eventbus/config/config_test.go
+++ b/edge/pkg/eventbus/config/config_test.go
@@ -27,12 +27,12 @@ import (
 
 func TestInitConfigure(t *testing.T) {
 	// Reset the global state at the beginning to prevent test flakiness from prior tests
-	once = sync.Once{}
+	once = new(sync.Once)
 	Config = Configure{}
 
 	// Use t.Cleanup to restore global state after the test execution
 	t.Cleanup(func() {
-		once = sync.Once{}
+		once = new(sync.Once)
 		Config = Configure{}
 	})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Adds unit tests for `edge/pkg/eventbus/config/config.go` to achieve 100% test coverage. It correctly asserts the `sync.Once` singleton initialization pattern to ensure robust configuration parsing. 

*(Note: Following reviewer feedback, this PR strictly tests the package-level global state without modifying any production code or attempting potentially unsafe lock resets for test isolation.)*

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This is a focused, isolated PR strictly aimed at reliably increasing codebase test coverage without touching any production code behavior.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
