### PR TITLE
viaduct: fix WSConnection.handleRawData using QUIC lane on a WS conn

### DIFF
--- a/pkg/viaduct/pkg/conn/ws.go
+++ b/pkg/viaduct/pkg/conn/ws.go
@@ -90,7 +90,7 @@ func (conn *WSConnection) handleRawData() {
 	}
 
 	// TODO: support control message processing in raw data mode
-	_, err := io.Copy(conn.consumer, lane.NewLane(api.ProtocolTypeQuic, conn.wsConn))
+	_, err := io.Copy(conn.consumer, lane.NewLane(api.ProtocolTypeWS, conn.wsConn))
 	if err != nil {
 		klog.Errorf("failed to copy data, error: %+v", err)
 		conn.state.State = api.StatDisconnected

--- a/pkg/viaduct/pkg/conn/ws_test.go
+++ b/pkg/viaduct/pkg/conn/ws_test.go
@@ -1,0 +1,65 @@
+package conn
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestWSConnection_handleRawData_CopiesData(t *testing.T) {
+	const payload = "hello from peer"
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerConn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("server failed to upgrade: %v", err)
+			return
+		}
+		defer peerConn.Close()
+
+		if err := peerConn.WriteMessage(websocket.BinaryMessage, []byte(payload)); err != nil {
+			t.Errorf("server failed to write message: %v", err)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):]
+	clientConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	defer clientConn.Close()
+
+	var consumer bytes.Buffer
+	c := &WSConnection{
+		wsConn:    clientConn,
+		state:     &ConnectionState{},
+		consumer:  &consumer,
+		autoRoute: true,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.handleRawData()
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+	case <-timer.C:
+		t.Fatal("handleRawData did not return; it may be blocked or the fix regressed")
+	}
+
+	if got := consumer.String(); got != payload {
+		t.Fatalf("consumer got %q, want %q", got, payload)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
WSConnection.handleRawData() constructed its Lane with api.ProtocolTypeQuic instead of api.ProtocolTypeWS, even though WSConnection always wraps a *websocket.Conn, never a quic.Stream.

Because of that mismatch, lane.NewLane's internal type assertion for QUIC fails, NewQuicLane returns a typed-nil *QuicLane, and that nil gets boxed into a non-nil Lane interface value. io.Copy then calls Read on it and hits a nil pointer dereference — a guaranteed panic on the first byte of any raw-stream connection served over WebSocket.

Six other call sites in the same file already build the lane with api.ProtocolTypeWS. This fix brings the seventh in line and adds a regression test using a real websocket.Conn (via httptest + gorilla/websocket) that proves data flows through handleRawData without panicking.

**Which issue(s) this PR fixes**:
Fixes #6944

**Special notes for your reviewer**:
Single-line functional change (pkg/viaduct/pkg/conn/ws.go:93), plus a new regression test. Verified: gofmt clean, golangci-lint clean (scoped to this diff via --new-from-rev=HEAD, all 9 enabled linters), go vet clean, go build clean across the whole viaduct tree, and go test ./pkg/viaduct/... passes with zero regressions across conn/fifo/filter/packer. Confirmed the fix by temporarily reverting it locally and observing the new test correctly fails/panics on the old code.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```