### PR TITLE
Fix goroutine leak in EdgeHub upon reconnection

### DIFF
--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -1,6 +1,7 @@
 package edgehub
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	messagepkg "github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/clients"
@@ -46,7 +48,7 @@ func newEdgeHub(enable bool) *EdgeHub {
 	NewCertSyncChannel()
 	return &EdgeHub{
 		enable:        enable,
-		reconnectChan: make(chan struct{}),
+		reconnectChan: make(chan struct{}, 1),
 		rateLimiter: flowcontrol.NewTokenBucketRateLimiter(
 			float32(config.Config.EdgeHub.MessageQPS),
 			int(config.Config.EdgeHub.MessageBurst)),
@@ -122,13 +124,20 @@ func (eh *EdgeHub) Start() {
 		}
 		// execute hook func after connect
 		eh.pubConnectInfo(true)
-		go eh.routeToEdge()
-		go eh.routeToCloud()
-		go eh.keepalive()
+		ctx, cancel := context.WithCancel(context.Background())
+		go eh.routeToEdge(ctx)
+		go eh.routeToCloud(ctx)
+		go eh.keepalive(ctx)
 
 		// wait the stop signal
 		// stop authinfo manager/websocket connection
 		<-eh.reconnectChan
+		cancel()
+
+		// Send a stop message to unblock routeToCloud if it's waiting on Receive()
+		stopMsg := messagepkg.BuildMsg(modules.HubGroup, "", modules.EdgeHubModuleName, "", messagepkg.OperationStop, nil)
+		beehiveContext.Send(modules.EdgeHubModuleName, *stopMsg)
+
 		eh.chClient.UnInit()
 
 		// execute hook fun after disconnect

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -39,18 +39,24 @@ func (eh *EdgeHub) dispatch(message model.Message) error {
 	return msghandler.ProcessHandler(message, eh.chClient)
 }
 
-func (eh *EdgeHub) routeToEdge() {
+func (eh *EdgeHub) routeToEdge(ctx context.Context) {
 	for {
 		select {
 		case <-beehiveContext.Done():
 			klog.Warning("EdgeHub RouteToEdge stop")
+			return
+		case <-ctx.Done():
+			klog.Warning("EdgeHub RouteToEdge reconnect stop")
 			return
 		default:
 		}
 		message, err := eh.chClient.Receive()
 		if err != nil {
 			klog.Errorf("websocket read error: %v", err)
-			eh.reconnectChan <- struct{}{}
+			select {
+			case eh.reconnectChan <- struct{}{}:
+			default:
+			}
 			return
 		}
 		klog.V(4).Infof("[edgehub/routeToEdge] receive msg from cloud, msg: %+v", message)
@@ -72,11 +78,14 @@ func (eh *EdgeHub) sendToCloud(message model.Message) error {
 	return nil
 }
 
-func (eh *EdgeHub) routeToCloud() {
+func (eh *EdgeHub) routeToCloud(ctx context.Context) {
 	for {
 		select {
 		case <-beehiveContext.Done():
 			klog.Warning("EdgeHub RouteToCloud stop")
+			return
+		case <-ctx.Done():
+			klog.Warning("EdgeHub RouteToCloud reconnect stop")
 			return
 		default:
 		}
@@ -84,6 +93,18 @@ func (eh *EdgeHub) routeToCloud() {
 		if err != nil {
 			klog.Errorf("failed to receive message from edge: %v", err)
 			time.Sleep(time.Second)
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			klog.Warning("EdgeHub RouteToCloud reconnect stop after receive")
+			return
+		default:
+		}
+
+		if message.GetOperation() == messagepkg.OperationStop {
+			klog.Warning("EdgeHub RouteToCloud received stale stop message, discarding")
 			continue
 		}
 
@@ -97,17 +118,30 @@ func (eh *EdgeHub) routeToCloud() {
 		err = eh.sendToCloud(message)
 		if err != nil {
 			klog.Errorf("failed to send message to cloud: %v", err)
-			eh.reconnectChan <- struct{}{}
+			select {
+			case eh.reconnectChan <- struct{}{}:
+			default:
+			}
 			return
+		}
+
+		select {
+		case <-ctx.Done():
+			klog.Warning("EdgeHub RouteToCloud reconnect stop")
+			return
+		default:
 		}
 	}
 }
 
-func (eh *EdgeHub) keepalive() {
+func (eh *EdgeHub) keepalive(ctx context.Context) {
 	for {
 		select {
 		case <-beehiveContext.Done():
 			klog.Warning("EdgeHub KeepAlive stop")
+			return
+		case <-ctx.Done():
+			klog.Warning("EdgeHub KeepAlive reconnect stop")
 			return
 		default:
 		}
@@ -119,11 +153,21 @@ func (eh *EdgeHub) keepalive() {
 		err := eh.sendToCloud(*msg)
 		if err != nil {
 			klog.Errorf("websocket write error: %v", err)
-			eh.reconnectChan <- struct{}{}
+			select {
+			case eh.reconnectChan <- struct{}{}:
+			default:
+			}
 			return
 		}
 
-		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second)
+		timer := time.NewTimer(time.Duration(config.Config.Heartbeat) * time.Second)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			klog.Warning("EdgeHub KeepAlive reconnect stop")
+			return
+		}
 	}
 }
 

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package edgehub
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -233,7 +234,7 @@ func TestRouteToEdge(t *testing.T) {
 			mockAdapter.EXPECT().Receive().
 				Return(*model.NewMessage(""), errors.New("Connection Refused")).
 				Times(1)
-			go tt.hub.routeToEdge()
+			go tt.hub.routeToEdge(context.Background())
 			stop := <-tt.hub.reconnectChan
 			if stop != struct{}{} {
 				t.Errorf("TestRouteToEdge error got: %v want: %v", stop, struct{}{})
@@ -328,7 +329,7 @@ func TestRouteToCloud(t *testing.T) {
 
 			core.Register(&EdgeHub{enable: true})
 
-			go tt.hub.routeToCloud()
+			go tt.hub.routeToCloud(context.Background())
 			time.Sleep(2 * time.Second)
 
 			msg := model.NewMessage("").BuildHeader("test_id", "", 1)
@@ -369,11 +370,143 @@ func TestKeepalive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAdapter.EXPECT().Send(gomock.Any()).Return(nil).Times(1)
 			mockAdapter.EXPECT().Send(gomock.Any()).Return(errors.New("Connection Refused")).Times(1)
-			go tt.hub.keepalive()
+			go tt.hub.keepalive(context.Background())
 			got := <-tt.hub.reconnectChan
 			if got != struct{}{} {
 				t.Errorf("TestKeepalive() StopChan = %v, want %v", got, struct{}{})
 			}
 		})
+	}
+}
+
+// TestRouteToCloudGracefulExit tests that routeToCloud exits upon receiving a stop message when context is done.
+func TestRouteToCloudGracefulExit(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+	// Expect NO messages sent to cloud
+	mockAdapter.EXPECT().Send(gomock.Any()).Times(0)
+
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+
+	ctx, cancel := context.WithCancel(context.Background())
+	exited := make(chan struct{})
+
+	go func() {
+		hub.routeToCloud(ctx)
+		close(exited)
+	}()
+
+	// Let goroutine start and block on Receive
+	time.Sleep(200 * time.Millisecond)
+
+	cancel()
+	stopMsg := message.BuildMsg(modules.HubGroup, "", modules.EdgeHubModuleName, "", message.OperationStop, nil)
+	beehiveContext.Send(modules.EdgeHubModuleName, *stopMsg)
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Errorf("routeToCloud did not exit gracefully upon cancellation and stop message")
+	}
+}
+
+// TestRouteToCloudStaleStopMessageDiscarded tests that a healthy routeToCloud discards a stale stop message,
+// does NOT call sendToCloud for the stop message, and remains running for subsequent normal messages.
+func TestRouteToCloudStaleStopMessageDiscarded(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+
+	// Normal message should be sent to cloud, but stop message must NOT be sent to cloud!
+	normalMsg := model.NewMessage("msg-1").BuildHeader("msg-1", "", 1)
+	mockAdapter.EXPECT().Send(gomock.Any()).DoAndReturn(func(msg model.Message) error {
+		if msg.GetOperation() == message.OperationStop {
+			t.Errorf("sendToCloud was called for an internal stop message!")
+		}
+		return nil
+	}).Times(1)
+
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	exited := make(chan struct{})
+	go func() {
+		hub.routeToCloud(ctx)
+		close(exited)
+	}()
+
+	// Send a stale stop message followed by a normal message
+	stopMsg := message.BuildMsg(modules.HubGroup, "", modules.EdgeHubModuleName, "", message.OperationStop, nil)
+	beehiveContext.Send(modules.EdgeHubModuleName, *stopMsg)
+	beehiveContext.Send(modules.EdgeHubModuleName, *normalMsg)
+
+	// Wait briefly to allow processing
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify routeToCloud is still running (exited channel is NOT closed)
+	select {
+	case <-exited:
+		t.Errorf("routeToCloud exited unexpectedly on a stale stop message when context was active")
+	default:
+		// Success: routeToCloud is still running and discarded stale stop message
+	}
+
+	// Clean up the goroutine before finishing the test to avoid cross-test contamination
+	cancel()
+	beehiveContext.Send(modules.EdgeHubModuleName, *stopMsg)
+	<-exited
+}
+
+// TestReconnectChanBuffered tests that reconnectChan is buffered and does not block when no receiver is ready.
+func TestReconnectChanBuffered(t *testing.T) {
+	hub := newEdgeHub(true)
+
+	select {
+	case hub.reconnectChan <- struct{}{}:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Errorf("reconnectChan is not buffered to 1 and blocked unexpectedly")
+	}
+}
+
+// TestRouteToCloudCancelledContextWithNormalMessage tests that a cancelled routeToCloud goroutine
+// correctly exits when woken up by a normal business message, without forwarding it to the cloud.
+func TestRouteToCloudCancelledContextWithNormalMessage(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+
+	// Expect NO messages sent to cloud
+	mockAdapter.EXPECT().Send(gomock.Any()).Times(0)
+
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+
+	ctx, cancel := context.WithCancel(context.Background())
+	exited := make(chan struct{})
+
+	go func() {
+		hub.routeToCloud(ctx)
+		close(exited)
+	}()
+
+	// Let goroutine start and block on Receive
+	time.Sleep(200 * time.Millisecond)
+
+	cancel()
+	normalMsg := model.NewMessage("msg-1").BuildHeader("msg-1", "", 1)
+	beehiveContext.Send(modules.EdgeHubModuleName, *normalMsg)
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Errorf("routeToCloud did not exit gracefully upon cancellation and normal message")
 	}
 }

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -510,3 +510,190 @@ func TestRouteToCloudCancelledContextWithNormalMessage(t *testing.T) {
 		t.Errorf("routeToCloud did not exit gracefully upon cancellation and normal message")
 	}
 }
+
+// TestRouteToCloudContextDoneInitially tests that routeToCloud exits immediately if context is already done.
+func TestRouteToCloudContextDoneInitially(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	exited := make(chan struct{})
+	go func() {
+		hub.routeToCloud(ctx)
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Errorf("routeToCloud did not exit on initially cancelled context")
+	}
+}
+
+// TestKeepaliveContextDoneInitially tests that keepalive exits immediately if context is already done.
+func TestKeepaliveContextDoneInitially(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	exited := make(chan struct{})
+	go func() {
+		hub.keepalive(ctx)
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Errorf("keepalive did not exit on initially cancelled context")
+	}
+}
+
+// TestKeepaliveGracefulExit tests that keepalive exits gracefully if context is cancelled during sleep.
+func TestKeepaliveGracefulExit(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+
+	// Send one keepalive successfully
+	mockAdapter.EXPECT().Send(gomock.Any()).Return(nil).Times(1)
+
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+
+	ctx, cancel := context.WithCancel(context.Background())
+	exited := make(chan struct{})
+	
+	// Temporarily override heartbeat
+	oldHeartbeat := config.Config.Heartbeat
+	config.Config.Heartbeat = 10 
+	defer func() { config.Config.Heartbeat = oldHeartbeat }()
+
+	go func() {
+		hub.keepalive(ctx)
+		close(exited)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Errorf("keepalive did not exit on cancelled context during timer")
+	}
+}
+
+// TestRouteToCloudReconnectChanFull tests the default branch when reconnectChan is full.
+func TestRouteToCloudReconnectChanFull(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+	mockAdapter.EXPECT().Send(gomock.Any()).Return(errors.New("Send Error")).Times(1)
+
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+	// fill the buffered channel
+	hub.reconnectChan <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	exited := make(chan struct{})
+	go func() {
+		hub.routeToCloud(ctx)
+		close(exited)
+	}()
+	
+	time.Sleep(200 * time.Millisecond)
+
+	normalMsg := model.NewMessage("msg-1").BuildHeader("msg-1", "", 1)
+	beehiveContext.Send(modules.EdgeHubModuleName, *normalMsg)
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Errorf("routeToCloud blocked on full reconnectChan")
+	}
+	
+	cancel()
+}
+
+// TestKeepaliveReconnectChanFull tests the default branch when reconnectChan is full.
+func TestKeepaliveReconnectChanFull(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+	mockAdapter.EXPECT().Send(gomock.Any()).Return(errors.New("Send Error")).Times(1)
+
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+	// fill the buffered channel
+	hub.reconnectChan <- struct{}{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	exited := make(chan struct{})
+	go func() {
+		hub.keepalive(ctx)
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Errorf("keepalive blocked on full reconnectChan")
+	}
+}
+
+// TestRouteToCloudContextDoneAfterSend tests that routeToCloud gracefully handles context cancellation right after sendToCloud.
+func TestRouteToCloudContextDoneAfterSend(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockAdapter := edgehub.NewMockAdapter(mockCtrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mockAdapter.EXPECT().Send(gomock.Any()).DoAndReturn(func(msg model.Message) error {
+		cancel() // Cancel the context right inside Send!
+		return nil
+	}).Times(1)
+
+	hub := newEdgeHub(true)
+	hub.chClient = mockAdapter
+
+	exited := make(chan struct{})
+	go func() {
+		hub.routeToCloud(ctx)
+		close(exited)
+	}()
+	
+	time.Sleep(200 * time.Millisecond)
+
+	normalMsg := model.NewMessage("msg-1").BuildHeader("msg-1", "", 1)
+	beehiveContext.Send(modules.EdgeHubModuleName, *normalMsg)
+
+	select {
+	case <-exited:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Errorf("routeToCloud did not exit gracefully upon cancellation after send")
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR resolves #7051 by improving goroutine lifecycle management, context cancellation, and reconnection stability in `EdgeHub`.

#### Summary of Changes:
- **Context Lifecycle**: Passed `ctx` to `routeToEdge`, `routeToCloud`, and `keepalive` goroutines in [`edge/pkg/edgehub/process.go`](file:///c:/Users/Vishal/Code_File/Repo%20Folder/kubeedge/edge/pkg/edgehub/process.go), replacing `time.Sleep` with a selectable `time.NewTimer` listening on `ctx.Done()`.
- **Stale Stop Message Filtering**: Discarded `OperationStop` messages in `routeToCloud` to avoid forwarding stale unblocking control messages to CloudHub.
- **Non-blocking Reconnect**: Buffered `reconnectChan` to size 1 in [`edge/pkg/edgehub/edgehub.go`](file:///c:/Users/Vishal/Code_File/Repo%20Folder/kubeedge/edge/pkg/edgehub/edgehub.go) and used non-blocking `select-default` channel sends to prevent deadlocks.
- **Unit Tests**: Added 4 unit tests in [`edge/pkg/edgehub/process_test.go`](file:///c:/Users/Vishal/Code_File/Repo%20Folder/kubeedge/edge/pkg/edgehub/process_test.go) for context cancellation, message filtering, and channel buffering. Removed accidental `umask` files.

### Which issue(s) this PR fixes
Fixes #7051

### Special notes for your reviewer
- All unit tests in `edge/pkg/edgehub` pass cleanly (`go test -v ./edge/pkg/edgehub/...`).

### Does this PR introduce a user-facing change?
```release-note
NONE
