### PR TITLE
upgrade: restrict upgrade report file permissions

### DIFF
--- a/pkg/upgrade/edge/upgrade_reporter.go
+++ b/pkg/upgrade/edge/upgrade_reporter.go
@@ -37,6 +37,7 @@ const (
 	EventTypeUpgrade      = "Upgrade"
 	EventTypeRollback     = "Rollback"
 	EventTypeConfigUpdate = "ConfigUpdate"
+	upgradeReportFileMode = 0o600
 )
 
 var upgradeReportJSONFile = filepath.Join(constants.KubeEdgePath, "upgrade_report.json")
@@ -85,7 +86,16 @@ func (r JSONFileReporter) Report(inerr error) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal upgrade result, err: %v", err)
 	}
-	if err := os.WriteFile(upgradeReportJSONFile, bff, os.ModePerm); err != nil {
+	if _, statErr := os.Stat(upgradeReportJSONFile); statErr == nil {
+		if err := os.Chmod(upgradeReportJSONFile, upgradeReportFileMode); err != nil {
+			return fmt.Errorf("failed to tighten permissions on existing upgrade result file %s, err: %v",
+				upgradeReportJSONFile, err)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("failed to stat upgrade result file %s, err: %v",
+			upgradeReportJSONFile, statErr)
+	}
+	if err := os.WriteFile(upgradeReportJSONFile, bff, upgradeReportFileMode); err != nil {
 		return fmt.Errorf("failed to write upgrade result to file %s, err: %v",
 			upgradeReportJSONFile, err)
 	}

--- a/pkg/upgrade/edge/upgrade_reporter_test.go
+++ b/pkg/upgrade/edge/upgrade_reporter_test.go
@@ -18,6 +18,8 @@ package edge
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,37 +27,34 @@ import (
 
 func TestJSONFileReporter(t *testing.T) {
 	srcJSONFile := upgradeReportJSONFile
-	upgradeReportJSONFile = "test.json"
 	defer func() {
 		upgradeReportJSONFile = srcJSONFile
 	}()
 
 	t.Run("report upgrade successful", func(t *testing.T) {
+		upgradeReportJSONFile = filepath.Join(t.TempDir(), "upgrade_report.json")
 		var err error
 		err = NewJSONFileReporter(EventTypeBackup, "v1.20.0", "").
 			Report(nil)
 		assert.NoError(t, err)
-		defer func() {
-			err = RemoveJSONReporterInfo()
-			assert.NoError(t, err)
-		}()
 		info, err := ParseJSONReporterInfo()
 		assert.NoError(t, err)
 		assert.Equal(t, EventTypeBackup, info.EventType)
 		assert.True(t, info.Success)
 		assert.Empty(t, info.ErrorMessage)
 		assert.Equal(t, "v1.20.0", info.FromVersion)
+
+		fileInfo, err := os.Stat(upgradeReportJSONFile)
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(upgradeReportFileMode), fileInfo.Mode().Perm())
 	})
 
 	t.Run("report upgrade failed", func(t *testing.T) {
+		upgradeReportJSONFile = filepath.Join(t.TempDir(), "upgrade_report.json")
 		var err error
 		err = NewJSONFileReporter(EventTypeUpgrade, "v1.20.0", "v1.21.0").
 			Report(errors.New("test error"))
 		assert.NoError(t, err)
-		defer func() {
-			err = RemoveJSONReporterInfo()
-			assert.NoError(t, err)
-		}()
 		info, err := ParseJSONReporterInfo()
 		assert.NoError(t, err)
 		assert.Equal(t, EventTypeUpgrade, info.EventType)
@@ -63,5 +62,18 @@ func TestJSONFileReporter(t *testing.T) {
 		assert.Equal(t, "test error", info.ErrorMessage)
 		assert.Equal(t, "v1.20.0", info.FromVersion)
 		assert.Equal(t, "v1.21.0", info.ToVersion)
+	})
+
+	t.Run("report rewrites overly permissive file with restrictive permissions", func(t *testing.T) {
+		upgradeReportJSONFile = filepath.Join(t.TempDir(), "upgrade_report.json")
+		err := os.WriteFile(upgradeReportJSONFile, []byte("{}"), 0o666)
+		assert.NoError(t, err)
+
+		err = NewJSONFileReporter(EventTypeRollback, "v1.21.0", "v1.20.0").Report(nil)
+		assert.NoError(t, err)
+
+		fileInfo, err := os.Stat(upgradeReportJSONFile)
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(upgradeReportFileMode), fileInfo.Mode().Perm())
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Restricts `pkg/upgrade/edge` report-file permissions so `upgrade_report.json`
is written as owner-only and rewritten back to the same restrictive mode when an
existing file is already present.

**Which issue(s) this PR fixes**:

Fixes #7080

**Special notes for your reviewer**:

## Summary
- tighten `upgrade_report.json` writes from `os.ModePerm` to `0600`
- apply `os.Chmod` after each write so pre-existing report files are also reset
  to restrictive permissions
- add regression coverage for new and pre-existing report files

## What Changed
- update `JSONFileReporter.Report` to write and enforce owner-only permissions
- extend `upgrade_reporter_test.go` to assert the final file mode directly

## Verification
- `go test ./pkg/upgrade/edge/...` — passed
- `make verify` — failed: `verify-vendor` rewrote unrelated module files (`go.mod` and `staging/src/github.com/kubeedge/mapper-framework/go.mod`) on this macOS Go 1.26.5 host and exited with `FAILED: Vendor Verify failed`
- `make test WHAT=edge` — failed: repo-wide edge tests hit existing host/toolchain issues outside this change, including workspace resolution for `github.com/lucas-clemente/quic-go-certificates`, a `SIGBUS` in `edge/pkg/metamanager/client`, and a `gomonkey` crash in `edge/pkg/taskmanager`
- `make integrationtest` — failed: integration scripts require Linux-style local tooling and elevated access; this macOS host lacks `pidof` and `sudo` is non-interactive in the current session

## Scope
- only `pkg/upgrade/edge/upgrade_reporter.go` and `pkg/upgrade/edge/upgrade_reporter_test.go` were changed

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
