### PR TITLE
fix: handle CloudCore pod delete tombstones in iptables

### DIFF
--- a/cloud/pkg/cloudstream/iptables/iptables.go
+++ b/cloud/pkg/cloudstream/iptables/iptables.go
@@ -273,22 +273,7 @@ func (im *Manager) listenCloudCore(ctx context.Context) {
 	_, err := podInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			DeleteFunc: func(obj interface{}) {
-				// listen pod delete event
-				pod, ok := obj.(*v1.Pod)
-				if !ok {
-					klog.Warningf("object type: %T unsupported when listen CloudCore pod delete", obj)
-					return
-				}
-				value, ok := pod.Labels[constants.SystemName]
-				if ok && value == constants.CloudConfigMapName {
-					// only handle coudcore pod delete
-					podIP := pod.Status.PodIP
-					if len(podIP) == 0 {
-						return
-					}
-					// find deleted cloudcore pod, put it in queue
-					im.enqueuePod(pod)
-				}
+				im.handleCloudCorePodDelete(obj)
 			},
 		},
 	)
@@ -296,6 +281,29 @@ func (im *Manager) listenCloudCore(ctx context.Context) {
 		klog.Fatalf("new podInformer failed, add event handler err: %v", err)
 	}
 	podInformer.Informer().Run(ctx.Done())
+}
+
+func (im *Manager) handleCloudCorePodDelete(obj interface{}) {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		klog.Warningf("object type: %T unsupported when listen CloudCore pod delete", obj)
+		return
+	}
+
+	value, ok := pod.Labels[constants.SystemName]
+	if ok && value == constants.CloudConfigMapName {
+		// only handle coudcore pod delete
+		podIP := pod.Status.PodIP
+		if len(podIP) == 0 {
+			return
+		}
+		// find deleted cloudcore pod, put it in queue
+		im.enqueuePod(pod)
+	}
 }
 
 func (im *Manager) CleanCloudCoreIPPort(ctx context.Context, pod *v1.Pod) error {

--- a/cloud/pkg/cloudstream/iptables/iptables_test.go
+++ b/cloud/pkg/cloudstream/iptables/iptables_test.go
@@ -1,0 +1,114 @@
+//go:build linux
+// +build linux
+
+package iptables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubeedge/kubeedge/common/constants"
+)
+
+func TestHandleCloudCorePodDelete(t *testing.T) {
+	tests := []struct {
+		name         string
+		obj          interface{}
+		wantEnqueued bool
+		wantName     string
+	}{
+		{
+			name: "Delete cloudcore pod",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cloudcore-0",
+					Labels: map[string]string{
+						constants.SystemName: constants.CloudConfigMapName,
+					},
+				},
+				Status: v1.PodStatus{
+					PodIP: "10.0.0.1",
+				},
+			},
+			wantEnqueued: true,
+			wantName:     "cloudcore-0",
+		},
+		{
+			name: "Delete tombstone cloudcore pod",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "kubeedge/cloudcore-1",
+				Obj: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cloudcore-1",
+						Labels: map[string]string{
+							constants.SystemName: constants.CloudConfigMapName,
+						},
+					},
+					Status: v1.PodStatus{
+						PodIP: "10.0.0.2",
+					},
+				},
+			},
+			wantEnqueued: true,
+			wantName:     "cloudcore-1",
+		},
+		{
+			name: "Delete invalid tombstone",
+			obj: cache.DeletedFinalStateUnknown{
+				Key: "kubeedge/cloudcore-2",
+				Obj: "not-a-pod",
+			},
+			wantEnqueued: false,
+		},
+		{
+			name: "Delete pod without cloudcore label",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "other-pod",
+				},
+				Status: v1.PodStatus{
+					PodIP: "10.0.0.3",
+				},
+			},
+			wantEnqueued: false,
+		},
+		{
+			name: "Delete cloudcore pod without pod ip",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cloudcore-2",
+					Labels: map[string]string{
+						constants.SystemName: constants.CloudConfigMapName,
+					},
+				},
+			},
+			wantEnqueued: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var enqueued *v1.Pod
+			im := &Manager{
+				enqueuePod: func(pod *v1.Pod) {
+					enqueued = pod
+				},
+			}
+
+			im.handleCloudCorePodDelete(tt.obj)
+
+			if !tt.wantEnqueued {
+				assert.Nil(t, enqueued)
+				return
+			}
+
+			if assert.NotNil(t, enqueued) {
+				assert.Equal(t, tt.wantName, enqueued.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description:

Issue #7039 reported that the cloudstream iptables manager could ignore pod delete events when the informer delivered `cache.DeletedFinalStateUnknown`.

This PR updates `cloud/pkg/cloudstream/iptables/iptables.go` to unwrap tombstone delete payloads before converting them to `*v1.Pod` in the CloudCore pod delete path, so deleted CloudCore pods are still enqueued for tunnel-port cleanup.

It also adds regression coverage in `cloud/pkg/cloudstream/iptables/iptables_test.go` for direct pod deletes, tombstone pod deletes, and invalid tombstone payloads.

The fix is minimal and limited to the affected CloudCore pod delete handling path in the iptables manager.

## Validation:

- `gofmt -w cloud/pkg/cloudstream/iptables/iptables.go cloud/pkg/cloudstream/iptables/iptables_test.go`
- `go test ./cloud/pkg/cloudstream/iptables -count=1`
- `go test -v ./cloud/pkg/cloudstream/iptables -run TestHandleCloudCorePodDelete -count=1`
- `golangci-lint run ./cloud/pkg/cloudstream/iptables --timeout=5m`

Closes #7039.

## Checklist:

- [x] I have added regression test cases for direct, tombstone, and invalid delete payloads.
- [x] I have run validation using the focused `go test` and `golangci-lint` commands above.

## Release note:

```release-note
CloudStream iptables cleanup now handles CloudCore pod delete tombstones correctly.
```
