### PR TITLE
edge/devicetwin: skip bad rows when restoring DMI cache from DB

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -209,7 +209,7 @@ func (dw *DMIWorker) initDeviceModelInfoFromDB() {
 		deviceModel := v1beta1.DeviceModel{}
 		if err := json.Unmarshal([]byte(meta), &deviceModel); err != nil {
 			klog.Errorf("fail to unmarshal device model info from db with err: %v", err)
-			return
+			continue
 		}
 		dw.dmiCache.PutDeviceModel(&deviceModel)
 	}
@@ -227,7 +227,7 @@ func (dw *DMIWorker) initDeviceInfoFromDB() {
 		device := v1beta1.Device{}
 		if err := json.Unmarshal([]byte(meta), &device); err != nil {
 			klog.Errorf("fail to unmarshal device info from db with err: %v", err)
-			return
+			continue
 		}
 		dw.dmiCache.PutDevice(&device)
 	}
@@ -245,7 +245,7 @@ func (dw *DMIWorker) initDeviceMapperInfoFromDB() {
 		deviceMapper := pb.MapperInfo{}
 		if err := json.Unmarshal([]byte(meta), &deviceMapper); err != nil {
 			klog.Errorf("fail to unmarshal device mapper info from db with err: %v", err)
-			return
+			continue
 		}
 
 		err := dmiclient.DMIClientsImp.CreateDMIClient(deviceMapper.Protocol, string(deviceMapper.Address), true)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The three DB-restore loops in `edge/pkg/devicetwin/dtmanager/dmiworker.go`  `initDeviceModelInfoFromDB`, `initDeviceInfoFromDB` and `initDeviceMapperInfoFromDB`  `return` on the first row that fails to `json.Unmarshal`. As a result, a single corrupt or schema-migrated row in the metadata DB silently prevents **every subsequent** device, device model or device mapper from being restored into the DMI cache after an edgecore restart, leaving mappers unable to resolve those devices
while offline.

This PR changes the unmarshal-error branch in each of the three loops from `return` to `continue`, so a bad row is logged and skipped while the remaining rows are still loaded. This matches the `CreateDMIClient` error path already present in `initDeviceMapperInfoFromDB`, which correctly uses `continue`.

**Which issue(s) this PR fixes**:

Fixes #7071

**Special notes for your reviewer**:

Minimal three-line change (`return` → `continue`) in the unmarshal-error branch of each of the three functions. No test is added: `MetaService` wraps an unexported `*gorm.DB` obtained from `dao.GetDB()` with no injection point, so exercising these loops would require adding production code (a DB setter) or a full sqlite `InitDBManager` harness  both beyond the minimal scope of this fix. Verified locally with `gofmt`, `go vet`, `golangci-lint`, `make verify` and
`go test ./edge/pkg/devicetwin/dtmanager/...` (all pass).

**Does this PR introduce a user-facing change?**:

```release-note
edge/devicetwin: fix DMI cache restore aborting on the first unreadable metadata DB row, which prevented later devices, device models and device mappers from being loaded after an edgecore restart.
```
