### PR TITLE
cloud/router: check GetContentData error instead of stale ok

### DIFF
--- a/cloud/pkg/router/provider/eventbus/eventbus.go
+++ b/cloud/pkg/router/provider/eventbus/eventbus.go
@@ -103,7 +103,7 @@ func (*EventBus) Forward(target provider.Target, data interface{}) (response int
 	}
 	res := make(map[string]interface{})
 	content, err := message.GetContentData()
-	if !ok {
+	if err != nil {
 		klog.Errorf("get message %s content err: %v", message.GetID(), err)
 		return nil, fmt.Errorf("get message %s content err: %v", message.GetID(), err)
 	}

--- a/cloud/pkg/router/provider/eventbus/eventbus_test.go
+++ b/cloud/pkg/router/provider/eventbus/eventbus_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/router/constants"
 )
 
+// spyTarget is a test double for provider.Target that records whether
+// GoToTarget was invoked.  It never calls into any real infrastructure.
+type spyTarget struct {
+	called bool
+}
+
+func (s *spyTarget) Name() string { return "spy" }
+func (s *spyTarget) GoToTarget(_ map[string]interface{}, _ chan struct{}) (interface{}, error) {
+	s.called = true
+	return nil, fmt.Errorf("spy: GoToTarget should not have been called")
+}
+
 func TestPathJoin(t *testing.T) {
 	var s1, s2 string
 	s1 = fmt.Sprintf("%s/node/%s/%s/%s", "bus", "nodeName", "namespace", "subTopic")
@@ -190,6 +202,25 @@ func TestForward(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestForward_GetContentDataError is the regression test requested by PR #7054
+// review: when GetContentData() fails, Forward must return an error and must
+// never invoke target.GoToTarget().
+func TestForward_GetContentDataError(t *testing.T) {
+	eb := &EventBus{}
+	spy := &spyTarget{}
+
+	// GetContentData returns (data, nil) for string and []byte content;
+	// it calls json.Marshal for anything else.  A channel cannot be marshalled
+	// so it reliably triggers the error branch.
+	msg := model.NewMessage("")
+	msg.Content = make(chan struct{})
+
+	_, err := eb.Forward(spy, msg)
+
+	assert.Error(t, err, "Forward must return an error when GetContentData fails")
+	assert.False(t, spy.called, "GoToTarget must NOT be called when GetContentData fails")
 }
 
 func TestGoToTarget(t *testing.T) {

--- a/cloud/pkg/router/provider/servicebus/servicebus.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus.go
@@ -89,7 +89,7 @@ func (sb *ServiceBus) Forward(target provider.Target, data interface{}) (respons
 	}
 	res := make(map[string]interface{})
 	content, err := message.GetContentData()
-	if !ok {
+	if err != nil {
 		klog.Errorf("get message %s content err: %v", message.GetID(), err)
 		return nil, fmt.Errorf("get message %s content err: %v", message.GetID(), err)
 	}

--- a/cloud/pkg/router/provider/servicebus/servicebus_test.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus_test.go
@@ -1,0 +1,155 @@
+package servicebus
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/kubeedge/api/apis/rules/v1"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/cloud/pkg/router/constants"
+)
+
+// spyTarget is a test double for provider.Target that records whether
+// GoToTarget was invoked.  It never calls into any real infrastructure.
+type spyTarget struct {
+	called bool
+}
+
+func (s *spyTarget) Name() string { return "spy" }
+func (s *spyTarget) GoToTarget(_ map[string]interface{}, _ chan struct{}) (interface{}, error) {
+	s.called = true
+	return nil, fmt.Errorf("spy: GoToTarget should not have been called")
+}
+
+func TestServicebusFactoryType(t *testing.T) {
+	factory := &servicebusFactory{}
+	assert.Equal(t, v1.RuleEndpointTypeServiceBus, factory.Type())
+}
+
+func TestServicebusName(t *testing.T) {
+	sb := &ServiceBus{}
+	assert.Equal(t, constants.ServicebusProvider, sb.Name())
+}
+
+func TestServicebusGetSource(t *testing.T) {
+	factory := &servicebusFactory{}
+	ep := &v1.RuleEndpoint{}
+
+	testCases := []struct {
+		name           string
+		sourceResource map[string]string
+		expectNil      bool
+	}{
+		{
+			name: "valid source",
+			sourceResource: map[string]string{
+				constants.TargetURL: "http://example.com",
+				constants.NodeName:  "test-node",
+			},
+			expectNil: false,
+		},
+		{
+			name: "missing target_url",
+			sourceResource: map[string]string{
+				constants.NodeName: "test-node",
+			},
+			expectNil: true,
+		},
+		{
+			name: "missing node_name",
+			sourceResource: map[string]string{
+				constants.TargetURL: "http://example.com",
+			},
+			expectNil: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := factory.GetSource(ep, tc.sourceResource)
+			if tc.expectNil {
+				assert.Nil(t, source)
+			} else {
+				assert.NotNil(t, source)
+			}
+		})
+	}
+}
+
+func TestServicebusGetTarget(t *testing.T) {
+	factory := &servicebusFactory{}
+
+	testCases := []struct {
+		name           string
+		ep             *v1.RuleEndpoint
+		targetResource map[string]string
+		expectNil      bool
+	}{
+		{
+			name: "valid target",
+			ep: &v1.RuleEndpoint{
+				Spec: v1.RuleEndpointSpec{
+					Properties: map[string]string{
+						"service_port": "8080",
+					},
+				},
+			},
+			targetResource: map[string]string{
+				constants.Path: "/api/v1",
+			},
+			expectNil: false,
+		},
+		{
+			name: "missing path",
+			ep: &v1.RuleEndpoint{
+				Spec: v1.RuleEndpointSpec{
+					Properties: map[string]string{},
+				},
+			},
+			targetResource: map[string]string{},
+			expectNil:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := factory.GetTarget(tc.ep, tc.targetResource)
+			if tc.expectNil {
+				assert.Nil(t, target)
+			} else {
+				assert.NotNil(t, target)
+			}
+		})
+	}
+}
+
+func TestServicebusForward_InvalidMessageType(t *testing.T) {
+	sb := &ServiceBus{}
+	spy := &spyTarget{}
+
+	_, err := sb.Forward(spy, "not-a-message")
+
+	assert.Error(t, err, "Forward must return an error for a non-*model.Message input")
+	assert.False(t, spy.called, "GoToTarget must NOT be called when message type assertion fails")
+}
+
+// TestServicebusForward_GetContentDataError is the regression test requested by
+// PR #7054 review: when GetContentData() fails, Forward must return an error and
+// must never invoke target.GoToTarget().
+func TestServicebusForward_GetContentDataError(t *testing.T) {
+	sb := &ServiceBus{}
+	spy := &spyTarget{}
+
+	// GetContentData returns (data, nil) for string and []byte content;
+	// it calls json.Marshal for anything else.  A channel cannot be marshalled
+	// so it reliably triggers the error branch.
+	msg := model.NewMessage("")
+	msg.Content = make(chan struct{})
+
+	_, err := sb.Forward(spy, msg)
+
+	assert.Error(t, err, "Forward must return an error when GetContentData fails")
+	assert.False(t, spy.called, "GoToTarget must NOT be called when GetContentData fails")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Forward` in the servicebus and eventbus router providers calls `message.GetContentData()`, which returns `([]byte, error)`, but then checks the stale `ok` variable from the earlier `data.(*model.Message)` type assertion instead of the returned `err`:

```go
message, ok := data.(*model.Message)
if !ok {
    return nil, fmt.Errorf("message type %T error", data)
}
res := make(map[string]interface{})
content, err := message.GetContentData()
if !ok {   // always false here — err is never checked
    ...
}
```

At this point `ok` is always `true` (the type assertion already succeeded), so `if !ok` is always false / unreachable dead code and the `GetContentData` error is silently discarded before the following `resp, err := target.GoToTarget(...)` call. This PR checks `err != nil` in both providers so a content-extraction error is returned instead of silently passing empty content on to `GoToTarget`. The two blocks are identical copy-paste siblings, so both are fixed together.

Note this is a latent defect: `GetContentData` only fails on malformed message content, which does not occur for the wire-deserialized messages that currently reach `Forward`. The guard protects the code path if content handling changes.

**Which issue(s) this PR fixes**:

Fixes #7045

**Special notes for your reviewer**:

Two-character change (`!ok` → `err != nil`) in each file. `ok` remains used afterwards in both functions (servicebus reuses it for the `*http.Response` assertion, eventbus for the `*model.Message` guard), so nothing becomes an unused variable. `go build`, `go vet`, and `golangci-lint` all pass on both packages.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
