### PR TITLE
fix: handle dynamiccontroller delete tombstones

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/eventhandler.go
+++ b/cloud/pkg/dynamiccontroller/application/eventhandler.go
@@ -144,6 +144,9 @@ func NewCommonResourceEventHandler(
 }
 
 func (c *CommonResourceEventHandler) objToEvent(t watch.EventType, obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
 	eventObj, ok := obj.(runtime.Object)
 	if !ok {
 		klog.Warningf("Unknown type: %T, ignore", obj)

--- a/cloud/pkg/dynamiccontroller/application/eventhandler_test.go
+++ b/cloud/pkg/dynamiccontroller/application/eventhandler_test.go
@@ -711,7 +711,7 @@ func TestEventHandlerObjectConversion(t *testing.T) {
 		select {
 		case <-freshHandler.events:
 			t.Fatal("Unexpected event received for invalid tombstone object")
-		case <-time.After(100 * time.Millisecond):
+		default:
 		}
 	})
 

--- a/cloud/pkg/dynamiccontroller/application/eventhandler_test.go
+++ b/cloud/pkg/dynamiccontroller/application/eventhandler_test.go
@@ -674,6 +674,47 @@ func TestEventHandlerObjectConversion(t *testing.T) {
 		}
 	})
 
+	t.Run("Delete tombstone object", func(t *testing.T) {
+		freshHandler := &CommonResourceEventHandler{
+			events: make(chan watch.Event, 10),
+		}
+
+		freshHandler.objToEvent(watch.Deleted, cache.DeletedFinalStateUnknown{
+			Key: "default/test-deployment",
+			Obj: testObj,
+		})
+
+		select {
+		case event := <-freshHandler.events:
+			assert.Equal(t, watch.Deleted, event.Type)
+			actualObj, ok := event.Object.(*unstructured.Unstructured)
+			if assert.True(t, ok, "Expected *unstructured.Unstructured, got %T", event.Object) {
+				assert.Equal(t, testObj.GetName(), actualObj.GetName())
+				assert.Equal(t, testObj.GetNamespace(), actualObj.GetNamespace())
+				assert.Equal(t, testObj.GetLabels(), actualObj.GetLabels())
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("No event received for tombstone object")
+		}
+	})
+
+	t.Run("Delete invalid tombstone object", func(t *testing.T) {
+		freshHandler := &CommonResourceEventHandler{
+			events: make(chan watch.Event, 10),
+		}
+
+		freshHandler.objToEvent(watch.Deleted, cache.DeletedFinalStateUnknown{
+			Key: "default/test-deployment",
+			Obj: "not-a-runtime-object",
+		})
+
+		select {
+		case <-freshHandler.events:
+			t.Fatal("Unexpected event received for invalid tombstone object")
+		case <-time.After(100 * time.Millisecond):
+		}
+	})
+
 	t.Run("SetMetaType error", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
 		defer patches.Reset()


### PR DESCRIPTION
## Description:

Issue #7038 reported that dynamiccontroller delete events could be dropped when the informer delivered `cache.DeletedFinalStateUnknown`.

This PR updates `cloud/pkg/dynamiccontroller/application/eventhandler.go` to unwrap tombstone delete payloads before converting them to `runtime.Object`, so valid delete events are still forwarded.

It also adds regression coverage in `cloud/pkg/dynamiccontroller/application/eventhandler_test.go` for both valid and invalid tombstone delete payloads.

The fix is minimal and limited to the affected dynamiccontroller delete event conversion path.

## Validation:

- `gofmt -w cloud/pkg/dynamiccontroller/application/eventhandler.go cloud/pkg/dynamiccontroller/application/eventhandler_test.go`
- `go test ./cloud/pkg/dynamiccontroller/application -count=1`
- `go test -v ./cloud/pkg/dynamiccontroller/application -run TestEventHandlerObjectConversion -count=1`
- `golangci-lint run ./cloud/pkg/dynamiccontroller/application --timeout=5m`

Closes #7038.

## Checklist:

- [x] I have added regression test cases for valid and invalid tombstone delete payloads.
- [x] I have run validation using the focused `go test` and `golangci-lint` commands above.

## Release note:

```release-note
DynamicController now correctly forwards delete events when informer delete payloads arrive as tombstones.
```
