### PR TITLE
test(devicetwin): add unit test for devicetwin config

### DIFF
--- a/edge/pkg/devicetwin/config/config.go
+++ b/edge/pkg/devicetwin/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var config Configure
-var once sync.Once
+var once = new(sync.Once)
 
 type Configure struct {
 	v1alpha2.DeviceTwin

--- a/edge/pkg/devicetwin/config/config.go
+++ b/edge/pkg/devicetwin/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 var config Configure
-var once = new(sync.Once)
+var once sync.Once
 
 type Configure struct {
 	v1alpha2.DeviceTwin

--- a/edge/pkg/devicetwin/config/config_test.go
+++ b/edge/pkg/devicetwin/config/config_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+)
+
+func TestInitConfigure(t *testing.T) {
+	// Reset the global state at the beginning to prevent test flakiness from prior tests
+	once = new(sync.Once)
+	config = Configure{}
+
+	// Use t.Cleanup to restore global state after the test execution
+	t.Cleanup(func() {
+		once = new(sync.Once)
+		config = Configure{}
+	})
+
+	dt := &v1alpha2.DeviceTwin{}
+	nodeName := "test-node"
+
+	InitConfigure(dt, nodeName)
+
+	require.Equal(t, *dt, config.DeviceTwin)
+	require.Equal(t, nodeName, config.NodeName)
+
+	// Save the initialized config state
+	expectedConfig := config
+
+	// Test sync.Once works, subsequent calls should not overwrite
+	dt2 := &v1alpha2.DeviceTwin{}
+	InitConfigure(dt2, "different-node")
+
+	require.Equal(t, expectedConfig, config, "Entire config should remain unchanged after first initialization")
+}
+
+func TestGet(t *testing.T) {
+	// Reset the global state at the beginning to prevent test flakiness from prior tests
+	once = new(sync.Once)
+	config = Configure{}
+
+	// Use t.Cleanup to restore global state after the test execution
+	t.Cleanup(func() {
+		once = new(sync.Once)
+		config = Configure{}
+	})
+
+	dt := &v1alpha2.DeviceTwin{}
+	nodeName := "test-node"
+
+	InitConfigure(dt, nodeName)
+
+	c := Get()
+	require.NotNil(t, c)
+	require.Equal(t, *dt, c.DeviceTwin)
+	require.Equal(t, nodeName, c.NodeName)
+}

--- a/edge/pkg/devicetwin/config/config_test.go
+++ b/edge/pkg/devicetwin/config/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,13 +25,8 @@ import (
 )
 
 func TestInitConfigure(t *testing.T) {
-	// Reset the global state at the beginning to prevent test flakiness from prior tests
-	once = new(sync.Once)
-	config = Configure{}
-
 	// Use t.Cleanup to restore global state after the test execution
 	t.Cleanup(func() {
-		once = new(sync.Once)
 		config = Configure{}
 	})
 
@@ -44,6 +38,11 @@ func TestInitConfigure(t *testing.T) {
 	require.Equal(t, *dt, config.DeviceTwin)
 	require.Equal(t, nodeName, config.NodeName)
 
+	c := Get()
+	require.NotNil(t, c)
+	require.Equal(t, *dt, c.DeviceTwin)
+	require.Equal(t, nodeName, c.NodeName)
+
 	// Save the initialized config state
 	expectedConfig := config
 
@@ -52,26 +51,4 @@ func TestInitConfigure(t *testing.T) {
 	InitConfigure(dt2, "different-node")
 
 	require.Equal(t, expectedConfig, config, "Entire config should remain unchanged after first initialization")
-}
-
-func TestGet(t *testing.T) {
-	// Reset the global state at the beginning to prevent test flakiness from prior tests
-	once = new(sync.Once)
-	config = Configure{}
-
-	// Use t.Cleanup to restore global state after the test execution
-	t.Cleanup(func() {
-		once = new(sync.Once)
-		config = Configure{}
-	})
-
-	dt := &v1alpha2.DeviceTwin{}
-	nodeName := "test-node"
-
-	InitConfigure(dt, nodeName)
-
-	c := Get()
-	require.NotNil(t, c)
-	require.Equal(t, *dt, c.DeviceTwin)
-	require.Equal(t, nodeName, c.NodeName)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Adds unit tests for `edge/pkg/devicetwin/config/config.go` to achieve 100% test coverage. It correctly asserts the `sync.Once` singleton initialization pattern to ensure robust configuration parsing. 

*(Note: Following reviewer feedback, this PR strictly tests the package-level global state without modifying any production code or attempting potentially unsafe lock resets for test isolation.)*

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This is a focused, isolated PR strictly aimed at reliably increasing codebase test coverage without touching any production code behavior.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
