### PR TITLE
synccontroller: garbage collect node sync records via a workqueue

### DIFF
--- a/cloud/pkg/synccontroller/synccontroller.go
+++ b/cloud/pkg/synccontroller/synccontroller.go
@@ -5,14 +5,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/avast/retry-go"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	configv1alpha1 "github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
@@ -28,9 +30,15 @@ import (
 )
 
 const (
-	// maxRetries is the number of times trying to delete ObjectSyncs and ClusterObjectSyncs.
-	maxRetries       = 5
-	deleteSyncsDelay = 1 * time.Second
+	// maxRetries is the number of times a node's sync-record garbage collection is
+	// retried before it is dropped and left to the periodic backstop.
+	maxRetries = 5
+	// nodeGCResyncPeriod is how often all sync records are scanned to re-enqueue
+	// nodes that are gone but still have sync records (e.g. a delete that exhausted
+	// its retries, or a node deletion missed while the controller was down).
+	nodeGCResyncPeriod = 5 * time.Minute
+	// nodeGCQueueName names the workqueue used for node sync-record GC.
+	nodeGCQueueName = "synccontroller_node_gc"
 )
 
 // SyncController use beehive context message layer
@@ -49,6 +57,12 @@ type SyncController struct {
 	informersSyncedFuncs []cache.InformerSynced
 
 	informerManager informers.Manager
+
+	// nodeGCQueue holds the names of deleted nodes whose ObjectSync and
+	// ClusterObjectSync records need to be garbage collected. A workqueue keeps
+	// the GC off the node informer goroutine, coalesces duplicate node deletions,
+	// and provides cancellable, rate-limited retries.
+	nodeGCQueue workqueue.RateLimitingInterface
 }
 
 var _ core.Module = (*SyncController)(nil)
@@ -59,6 +73,7 @@ func newSyncController(enable bool) *SyncController {
 		crdclient:       keclient.GetCRDClient(),
 		kubeclient:      keclient.GetDynamicClient(),
 		informerManager: informers.GetInformersManager(),
+		nodeGCQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), nodeGCQueueName),
 	}
 	// informer factory
 	k8sInformerFactory := informers.GetInformersManager().GetKubeInformerFactory()
@@ -68,10 +83,7 @@ func newSyncController(enable bool) *SyncController {
 	clusterObjectSyncsInformer := crdInformerFactory.Reliablesyncs().V1alpha1().ClusterObjectSyncs()
 	nodesInformer := k8sInformerFactory.Core().V1().Nodes()
 	_, err := nodesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
-			sctl.deleteObjectSyncs()
-			sctl.deleteClusterObjectSyncs()
-		},
+		DeleteFunc: sctl.enqueueNodeForGC,
 	})
 	if err != nil {
 		klog.Fatalf("new synccontroller failed, add event handler err: %v", err)
@@ -120,8 +132,18 @@ func (sctl *SyncController) Start() {
 		return
 	}
 
-	sctl.deleteObjectSyncs() //check outdate sync before start to reconcile
-	sctl.deleteClusterObjectSyncs()
+	// Shut the GC queue down when the module stops so the worker goroutine exits.
+	go func() {
+		<-beehiveContext.Done()
+		sctl.nodeGCQueue.ShutDown()
+	}()
+
+	// Garbage collect sync records for deleted nodes off the informer goroutine.
+	go wait.Until(sctl.runNodeGCWorker, time.Second, beehiveContext.Done())
+	// Periodic backstop: re-enqueue nodes that are gone but still have sync records,
+	// so retry-exhausted or missed deletions are eventually reclaimed. Its first run
+	// also cleans up records left behind while the controller was down.
+	go wait.Until(sctl.enqueueOrphanedNodeSyncs, nodeGCResyncPeriod, beehiveContext.Done())
 
 	go wait.Until(sctl.reconcileObjectSyncs, 5*time.Second, beehiveContext.Done())
 
@@ -156,70 +178,129 @@ func (sctl *SyncController) reconcileClusterObjectSyncs() {
 	}
 }
 
