### PR TITLE
fix: handle IPv6 host parsing in cloudstream

### DIFF
--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -178,7 +178,7 @@ func (s *StreamServer) getMetrics(r *restful.Request, w *restful.Response) {
 		}
 	}()
 
-	sessionKey := strings.Split(r.Request.Host, ":")[0]
+	sessionKey := getAddressHost(r.Request.Host)
 	if forwardedURI := r.Request.Header.Get("X-Forwarded-Uri"); forwardedURI != "" {
 		if t := strings.Split(forwardedURI, "/"); strings.HasPrefix(forwardedURI, "/api/v1/nodes/") && len(t) > 6 {
 			sessionKey = t[4]

--- a/cloud/pkg/cloudstream/streamserver_test.go
+++ b/cloud/pkg/cloudstream/streamserver_test.go
@@ -61,3 +61,35 @@ func TestGetMetricsDeletesConnectionOnRequestCancel(t *testing.T) {
 	assert.Equal(t, stream.MessageTypeRemoveConnect, mockTunneler.lastMessage.MessageType)
 	assert.Empty(t, session.apiServerConn)
 }
+
+func TestGetMetricsDeletesConnectionOnRequestCancelWithIPv6Host(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil).WithContext(ctx)
+	req.Host = "[2001:db8::1]:10003"
+	resp := httptest.NewRecorder()
+
+	tunnel := &TunnelServer{
+		sessions: make(map[string]*Session),
+	}
+	mockTunneler := &MockTunneler{}
+	session := &Session{
+		sessionID:     "2001:db8::1",
+		tunnel:        mockTunneler,
+		apiServerConn: make(map[uint64]APIServerConnection),
+		apiConnlock:   &sync.RWMutex{},
+	}
+	tunnel.addSession("2001:db8::1", session)
+
+	streamServer := &StreamServer{
+		tunnel: tunnel,
+	}
+
+	streamServer.getMetrics(restful.NewRequest(req), restful.NewResponse(resp))
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	require.NotNil(t, mockTunneler.lastMessage)
+	assert.Equal(t, stream.MessageTypeRemoveConnect, mockTunneler.lastMessage.MessageType)
+	assert.Empty(t, session.apiServerConn)
+}

--- a/cloud/pkg/cloudstream/tunnelserver.go
+++ b/cloud/pkg/cloudstream/tunnelserver.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -129,7 +130,7 @@ func (s *TunnelServer) connect(r *restful.Request, w *restful.Response) {
 	hostNameOverride := r.HeaderParameter(stream.SessionKeyHostNameOverride)
 	internalIP := r.HeaderParameter(stream.SessionKeyInternalIP)
 	if internalIP == "" {
-		internalIP = strings.Split(r.Request.RemoteAddr, ":")[0]
+		internalIP = getAddressHost(r.Request.RemoteAddr)
 	}
 	con, err := s.upgrader.Upgrade(w, r.Request, nil)
 	if err != nil {
@@ -238,4 +239,17 @@ func (s *TunnelServer) updateNodeKubeletEndpoint(nodeName string) error {
 	}
 	klog.V(4).Infof("Update node KubeletEndpoint Port successfully, node: %s, tunnelPort: %d", nodeName, s.tunnelPort)
 	return nil
+}
+
+func getAddressHost(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err == nil {
+		return host
+	}
+
+	if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+		return strings.TrimSuffix(strings.TrimPrefix(addr, "["), "]")
+	}
+
+	return addr
 }

--- a/cloud/pkg/cloudstream/tunnelserver_test.go
+++ b/cloud/pkg/cloudstream/tunnelserver_test.go
@@ -322,9 +322,24 @@ func TestGetAddressHost(t *testing.T) {
 			want: "2001:db8::1",
 		},
 		{
+			name: "IPv6 host without port",
+			addr: "2001:db8::1",
+			want: "2001:db8::1",
+		},
+		{
+			name: "Bracketed IPv6 host without port",
+			addr: "[2001:db8::1]",
+			want: "2001:db8::1",
+		},
+		{
 			name: "Host without port",
 			addr: "edge-node",
 			want: "edge-node",
+		},
+		{
+			name: "Empty address",
+			addr: "",
+			want: "",
 		},
 	}
 

--- a/cloud/pkg/cloudstream/tunnelserver_test.go
+++ b/cloud/pkg/cloudstream/tunnelserver_test.go
@@ -305,6 +305,36 @@ func TestConnect(t *testing.T) {
 	}
 }
 
+func TestGetAddressHost(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			name: "IPv4 host port",
+			addr: "192.168.1.3:12345",
+			want: "192.168.1.3",
+		},
+		{
+			name: "IPv6 host port",
+			addr: "[2001:db8::1]:12345",
+			want: "2001:db8::1",
+		},
+		{
+			name: "Host without port",
+			addr: "edge-node",
+			want: "edge-node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, getAddressHost(tt.addr))
+		})
+	}
+}
+
 func TestTLSSetup(t *testing.T) {
 	fakeCert := []byte("fake-certificate-data")
 	fakeKey := []byte("fake-key-data")


### PR DESCRIPTION
## Description:

Issue #7040 reported that cloudstream parsed `host:port` values by splitting on `":"`, which breaks bracketed IPv6 addresses.

This PR updates `cloud/pkg/cloudstream/tunnelserver.go` and `cloud/pkg/cloudstream/streamserver.go` to use proper host extraction for `RemoteAddr` and `Host`, so IPv4 and IPv6 addresses are both handled correctly.

It also adds regression coverage in `cloud/pkg/cloudstream/tunnelserver_test.go` and `cloud/pkg/cloudstream/streamserver_test.go` for IPv6 host parsing and IPv6 metrics session lookup.

The fix is minimal and limited to the affected cloudstream host parsing paths.

## Validation:

- `gofmt -w cloud/pkg/cloudstream/tunnelserver.go cloud/pkg/cloudstream/streamserver.go cloud/pkg/cloudstream/tunnelserver_test.go cloud/pkg/cloudstream/streamserver_test.go`
- `go test ./cloud/pkg/cloudstream -count=1`
- `go test -v ./cloud/pkg/cloudstream -run "TestGetAddressHost|TestGetMetricsDeletesConnectionOnRequestCancelWithIPv6Host" -count=1`
- `golangci-lint run ./cloud/pkg/cloudstream --timeout=10m`

Closes #7040.

## Checklist:

- [x]  I have added regression test cases for IPv6 host parsing and IPv6 metrics session lookup.
- [x] I have run validation using the focused `go test` and `golangci-lint` commands above.

## Release note:

```release-note
CloudStream now correctly parses IPv6 host:port values for session lookup and internal IP fallback.
```
