### PR TITLE
keadm: fail fast with a clear error when not run as root

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/init.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init.go
@@ -52,6 +52,12 @@ func NewCloudInit() *cobra.Command {
 		Short:   "Bootstraps cloud component. Checks and install (if required) the pre-requisites.",
 		Long:    cloudInitLongDescription,
 		Example: fmt.Sprintf(cloudInitExample, types.DefaultKubeEdgeVersion),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if opts.DryRun {
+				return nil
+			}
+			return util.CheckRootPrivileges()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tool := helm.NewCloudCoreHelmTool(opts.KubeConfig, opts.KubeEdgeVersion)
 			return tool.Install(opts)

--- a/keadm/cmd/keadm/app/cmd/cloud/init_test.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/init_test.go
@@ -35,6 +35,7 @@ func TestNewCloudInit(t *testing.T) {
 	assert.Equal(cmd.Long, cloudInitLongDescription)
 	assert.Equal(cmd.Example, fmt.Sprintf(cloudInitExample, types.DefaultKubeEdgeVersion))
 
+	assert.NotNil(cmd.PreRunE)
 	assert.NotNil(cmd.RunE)
 
 	expectedFlags := []struct {
@@ -91,6 +92,16 @@ func TestNewCloudInit(t *testing.T) {
 		assert.Equal(flag.defaultValue, cmd.Flag(flag.name).DefValue)
 		assert.Equal(flag.name, cmd.Flag(flag.name).Name)
 	}
+}
+
+func TestNewCloudInitPreRunEDryRun(t *testing.T) {
+	assert := assert.New(t)
+	cmd := NewCloudInit()
+
+	err := cmd.Flags().Set(types.FlagNameDryRun, "true")
+	assert.Nil(err)
+
+	assert.Nil(cmd.PreRunE(cmd, []string{}))
 }
 
 func TestNewInitOptions(t *testing.T) {

--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -64,6 +64,10 @@ func NewEdgeJoin() *cobra.Command {
 		Example:      edgeJoinExample,
 		SilenceUsage: true,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if err := util.CheckRootPrivileges(); err != nil {
+				return err
+			}
+
 			if joinOptions.PreRun != "" {
 				step.Printf("Executing pre-run script: %s\n", joinOptions.PreRun)
 				if err := util.RunScript(joinOptions.PreRun); err != nil {

--- a/keadm/cmd/keadm/app/cmd/util/common_others.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_others.go
@@ -34,6 +34,16 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 )
 
+// CheckRootPrivileges verifies the current process is running as root, since keadm
+// writes to system directories (/etc/kubeedge, /var/lib/kubeedge) and manages host
+// services that a regular user cannot access.
+func CheckRootPrivileges() error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("this command must be run as root, please use sudo")
+	}
+	return nil
+}
+
 // IsKubeEdgeProcessRunning checks if the given process is running or not
 func IsKubeEdgeProcessRunning(proc string) (bool, error) {
 	procRunning := fmt.Sprintf("pidof %s 2>&1", proc)

--- a/keadm/cmd/keadm/app/cmd/util/common_others_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_others_test.go
@@ -57,6 +57,44 @@ func (m MockFileInfo) ModTime() time.Time { return m.modTime }
 func (m MockFileInfo) IsDir() bool        { return m.isDir }
 func (m MockFileInfo) Sys() interface{}   { return m.sys }
 
+func TestCheckRootPrivilegesOthers(t *testing.T) {
+	tests := []struct {
+		name      string
+		euid      int
+		expectErr bool
+	}{
+		{
+			name:      "Running as root",
+			euid:      0,
+			expectErr: false,
+		},
+		{
+			name:      "Running as non-root",
+			euid:      1000,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			patches.ApplyFunc(os.Geteuid, func() int {
+				return tt.euid
+			})
+
+			err := CheckRootPrivileges()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestIsKubeEdgeProcessRunningOthers(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/keadm/cmd/keadm/app/cmd/util/common_windows.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_windows.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"golang.org/x/sys/windows"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/common/constants"
@@ -36,6 +37,33 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 	"github.com/kubeedge/kubeedge/pkg/util/files"
 )
+
+// CheckRootPrivileges verifies the current process is running with Administrator
+// privileges, since keadm writes to system directories and manages host services
+// that a regular user cannot access.
+func CheckRootPrivileges() error {
+	var sid *windows.SID
+	err := windows.AllocateAndInitializeSid(
+		&windows.SECURITY_NT_AUTHORITY,
+		2,
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&sid)
+	if err != nil {
+		return fmt.Errorf("failed to check administrator privileges: %v", err)
+	}
+	defer windows.FreeSid(sid)
+
+	isAdmin, err := windows.Token(0).IsMember(sid)
+	if err != nil {
+		return fmt.Errorf("failed to check administrator privileges: %v", err)
+	}
+	if !isAdmin {
+		return fmt.Errorf("this command must be run as Administrator")
+	}
+	return nil
+}
 
 // Constants used by installers
 const (


### PR DESCRIPTION
Closes #6683

Right now keadm init and keadm join don't check for root privileges before doing anything. When someone runs either command as a regular user, they get a scattered pile of confusing permission denied errors as keadm tries to write to /etc/kubeedge, /var/lib/kubeedge, and manage host services. Nothing tells them upfront that root is required.

This adds a CheckRootPrivileges check that runs before the actual install/join logic, in PreRunE for both commands. On Linux it checks the effective UID, on Windows it checks for Administrator group membership via the security token. If the check fails, the user gets a single clear error telling them to use sudo (or run as Administrator on Windows) instead of a wall of unrelated failures partway through the process.

Added unit tests for the Linux path covering both the root and non-root cases, and a test asserting PreRunE is wired up on the cloud init command (join already had a PreRunE hook to extend).

Tested locally by running keadm init and keadm join as both root and a non-root user on Ubuntu, confirming the non-root path now fails immediately with the new error message instead of partway through with permission denied.