-func (sctl *SyncController) deleteObjectSyncs() {
-	syncs, err := sctl.objectSyncLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("Failed to list all the ObjectSyncs: %v", err)
-	}
-	for _, sync := range syncs {
-		// If an error occurs while deleting ObjectSyncs, will retry.
-		err = retry.Do(
-			func() error {
-				nodeName := getNodeName(sync.Name)
-				isGarbage, err := sctl.checkObjectSync(sync)
-				if err != nil {
-					klog.Warningf("failed to check ObjectSync outdated, %s", err)
-					return err
-				}
-				if isGarbage {
-					klog.Infof("ObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
-					err = sctl.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(sync.Namespace).Delete(context.Background(), sync.Name, *metav1.NewDeleteOptions(0))
-					if err != nil {
-						klog.Warningf("failed to delete objectSync %s for edgenode %s, err: %v", sync.Name, nodeName, err)
-						return err
-					}
-				}
-				return nil
-			},
-			retry.Delay(deleteSyncsDelay),
-			retry.Attempts(maxRetries),
-		)
-		if err != nil {
-			klog.Errorf("failed to delete objectSync %s, err: %v", sync.Name, err)
+// enqueueNodeForGC queues a deleted node's name so its sync records are garbage
+// collected by the worker instead of on the informer goroutine.
+func (sctl *SyncController) enqueueNodeForGC(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("cannot convert to Node, unexpected object type: %T", obj)
+			return
 		}
+		node, ok = tombstone.Obj.(*v1.Node)
+		if !ok {
+			klog.Errorf("cannot convert tombstone to Node, unexpected object type: %T", tombstone.Obj)
+			return
+		}
+	}
+	sctl.nodeGCQueue.Add(node.Name)
+}
+
+func (sctl *SyncController) runNodeGCWorker() {
+	for sctl.processNextNodeGC() {
 	}
 }
 
-func (sctl *SyncController) deleteClusterObjectSyncs() {
-	syncs, err := sctl.clusterObjectSyncLister.List(labels.Everything())
-	if err != nil {
-		klog.Errorf("Failed to list all the clusterObjectSync: %v", err)
+func (sctl *SyncController) processNextNodeGC() bool {
+	key, quit := sctl.nodeGCQueue.Get()
+	if quit {
+		return false
 	}
-	for _, sync := range syncs {
-		// If an error occurs while deleting ClusterObjectSyncs, will retry.
-		err = retry.Do(
-			func() error {
-				nodeName := getNodeName(sync.Name)
-				isGarbage, err := sctl.checkClusterObjectSync(sync)
-				if err != nil {
-					klog.Warningf("failed to check ClusterObjectSync outdated, %s", err)
-					return err
-				}
-				if isGarbage {
-					klog.Infof("ClusterObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
-					err = sctl.crdclient.ReliablesyncsV1alpha1().ClusterObjectSyncs().Delete(context.Background(), sync.Name, *metav1.NewDeleteOptions(0))
-					if err != nil {
-						klog.Warningf("failed to delete ClusterObjectSync %s for edgenode %s, err: %v", sync.Name, nodeName, err)
-						return err
-					}
-				}
-				return nil
-			},
-			retry.Delay(deleteSyncsDelay),
-			retry.Attempts(maxRetries),
-		)
+	defer sctl.nodeGCQueue.Done(key)
+
+	nodeName := key.(string)
+	if err := sctl.gcNodeSyncs(nodeName); err != nil {
+		if sctl.nodeGCQueue.NumRequeues(key) < maxRetries {
+			klog.Warningf("retrying GC of sync records for node %s: %v", nodeName, err)
+			sctl.nodeGCQueue.AddRateLimited(key)
+			return true
+		}
+		klog.Errorf("dropping GC of sync records for node %s after %d retries: %v", nodeName, maxRetries, err)
+	}
+	sctl.nodeGCQueue.Forget(key)
+	return true
+}
+
+// gcNodeSyncs deletes the ObjectSync and ClusterObjectSync records that belong to
+// nodeName once that node no longer exists.
+func (sctl *SyncController) gcNodeSyncs(nodeName string) error {
+	var errs []error
+
+	objectSyncs, err := sctl.objectSyncLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, sync := range objectSyncs {
+		if getNodeName(sync.Name) != nodeName {
+			continue
+		}
+		isGarbage, err := sctl.checkObjectSync(sync)
 		if err != nil {
-			klog.Errorf("failed to delete ClusterObjectSync %s, err: %v", sync.Name, err)
+			errs = append(errs, err)
+			continue
+		}
+		if !isGarbage {
+			continue
+		}
+		klog.Infof("ObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
+		if err := sctl.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(sync.Namespace).Delete(context.TODO(), sync.Name, *metav1.NewDeleteOptions(0)); err != nil && !errors.IsNotFound(err) {
+			errs = append(errs, err)
+		}
+	}
+
+	clusterObjectSyncs, err := sctl.clusterObjectSyncLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, sync := range clusterObjectSyncs {
+		if getNodeName(sync.Name) != nodeName {
+			continue
+		}
+		isGarbage, err := sctl.checkClusterObjectSync(sync)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if !isGarbage {
+			continue
+		}
+		klog.Infof("ClusterObjectSync %s will be deleted since node %s has been deleted", sync.Name, nodeName)
+		if err := sctl.crdclient.ReliablesyncsV1alpha1().ClusterObjectSyncs().Delete(context.TODO(), sync.Name, *metav1.NewDeleteOptions(0)); err != nil && !errors.IsNotFound(err) {
+			errs = append(errs, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+// enqueueOrphanedNodeSyncs scans all sync records and enqueues the nodes that no
+// longer exist so their records are garbage collected. It is the periodic backstop
+// for deletions that were missed or that exhausted their retries.
+func (sctl *SyncController) enqueueOrphanedNodeSyncs() {
+	nodeNames := make(map[string]struct{})
+
+	objectSyncs, err := sctl.objectSyncLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list ObjectSyncs for node GC: %v", err)
+		return
+	}
+	for _, sync := range objectSyncs {
+		nodeNames[getNodeName(sync.Name)] = struct{}{}
+	}
+
+	clusterObjectSyncs, err := sctl.clusterObjectSyncLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list ClusterObjectSyncs for node GC: %v", err)
+		return
+	}
+	for _, sync := range clusterObjectSyncs {
+		nodeNames[getNodeName(sync.Name)] = struct{}{}
+	}
+
+	for nodeName := range nodeNames {
+		if _, err := sctl.nodeLister.Get(nodeName); errors.IsNotFound(err) {
+			sctl.nodeGCQueue.Add(nodeName)
 		}
 	}
 }

--- a/cloud/pkg/synccontroller/synccontroller_test.go
+++ b/cloud/pkg/synccontroller/synccontroller_test.go
@@ -18,14 +18,19 @@ package synccontroller
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 
 	configv1alpha1 "github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
@@ -180,45 +185,146 @@ func TestCheckObjectSync(t *testing.T) {
 	}
 }
 
-func TestDeleteObjectSyncs(t *testing.T) {
-	tests := []struct {
-		name          string
-		ExpectedSyncs int
-		ObjectSyncs   *v1alpha1.ObjectSync
-	}{
-		{
-			name:          "test deleteObjectSyncs false",
-			ObjectSyncs:   tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod"),
-			ExpectedSyncs: 0,
-		},
+// newGCTestController builds a SyncController wired to fake clients, with the
+// given ObjectSync present in both the lister cache and the API, and an empty
+// node lister (so the sync's node is treated as deleted).
+func newGCTestController(t *testing.T, objectSync *v1alpha1.ObjectSync) *SyncController {
+	t.Helper()
+	crdClient := crdfake.NewSimpleClientset()
+	crdInformers := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	if err := crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Informer().GetIndexer().Add(objectSync); err != nil {
+		t.Fatalf("failed to add ObjectSync to indexer: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run("deleteObjectSyncs()", func(t *testing.T) {
-			crdClient := crdfake.NewSimpleClientset()
-			crdInformers := crdinformers.NewSharedInformerFactory(crdClient, 0)
-			err := crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Informer().GetIndexer().Add(tt.ObjectSyncs)
-			if err != nil {
-				t.Errorf("deleteObjectSyncs() failed when create ObjectSyncs indexer, error: %v", err)
-			}
-			_, err = crdClient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Create(context.Background(), tt.ObjectSyncs, metav1.CreateOptions{})
-			if err != nil {
-				t.Errorf("deleteObjectSyncs() failed when create ObjectSyncs, error: %v", err)
-			}
-			client := fake.NewSimpleClientset()
-			informers := informers.NewSharedInformerFactory(client, 0)
-			testController := newSyncController(true)
-			testController.nodeLister = informers.Core().V1().Nodes().Lister()
-			testController.crdclient = crdClient
-			testController.objectSyncLister = crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Lister()
-			syncs, _ := crdClient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
-			if len(syncs.Items) != 1 {
-				t.Errorf("deleteObjectSyncs() list returned unexpected result. got = %v, want = %v", len(syncs.Items), 1)
-			}
-			testController.deleteObjectSyncs()
-			got, _ := crdClient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
-			if len(got.Items) != tt.ExpectedSyncs {
-				t.Errorf("deleteObjectSyncs() list returned unexpected result. got = %v, want = %v", len(got.Items), tt.ExpectedSyncs)
-			}
-		})
+	if _, err := crdClient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).Create(context.Background(), objectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create ObjectSync: %v", err)
+	}
+
+	// A ClusterObjectSync for the same node, so the cluster-scoped GC path is exercised too.
+	clusterObjectSync := &v1alpha1.ClusterObjectSync{ObjectMeta: metav1.ObjectMeta{Name: objectSync.Name}}
+	if err := crdInformers.Reliablesyncs().V1alpha1().ClusterObjectSyncs().Informer().GetIndexer().Add(clusterObjectSync); err != nil {
+		t.Fatalf("failed to add ClusterObjectSync to indexer: %v", err)
+	}
+	if _, err := crdClient.ReliablesyncsV1alpha1().ClusterObjectSyncs().Create(context.Background(), clusterObjectSync, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create ClusterObjectSync: %v", err)
+	}
+
+	client := fake.NewSimpleClientset()
+	kubeInformers := informers.NewSharedInformerFactory(client, 0)
+
+	testController := newSyncController(true)
+	testController.crdclient = crdClient
+	testController.nodeLister = kubeInformers.Core().V1().Nodes().Lister()
+	testController.objectSyncLister = crdInformers.Reliablesyncs().V1alpha1().ObjectSyncs().Lister()
+	testController.clusterObjectSyncLister = crdInformers.Reliablesyncs().V1alpha1().ClusterObjectSyncs().Lister()
+	return testController
+}
+
+func TestGCNodeSyncs(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	testController := newGCTestController(t, objectSync)
+
+	before, _ := testController.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
+	if len(before.Items) != 1 {
+		t.Fatalf("gcNodeSyncs() setup: got %d ObjectSyncs, want 1", len(before.Items))
+	}
+
+	if err := testController.gcNodeSyncs(getNodeName(objectSync.Name)); err != nil {
+		t.Fatalf("gcNodeSyncs() returned error: %v", err)
+	}
+
+	got, _ := testController.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
+	if len(got.Items) != 0 {
+		t.Errorf("gcNodeSyncs() got %d ObjectSyncs, want 0", len(got.Items))
+	}
+	gotCluster, _ := testController.crdclient.ReliablesyncsV1alpha1().ClusterObjectSyncs().List(context.Background(), metav1.ListOptions{})
+	if len(gotCluster.Items) != 0 {
+		t.Errorf("gcNodeSyncs() got %d ClusterObjectSyncs, want 0", len(gotCluster.Items))
+	}
+}
+
+func TestGCNodeSyncsKeepsLiveNode(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	testController := newGCTestController(t, objectSync)
+
+	// The node still exists (e.g. it was recreated), so its sync records must be kept.
+	nodeName := getNodeName(objectSync.Name)
+	client := fake.NewSimpleClientset()
+	kubeInformers := informers.NewSharedInformerFactory(client, 0)
+	if err := kubeInformers.Core().V1().Nodes().Informer().GetIndexer().Add(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName}}); err != nil {
+		t.Fatalf("failed to add node: %v", err)
+	}
+	testController.nodeLister = kubeInformers.Core().V1().Nodes().Lister()
+
+	if err := testController.gcNodeSyncs(nodeName); err != nil {
+		t.Fatalf("gcNodeSyncs() returned error: %v", err)
+	}
+	got, _ := testController.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
+	if len(got.Items) != 1 {
+		t.Errorf("gcNodeSyncs() deleted syncs for a live node; got %d ObjectSyncs, want 1", len(got.Items))
+	}
+}
+
+func TestProcessNextNodeGC(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	testController := newGCTestController(t, objectSync)
+
+	testController.nodeGCQueue.Add(getNodeName(objectSync.Name))
+	if cont := testController.processNextNodeGC(); !cont {
+		t.Errorf("processNextNodeGC() = false, want true")
+	}
+	got, _ := testController.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
+	if len(got.Items) != 0 {
+		t.Errorf("processNextNodeGC() left %d ObjectSyncs, want 0", len(got.Items))
+	}
+
+	testController.nodeGCQueue.ShutDown()
+	if cont := testController.processNextNodeGC(); cont {
+		t.Errorf("processNextNodeGC() after shutdown = true, want false")
+	}
+}
+
+func TestEnqueueOrphanedNodeSyncs(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	testController := newGCTestController(t, objectSync)
+
+	testController.enqueueOrphanedNodeSyncs()
+	if got := testController.nodeGCQueue.Len(); got != 1 {
+		t.Errorf("enqueueOrphanedNodeSyncs() queue len = %d, want 1", got)
+	}
+}
+
+func TestEnqueueNodeForGC(t *testing.T) {
+	testController := newSyncController(true)
+
+	testController.enqueueNodeForGC(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}})
+	testController.enqueueNodeForGC(cache.DeletedFinalStateUnknown{Obj: &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}}})
+	testController.enqueueNodeForGC("not-a-node")
+	testController.enqueueNodeForGC(cache.DeletedFinalStateUnknown{Obj: "not-a-node"})
+
+	if got := testController.nodeGCQueue.Len(); got != 2 {
+		t.Errorf("enqueueNodeForGC() queue len = %d, want 2", got)
+	}
+}
+
+func TestProcessNextNodeGCRetriesOnError(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	testController := newGCTestController(t, objectSync)
+
+	// Force ObjectSync deletes to fail so gcNodeSyncs returns an error.
+	fakeCRD := testController.crdclient.(*crdfake.Clientset)
+	fakeCRD.PrependReactor("delete", "objectsyncs", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errors.New("simulated delete failure"))
+	})
+	fakeCRD.PrependReactor("delete", "clusterobjectsyncs", func(_ clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewInternalError(errors.New("simulated cluster delete failure"))
+	})
+
+	nodeName := getNodeName(objectSync.Name)
+	testController.nodeGCQueue.Add(nodeName)
+	if cont := testController.processNextNodeGC(); !cont {
+		t.Errorf("processNextNodeGC() = false, want true")
+	}
+	if got := testController.nodeGCQueue.NumRequeues(nodeName); got == 0 {
+		t.Errorf("processNextNodeGC() did not requeue after a failed GC")
 	}
 }

