### PR TITLE
Fix silent pod status unmarshal errors in upstream controller

### DIFF
--- a/cloud/pkg/edgecontroller/controller/upstream.go
+++ b/cloud/pkg/edgecontroller/controller/upstream.go
@@ -1474,13 +1474,18 @@ func (uc *UpstreamController) unmarshalPodStatusMessage(msg model.Message) (ns s
 
 	if name, _ := messagelayer.GetResourceName(msg); name == "" {
 		// multi pod status in one message
-		_ = json.Unmarshal(data, &podStatuses)
+		err = json.Unmarshal(data, &podStatuses)
+		if err != nil {
+			klog.Warningf("message: %s process failure, unmarshal content data with error: %s", msg.GetID(), err)
+			podStatuses = nil
+		}
 		return
 	}
 
 	// one pod status per message
 	var status edgeapi.PodStatusRequest
 	if err := json.Unmarshal(data, &status); err != nil {
+		klog.Warningf("message: %s process failure, unmarshal content data with error: %s", msg.GetID(), err)
 		return
 	}
 	podStatuses = append(podStatuses, status)

--- a/cloud/pkg/edgecontroller/controller/upstream_test.go
+++ b/cloud/pkg/edgecontroller/controller/upstream_test.go
@@ -1173,3 +1173,86 @@ func TestUpdatePodStatus(t *testing.T) {
 		t.Errorf("Pod phase mismatch, expected %s, got %s", corev1.PodRunning, updatedPod.Status.Phase)
 	}
 }
+
+func TestUnmarshalPodStatusMessage(t *testing.T) {
+	uc := &UpstreamController{}
+
+	// Case 1: Multi-pod status valid unmarshal
+	multiStatuses := []edgeapi.PodStatusRequest{
+		{Name: "pod1", UID: types.UID("uid-1")},
+		{Name: "pod2", UID: types.UID("uid-2")},
+	}
+	multiData, err := json.Marshal(multiStatuses)
+	if err != nil {
+		t.Fatalf("Failed to marshal multi-pod statuses: %v", err)
+	}
+
+	msgMulti := model.Message{
+		Header: model.MessageHeader{ID: "msg-1"},
+		Router: model.MessageRoute{
+			Resource: "node/node1/default/podstatus",
+		},
+		Content: string(multiData),
+	}
+
+	ns, res := uc.unmarshalPodStatusMessage(msgMulti)
+	if ns != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", ns)
+	}
+	if len(res) != 2 {
+		t.Errorf("expected 2 pod statuses, got %d", len(res))
+	}
+
+	// Case 2: Multi-pod status invalid JSON (verify podStatuses is set to nil)
+	msgMultiInvalid := model.Message{
+		Header: model.MessageHeader{ID: "msg-2"},
+		Router: model.MessageRoute{
+			Resource: "node/node1/default/podstatus",
+		},
+		Content: `{invalid json array}`,
+	}
+
+	_, resInvalid := uc.unmarshalPodStatusMessage(msgMultiInvalid)
+	if resInvalid != nil {
+		t.Errorf("expected nil podStatuses on unmarshal error, got %v", resInvalid)
+	}
+
+	// Case 3: Single-pod status valid unmarshal
+	singleStatus := edgeapi.PodStatusRequest{Name: "pod1", UID: types.UID("uid-1")}
+	singleData, err := json.Marshal(singleStatus)
+	if err != nil {
+		t.Fatalf("Failed to marshal single pod status: %v", err)
+	}
+
+	msgSingle := model.Message{
+		Header: model.MessageHeader{ID: "msg-3"},
+		Router: model.MessageRoute{
+			Resource: "node/node1/default/podstatus/pod1",
+		},
+		Content: string(singleData),
+	}
+
+	nsSingle, resSingle := uc.unmarshalPodStatusMessage(msgSingle)
+	if nsSingle != "default" {
+		t.Errorf("expected namespace 'default', got '%s'", nsSingle)
+	}
+	if len(resSingle) != 1 {
+		t.Errorf("expected 1 pod status, got %d", len(resSingle))
+	}
+
+	// Case 4: Single-pod status invalid JSON
+	msgSingleInvalid := model.Message{
+		Header: model.MessageHeader{ID: "msg-4"},
+		Router: model.MessageRoute{
+			Resource: "node/node1/default/podstatus/pod1",
+		},
+		Content: `invalid json object`,
+	}
+
+	_, resSingleInvalid := uc.unmarshalPodStatusMessage(msgSingleInvalid)
+	if resSingleInvalid != nil {
+		t.Errorf("expected nil podStatuses on single pod unmarshal error, got %v", resSingleInvalid)
+	}
+}
+
+

--- a/cloud/pkg/edgecontroller/controller/upstream_test.go
+++ b/cloud/pkg/edgecontroller/controller/upstream_test.go
@@ -1254,5 +1254,3 @@ func TestUnmarshalPodStatusMessage(t *testing.T) {
 		t.Errorf("expected nil podStatuses on single pod unmarshal error, got %v", resSingleInvalid)
 	}
 }
-
-


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in CloudCore where `json.Unmarshal` errors are silently swallowed during the parsing of pod status messages (`unmarshalPodStatusMessage`). 

Previously, if CloudCore received a malformed pod status message, the error was ignored, which made troubleshooting edge-to-cloud synchronization failures difficult. Furthermore, in the multi-pod status path, failing to handle these errors properly could result in partially decoded or corrupted data being passed along for further processing.

This fix:
1. Logs a warning when `json.Unmarshal` fails for both single and multi-pod status messages, making issues traceable.
2. Explicitly drops and sets `podStatuses = nil` on unmarshal failure in the multi-pod status path, ensuring that CloudCore avoids returning or processing partially decoded, incomplete, or corrupted data.
3. Adds regression tests to cover valid and invalid inputs for both single and multi-pod status messages.

**Which issue(s) this PR fixes**:
Fixes #7062

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Fix an issue in CloudCore where pod status unmarshal errors were silently ignored, and prevent partially decoded multi-pod statuses from being processed upon JSON decode failure.
```
