### PR TITLE
metamanager: propagate local meta cache write failures instead of acking the cloud OK

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/client.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/client.go
@@ -24,8 +24,9 @@ var Versioner = storage.APIObjectVersioner{}
 
 type Client interface {
 	// This set of functions is for metamanager
-	// Inject the msg to the backend storage
-	Inject(msg model.Message)
+	// Inject the msg to the backend storage. It returns an error if the message
+	// fails to be saved to the local cache.
+	Inject(msg model.Message) error
 	InsertOrUpdateObj(ctx context.Context, obj runtime.Object) error
 	DeleteObj(ctx context.Context, obj runtime.Object) error
 	InsertOrUpdatePassThroughObj(ctx context.Context, obj []byte, key string) error

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake/fake.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake/fake.go
@@ -12,7 +12,7 @@ import (
 
 // Client fake
 type Client struct {
-	InjectF                       func(msg model.Message)
+	InjectF                       func(msg model.Message) error
 	InsertOrUpdateObjF            func(ctx context.Context, obj runtime.Object) error
 	DeleteObjF                    func(ctx context.Context, obj runtime.Object) error
 	InsertOrUpdatePassThroughObjF func(ctx context.Context, obj []byte, key string) error
@@ -25,8 +25,8 @@ type Client struct {
 }
 
 // Inject fake
-func (c Client) Inject(msg model.Message) {
-	c.InjectF(msg)
+func (c Client) Inject(msg model.Message) error {
+	return c.InjectF(msg)
 }
 
 // InsertOrUpdateObj fake

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -37,8 +38,11 @@ type imitator struct {
 }
 
 // Inject transform the message to watch.event, save internal obj/objs to table meta_v2
-// and trigger the corresponding hook to serve watch
-func (s *imitator) Inject(msg model.Message) {
+// and trigger the corresponding hook to serve watch. It returns an aggregated error
+// if any event fails to be saved, so the caller can avoid acknowledging the cloud as
+// if the local cache had been updated.
+func (s *imitator) Inject(msg model.Message) error {
+	var errs []error
 	for _, e := range s.Event(&msg) {
 		// save to meta_v2
 		var err error
@@ -50,12 +54,14 @@ func (s *imitator) Inject(msg model.Message) {
 		}
 		if err != nil {
 			key := metaserver.KeyFunc(e.Object)
-			klog.Errorf("failed to serve event {type:%v,key:%v}", e.Type, key)
+			klog.Errorf("failed to serve event {type:%v,key:%v}, err: %v", e.Type, key, err)
+			errs = append(errs, fmt.Errorf("serve event {type:%v,key:%v}: %w", e.Type, key, err))
 			continue
 		}
 		// TODO: move Trigger inside InsertOrUpdateObj and DeleteObj
 		watchhook.Trigger(e)
 	}
+	return errors.Join(errs...)
 }
 
 // TODO: filter out insert or update req that the obj's rev is smaller than the stored
@@ -75,6 +81,9 @@ func (s *imitator) InsertOrUpdateObj(_ context.Context, obj runtime.Object) erro
 		return err
 	}
 	objRv, err := s.versioner.ObjectResourceVersion(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get object resource version, key: %s, err: %w", key, err)
+	}
 	m := models.MetaV2{
 		Key:                  key,
 		GroupVersionResource: gvr.String(),

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
@@ -37,10 +37,18 @@ type imitator struct {
 	codec runtime.Codec
 }
 
-// Inject transform the message to watch.event, save internal obj/objs to table meta_v2
-// and trigger the corresponding hook to serve watch. It returns an aggregated error
-// if any event fails to be saved, so the caller can avoid acknowledging the cloud as
-// if the local cache had been updated.
+// Inject transforms the message to watch event(s), saves the internal obj/objs to table
+// meta_v2 and triggers the corresponding hook to serve watch. It returns an aggregated
+// error if any event fails to be saved, so the caller can avoid acknowledging the cloud
+// as if the local cache had been updated.
+//
+// A single message may expand into several events when its payload is a list. Events are
+// applied independently: a successful event is persisted and triggers its watch hook, a
+// failed one is joined into the returned error. This partial application is safe to retry:
+// the writes are idempotent (InsertOrUpdateObj is an upsert keyed by the object key,
+// DeleteObj is a delete-by-key), and when the edge does not acknowledge success the cloud
+// replays the whole object on its next sync reconcile (see synccontroller). Re-applying an
+// already-stored event only re-triggers its watch hook, which watch consumers tolerate.
 func (s *imitator) Inject(msg model.Message) error {
 	var errs []error
 	for _, e := range s.Event(&msg) {

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -36,9 +37,34 @@ type imitator struct {
 	codec runtime.Codec
 }
 
-// Inject transform the message to watch.event, save internal obj/objs to table meta_v2
-// and trigger the corresponding hook to serve watch
-func (s *imitator) Inject(msg model.Message) {
+// errUnrepresentableEvent marks a watch event that cannot be turned into a meta_v2 row at
+// all: the object carries no group/version/kind, is not unstructured, cannot be encoded, or
+// has an unparsable resourceVersion. It is kept distinct from a cache write failure because
+// it is deterministic - replaying the identical payload fails identically - so refusing to
+// acknowledge the cloud would retry forever and block delivery to edged instead of repairing
+// the local cache.
+var errUnrepresentableEvent = errors.New("event cannot be represented in meta_v2")
+
+// Inject transforms the message to watch event(s), saves the internal obj/objs to table
+// meta_v2 and triggers the corresponding hook to serve watch. It returns an aggregated error
+// if any event fails to be written to the local cache, so the caller can avoid acknowledging
+// the cloud as if the local cache had been updated.
+//
+// Only write failures are propagated, because that is the class a resend can repair:
+// RetryInsertOrReplaceMetaV2 exhausting its retries (a locked or full database, contention)
+// leaves the row unwritten, and the writes are idempotent - InsertOrUpdateObj is an upsert
+// keyed by the object key, DeleteObj a delete-by-key - so replaying the object on the next
+// sync reconcile (see synccontroller) converges the cache. Re-applying an already-stored
+// event only re-triggers its watch hook, which watch consumers tolerate.
+//
+// Events that cannot be represented at all (errUnrepresentableEvent) are logged and skipped
+// instead, which is the pre-existing best-effort behavior. A resend cannot fix them, so
+// propagating them would both loop and stop the message from ever reaching edged. This is
+// the common case rather than a corner case: a message whose payload is a list expands into
+// one event per item, and list items decoded from a cloud message do not repeat their
+// TypeMeta, so none of them can be keyed.
+func (s *imitator) Inject(msg model.Message) error {
+	var errs []error
 	for _, e := range s.Event(&msg) {
 		// save to meta_v2
 		var err error
@@ -49,32 +75,41 @@ func (s *imitator) Inject(msg model.Message) {
 			err = s.DeleteObj(context.TODO(), e.Object)
 		}
 		if err != nil {
+			if errors.Is(err, errUnrepresentableEvent) {
+				klog.Errorf("skip event {type:%v}, err: %v", e.Type, err)
+				continue
+			}
 			key := metaserver.KeyFunc(e.Object)
-			klog.Errorf("failed to serve event {type:%v,key:%v}", e.Type, key)
+			klog.Errorf("failed to serve event {type:%v,key:%v}, err: %v", e.Type, key, err)
+			errs = append(errs, fmt.Errorf("serve event {type:%v,key:%v}: %w", e.Type, key, err))
 			continue
 		}
 		// TODO: move Trigger inside InsertOrUpdateObj and DeleteObj
 		watchhook.Trigger(e)
 	}
+	return errors.Join(errs...)
 }
 
 // TODO: filter out insert or update req that the obj's rev is smaller than the stored
 func (s *imitator) InsertOrUpdateObj(_ context.Context, obj runtime.Object) error {
 	key, err := metaserver.KeyFuncObj(obj)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %v", errUnrepresentableEvent, err)
 	}
 	gvr, ns, name := metaserver.ParseKey(key)
 	unstr, isUnstr := obj.(*unstructured.Unstructured)
 	if !isUnstr {
-		return fmt.Errorf("obj is not unstructured type")
+		return fmt.Errorf("%w: obj is not unstructured type", errUnrepresentableEvent)
 	}
 	buf := bytes.NewBuffer(nil)
 	err = s.codec.Encode(unstr, buf)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: failed to encode obj, key: %s, err: %v", errUnrepresentableEvent, key, err)
 	}
 	objRv, err := s.versioner.ObjectResourceVersion(obj)
+	if err != nil {
+		return fmt.Errorf("%w: failed to get object resource version, key: %s, err: %v", errUnrepresentableEvent, key, err)
+	}
 	m := models.MetaV2{
 		Key:                  key,
 		GroupVersionResource: gvr.String(),
@@ -137,7 +172,7 @@ func (s *imitator) InsertOrUpdatePassThroughObj(_ context.Context, obj []byte, k
 func (s *imitator) DeleteObj(_ context.Context, obj runtime.Object) error {
 	key, err := metaserver.KeyFuncObj(obj)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %v", errUnrepresentableEvent, err)
 	}
 	err = s.Delete(context.TODO(), key)
 	return err

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imitator
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+)
+
+func newTestImitator() *imitator {
+	return &imitator{
+		versioner: Versioner,
+		codec:     unstructured.UnstructuredJSONScheme,
+	}
+}
+
+func newObjectMessage(operation string) model.Message {
+	const configMap = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"10"}}`
+	msg := model.NewMessage("")
+	msg.BuildRouter("edgecontroller", "resource", "default/configmap/cm1", operation)
+	msg.Content = []byte(configMap)
+	return *msg
+}
+
+func TestInjectReturnsErrorWhenWriteFails(t *testing.T) {
+	s := newTestImitator()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf(s), "InsertOrUpdateObj",
+		func(_ context.Context, _ runtime.Object) error {
+			return errors.New("database is locked")
+		})
+
+	err := s.Inject(newObjectMessage(model.InsertOperation))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database is locked")
+}
+
+func TestInjectSuccess(t *testing.T) {
+	s := newTestImitator()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf(s), "InsertOrUpdateObj",
+		func(_ context.Context, _ runtime.Object) error {
+			return nil
+		})
+
+	err := s.Inject(newObjectMessage(model.InsertOperation))
+	assert.NoError(t, err)
+}
+
+func TestInsertOrUpdateObjResourceVersionError(t *testing.T) {
+	s := newTestImitator()
+
+	obj := &unstructured.Unstructured{}
+	err := obj.UnmarshalJSON([]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"not-a-number"}}`))
+	require.NoError(t, err)
+
+	err = s.InsertOrUpdateObj(context.TODO(), obj)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource version")
+}

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook"
 )
 
 func newTestImitator() *imitator {
@@ -43,6 +45,18 @@ func newObjectMessage(operation string) model.Message {
 	msg := model.NewMessage("")
 	msg.BuildRouter("edgecontroller", "resource", "default/configmap/cm1", operation)
 	msg.Content = []byte(configMap)
+	return *msg
+}
+
+// newListMessage builds a message whose payload is a List of two ConfigMaps (cm1, cm2),
+// so that Inject expands it into two independent events.
+func newListMessage(operation string) model.Message {
+	const list = `{"apiVersion":"v1","kind":"List","items":[` +
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"10"}},` +
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm2","namespace":"default","resourceVersion":"11"}}]}`
+	msg := model.NewMessage("")
+	msg.BuildRouter("edgecontroller", "resource", "default/configmaps", operation)
+	msg.Content = []byte(list)
 	return *msg
 }
 
@@ -85,4 +99,45 @@ func TestInsertOrUpdateObjResourceVersionError(t *testing.T) {
 	err = s.InsertOrUpdateObj(context.TODO(), obj)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resource version")
+}
+
+// TestInjectPartialApply verifies that when a list message expands into several events
+// and only some fail, Inject applies the successful events (triggering their watch hook)
+// and still returns an aggregated error covering the failed ones. This is the behavior
+// the cloud sync retry relies on: the whole object is replayed and the idempotent writes
+// re-converge the local cache.
+func TestInjectPartialApply(t *testing.T) {
+	s := newTestImitator()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// cm1 succeeds, cm2 fails.
+	patches.ApplyMethodFunc(reflect.TypeOf(s), "InsertOrUpdateObj",
+		func(_ context.Context, obj runtime.Object) error {
+			u, ok := obj.(*unstructured.Unstructured)
+			require.True(t, ok)
+			if u.GetName() == "cm2" {
+				return errors.New("database is locked")
+			}
+			return nil
+		})
+
+	var triggered []string
+	patches.ApplyFunc(watchhook.Trigger, func(e watch.Event) {
+		u, ok := e.Object.(*unstructured.Unstructured)
+		require.True(t, ok)
+		triggered = append(triggered, u.GetName())
+	})
+
+	err := s.Inject(newListMessage(model.InsertOperation))
+
+	// The failed event is surfaced to the caller so the cloud is not acknowledged.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cm2")
+	assert.Contains(t, err.Error(), "database is locked")
+	assert.NotContains(t, err.Error(), "cm1")
+
+	// Only the successful event triggers its watch hook.
+	assert.Equal(t, []string{"cm1"}, triggered)
 }

--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator_test.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/imitator_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imitator
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/watchhook"
+)
+
+func newTestImitator() *imitator {
+	return &imitator{
+		versioner: Versioner,
+		codec:     unstructured.UnstructuredJSONScheme,
+	}
+}
+
+func newObjectMessage(operation string) model.Message {
+	const configMap = `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"10"}}`
+	msg := model.NewMessage("")
+	msg.BuildRouter("edgecontroller", "resource", "default/configmap/cm1", operation)
+	msg.Content = []byte(configMap)
+	return *msg
+}
+
+// newListMessage builds a message whose payload is a List of two ConfigMaps (cm1, cm2),
+// so that Inject expands it into two independent events.
+func newListMessage(operation string) model.Message {
+	const list = `{"apiVersion":"v1","kind":"List","items":[` +
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm1","namespace":"default","resourceVersion":"10"}},` +
+		`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm2","namespace":"default","resourceVersion":"11"}}]}`
+	msg := model.NewMessage("")
+	msg.BuildRouter("edgecontroller", "resource", "default/configmaps", operation)
+	msg.Content = []byte(list)
+	return *msg
+}
+
+func TestInjectReturnsErrorWhenWriteFails(t *testing.T) {
+	s := newTestImitator()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf(s), "InsertOrUpdateObj",
+		func(_ context.Context, _ runtime.Object) error {
+			return errors.New("database is locked")
+		})
+
+	err := s.Inject(newObjectMessage(model.InsertOperation))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "database is locked")
+}
+
+func TestInjectSuccess(t *testing.T) {
+	s := newTestImitator()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethodFunc(reflect.TypeOf(s), "InsertOrUpdateObj",
+		func(_ context.Context, _ runtime.Object) error {
+			return nil
+		})
+
+	err := s.Inject(newObjectMessage(model.InsertOperation))
+	assert.NoError(t, err)
+}
+
+// TestInjectPartialApply verifies that when a list message expands into several events
+// and only some fail, Inject applies the successful events (triggering their watch hook)
+// and still returns an aggregated error covering the failed ones. This is the behavior
+// the cloud sync retry relies on: the whole object is replayed and the idempotent writes
+// re-converge the local cache.
+func TestInjectPartialApply(t *testing.T) {
+	s := newTestImitator()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// cm1 succeeds, cm2 fails.
+	patches.ApplyMethodFunc(reflect.TypeOf(s), "InsertOrUpdateObj",
+		func(_ context.Context, obj runtime.Object) error {
+			u, ok := obj.(*unstructured.Unstructured)
+			require.True(t, ok)
+			if u.GetName() == "cm2" {
+				return errors.New("database is locked")
+			}
+			return nil
+		})
+
+	var triggered []string
+	patches.ApplyFunc(watchhook.Trigger, func(e watch.Event) {
+		u, ok := e.Object.(*unstructured.Unstructured)
+		require.True(t, ok)
+		triggered = append(triggered, u.GetName())
+	})
+
+	err := s.Inject(newListMessage(model.InsertOperation))
+
+	// The failed event is surfaced to the caller so the cloud is not acknowledged.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cm2")
+	assert.Contains(t, err.Error(), "database is locked")
+	assert.NotContains(t, err.Error(), "cm1")
+
+	// Only the successful event triggers its watch hook.
+	assert.Equal(t, []string{"cm1"}, triggered)
+}
+
+// realPodListJSON is a PodList serialized the way the apiserver and client-go produce one:
+// the wrapper carries apiVersion/kind, the items do not repeat their TypeMeta.
+const realPodListJSON = `{"apiVersion":"v1","kind":"PodList","metadata":{"resourceVersion":"100"},"items":[` +
+	`{"metadata":{"name":"p1","namespace":"default","resourceVersion":"10"},"spec":{},"status":{}},` +
+	`{"metadata":{"name":"p2","namespace":"default","resourceVersion":"11"},"spec":{},"status":{}}]}`
+
+func newRealListMessage(operation string) model.Message {
+	msg := model.NewMessage("")
+	msg.BuildRouter("edgecontroller", "resource", "default/pods", operation)
+	msg.Content = []byte(realPodListJSON)
+	return *msg
+}
+
+// TestInjectSkipsUnrepresentableListItems covers a list payload from the cloud, which expands
+// into one event per item. The items do not repeat their TypeMeta, so KeyFuncObj cannot build
+// a meta_v2 key for any of them. That failure is deterministic, so Inject must log and skip
+// it: returning an error would make metamanager feed the error back and never deliver the
+// message to edged, and no resend from the cloud could repair it.
+func TestInjectSkipsUnrepresentableListItems(t *testing.T) {
+	s := newTestImitator()
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	var triggered int
+	patches.ApplyFunc(watchhook.Trigger, func(_ watch.Event) { triggered++ })
+
+	err := s.Inject(newRealListMessage(model.InsertOperation))
+	assert.NoError(t, err, "a deterministic representation failure must not be propagated")
+	assert.Zero(t, triggered, "an unrepresentable event must not trigger a watch hook")
+}
+
+// TestInsertOrUpdateObjClassifiesUnrepresentable checks that the deterministic failures are
+// tagged, so Inject can tell them apart from a local cache write failure.
+func TestInsertOrUpdateObjClassifiesUnrepresentable(t *testing.T) {
+	s := newTestImitator()
+
+	tests := []struct {
+		name string
+		obj  *unstructured.Unstructured
+	}{
+		{
+			// What EachListItem yields for an item of a decoded list.
+			name: "no group/version/kind",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "p1", "namespace": "default", "resourceVersion": "10"},
+			}},
+		},
+		{
+			name: "unparsable resource version",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]interface{}{"name": "cm1", "namespace": "default", "resourceVersion": "not-a-number"},
+			}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := s.InsertOrUpdateObj(context.TODO(), test.obj)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errUnrepresentableEvent)
+		})
+	}
+}

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -198,7 +198,7 @@ func (m *metaManager) processInsert(message model.Message) {
 		sendToCloud(&message)
 		return
 	}