--- a/cloud/pkg/synccontroller/synccontroller_test.go
+++ b/cloud/pkg/synccontroller/synccontroller_test.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -36,6 +37,7 @@ import (
 	"github.com/kubeedge/api/apis/reliablesyncs/v1alpha1"
 	crdfake "github.com/kubeedge/api/client/clientset/versioned/fake"
 	crdinformers "github.com/kubeedge/api/client/informers/externalversions"
+	reliablesyncslisters "github.com/kubeedge/api/client/listers/reliablesyncs/v1alpha1"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	tf "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/common/testing"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
@@ -303,6 +305,88 @@ func TestEnqueueNodeForGC(t *testing.T) {
 
 	if got := testController.nodeGCQueue.Len(); got != 2 {
 		t.Errorf("enqueueNodeForGC() queue len = %d, want 2", got)
+	}
+}
+
+type failingObjectSyncLister struct{}
+
+func (failingObjectSyncLister) List(labels.Selector) ([]*v1alpha1.ObjectSync, error) {
+	return nil, errors.New("list error")
+}
+func (failingObjectSyncLister) ObjectSyncs(string) reliablesyncslisters.ObjectSyncNamespaceLister {
+	return nil
+}
+
+type failingClusterObjectSyncLister struct{}
+
+func (failingClusterObjectSyncLister) List(labels.Selector) ([]*v1alpha1.ClusterObjectSync, error) {
+	return nil, errors.New("list error")
+}
+func (failingClusterObjectSyncLister) Get(string) (*v1alpha1.ClusterObjectSync, error) {
+	return nil, errors.New("get error")
+}
+
+type failingNodeLister struct{}
+
+func (failingNodeLister) List(labels.Selector) ([]*v1.Node, error) {
+	return nil, errors.New("node list error")
+}
+func (failingNodeLister) Get(string) (*v1.Node, error) {
+	return nil, errors.New("node get error")
+}
+
+func TestNodeGCHandlesListErrors(t *testing.T) {
+	emptyCRD := crdinformers.NewSharedInformerFactory(crdfake.NewSimpleClientset(), 0)
+	emptyObjectSyncLister := emptyCRD.Reliablesyncs().V1alpha1().ObjectSyncs().Lister()
+
+	t.Run("ObjectSync list error", func(t *testing.T) {
+		ctl := newSyncController(true)
+		ctl.objectSyncLister = failingObjectSyncLister{}
+		ctl.clusterObjectSyncLister = failingClusterObjectSyncLister{}
+		if err := ctl.gcNodeSyncs("node"); err == nil {
+			t.Error("gcNodeSyncs() expected error from ObjectSync lister, got nil")
+		}
+		ctl.enqueueOrphanedNodeSyncs() // must return after the list error, not panic
+	})
+
+	t.Run("ClusterObjectSync list error", func(t *testing.T) {
+		ctl := newSyncController(true)
+		ctl.objectSyncLister = emptyObjectSyncLister
+		ctl.clusterObjectSyncLister = failingClusterObjectSyncLister{}
+		if err := ctl.gcNodeSyncs("node"); err == nil {
+			t.Error("gcNodeSyncs() expected error from ClusterObjectSync lister, got nil")
+		}
+		ctl.enqueueOrphanedNodeSyncs() // must return after the cluster list error, not panic
+	})
+}
+
+func TestGCNodeSyncsSkipsOtherNodes(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	testController := newGCTestController(t, objectSync)
+
+	// GC for a different node must not touch this node's records.
+	if err := testController.gcNodeSyncs("some-other-node"); err != nil {
+		t.Fatalf("gcNodeSyncs() returned error: %v", err)
+	}
+	got, _ := testController.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
+	if len(got.Items) != 1 {
+		t.Errorf("gcNodeSyncs() for another node deleted this node's syncs; got %d, want 1", len(got.Items))
+	}
+}
+
+func TestGCNodeSyncsCheckError(t *testing.T) {
+	objectSync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "2"), "Pod")
+	testController := newGCTestController(t, objectSync)
+	// The node lister returns a non-NotFound error, so garbage cannot be determined
+	// and the records must be kept.
+	testController.nodeLister = failingNodeLister{}
+
+	if err := testController.gcNodeSyncs(getNodeName(objectSync.Name)); err == nil {
+		t.Error("gcNodeSyncs() expected error from node lister, got nil")
+	}
+	got, _ := testController.crdclient.ReliablesyncsV1alpha1().ObjectSyncs(tf.TestNamespace).List(context.Background(), metav1.ListOptions{})
+	if len(got.Items) != 1 {
+		t.Errorf("gcNodeSyncs() deleted syncs despite a node-check error; got %d, want 1", len(got.Items))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When a node is deleted, SyncController's node informer DeleteFunc discarded the
deleted node and rescanned every ObjectSync and ClusterObjectSync in the
cluster, synchronously on the informer goroutine, retrying each delete with an
uncancellable exponential backoff (retry.Do with context.Background()). That is
O(nodes x syncs), blocks the informer during scaledown/rolling upgrades, and
cannot be interrupted on shutdown. Nodeexistence GC was also reachable only from
this path, so a retryexhausted delete leaked the sync record and the reconcile
loop kept sending resyncs toward the gone node every 5s.

This moves the GC to a ratelimiting workqueue keyed by node name:
- the informer DeleteFunc only enqueues the deleted node (off the informer
  goroutine, coalescing duplicate deletions);
- a worker deletes just that node's ObjectSync/ClusterObjectSync records, with
  cancellable, ratelimited retries, and the queue is shut down on module stop;
- a periodic backstop reenqueues nodes that no longer exist but still have sync
  records, so retryexhausted or missed deletions are eventually reclaimed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7027 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed SyncController so deleting a node no longer rescans all sync records on the informer goroutine, and node sync records left behind by failed or missed deletions are now garbage collected by a periodic backstop.
```
