### PR TITLE
taskmanager: enforce node task timeout so an unresponsive node no longer wedges the job

### DIFF
--- a/cloud/pkg/taskmanager/executor/executor.go
+++ b/cloud/pkg/taskmanager/executor/executor.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
@@ -64,6 +65,10 @@ func NewNodeTaskExecutor(ctx context.Context, job wrap.NodeJob, updateFun Update
 		messageLayer:         messagelayer.TaskManagerMessageLayer(),
 		UpdateNodeTaskStatus: updateFun,
 		logger:               logger,
+		ctx:                  ctx,
+		taskTimeout:          job.Timeout(),
+		running:              make(map[string]*runningTask),
+		interrupt:            make(chan struct{}),
 	})
 	executor, ok := actual.(*NodeTaskExecutor)
 	if !ok {
@@ -112,6 +117,32 @@ type NodeTaskExecutor struct {
 	// wg is the wait group for the executor. Used to wait for all node tasks to complete
 	// before deleting the executor.
 	wg sync.WaitGroup
+
+	// ctx controls the lifecycle of the executor. It is used by the asynchronous
+	// timeout callbacks that outlive the Execute call.
+	ctx context.Context
+	// taskTimeout is the maximum duration to wait for a node to report a task
+	// action before the task is marked as a timeout failure.
+	taskTimeout time.Duration
+	// mu guards running.
+	mu sync.Mutex
+	// running holds the in-flight node tasks keyed by node name, so that a task
+	// can be completed exactly once, whether by the node report or by timeout.
+	running map[string]*runningTask
+	// interrupt is closed by Interrupt to unblock a running Execute.
+	interrupt chan struct{}
+	// interruptOnce guards closing the interrupt channel.
+	interruptOnce sync.Once
+}
+
+// runningTask tracks an in-flight node task and its timeout timer.
+type runningTask struct {
+	task  wrap.NodeJobTask
+	timer *time.Timer
+	// gen is incremented every time the timeout is refreshed. A timeout callback
+	// only fires when its generation still matches, which prevents a refresh that
+	// races with an expiring timer from wrongly failing the task.
+	gen int
 }
 
 type UpdateNodeTaskStatus func(ctx context.Context, job wrap.NodeJob, task wrap.NodeJobTask)
@@ -126,7 +157,7 @@ func (executor *NodeTaskExecutor) Execute(ctx context.Context, connectedNodes []
 	tasks := executor.job.Tasks()
 	for i := range tasks {
 		if executor.interrupted.Load() {
-			return
+			break
 		}
 		task := tasks[i]
 		if !task.CanExecute() {
@@ -136,21 +167,27 @@ func (executor *NodeTaskExecutor) Execute(ctx context.Context, connectedNodes []
 		}
 
 		executor.logger.V(2).Info("acquire a pool item ...")
-		executor.pool.Acquire()
+		if !executor.pool.AcquireWithContext(ctx, executor.interrupt) {
+			break
+		}
 		executor.logger.V(2).Info("do node action", "nodename", task.NodeName())
 		executor.wg.Add(1)
 
+		// Mark the task in progress and start tracking it (including the timeout
+		// countdown) before the message is sent, so that a completion report which
+		// arrives while the message is still in flight is not missed.
+		if task.Phase() != operationsv1alpha2.NodeTaskPhaseInProgress {
+			task.SetPhase(operationsv1alpha2.NodeTaskPhaseInProgress)
+		}
+		executor.trackTask(task)
+
 		if err := executor.executeTask(ctx, task, connectedNodes); err != nil {
 			task.SetPhase(operationsv1alpha2.NodeTaskPhaseFailure, err.Error())
-			executor.FinishTask()
-		} else {
-			if task.Phase() != operationsv1alpha2.NodeTaskPhaseInProgress {
-				task.SetPhase(operationsv1alpha2.NodeTaskPhaseInProgress)
-			}
+			executor.finishTask(task.NodeName())
 		}
 		executor.UpdateNodeTaskStatus(ctx, executor.job, task)
 	}
-	executor.wg.Wait()
+	executor.wait(ctx)
 }
 
 // executeTask executes the node task. It sends a message to the edge node to execute the task.
@@ -179,14 +216,125 @@ func (executor *NodeTaskExecutor) executeTask(_ctx context.Context, task wrap.No
 
 // FinishTask when a node task has been completed, this function needs to be executed.
 // Whether the node task is completed is sensed in the upstream.
-func (executor *NodeTaskExecutor) FinishTask() {
-	executor.logger.V(2).Info("release a pool item")
+func (executor *NodeTaskExecutor) FinishTask(nodeName string) {
+	executor.logger.V(2).Info("release a pool item", "nodename", nodeName)
+	executor.finishTask(nodeName)
+}
+
+// RefreshTask resets the timeout of the in-flight node task on nodeName. It is
+// called when the node reports progress on a non-final action, so that a healthy
+// but long multi-stage task is not wrongly failed.
+func (executor *NodeTaskExecutor) RefreshTask(nodeName string) {
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	rt, ok := executor.running[nodeName]
+	if !ok {
+		return
+	}
+	rt.timer.Stop()
+	rt.gen++
+	rt.timer = executor.newTimeoutTimer(nodeName, rt.gen)
+}
+
+// trackTask registers an in-flight node task and starts its timeout timer.
+func (executor *NodeTaskExecutor) trackTask(task wrap.NodeJobTask) {
+	nodeName := task.NodeName()
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	rt := &runningTask{task: task}
+	rt.timer = executor.newTimeoutTimer(nodeName, rt.gen)
+	executor.running[nodeName] = rt
+}
+
+// newTimeoutTimer returns a timer that fails the node task on nodeName when it
+// does not report within taskTimeout.
+func (executor *NodeTaskExecutor) newTimeoutTimer(nodeName string, gen int) *time.Timer {
+	return time.AfterFunc(executor.taskTimeout, func() {
+		executor.timeoutTask(nodeName, gen)
+	})
+}
+
+// finishTask removes and releases the in-flight node task on nodeName exactly
+// once. It is a no-op if the task has already been completed.
+func (executor *NodeTaskExecutor) finishTask(nodeName string) {
+	executor.mu.Lock()
+	rt, ok := executor.running[nodeName]
+	if ok {
+		delete(executor.running, nodeName)
+		rt.timer.Stop()
+	}
+	executor.mu.Unlock()
+	if !ok {
+		return
+	}
+	executor.releaseSlot()
+}
+
+// timeoutTask fails the in-flight node task on nodeName when it has not reported
+// within taskTimeout. The generation check ignores a stale timer that has been
+// superseded by RefreshTask.
+func (executor *NodeTaskExecutor) timeoutTask(nodeName string, gen int) {
+	executor.mu.Lock()
+	rt, ok := executor.running[nodeName]
+	if !ok || rt.gen != gen {
+		executor.mu.Unlock()
+		return
+	}
+	delete(executor.running, nodeName)
+	executor.mu.Unlock()
+
+	executor.logger.Info("node task timed out waiting for completion, mark it failed",
+		"nodename", nodeName, "timeout", executor.taskTimeout)
+	rt.task.SetPhase(operationsv1alpha2.NodeTaskPhaseFailure,
+		fmt.Sprintf("node %s did not report task completion within %s", nodeName, executor.taskTimeout))
+	executor.UpdateNodeTaskStatus(executor.ctx, executor.job, rt.task)
+	executor.releaseSlot()
+}
+
+// releaseSlot releases one concurrency slot and marks one tracked task done.
+func (executor *NodeTaskExecutor) releaseSlot() {
 	executor.pool.Release()
 	executor.wg.Done()
 }
 
-// Interrupt interrupts the executor
+// wait blocks until all in-flight node tasks complete, or returns early after
+// draining them when the executor is interrupted or the context is canceled.
+func (executor *NodeTaskExecutor) wait(ctx context.Context) {
+	done := make(chan struct{})
+	go func() {
+		executor.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-executor.interrupt:
+		executor.drain()
+		<-done
+	case <-ctx.Done():
+		executor.drain()
+		<-done
+	}
+}
+
+// drain stops all outstanding timeout timers and releases their concurrency
+// slots, so that a wedged Execute can return promptly on interrupt or shutdown.
+func (executor *NodeTaskExecutor) drain() {
+	executor.mu.Lock()
+	running := executor.running
+	executor.running = make(map[string]*runningTask)
+	executor.mu.Unlock()
+	for _, rt := range running {
+		rt.timer.Stop()
+		executor.releaseSlot()
+	}
+}
+
+// Interrupt interrupts the executor and unblocks a running Execute. Any
+// in-flight node tasks are drained by Execute's wait.
 func (executor *NodeTaskExecutor) Interrupt() {
 	executor.logger.V(2).Info("interrupt the executor")
 	executor.interrupted.Store(true)
+	executor.interruptOnce.Do(func() {
+		close(executor.interrupt)
+	})
 }

--- a/cloud/pkg/taskmanager/executor/executor_test.go
+++ b/cloud/pkg/taskmanager/executor/executor_test.go
@@ -19,7 +19,9 @@ package executor
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -128,7 +130,7 @@ func TestExecute(t *testing.T) {
 			if res.NodeName == "node5" {
 				return errors.New("test error")
 			}
-			exec.FinishTask()
+			exec.FinishTask(res.NodeName)
 			return nil
 		})
 
@@ -140,4 +142,144 @@ func TestExecute(t *testing.T) {
 	assert.Contains(t, obj.Status.NodeStatus[3].Reason, "the node node4 is not connected to the current cloudcore instance")
 	assert.Equal(t, operationsv1alpha2.NodeTaskPhaseFailure, obj.Status.NodeStatus[4].Phase)
 	assert.Contains(t, obj.Status.NodeStatus[4].Reason, "failed to send message to edge")
+}
+
+func TestExecuteTaskTimeout(t *testing.T) {
+	obj := &operationsv1alpha2.ImagePrePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "timeout-job",
+		},
+		Spec: operationsv1alpha2.ImagePrePullJobSpec{
+			ImagePrePullTemplate: operationsv1alpha2.ImagePrePullTemplate{
+				Concurrency: 1,
+			},
+		},
+		Status: operationsv1alpha2.ImagePrePullJobStatus{
+			NodeStatus: []operationsv1alpha2.ImagePrePullNodeTaskStatus{
+				{
+					NodeName: "node1",
+					Phase:    operationsv1alpha2.NodeTaskPhasePending,
+				},
+				{
+					NodeName: "node2",
+					Phase:    operationsv1alpha2.NodeTaskPhasePending,
+				},
+			},
+		},
+	}
+	job, err := wrap.WithEventObj(obj)
+	assert.NoError(t, err)
+
+	updateFun := func(_ctx context.Context, _job wrap.NodeJob, _task wrap.NodeJobTask) {}
+
+	ctx := context.TODO()
+	exec, _, err := NewNodeTaskExecutor(ctx, job, updateFun)
+	assert.NoError(t, err)
+	// Simulate silent nodes: the message is sent, but no completion is ever reported.
+	exec.taskTimeout = 100 * time.Millisecond
+
+	var sent atomic.Int32
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodFunc(&messagelayer.ContextMessageLayer{}, "Send",
+		func(_message model.Message) error {
+			sent.Add(1)
+			return nil
+		})
+
+	done := make(chan struct{})
+	go func() {
+		exec.Execute(ctx, []string{"node1", "node2"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return, the job is wedged")
+	}
+
+	// The concurrency is 1, so the second node can only be dispatched after the
+	// first node's timeout releases the slot. Both silent tasks must be failed.
+	assert.Equal(t, int32(2), sent.Load())
+	assert.Equal(t, operationsv1alpha2.NodeTaskPhaseFailure, obj.Status.NodeStatus[0].Phase)
+	assert.Contains(t, obj.Status.NodeStatus[0].Reason, "did not report task completion within")
+	assert.Equal(t, operationsv1alpha2.NodeTaskPhaseFailure, obj.Status.NodeStatus[1].Phase)
+	assert.Contains(t, obj.Status.NodeStatus[1].Reason, "did not report task completion within")
+
+	// The executor must be cleaned up so a job of the same name can run again.
+	_, err = GetExecutor(job.ResourceType(), job.Name())
+	assert.Equal(t, ErrExecutorNotExists, err)
+}
+
+func TestInterrupt(t *testing.T) {
+	obj := &operationsv1alpha2.ImagePrePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "interrupt-job",
+		},
+		Spec: operationsv1alpha2.ImagePrePullJobSpec{
+			ImagePrePullTemplate: operationsv1alpha2.ImagePrePullTemplate{
+				Concurrency: 1,
+			},
+		},
+		Status: operationsv1alpha2.ImagePrePullJobStatus{
+			NodeStatus: []operationsv1alpha2.ImagePrePullNodeTaskStatus{
+				{
+					NodeName: "node1",
+					Phase:    operationsv1alpha2.NodeTaskPhasePending,
+				},
+				{
+					NodeName: "node2",
+					Phase:    operationsv1alpha2.NodeTaskPhasePending,
+				},
+			},
+		},
+	}
+	job, err := wrap.WithEventObj(obj)
+	assert.NoError(t, err)
+
+	updateFun := func(_ctx context.Context, _job wrap.NodeJob, _task wrap.NodeJobTask) {}
+
+	ctx := context.TODO()
+	exec, _, err := NewNodeTaskExecutor(ctx, job, updateFun)
+	assert.NoError(t, err)
+	// A long timeout, so the test only passes if Interrupt (not the timeout)
+	// unblocks the wedged executor.
+	exec.taskTimeout = time.Hour
+
+	dispatched := make(chan struct{}, 1)
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodFunc(&messagelayer.ContextMessageLayer{}, "Send",
+		func(_message model.Message) error {
+			select {
+			case dispatched <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+
+	done := make(chan struct{})
+	go func() {
+		exec.Execute(ctx, []string{"node1", "node2"})
+		close(done)
+	}()
+
+	// Wait until a node task has been dispatched and is holding the only slot,
+	// then interrupt the executor.
+	select {
+	case <-dispatched:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no node task was dispatched")
+	}
+	exec.Interrupt()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Execute did not return after Interrupt, the job is wedged")
+	}
+
+	_, err = GetExecutor(job.ResourceType(), job.Name())
+	assert.Equal(t, ErrExecutorNotExists, err)
 }

--- a/cloud/pkg/taskmanager/executor/pool.go
+++ b/cloud/pkg/taskmanager/executor/pool.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package executor
 
+import "context"
+
 type Pool struct {
 	pool chan struct{}
 }
@@ -31,6 +33,20 @@ func NewPool(size int) *Pool {
 
 func (p *Pool) Acquire() {
 	p.pool <- struct{}{}
+}
+
+// AcquireWithContext acquires a slot from the pool. It returns false without
+// acquiring a slot if stop is closed or ctx is canceled before a slot becomes
+// available.
+func (p *Pool) AcquireWithContext(ctx context.Context, stop <-chan struct{}) bool {
+	select {
+	case p.pool <- struct{}{}:
+		return true
+	case <-stop:
+		return false
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func (p *Pool) Release() {

--- a/cloud/pkg/taskmanager/upstream/upstream.go
+++ b/cloud/pkg/taskmanager/upstream/upstream.go
@@ -119,11 +119,14 @@ func handleUpstreamMessage(
 	isFinalAction := upmsg.Succ && action.NextSuccessful == nil ||
 		!upmsg.Succ && action.NextFailure == nil
 
-	// It's the final action, so release the executor.
+	// It's the final action, so release the executor. Otherwise, the node is
+	// still making progress, so refresh its timeout to avoid a false timeout.
 	if isFinalAction {
 		if err := releaseExecutorConcurrent(res); err != nil {
 			return fmt.Errorf("failed to release executor concurrent, err: %v", err)
 		}
+	} else {
+		refreshExecutorConcurrent(res)
 	}
 
 	if err := handler.UpdateNodeTaskStatus(res.JobName, res.NodeName, isFinalAction, upmsg); err != nil {
@@ -138,7 +141,23 @@ func releaseExecutorConcurrent(res taskmsg.Resource) error {
 		return fmt.Errorf("failed to get executor, err: %v", err)
 	}
 	if exec != nil {
-		exec.FinishTask()
+		exec.FinishTask(res.NodeName)
 	}
 	return nil
+}
+
+// refreshExecutorConcurrent refreshes the timeout of the node task on a progress
+// report. A missing executor means the task is already finished, so it is
+// ignored on a best-effort basis.
+func refreshExecutorConcurrent(res taskmsg.Resource) {
+	exec, err := executor.GetExecutor(res.ResourceType, res.JobName)
+	if err != nil {
+		if !errors.Is(err, executor.ErrExecutorNotExists) {
+			klog.Errorf("failed to get executor to refresh node task timeout, err: %v", err)
+		}
+		return
+	}
+	if exec != nil {
+		exec.RefreshTask(res.NodeName)
+	}
 }

--- a/cloud/pkg/taskmanager/upstream/upstream_test.go
+++ b/cloud/pkg/taskmanager/upstream/upstream_test.go
@@ -149,7 +149,7 @@ func TestReleaseExecutorConcurrent(t *testing.T) {
 	})
 
 	globpatches.ApplyMethodFunc(reflect.TypeOf((*executor.NodeTaskExecutor)(nil)),
-		"FinishTask", func() {
+		"FinishTask", func(_nodeName string) {
 			finishTaskCalled = true
 		})
 

--- a/cloud/pkg/taskmanager/wrap/config_update.go
+++ b/cloud/pkg/taskmanager/wrap/config_update.go
@@ -17,6 +17,8 @@ limitations under the License.
 package wrap
 
 import (
+	"time"
+
 	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
 )
@@ -77,6 +79,10 @@ func (job ConfigUpdateJob) ResourceType() string {
 
 func (job ConfigUpdateJob) Concurrency() int {
 	return int(job.Obj.Spec.Concurrency)
+}
+
+func (job ConfigUpdateJob) Timeout() time.Duration {
+	return jobTimeout(job.Obj.Spec.TimeoutSeconds)
 }
 
 func (job ConfigUpdateJob) Spec() any {

--- a/cloud/pkg/taskmanager/wrap/image_prepull.go
+++ b/cloud/pkg/taskmanager/wrap/image_prepull.go
@@ -17,6 +17,8 @@ limitations under the License.
 package wrap
 
 import (
+	"time"
+
 	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
 )
@@ -77,6 +79,10 @@ func (job ImagePrePullJob) ResourceType() string {
 
 func (job ImagePrePullJob) Concurrency() int {
 	return int(job.Obj.Spec.ImagePrePullTemplate.Concurrency)
+}
+
+func (job ImagePrePullJob) Timeout() time.Duration {
+	return jobTimeout(job.Obj.Spec.ImagePrePullTemplate.TimeoutSeconds)
 }
 
 func (job ImagePrePullJob) Spec() any {

--- a/cloud/pkg/taskmanager/wrap/interface.go
+++ b/cloud/pkg/taskmanager/wrap/interface.go
@@ -18,6 +18,7 @@ package wrap
 
 import (
 	"fmt"
+	"time"
 
 	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
@@ -30,6 +31,9 @@ type NodeJob interface {
 	ResourceType() string
 	// Concurrency returns the concurrency in the node job spec.
 	Concurrency() int
+	// Timeout returns the maximum duration to wait for a node to report a task
+	// action before the task is marked as a timeout failure.
+	Timeout() time.Duration
 	// Spec returns the spec of the node job.
 	Spec() any
 	// Tasks returns the node tasks of the node job.
@@ -52,6 +56,20 @@ type NodeJobTask interface {
 	Action() (*actionflow.Action, error)
 	// GetObject returns the node task object.
 	GetObject() any
+}
+
+// DefaultJobTimeout is the timeout used for a node task when the job spec does
+// not set TimeoutSeconds (or sets it to 0). It matches the default documented
+// on the operations v1alpha2 job specs.
+const DefaultJobTimeout = 300 * time.Second
+
+// jobTimeout converts a spec TimeoutSeconds value to a duration, falling back to
+// DefaultJobTimeout when it is unset or zero.
+func jobTimeout(seconds *uint32) time.Duration {
+	if seconds == nil || *seconds == 0 {
+		return DefaultJobTimeout
+	}
+	return time.Duration(*seconds) * time.Second
 }
 
 // WithEventObj returns the node job wrap based on the event object.

--- a/cloud/pkg/taskmanager/wrap/node_upgrade.go
+++ b/cloud/pkg/taskmanager/wrap/node_upgrade.go
@@ -17,6 +17,8 @@ limitations under the License.
 package wrap
 
 import (
+	"time"
+
 	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
 )
@@ -77,6 +79,10 @@ func (job NodeUpgradeJob) ResourceType() string {
 
 func (job NodeUpgradeJob) Concurrency() int {
 	return int(job.Obj.Spec.Concurrency)
+}
+
+func (job NodeUpgradeJob) Timeout() time.Duration {
+	return jobTimeout(job.Obj.Spec.TimeoutSeconds)
 }
 
 func (job NodeUpgradeJob) Spec() any {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

The v1alpha2 node task executor dispatches a task to an edge node and then
waits for the node to report the final action before releasing the concurrency
slot (`FinishTask`, called from the upstream handler). There is no timeout on
this wait. If a connected node receives a task and never reports back a node
that reboots into a failed upgrade, crashes, or whose reply is lost the slot
is never released, `wg.Wait()` blocks forever (leaking the `Execute`
goroutine), and `defer RemoveExecutor(...)` never runs, so a job with the same
name can no longer be created.

Because `Concurrency` defaults to `1`, a single unresponsive node exhausts the
pool and stalls the whole job: no remaining node is ever dispatched. `Interrupt()`
only set a flag checked at the top of the loop, so deleting the job CR could not
recover an already wedged job either.

The job specs already declare `TimeoutSeconds` (documented as "default 300; if 0,
use 300") for NodeUpgradeJob, ImagePrePullJob and ConfigUpdateJob, and the
v1alpha1 executor honored it, but the v1alpha2 executor never read it. This PR
restores that enforcement no API or CRD change:

- `wrap.NodeJob` exposes `Timeout()`, sourced from each spec's `TimeoutSeconds`,
  defaulting to 300s when unset or zero.
- The executor tracks in flight tasks per node and completes each one exactly
  once, whether by the node's report or by a timeout. On timeout the task is
  marked `Failure` and its slot is released so other nodes proceed.
- Each non final progress report from a node refreshes that node's timeout, so a
  healthy but long multi stage task is not failed prematurely.
- `Acquire` and the final wait now honor cancellation, and `Interrupt()` unblocks
  and drains a running `Execute`, so deleting the job CR recovers a stuck job.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7049 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The v1alpha2 task manager now enforces `spec.timeoutSeconds` (default 300s) for NodeUpgradeJob, ImagePrePullJob and ConfigUpdateJob. A node that does not report task completion within the timeout is marked failed and its concurrency slot is released, so a single unresponsive node no longer stalls the entire job
```
