### PR TITLE
test(metamanager): add unit test for meta models

### DIFF
--- a/edge/pkg/metamanager/dao/models/meta_test.go
+++ b/edge/pkg/metamanager/dao/models/meta_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaTableName(t *testing.T) {
+	m := Meta{}
+	require.Equal(t, MetaTableName, m.TableName(), "TableName() should return the constant MetaTableName")
+}
+
+func TestMetaV2TableName(t *testing.T) {
+	m2 := MetaV2{}
+	require.Equal(t, NewMetaTableName, m2.TableName(), "TableName() should return the constant NewMetaTableName")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Adds simple unit tests for `edge/pkg/metamanager/dao/models/meta.go` to achieve 100% test coverage for these models. It verifies that the `TableName()` receiver functions correctly return their respective constants (`MetaTableName` and `NewMetaTableName`).

This is a clean, pure-function test that does not mutate global state and does not require any production code modifications.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This PR strictly adds test coverage for pure functions without modifying any production code behavior.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