-	imitator.DefaultV2Client.Inject(message)
+	injectErr := imitator.DefaultV2Client.Inject(message)
 
 	msgSource := message.GetSource()
 	if msgSource == modules.EdgedModuleName {
@@ -208,6 +208,10 @@ func (m *metaManager) processInsert(message model.Message) {
 			return
 		}
 		m.processRemote(message)
+		return
+	}
+	if injectErr != nil {
+		feedbackError(injectErr, message)
 		return
 	}
 	if err := m.handleMessage(&message); err != nil {
@@ -232,7 +236,7 @@ func (m *metaManager) processUpdate(message model.Message) {
 		sendToCloud(&message)
 		return
 	}
-	imitator.DefaultV2Client.Inject(message)
+	injectErr := imitator.DefaultV2Client.Inject(message)
 
 	msgSource := message.GetSource()
 	if msgSource == modules.EdgedModuleName && resType == model.ResourceTypeLease {
@@ -242,6 +246,14 @@ func (m *metaManager) processUpdate(message model.Message) {
 			return
 		}
 		m.processRemote(message)
+		return
+	}
+	// As in processDelete, only cloud-sourced updates must fail when the local meta_v2
+	// cache write fails; edge-sourced updates stay best-effort. In practice status and
+	// node-lease updates produce no meta_v2 event (see imitator.Event), so injectErr is
+	// already nil for them, but the source guard keeps the two paths consistent.
+	if injectErr != nil && msgSource != modules.EdgedModuleName {
+		feedbackError(injectErr, message)
 		return
 	}
 	if err := m.handleMessage(&message); err != nil {
@@ -312,11 +324,20 @@ func (m *metaManager) processResponse(message model.Message) {
 }
 
 func (m *metaManager) processDelete(message model.Message) {
-	imitator.DefaultV2Client.Inject(message)
+	injectErr := imitator.DefaultV2Client.Inject(message)
 	_, resType, _ := parseResource(&message)
 	if resType == model.ResourceTypePod && message.GetSource() == modules.EdgedModuleName {
 		// if pod is deleted in K8s, then a new delete message will be sent to edge
 		sendToCloud(&message)
+		return
+	}
+	// Only cloud-sourced deletes must not be acknowledged when the local meta_v2 cache
+	// write fails, otherwise the metaserver would keep serving the deleted object as if
+	// it still existed while the cloud believes the delete succeeded. Edge-sourced deletes
+	// (e.g. pod above, volumeattachment) report state up to the cloud, so they are kept
+	// best-effort: a local cache write failure must not block them.
+	if injectErr != nil && message.GetSource() != modules.EdgedModuleName {
+		feedbackError(injectErr, message)
 		return
 	}
 
@@ -424,6 +445,8 @@ func (m *metaManager) processVolume(message model.Message) {
 	klog.Infof("process volume get: req[%+v], back[%+v], err[%+v]", message, back, err)
 	if err != nil {
 		klog.Errorf("process volume send to edged failed: %v", err)
+		feedbackError(fmt.Errorf("failed to process volume: %v", err), message)
+		return
 	}
 
 	resp := message.NewRespByMessage(&message, back.GetContent())

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -248,7 +248,11 @@ func (m *metaManager) processUpdate(message model.Message) {
 		m.processRemote(message)
 		return
 	}
-	if injectErr != nil {
+	// As in processDelete, only cloud-sourced updates must fail when the local meta_v2
+	// cache write fails; edge-sourced updates stay best-effort. In practice status and
+	// node-lease updates produce no meta_v2 event (see imitator.Event), so injectErr is
+	// already nil for them, but the source guard keeps the two paths consistent.
+	if injectErr != nil && msgSource != modules.EdgedModuleName {
 		feedbackError(injectErr, message)
 		return
 	}
@@ -327,7 +331,12 @@ func (m *metaManager) processDelete(message model.Message) {
 		sendToCloud(&message)
 		return
 	}
-	if injectErr != nil {
+	// Only cloud-sourced deletes must not be acknowledged when the local meta_v2 cache
+	// write fails, otherwise the metaserver would keep serving the deleted object as if
+	// it still existed while the cloud believes the delete succeeded. Edge-sourced deletes
+	// (e.g. pod above, volumeattachment) report state up to the cloud, so they are kept
+	// best-effort: a local cache write failure must not block them.
+	if injectErr != nil && message.GetSource() != modules.EdgedModuleName {
 		feedbackError(injectErr, message)
 		return
 	}

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -198,7 +198,7 @@ func (m *metaManager) processInsert(message model.Message) {
 		sendToCloud(&message)
 		return
 	}
-	imitator.DefaultV2Client.Inject(message)
+	injectErr := imitator.DefaultV2Client.Inject(message)
 
 	msgSource := message.GetSource()
 	if msgSource == modules.EdgedModuleName {
@@ -208,6 +208,10 @@ func (m *metaManager) processInsert(message model.Message) {
 			return
 		}
 		m.processRemote(message)
+		return
+	}
+	if injectErr != nil {
+		feedbackError(injectErr, message)
 		return
 	}
 	if err := m.handleMessage(&message); err != nil {
@@ -232,7 +236,7 @@ func (m *metaManager) processUpdate(message model.Message) {
 		sendToCloud(&message)
 		return
 	}
-	imitator.DefaultV2Client.Inject(message)
+	injectErr := imitator.DefaultV2Client.Inject(message)
 
 	msgSource := message.GetSource()
 	if msgSource == modules.EdgedModuleName && resType == model.ResourceTypeLease {
@@ -242,6 +246,10 @@ func (m *metaManager) processUpdate(message model.Message) {
 			return
 		}
 		m.processRemote(message)
+		return
+	}
+	if injectErr != nil {
+		feedbackError(injectErr, message)
 		return
 	}
 	if err := m.handleMessage(&message); err != nil {
@@ -312,11 +320,15 @@ func (m *metaManager) processResponse(message model.Message) {
 }
 
 func (m *metaManager) processDelete(message model.Message) {
-	imitator.DefaultV2Client.Inject(message)
+	injectErr := imitator.DefaultV2Client.Inject(message)
 	_, resType, _ := parseResource(&message)
 	if resType == model.ResourceTypePod && message.GetSource() == modules.EdgedModuleName {
 		// if pod is deleted in K8s, then a new delete message will be sent to edge
 		sendToCloud(&message)
+		return
+	}
+	if injectErr != nil {
+		feedbackError(injectErr, message)
 		return
 	}
 
@@ -424,6 +436,8 @@ func (m *metaManager) processVolume(message model.Message) {
 	klog.Infof("process volume get: req[%+v], back[%+v], err[%+v]", message, back, err)
 	if err != nil {
 		klog.Errorf("process volume send to edged failed: %v", err)
+		feedbackError(fmt.Errorf("failed to process volume: %v", err), message)
+		return
 	}
 
 	resp := message.NewRespByMessage(&message, back.GetContent())

--- a/edge/pkg/metamanager/process_test.go
+++ b/edge/pkg/metamanager/process_test.go
@@ -18,6 +18,7 @@ package metamanager
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/beehive/pkg/core/model"
 	cloudmodules "github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator"
 	fakeclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake"
 )
@@ -121,4 +123,44 @@ func TestProcessVolumeFeedsBackErrorOnTimeout(t *testing.T) {
 	require.Error(t, gotErr)
 	assert.Contains(t, gotErr.Error(), "sync timeout")
 	assert.False(t, acked, "the cloud must not be acked when the volume operation times out")
+}
+
+// newEdgeMessage builds a message originating from Edged (an edge-sourced path).
+func newEdgeMessage(operation, resource string) model.Message {
+	msg := model.NewMessage("")
+	msg.BuildRouter(modules.EdgedModuleName, "resource", resource, operation)
+	return *msg
+}
+
+// TestProcessDeleteEdgeSourcedStaysBestEffort verifies that an edge-sourced delete other
+// than the special-cased pod delete (here a volumeattachment) is not blocked when the
+// local meta_v2 cache write fails: the inject error is ignored and the message is still
+// processed and forwarded, matching the best-effort behavior of edge-sourced paths.
+func TestProcessDeleteEdgeSourcedStaysBestEffort(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyGlobalVar(&imitator.DefaultV2Client, fakeclient.Client{
+		InjectF: func(_ model.Message) error {
+			return errors.New("cache write failed")
+		},
+	})
+	var fedBack bool
+	patches.ApplyFunc(feedbackError, func(_ error, _ model.Message) {
+		fedBack = true
+	})
+	// handleMessage would reach the (nil) metaService; stub it out so the test exercises
+	// only the injectErr branch.
+	patches.ApplyPrivateMethod(reflect.TypeOf(m), "handleMessage",
+		func(_ *metaManager, _ *model.Message) error { return nil })
+	patches.ApplyFunc(sendToEdged, func(_ *model.Message, _ bool) {})
+	var acked bool
+	patches.ApplyFunc(sendToCloud, func(_ *model.Message) {
+		acked = true
+	})
+
+	m.processDelete(newEdgeMessage(model.DeleteOperation, "default/volumeattachment/va1"))
+	assert.False(t, fedBack, "edge-sourced delete must stay best-effort when the local cache write fails")
+	assert.True(t, acked, "edge-sourced delete should still be forwarded to the cloud")
 }

--- a/edge/pkg/metamanager/process_test.go
+++ b/edge/pkg/metamanager/process_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metamanager
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	cloudmodules "github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator"
+	fakeclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake"
+)
+
+func newCloudMessage(operation, resource string) model.Message {
+	msg := model.NewMessage("")
+	msg.BuildRouter(cloudmodules.EdgeControllerModuleName, "resource", resource, operation)
+	return *msg
+}
+
+// injectFails replaces the imitator with a fake whose Inject always fails, and
+// records whether feedbackError and sendToCloud are called.
+func injectFails(patches *gomonkey.Patches, gotErr *error, acked *bool) {
+	patches.ApplyGlobalVar(&imitator.DefaultV2Client, fakeclient.Client{
+		InjectF: func(_ model.Message) error {
+			return errors.New("cache write failed")
+		},
+	})
+	patches.ApplyFunc(feedbackError, func(err error, _ model.Message) {
+		*gotErr = err
+	})
+	patches.ApplyFunc(sendToCloud, func(_ *model.Message) {
+		*acked = true
+	})
+}
+
+func TestProcessInsertFeedsBackErrorWhenInjectFails(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var gotErr error
+	var acked bool
+	injectFails(patches, &gotErr, &acked)
+
+	m.processInsert(newCloudMessage(model.InsertOperation, "default/configmap/cm1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "cache write failed")
+	assert.False(t, acked, "the cloud must not be acked OK when the local cache write fails")
+}
+
+func TestProcessUpdateFeedsBackErrorWhenInjectFails(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var gotErr error
+	var acked bool
+	injectFails(patches, &gotErr, &acked)
+
+	m.processUpdate(newCloudMessage(model.UpdateOperation, "default/configmap/cm1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "cache write failed")
+	assert.False(t, acked, "the cloud must not be acked OK when the local cache write fails")
+}
+
+func TestProcessDeleteFeedsBackErrorWhenInjectFails(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var gotErr error
+	var acked bool
+	injectFails(patches, &gotErr, &acked)
+
+	m.processDelete(newCloudMessage(model.DeleteOperation, "default/configmap/cm1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "cache write failed")
+	assert.False(t, acked, "the cloud must not be acked OK when the local cache write fails")
+}
+
+func TestProcessVolumeFeedsBackErrorOnTimeout(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(beehiveContext.SendSync,
+		func(_ string, _ model.Message, _ time.Duration) (model.Message, error) {
+			return model.Message{}, errors.New("sync timeout")
+		})
+	var gotErr error
+	patches.ApplyFunc(feedbackError, func(err error, _ model.Message) {
+		gotErr = err
+	})
+	var acked bool
+	patches.ApplyFunc(sendToCloud, func(_ *model.Message) {
+		acked = true
+	})
+
+	m.processVolume(newCloudMessage(model.InsertOperation, "default/volume/v1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "sync timeout")
+	assert.False(t, acked, "the cloud must not be acked when the volume operation times out")
+}
+
+// newEdgeMessage builds a message originating from Edged (an edge-sourced path).
+func newEdgeMessage(operation, resource string) model.Message {
+	msg := model.NewMessage("")
+	msg.BuildRouter(modules.EdgedModuleName, "resource", resource, operation)
+	return *msg
+}
+
+// TestProcessDeleteEdgeSourcedStaysBestEffort verifies that an edge-sourced delete other
+// than the special-cased pod delete (here a volumeattachment) is not blocked when the
+// local meta_v2 cache write fails: the inject error is ignored and the message is still
+// processed and forwarded, matching the best-effort behavior of edge-sourced paths.
+func TestProcessDeleteEdgeSourcedStaysBestEffort(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyGlobalVar(&imitator.DefaultV2Client, fakeclient.Client{
+		InjectF: func(_ model.Message) error {
+			return errors.New("cache write failed")
+		},
+	})
+	var fedBack bool
+	patches.ApplyFunc(feedbackError, func(_ error, _ model.Message) {
+		fedBack = true
+	})
+	// handleMessage would reach the (nil) metaService; stub it out so the test exercises
+	// only the injectErr branch.
+	patches.ApplyPrivateMethod(reflect.TypeOf(m), "handleMessage",
+		func(_ *metaManager, _ *model.Message) error { return nil })
+	patches.ApplyFunc(sendToEdged, func(_ *model.Message, _ bool) {})
+	var acked bool
+	patches.ApplyFunc(sendToCloud, func(_ *model.Message) {
+		acked = true
+	})
+
+	m.processDelete(newEdgeMessage(model.DeleteOperation, "default/volumeattachment/va1"))
+	assert.False(t, fedBack, "edge-sourced delete must stay best-effort when the local cache write fails")
+	assert.True(t, acked, "edge-sourced delete should still be forwarded to the cloud")
+}

--- a/edge/pkg/metamanager/process_test.go
+++ b/edge/pkg/metamanager/process_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metamanager
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	cloudmodules "github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator"
+	fakeclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/imitator/fake"
+)
+
+func newCloudMessage(operation, resource string) model.Message {
+	msg := model.NewMessage("")
+	msg.BuildRouter(cloudmodules.EdgeControllerModuleName, "resource", resource, operation)
+	return *msg
+}
+
+// injectFails replaces the imitator with a fake whose Inject always fails, and
+// records whether feedbackError and sendToCloud are called.
+func injectFails(patches *gomonkey.Patches, gotErr *error, acked *bool) {
+	patches.ApplyGlobalVar(&imitator.DefaultV2Client, fakeclient.Client{
+		InjectF: func(_ model.Message) error {
+			return errors.New("cache write failed")
+		},
+	})
+	patches.ApplyFunc(feedbackError, func(err error, _ model.Message) {
+		*gotErr = err
+	})
+	patches.ApplyFunc(sendToCloud, func(_ *model.Message) {
+		*acked = true
+	})
+}
+
+func TestProcessInsertFeedsBackErrorWhenInjectFails(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var gotErr error
+	var acked bool
+	injectFails(patches, &gotErr, &acked)
+
+	m.processInsert(newCloudMessage(model.InsertOperation, "default/configmap/cm1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "cache write failed")
+	assert.False(t, acked, "the cloud must not be acked OK when the local cache write fails")
+}
+
+func TestProcessUpdateFeedsBackErrorWhenInjectFails(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var gotErr error
+	var acked bool
+	injectFails(patches, &gotErr, &acked)
+
+	m.processUpdate(newCloudMessage(model.UpdateOperation, "default/configmap/cm1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "cache write failed")
+	assert.False(t, acked, "the cloud must not be acked OK when the local cache write fails")
+}
+
+func TestProcessDeleteFeedsBackErrorWhenInjectFails(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	var gotErr error
+	var acked bool
+	injectFails(patches, &gotErr, &acked)
+
+	m.processDelete(newCloudMessage(model.DeleteOperation, "default/configmap/cm1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "cache write failed")
+	assert.False(t, acked, "the cloud must not be acked OK when the local cache write fails")
+}
+
+func TestProcessVolumeFeedsBackErrorOnTimeout(t *testing.T) {
+	m := &metaManager{}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(beehiveContext.SendSync,
+		func(_ string, _ model.Message, _ time.Duration) (model.Message, error) {
+			return model.Message{}, errors.New("sync timeout")
+		})
+	var gotErr error
+	patches.ApplyFunc(feedbackError, func(err error, _ model.Message) {
+		gotErr = err
+	})
+	var acked bool
+	patches.ApplyFunc(sendToCloud, func(_ *model.Message) {
+		acked = true
+	})
+
+	m.processVolume(newCloudMessage(model.InsertOperation, "default/volume/v1"))
+	require.Error(t, gotErr)
+	assert.Contains(t, gotErr.Error(), "sync timeout")
+	assert.False(t, acked, "the cloud must not be acked when the volume operation times out")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When CloudCore sends an object add/update/delete to an edge node, metamanager writes it to the local `meta_v2` cache (the etcd imitator backing the edge metaserver's list/watch) via `imitator.Inject`, then acks the cloud with `OK`. The result of `Inject` was ignored, so when the local cache write failed (e.g. SQLite `database is locked` / disk full, after `RetryInsertOrReplaceMetaV2` exhausts its retries) the object was never resent: the metaserver kept serving the stale object with no watch event, and the cloud considered it synced. `Inject` also dropped the error from `ObjectResourceVersion`, storing an `RV=0` row and stalling the imitator revision. Separately, `processVolume` logged a `SendSync` timeout but still acked the cloud with empty content, masking a failed CSI volume operation as success.

This PR:
- makes `imitator.Inject` return an aggregated error and only trigger the watch hook on a successful write;
- checks the previously ignored `ObjectResourceVersion` error in `InsertOrUpdateObj`;
- has `processInsert` / `processUpdate` / `processDelete` report the failure via `feedbackError` instead of acking `OK`, so the cloud does not record the object as synced (edge-sourced paths are left unchanged, so local caching stays best effort for edge->cloud traffic);
- has `processVolume` report the `SendSync` timeout instead of forwarding an empty success.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7070 

**Special notes for your reviewer**:

- The `Inject` error is only acted upon on the paths that previously sent a false `OK` to the cloud; edgesourced early returns (`processRemote`, edge pod delete forwarding) are untouched, so there is no behavior change for edge->cloud messages.
- The `Inject` signature change ripples to the `imitator.Client` interface and its fake.
- Added unit tests: `imitator` (Inject returns/aggregates the write error, succeeds when the write succeeds, and `InsertOrUpdateObj` rejects an unparseable resourceVersion) and `metamanager` (each of processInsert/Update/Delete feeds back the error and does not ack the cloud; processVolume reports the timeout).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug where the edge metamanager acknowledged cloud object updates as successful even when the local meta cache write failed, causing the edge metaserver's list/watch to silently and permanently diverge from the cloud. Such failures are now reported so the update can be retried.

```
