### PR TITLE
test(metamanager): add unit test for eventbus model

### DIFF
--- a/edge/pkg/metamanager/dao/models/eventbus_test.go
+++ b/edge/pkg/metamanager/dao/models/eventbus_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubTopicsTableName(t *testing.T) {
+	st := SubTopics{}
+	require.Equal(t, SubTopicsName, st.TableName(), "TableName() should return the constant SubTopicsName")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Adds a simple unit test for `edge/pkg/metamanager/dao/models/eventbus.go` to achieve 100% test coverage for this model. It verifies that the `TableName()` receiver function correctly returns the `SubTopicsName` constant.

This is a clean, pure-function test that does not mutate global state and does not require any production code modifications, making it fully immune to static analysis or test parallelization issues.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This PR strictly adds test coverage for a pure function. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
