### PR TITLE
keadm: assign log paths for resource copy containers

### DIFF
--- a/pkg/containers/container_runtime.go
+++ b/pkg/containers/container_runtime.go
@@ -18,7 +18,9 @@ package containers
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -36,6 +38,13 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/image"
 )
 
+const (
+	defaultPodLogsDirectory     = "/var/log/pods"
+	copyResourcesCleanupTimeout = 45 * time.Second
+	copyResourcesStopTimeout    = int64(5)
+	copyResourcesContainerName  = "container"
+)
+
 type ContainerRuntime interface {
 	CopyResources(ctx context.Context, image string, files map[string]string) error
 
@@ -43,8 +52,9 @@ type ContainerRuntime interface {
 }
 
 type ContainerRuntimeImpl struct {
-	cgroupDriver string
-	ctrsvc       internalapi.RuntimeService
+	cgroupDriver     string
+	podLogsDirectory string
+	ctrsvc           internalapi.RuntimeService
 
 	*image.RuntimeImpl
 }
@@ -61,9 +71,10 @@ func NewContainerRuntime(endpoint, cgroupDriver string) (ContainerRuntime, error
 		return nil, fmt.Errorf("failed to new remote runtime service, err: %v", err)
 	}
 	return &ContainerRuntimeImpl{
-		RuntimeImpl:  imgrt,
-		cgroupDriver: cgroupDriver,
-		ctrsvc:       ctrsvc,
+		RuntimeImpl:      imgrt,
+		cgroupDriver:     cgroupDriver,
+		podLogsDirectory: defaultPodLogsDirectory,
+		ctrsvc:           ctrsvc,
 	}, nil
 }
 
