### PR TITLE
test: add unit tests for pure functions across components

### DIFF
--- a/cloud/pkg/common/messagelayer/nodetask_test.go
+++ b/cloud/pkg/common/messagelayer/nodetask_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package messagelayer
+
+import (
+	"testing"
+
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	nodetaskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildNodeTaskRouter(t *testing.T) {
+	resource := nodetaskmsg.Resource{
+		APIVersion:   "operations.kubeedge.io/v1alpha2",
+		ResourceType: "nodeupgradejobs",
+		JobName:      "upgrade-job-1",
+		NodeName:     "node-1",
+	}
+	opr := "upgrade"
+
+	msg := BuildNodeTaskRouter(resource, opr)
+
+	require.NotNil(t, msg)
+	require.Equal(t, modules.TaskManagerModuleName, msg.GetSource())
+	require.Equal(t, modules.TaskManagerModuleGroup, msg.GetGroup())
+	require.Equal(t, resource.String(), msg.GetResource())
+	require.Equal(t, opr, msg.GetOperation())
+}

--- a/edge/pkg/metamanager/dao/models/device_test.go
+++ b/edge/pkg/metamanager/dao/models/device_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeviceTableName(t *testing.T) {
+	d := Device{}
+	require.Equal(t, DeviceTableName, d.TableName(), "TableName() should return the constant DeviceTableName")
+}
+
+func TestDeviceTwinTableName(t *testing.T) {
+	dt := DeviceTwin{}
+	require.Equal(t, DeviceTwinTableName, dt.TableName(), "TableName() should return the constant DeviceTwinTableName")
+}
+
+func TestDeviceAttrTableName(t *testing.T) {
+	da := DeviceAttr{}
+	require.Equal(t, DeviceAttrTableName, da.TableName(), "TableName() should return the constant DeviceAttrTableName")
+}

--- a/edge/pkg/metamanager/dao/models/eventbus_test.go
+++ b/edge/pkg/metamanager/dao/models/eventbus_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubTopicsTableName(t *testing.T) {
+	st := SubTopics{}
+	require.Equal(t, SubTopicsName, st.TableName(), "TableName() should return the constant SubTopicsName")
+}

--- a/edge/pkg/metamanager/dao/models/meta_test.go
+++ b/edge/pkg/metamanager/dao/models/meta_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaTableName(t *testing.T) {
+	m := Meta{}
+	require.Equal(t, MetaTableName, m.TableName(), "TableName() should return the constant MetaTableName")
+}
+
+func TestMetaV2TableName(t *testing.T) {
+	m2 := MetaV2{}
+	require.Equal(t, NewMetaTableName, m2.TableName(), "TableName() should return the constant NewMetaTableName")
+}

--- a/edge/pkg/metamanager/dao/models/servicebus_test.go
+++ b/edge/pkg/metamanager/dao/models/servicebus_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTargetUrlsTableName(t *testing.T) {
+	tu := TargetUrls{}
+	require.Equal(t, TargetUrlsName, tu.TableName(), "TableName() should return the constant TargetUrlsName")
+}

--- a/edge/pkg/metamanager/metaserver/kubernetes/fakers/convertor_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/fakers/convertor_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fakers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestFakeObjectConvertor(t *testing.T) {
+	c := NewFakeObjectConvertor()
+	require.NotNil(t, c)
+
+	err := c.Convert(nil, nil, nil)
+	require.NoError(t, err)
+
+	obj, err := c.ConvertToVersion(nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, obj)
+
+	label, field, err := c.ConvertFieldLabel(schema.GroupVersionKind{}, "test-label", "test-field")
+	require.NoError(t, err)
+	require.Equal(t, "test-label", label)
+	require.Equal(t, "test-field", field)
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	info := Get()
+
+	if info.Major != gitMajor {
+		t.Errorf("Get() Major = %v, want %v", info.Major, gitMajor)
+	}
+	if info.Minor != gitMinor {
+		t.Errorf("Get() Minor = %v, want %v", info.Minor, gitMinor)
+	}
+	if info.GitVersion != gitVersion {
+		t.Errorf("Get() GitVersion = %v, want %v", info.GitVersion, gitVersion)
+	}
+	if info.GitCommit != gitCommit {
+		t.Errorf("Get() GitCommit = %v, want %v", info.GitCommit, gitCommit)
+	}
+	if info.GitTreeState != gitTreeState {
+		t.Errorf("Get() GitTreeState = %v, want %v", info.GitTreeState, gitTreeState)
+	}
+	if info.BuildDate != buildDate {
+		t.Errorf("Get() BuildDate = %v, want %v", info.BuildDate, buildDate)
+	}
+	if info.GoVersion != runtime.Version() {
+		t.Errorf("Get() GoVersion = %v, want %v", info.GoVersion, runtime.Version())
+	}
+	if info.Compiler != runtime.Compiler {
+		t.Errorf("Get() Compiler = %v, want %v", info.Compiler, runtime.Compiler)
+	}
+	expectedPlatform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+	if info.Platform != expectedPlatform {
+		t.Errorf("Get() Platform = %v, want %v", info.Platform, expectedPlatform)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind test

**What this PR does / why we need it**:
This PR groups several small, pure-function unit tests across different components to reduce review overhead (addressing maintainer feedback to group coverage-only changes).

It adds 100% statement coverage for the following models and utility functions:
- `edge/pkg/metamanager/dao/models/` (`eventbus.go`, `servicebus.go`, `meta.go`, `device.go`): Tests pure `TableName()` receiver functions.
- `edge/pkg/metamanager/metaserver/kubernetes/fakers/convertor.go`: Tests the pure `fakeObjectConvertor` implementation.
- `cloud/pkg/common/messagelayer/nodetask.go`: Tests the pure `BuildNodeTaskRouter` function.

All tests are clean, pure-function tests that do not mutate global state and do not require any production code modifications.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
This replaces multiple individual PRs to consolidate review efforts as requested.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
