### PR TITLE
cloud/router/servicebus: validate each field type assertion in GoToTarget

### DIFF
--- a/cloud/pkg/router/provider/servicebus/servicebus.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus.go
@@ -1,7 +1,6 @@
 package servicebus
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -124,22 +123,39 @@ func (sf *servicebusFactory) GetTarget(ep *v1.RuleEndpoint, targetResource map[s
 func (sb *ServiceBus) GoToTarget(data map[string]interface{}, stop chan struct{}) (interface{}, error) {
 	var response *model.Message
 	messageID, ok := data["messageID"].(string)
-	param, ok := data["param"].(string)
+	if !ok {
+		return nil, buildAndLogError("messageID")
+	}
 	nodeName, ok := data["nodeName"].(string)
+	if !ok {
+		return nil, buildAndLogError("nodeName")
+	}
 	request := commonType.HTTPRequest{}
 	request.Method, ok = data["method"].(string)
-	request.Header, ok = data["header"].(http.Header)
-	request.Body, ok = data["data"].([]byte)
 	if !ok {
-		err := errors.New("data transform failed")
-		klog.Error(err.Error())
-		return nil, err
+		return nil, buildAndLogError("method")
 	}
+	// header is optional; validate the type only when a value is provided
+	if rawHeader, exists := data["header"]; exists && rawHeader != nil {
+		request.Header, ok = rawHeader.(http.Header)
+		if !ok {
+			return nil, buildAndLogError("header")
+		}
+	}
+	// body is optional; validate the type only when a value is provided
+	if rawBody, exists := data["data"]; exists && rawBody != nil {
+		request.Body, ok = rawBody.([]byte)
+		if !ok {
+			return nil, buildAndLogError("data body")
+		}
+	}
+	// use zero value if not found param
+	param, _ := data["param"].(string)
 
 	msg := model.NewMessage("")
 	msg.BuildHeader(messageID, "", msg.GetTimestamp())
 	resource := "node/" + nodeName + "/" + sb.servicePort + ":"
-	if !ok || param == "" {
+	if param == "" {
 		resource = resource + sb.targetPath
 	} else {
 		resource = resource + strings.TrimSuffix(sb.targetPath, "/") + "/" + strings.TrimPrefix(param, "/")
@@ -165,4 +181,10 @@ func (sb *ServiceBus) GoToTarget(data map[string]interface{}, stop chan struct{}
 		listener.MessageHandlerInstance.DelCallback(messageID)
 	}
 	return response, nil
+}
+
+func buildAndLogError(key string) error {
+	err := fmt.Errorf("data transform failed, %s type is not matched or value is nil", key)
+	klog.Error(err.Error())
+	return err
 }

--- a/cloud/pkg/router/provider/servicebus/servicebus_test.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicebus
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoToTarget(t *testing.T) {
+	sb := &ServiceBus{
+		targetPath:  "/api",
+		servicePort: "8080",
+	}
+
+	// notInitialized is the error the valid cases hit: they pass every type
+	// assertion and reach the session manager, which is not initialised in a
+	// unit test.
+	const notInitialized = "cloudhub not initialized"
+
+	testCases := []struct {
+		name        string
+		data        map[string]interface{}
+		expectedErr string
+	}{
+		{
+			name: "valid data with param",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"method":    http.MethodGet,
+				"header":    http.Header{},
+				"data":      []byte("test-data"),
+				"param":     "test-param",
+			},
+			expectedErr: notInitialized,
+		},
+		{
+			name: "valid data without param",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"method":    http.MethodGet,
+				"header":    http.Header{},
+				"data":      []byte("test-data"),
+			},
+			expectedErr: notInitialized,
+		},
+		{
+			name: "valid data without optional header",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"method":    http.MethodGet,
+				"data":      []byte("test-data"),
+			},
+			expectedErr: notInitialized,
+		},
+		{
+			name: "valid data without optional body",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"method":    http.MethodGet,
+				"header":    http.Header{},
+			},
+			expectedErr: notInitialized,
+		},
+		{
+			name: "missing messageID",
+			data: map[string]interface{}{
+				"nodeName": "test-node",
+				"method":   http.MethodGet,
+				"header":   http.Header{},
+				"data":     []byte("test-data"),
+			},
+			expectedErr: "messageID",
+		},
+		{
+			name: "missing nodeName",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"method":    http.MethodGet,
+				"header":    http.Header{},
+				"data":      []byte("test-data"),
+			},
+			expectedErr: "nodeName",
+		},
+		{
+			name: "missing method",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"header":    http.Header{},
+				"data":      []byte("test-data"),
+			},
+			expectedErr: "method",
+		},
+		{
+			name: "invalid header type",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"method":    http.MethodGet,
+				"header":    "not-a-header",
+				"data":      []byte("test-data"),
+			},
+			expectedErr: "header",
+		},
+		{
+			name: "invalid body type",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"method":    http.MethodGet,
+				"header":    http.Header{},
+				"data":      "not-bytes",
+			},
+			expectedErr: "data body",
+		},
+		{
+			name: "mistyped messageID (not a string)",
+			data: map[string]interface{}{
+				"messageID": 42,
+				"nodeName":  "test-node",
+				"method":    http.MethodGet,
+				"header":    http.Header{},
+				"data":      []byte("test-data"),
+			},
+			expectedErr: "messageID",
+		},
+		{
+			name: "mistyped nodeName (not a string)",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  42,
+				"method":    http.MethodGet,
+				"header":    http.Header{},
+				"data":      []byte("test-data"),
+			},
+			expectedErr: "nodeName",
+		},
+		{
+			name: "mistyped method (not a string)",
+			data: map[string]interface{}{
+				"messageID": "test-id",
+				"nodeName":  "test-node",
+				"method":    42,
+				"header":    http.Header{},
+				"data":      []byte("test-data"),
+			},
+			expectedErr: "method",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The invalid cases fail their individual type assertion; the
+			// valid cases pass every assertion and error only at the
+			// session manager lookup. Asserting the substring keeps a bug
+			// in one assertion from being masked by a later error.
+			_, err := sb.GoToTarget(tc.data, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`GoToTarget` in `cloud/pkg/router/provider/servicebus/servicebus.go` reused a single `ok` variable across every type assertion and only checked it once (for the `data` body). As a result, a missing or mistyped `messageID`, `nodeName`, `method`, or `header` was silently swallowed and forwarded downstream as a zero value instead of being rejected.

This PR validates each type assertion individually and returns a descriptive error through a new `buildAndLogError` helper. The `param` field remains optional — it falls back to the zero value when absent, and the resource-path branch now keys off `param == ""` alone rather than the stale `ok` flag. The now-unused `errors` import is dropped.

It also adds `servicebus_test.go` with `TestGoToTarget`, a table test covering the valid-with-param, valid-without-param, and one-per-missing-field cases. Every case is expected to return an error: invalid cases fail their own assertion, valid cases reach the uninitialised session-manager lookup.

**Which issue(s) this PR fixes**:

Fixes #7057 

**Special notes for your reviewer**:

All local checks pass: `go build`, `go vet`, `go test ./cloud/pkg/router/provider/servicebus/...` (7 subtests), `gofmt`, and `golangci-lint`. No functional behavior changes for well-formed requests; the only behavioral change is that malformed input now returns an explicit error instead of being forwarded with zero values.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