@@ -73,13 +84,42 @@ func (runtime *ContainerRuntimeImpl) CopyResources(
 	ctx context.Context,
 	image string,
 	files map[string]string,
-) error {
+) (retErr error) {
+	podLogsDirectory := runtime.podLogsDirectory
+	if podLogsDirectory == "" {
+		podLogsDirectory = defaultPodLogsDirectory
+	}
+	sandboxUID := uuid.New().String()
+	logDirectory := filepath.Join(
+		podLogsDirectory,
+		fmt.Sprintf("%s_%s_%s", constants.SystemNamespace, apiconsts.KubeEdgeBinaryName, sandboxUID),
+	)
+	if err := os.MkdirAll(filepath.Join(logDirectory, copyResourcesContainerName), 0755); err != nil {
+		return fmt.Errorf("create resource copy log directory: %w", err)
+	}
+
+	var sandbox, containerID string
+	containerStarted := false
+	defer func() {
+		cleanupErr := runtime.cleanupCopyResources(ctx, sandbox, containerID, containerStarted, logDirectory)
+		if cleanupErr != nil {
+			if retErr != nil {
+				retErr = errors.Join(retErr, cleanupErr)
+				return
+			}
+			// The copy completed successfully. A transient CRI cleanup failure must not
+			// make keadm retry the whole join and create another resource-copy sandbox.
+			klog.Warningf("resource copy cleanup did not complete: %v", cleanupErr)
+		}
+	}()
+
 	psc := &runtimeapi.PodSandboxConfig{
 		Metadata: &runtimeapi.PodSandboxMetadata{
 			Name:      apiconsts.KubeEdgeBinaryName,
-			Uid:       uuid.New().String(),
+			Uid:       sandboxUID,
 			Namespace: constants.SystemNamespace,
 		},
+		LogDirectory: logDirectory,
 		Linux: &runtimeapi.LinuxPodSandboxConfig{
 			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
 				NamespaceOptions: &runtimeapi.NamespaceOption{
@@ -93,15 +133,11 @@ func (runtime *ContainerRuntimeImpl) CopyResources(
 		cgroupName := cm.NewCgroupName(cm.CgroupName{"kubeedge", "setup", "podcopyresource"})
 		psc.Linux.CgroupParent = cgroupName.ToSystemd()
 	}
-	sandbox, err := runtime.ctrsvc.RunPodSandbox(ctx, psc, "")
+	var err error
+	sandbox, err = runtime.ctrsvc.RunPodSandbox(ctx, psc, "")
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err := runtime.ctrsvc.RemovePodSandbox(ctx, sandbox); err != nil {
-			klog.V(3).ErrorS(err, "Remove pod sandbox failed", "containerID", sandbox)
-		}
-	}()
 
 	var mounts []*runtimeapi.Mount
 	for _, hostPath := range files {
@@ -112,7 +148,7 @@ func (runtime *ContainerRuntimeImpl) CopyResources(
 	}
 	containerConfig := &runtimeapi.ContainerConfig{
 		Metadata: &runtimeapi.ContainerMetadata{
-			Name: "container",
+			Name: copyResourcesContainerName,
 		},
 		Image: &runtimeapi.ImageSpec{
 			Image: image,
@@ -125,27 +161,24 @@ func (runtime *ContainerRuntimeImpl) CopyResources(
 			"-c",
 			"sleep infinity",
 		},
-		Mounts: mounts,
+		Mounts:  mounts,
+		LogPath: filepath.Join(copyResourcesContainerName, "0.log"),
 		Linux: &runtimeapi.LinuxContainerConfig{
 			SecurityContext: &runtimeapi.LinuxContainerSecurityContext{
 				Privileged: true,
 			},
 		},
 	}
-	containerID, err := runtime.ctrsvc.CreateContainer(ctx, sandbox, containerConfig, psc)
+	containerID, err = runtime.ctrsvc.CreateContainer(ctx, sandbox, containerConfig, psc)
 	if err != nil {
 		return fmt.Errorf("create container failed: %v", err)
 	}
-	defer func() {
-		if err := runtime.ctrsvc.RemoveContainer(ctx, containerID); err != nil {
-			klog.V(3).ErrorS(err, "Remove container failed", "containerID", containerID)
-		}
-	}()
 
 	err = runtime.ctrsvc.StartContainer(ctx, containerID)
 	if err != nil {
 		return fmt.Errorf("start container failed: %v", err)
 	}
+	containerStarted = true
 
 	cmd := []string{"/bin/sh", "-c", copyResourcesCmd(files)}
 	stdout, stderr, err := runtime.ctrsvc.ExecSync(ctx, containerID, cmd, 30*time.Second)
@@ -154,6 +187,38 @@ func (runtime *ContainerRuntimeImpl) CopyResources(
 	}
 
 	return nil
+}
+
+func (runtime *ContainerRuntimeImpl) cleanupCopyResources(
+	ctx context.Context,
+	sandboxID, containerID string,
+	containerStarted bool,
+	logDirectory string,
+) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), copyResourcesCleanupTimeout)
+	defer cancel()
+
+	var cleanupErrors []error
+	if containerID != "" && containerStarted {
+		if err := runtime.ctrsvc.StopContainer(cleanupCtx, containerID, copyResourcesStopTimeout); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("stop resource copy container %q: %w", containerID, err))
+		}
+	}
+	if containerID != "" {
+		if err := runtime.ctrsvc.RemoveContainer(cleanupCtx, containerID); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove resource copy container %q: %w", containerID, err))
+		}
+	}
+	if sandboxID != "" {
+		if err := runtime.ctrsvc.RemovePodSandbox(cleanupCtx, sandboxID); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove resource copy sandbox %q: %w", sandboxID, err))
+		}
+	}
+	if err := os.RemoveAll(logDirectory); err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("remove resource copy log directory %q: %w", logDirectory, err))
+	}
+
+	return errors.Join(cleanupErrors...)
 }
 
 func copyResourcesCmd(files map[string]string) string {

--- a/pkg/containers/container_runtime_test.go
+++ b/pkg/containers/container_runtime_test.go
@@ -19,6 +19,9 @@ package containers
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 	"time"
@@ -45,23 +48,35 @@ func TestCopyResources(t *testing.T) {
 			image:        "kubeedge/pause:3.1",
 			files:        map[string]string{"/tmp/src": "/usr/local/bin/dest"},
 			setupMock: func(t *testing.T, m *mock.MockRuntimeService) {
-				m.EXPECT().RunPodSandbox(gomock.Any(), gomock.Any(), gomock.Any()).Return("sb-123", nil)
-				m.EXPECT().CreateContainer(gomock.Any(), "sb-123", gomock.Any(), gomock.Any()).Return("cnt-123", nil)
+				var logDirectory string
+				m.EXPECT().RunPodSandbox(gomock.Any(), gomock.Any(), gomock.Any()).
+					Do(func(_ context.Context, config *runtimeapi.PodSandboxConfig, _ string) {
+						logDirectory = config.LogDirectory
+						if !filepath.IsAbs(logDirectory) {
+							t.Errorf("LogDirectory must be absolute, got %q", logDirectory)
+						}
+					}).Return("sb-123", nil)
+				m.EXPECT().CreateContainer(gomock.Any(), "sb-123", gomock.Any(), gomock.Any()).
+					Do(func(_ context.Context, _ string, config *runtimeapi.ContainerConfig, sandboxConfig *runtimeapi.PodSandboxConfig) {
+						if config.LogPath != filepath.Join(copyResourcesContainerName, "0.log") {
+							t.Errorf("unexpected LogPath %q", config.LogPath)
+						}
+						if sandboxConfig.LogDirectory != logDirectory {
+							t.Errorf("sandbox LogDirectory changed: got %q, want %q", sandboxConfig.LogDirectory, logDirectory)
+						}
+					}).Return("cnt-123", nil)
 				m.EXPECT().StartContainer(gomock.Any(), "cnt-123").Return(nil)
-
-				// Use .Do to verify the command manually instead of MatchedBy
 				m.EXPECT().ExecSync(gomock.Any(), "cnt-123", gomock.Any(), gomock.Any()).
-					Do(func(ctx context.Context, containerID string, cmd []string, timeout time.Duration) {
+					Do(func(_ context.Context, _ string, cmd []string, _ time.Duration) {
 						expected := "cp /tmp/src /tmp/usr/local/bin/dest"
 						if cmd[2] != expected {
 							t.Errorf("expected command %s, got %s", expected, cmd[2])
 						}
 					}).Return([]byte("stdout"), []byte(""), nil)
-
+				m.EXPECT().StopContainer(gomock.Any(), "cnt-123", copyResourcesStopTimeout).Return(nil)
 				m.EXPECT().RemoveContainer(gomock.Any(), "cnt-123").Return(nil)
 				m.EXPECT().RemovePodSandbox(gomock.Any(), "sb-123").Return(nil)
 			},
-			wantErr: false,
 		},
 		{
 			name:         "Success path: systemd cgroup driver validation",
@@ -69,21 +84,19 @@ func TestCopyResources(t *testing.T) {
 			image:        "kubeedge/pause:3.1",
 			files:        map[string]string{"/src": "/dest"},
 			setupMock: func(t *testing.T, m *mock.MockRuntimeService) {
-				// Use .Do to verify CgroupParent manually
 				m.EXPECT().RunPodSandbox(gomock.Any(), gomock.Any(), gomock.Any()).
-					Do(func(ctx context.Context, config *runtimeapi.PodSandboxConfig, runtimeHandler string) {
-						if config.Linux == nil || config.Linux.CgroupParent == "" {
+					Do(func(_ context.Context, config *runtimeapi.PodSandboxConfig, _ string) {
+						if goruntime.GOOS == "linux" && (config.Linux == nil || config.Linux.CgroupParent == "") {
 							t.Errorf("CgroupParent should be set for systemd driver")
 						}
 					}).Return("sb-systemd", nil)
-
 				m.EXPECT().CreateContainer(gomock.Any(), "sb-systemd", gomock.Any(), gomock.Any()).Return("cnt-systemd", nil)
 				m.EXPECT().StartContainer(gomock.Any(), "cnt-systemd").Return(nil)
 				m.EXPECT().ExecSync(gomock.Any(), "cnt-systemd", gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+				m.EXPECT().StopContainer(gomock.Any(), "cnt-systemd", copyResourcesStopTimeout).Return(nil)
 				m.EXPECT().RemoveContainer(gomock.Any(), "cnt-systemd").Return(nil)
 				m.EXPECT().RemovePodSandbox(gomock.Any(), "sb-systemd").Return(nil)
 			},
-			wantErr: false,
 		},
 		{
 			name:    "Failure: Sandbox creation fails",
@@ -105,26 +118,77 @@ func TestCopyResources(t *testing.T) {
 				m.EXPECT().RemovePodSandbox(gomock.Any(), "sb-fail").Return(nil)
 			},
 		},
+		{
+			name:    "Success: cleanup error after copy is nonfatal",
+			image:   "kubeedge/pause:3.1",
+			files:   map[string]string{"/src": "/dest"},
+			wantErr: false,
+			setupMock: func(t *testing.T, m *mock.MockRuntimeService) {
+				m.EXPECT().RunPodSandbox(gomock.Any(), gomock.Any(), gomock.Any()).Return("sb-cleanup", nil)
+				m.EXPECT().CreateContainer(gomock.Any(), "sb-cleanup", gomock.Any(), gomock.Any()).Return("cnt-cleanup", nil)
+				m.EXPECT().StartContainer(gomock.Any(), "cnt-cleanup").Return(nil)
+				m.EXPECT().ExecSync(gomock.Any(), "cnt-cleanup", gomock.Any(), gomock.Any()).Return(nil, nil, nil)
+				m.EXPECT().StopContainer(gomock.Any(), "cnt-cleanup", copyResourcesStopTimeout).Return(fmt.Errorf("stream terminated by RST_STREAM"))
+				m.EXPECT().RemoveContainer(gomock.Any(), "cnt-cleanup").Return(nil)
+				m.EXPECT().RemovePodSandbox(gomock.Any(), "sb-cleanup").Return(nil)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockSvc := mock.NewMockRuntimeService(ctrl)
-
+			podLogsDirectory := t.TempDir()
 			runtime := &ContainerRuntimeImpl{
-				cgroupDriver: tt.cgroupDriver,
-				ctrsvc:       mockSvc,
+				cgroupDriver:     tt.cgroupDriver,
+				podLogsDirectory: podLogsDirectory,
+				ctrsvc:           mockSvc,
 			}
 
 			tt.setupMock(t, mockSvc)
-
 			err := runtime.CopyResources(context.Background(), tt.image, tt.files)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CopyResources() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			entries, readErr := os.ReadDir(podLogsDirectory)
+			if readErr != nil {
+				t.Fatalf("read pod logs directory: %v", readErr)
+			}
+			if len(entries) != 0 {
+				t.Errorf("resource copy log directory was not cleaned: %v", entries)
+			}
 		})
+	}
+}
+
+func TestCopyResourcesCleanupUsesIndependentContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockSvc := mock.NewMockRuntimeService(ctrl)
+	runtime := &ContainerRuntimeImpl{
+		podLogsDirectory: t.TempDir(),
+		ctrsvc:           mockSvc,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mockSvc.EXPECT().RunPodSandbox(gomock.Any(), gomock.Any(), gomock.Any()).Return("sb-context", nil)
+	mockSvc.EXPECT().CreateContainer(gomock.Any(), "sb-context", gomock.Any(), gomock.Any()).Return("cnt-context", nil)
+	mockSvc.EXPECT().StartContainer(gomock.Any(), "cnt-context").Return(nil)
+	mockSvc.EXPECT().ExecSync(gomock.Any(), "cnt-context", gomock.Any(), gomock.Any()).
+		Do(func(context.Context, string, []string, time.Duration) {
+			cancel()
+		}).Return(nil, nil, nil)
+	stopCall := mockSvc.EXPECT().StopContainer(gomock.Any(), "cnt-context", copyResourcesStopTimeout).
+		Do(func(cleanupCtx context.Context, _ string, _ int64) {
+			if err := cleanupCtx.Err(); err != nil {
+				t.Errorf("cleanup context inherited cancellation: %v", err)
+			}
+		}).Return(nil)
+	removeCall := mockSvc.EXPECT().RemoveContainer(gomock.Any(), "cnt-context").Return(nil).After(stopCall)
+	mockSvc.EXPECT().RemovePodSandbox(gomock.Any(), "sb-context").Return(nil).After(removeCall)
+
+	if err := runtime.CopyResources(ctx, "kubeedge/pause:3.1", map[string]string{"/src": "/dest"}); err != nil {
+		t.Fatalf("CopyResources() error = %v", err)
 	}
 }
 
@@ -148,7 +212,6 @@ func Test_copyResourcesCmd(t *testing.T) {
 				"/src2": "/dest2",
 			},
 			check: func(res string) bool {
-				// Map iteration is random, so check for both segments
 				return strings.Contains(res, "cp /src1 /tmp/dest1") &&
 					strings.Contains(res, "cp /src2 /tmp/dest2") &&
 					strings.Contains(res, " && ")


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`CopyResources` creates a temporary CRI sandbox and container during `keadm join`.
Those resources were created without an explicit pod log directory or container log
path, leaving runtime cleanup without a scoped log location.

This change:

- creates a unique pod log directory for each resource-copy sandbox;
- sets the temporary container log path relative to that directory;
- cleans up the temporary CRI resources and log directory with an independent,
  bounded context; and
- preserves a successful resource copy when only cleanup sees a transient CRI
  transport error.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Validation performed:

- `go test -count=1 ./pkg/containers`
- `make verify`
- `make test WHAT='pkg keadm'`

The current Makefile does not define the `edge_test` target referenced by
CONTRIBUTING.md. The available integration script requires `sudo`, a Linux
EdgeCore process, and a local MQTT setup, so it was not run on macOS. The
focused unit tests cover the resource-copy lifecycle and cleanup behavior.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed keadm resource copying to use scoped CRI log paths and to tolerate
transient cleanup transport failures after a successful copy.
```
