### PR TITLE
Fix: Populate missing GroupVersionKind in ObjectSync update events

### DIFF
--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -89,6 +90,11 @@ func (sctl *SyncController) gcOrphanedObjectSync(sync *v1alpha1.ObjectSync) {
 
 func sendEvents(nodeName string, sync *v1alpha1.ObjectSync, resourceType string,
 	objectResourceVersion string, obj interface{}) {
+	runtimeObj := obj.(runtime.Object)
+	if err := util.SetMetaType(runtimeObj); err != nil {
+		klog.Warningf("failed to set metatype :%v", err)
+	}
+
 	if sync.Status.ObjectResourceVersion == "" {
 		klog.Errorf("The ObjectResourceVersion is empty in status of objectsync: %s", sync.Name)
 		return


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
When `synccontroller` attempts to sync a namespace-scoped resource to the edge (via `ObjectSync`), the dispatched beehive message payload was missing the object's `GroupVersionKind` (GVK). This PR adds the missing `util.SetMetaType()` call to `sendEvents` in `cloud/pkg/synccontroller/objectsync.go`. 

This aligns the behavior with how `sendClusterObjectSyncEvent` already correctly handles cluster-scoped resources and prevents downstream "ObjectKind is empty" failures when handling the sync message.

### Which issue(s) this PR fixes:
Fixes #7072

### Special notes for your reviewer:
This matches the exact pattern used in `clusterobjectsync.go:116`.

### Does this PR introduce a user-facing change?
```release-note
Fix missing GroupVersionKind in namespace-scoped objectsync update events.
