### PR TITLE
test: align release-1.22 envtest setup with release-1.23/master

### DIFF
--- a/cloud/test/integration/scripts/execute.sh
+++ b/cloud/test/integration/scripts/execute.sh
@@ -22,15 +22,15 @@ ENVTEST_BIN_DIR=""
 
 function do_preparation() {
     which setup-envtest &> /dev/null || {
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
-        sudo cp $GOPATH/bin/setup-envtest /usr/bin/
+        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+        sudo cp "$(go env GOPATH)/bin/setup-envtest" /usr/bin/
     }
 
-    ENVTEST_BIN_DIR=$(setup-envtest use 1.23.5 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
+    ENVTEST_BIN_DIR=$(setup-envtest use 1.29.0 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
 
     which ginkgo &>/dev/null || {
-        go install github.com/onsi/ginkgo/ginkgo@latest
-        sudo cp $GOPATH/bin/ginkgo /usr/bin/
+        go install github.com/onsi/ginkgo/v2/ginkgo@latest
+        sudo cp "$(go env GOPATH)/bin/ginkgo" /usr/bin/
     }
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

The release-1.22 integration test CI job was pinned to `setup-envtest@release-0.16` with envtest `1.22.1`, which resolves `kubebuilder-tools` binaries via the legacy GCS bucket path. That bucket location was deprecated upstream, so the fetch now returns `401 Unauthorized`, `/usr/local/kubebuilder/bin/etcd` never gets installed, and `make integrationtest` fails before the test suite runs.

A minimal CI-only fix (`setup-envtest@release-0.19`, envtest `1.23.5`) was already applied alongside the v1.22.2 security backport to unblock CI. This PR follows up with the more durable fix: align `release-1.22` with what `release-1.23` and `master` already do. It installs `setup-envtest@latest` and uses envtest `1.29.0`, so binaries are resolved through the still-maintained index instead of a pinned version that will eventually hit the same deprecation.

**Which issue(s) this PR fixes**:

Fixes #7064

**Special notes for your reviewer**:

Scoped to `cloud/test/integration/scripts/execute.sh` only. This is a CI/test-infra change, unrelated to the v1.22.2 security patch content, per the tracking issue.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```