### PR TITLE
test(metaserver): add unit test for fakers convertor

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/fakers/convertor_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/fakers/convertor_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fakers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestFakeObjectConvertor(t *testing.T) {
+	c := NewFakeObjectConvertor()
+	require.NotNil(t, c)
+
+	err := c.Convert(nil, nil, nil)
+	require.NoError(t, err)
+
+	obj, err := c.ConvertToVersion(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, obj)
+
+	label, field, err := c.ConvertFieldLabel(schema.GroupVersionKind{}, "test-label", "test-field")
+	require.NoError(t, err)
+	require.Equal(t, "test-label", label)
+	require.Equal(t, "test-field", field)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
Adds simple unit tests for `edge/pkg/metamanager/metaserver/kubernetes/fakers/convertor.go` to achieve 100% statement coverage for the fake object convertor. It verifies that the `fakeObjectConvertor` correctly implements the `runtime.ObjectConvertor` interface with pure, stateless receiver functions.

This is a clean, pure-function test that does not mutate global state and does not require any production code modifications.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This PR strictly adds test coverage for pure functions without modifying any production code behavior.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
