### PR TITLE
docs(cloud/common/messagelayer): add godoc comments to exported factory functions

### DIFF
--- a/cloud/pkg/common/messagelayer/context.go
+++ b/cloud/pkg/common/messagelayer/context.go
@@ -71,6 +71,10 @@ func isRouterMsg(message model.Message) bool {
 	return len(resourceArray) == 2 && (resourceArray[0] == model.ResourceTypeRule || resourceArray[0] == model.ResourceTypeRuleEndpoint)
 }
 
+// EdgeControllerMessageLayer returns a MessageLayer configured for the
+// EdgeController module. Messages are sent via CloudHub and optionally
+// routed to the Router module when the message resource matches a rule
+// or ruleEndpoint type.
 func EdgeControllerMessageLayer() MessageLayer {
 	return &ContextMessageLayer{
 		SendModuleName:       modules.CloudHubModuleName,
@@ -80,6 +84,8 @@ func EdgeControllerMessageLayer() MessageLayer {
 	}
 }
 
+// DeviceControllerMessageLayer returns a MessageLayer configured for the
+// DeviceController module. Messages are sent and responded to via CloudHub.
 func DeviceControllerMessageLayer() MessageLayer {
 	return &ContextMessageLayer{
 		SendModuleName:     modules.CloudHubModuleName,
@@ -88,6 +94,8 @@ func DeviceControllerMessageLayer() MessageLayer {
 	}
 }
 
+// DynamicControllerMessageLayer returns a MessageLayer configured for the
+// DynamicController module. Messages are sent and responded to via CloudHub.
 func DynamicControllerMessageLayer() MessageLayer {
 	return &ContextMessageLayer{
 		SendModuleName:     modules.CloudHubModuleName,
@@ -96,6 +104,8 @@ func DynamicControllerMessageLayer() MessageLayer {
 	}
 }
 
+// TaskManagerMessageLayer returns a MessageLayer configured for the
+// TaskManager module. Messages are sent and responded to via CloudHub.
 func TaskManagerMessageLayer() MessageLayer {
 	return &ContextMessageLayer{
 		SendModuleName:     modules.CloudHubModuleName,
@@ -104,6 +114,8 @@ func TaskManagerMessageLayer() MessageLayer {
 	}
 }
 
+// PolicyControllerMessageLayer returns a MessageLayer configured for the
+// PolicyController module. Messages are sent and responded to via CloudHub.
 func PolicyControllerMessageLayer() MessageLayer {
 	return &ContextMessageLayer{
 		SendModuleName:     modules.CloudHubModuleName,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to the five exported factory functions in `cloud/pkg/common/messagelayer/context.go`:

- `EdgeControllerMessageLayer` — documents CloudHub routing and the optional Router module path for rule/ruleEndpoint messages
- `DeviceControllerMessageLayer` — documents CloudHub send/response configuration
- `DynamicControllerMessageLayer` — documents CloudHub send/response configuration
- `TaskManagerMessageLayer` — documents CloudHub send/response configuration
- `PolicyControllerMessageLayer` — documents CloudHub send/response configuration

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
