### PR TITLE
edge/devicetwin: guard message.Content type assertion against panic

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/device.go
+++ b/edge/pkg/devicetwin/dtmanager/device.go
@@ -80,7 +80,12 @@ func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg in
 		return errors.New("msg not Message type")
 	}
 
-	updatedDevice, err := dttype.UnmarshalDeviceUpdate(message.Content.([]byte))
+	content, ok := message.Content.([]byte)
+	if !ok {
+		return errors.New("invalid message content")
+	}
+
+	updatedDevice, err := dttype.UnmarshalDeviceUpdate(content)
 	if err != nil {
 		klog.Errorf("Unmarshal device info failed, err: %#v", err)
 		return err
@@ -158,7 +163,12 @@ func dealDeviceAttrUpdate(context *dtcontext.DTContext, resource string, msg int
 		return errors.New("msg not Message type")
 	}
 
-	updatedDevice, err := dttype.UnmarshalDeviceUpdate(message.Content.([]byte))
+	content, ok := message.Content.([]byte)
+	if !ok {
+		return errors.New("invalid message content")
+	}
+
+	updatedDevice, err := dttype.UnmarshalDeviceUpdate(content)
 	if err != nil {
 		klog.Errorf("Unmarshal device info failed, err: %#v", err)
 		return err

--- a/edge/pkg/devicetwin/dtmanager/device_test.go
+++ b/edge/pkg/devicetwin/dtmanager/device_test.go
@@ -149,6 +149,16 @@ func TestDealDeviceStateUpdate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:     "dealDeviceStateUpdateTest-InvalidContentType",
+			context:  dtContexts,
+			resource: "DeviceD",
+			msg:      &model.Message{Content: "not-bytes"},
+			setupMock: func(m *mocks.MockDeviceService) {
+				// No database call expected
+			},
+			wantErr: true,
+		},
+		{
 			name:     "dealDeviceStateUpdateTest-DeviceDoesNotExist",
 			context:  dtContexts,
 			resource: "DeviceB",
@@ -241,6 +251,13 @@ func TestDealUpdateDeviceAttr(t *testing.T) {
 			resource: "Device",
 			msg:      "",
 			wantErr:  errors.New("msg not Message type"),
+		},
+		{
+			name:     "DealUpdateDeviceAttrTest-Invalid Content Type",
+			context:  dtContexts,
+			resource: "DeviceA",
+			msg:      &model.Message{Content: "not-bytes"},
+			wantErr:  errors.New("invalid message content"),
 		},
 		{
 			name:     "DealUpdateDeviceAttrTest-Correct Message Type",

--- a/edge/pkg/devicetwin/dtmanager/dmiworker.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker.go
@@ -114,11 +114,15 @@ func (dw *DMIWorker) dealMetaDeviceOperation(_ *dtcontext.DTContext, _ string, m
 	if len(resources) != 3 {
 		return fmt.Errorf("wrong resources %s", message.Router.Resource)
 	}
+	content, ok := message.Content.([]byte)
+	if !ok {
+		return errors.New("invalid message content")
+	}
 	var device v1beta1.Device
 	var dm v1beta1.DeviceModel
 	switch resources[1] {
 	case constants.ResourceTypeDevice:
-		err := json.Unmarshal(message.Content.([]byte), &device)
+		err := json.Unmarshal(content, &device)
 		if err != nil {
 			return fmt.Errorf("invalid message content with err: %+v", err)
 		}
@@ -161,7 +165,7 @@ func (dw *DMIWorker) dealMetaDeviceOperation(_ *dtcontext.DTContext, _ string, m
 			klog.Warningf("unsupported operation %s", message.GetOperation())
 		}
 	case constants.ResourceTypeDeviceModel:
-		err := json.Unmarshal(message.Content.([]byte), &dm)
+		err := json.Unmarshal(content, &dm)
 		if err != nil {
 			return fmt.Errorf("invalid message content with err: %+v", err)
 		}

--- a/edge/pkg/devicetwin/dtmanager/dmiworker_test.go
+++ b/edge/pkg/devicetwin/dtmanager/dmiworker_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dtmanager
+
+import (
+	"testing"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+)
+
+func TestDealMetaDeviceOperation(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     interface{}
+		wantErr bool
+	}{
+		{
+			name:    "dealMetaDeviceOperationTest-WrongMessageType",
+			msg:     "",
+			wantErr: true,
+		},
+		{
+			name:    "dealMetaDeviceOperationTest-WrongResourceCount",
+			msg:     &model.Message{Router: model.MessageRoute{Resource: "device"}},
+			wantErr: true,
+		},
+		{
+			name:    "dealMetaDeviceOperationTest-InvalidContentType",
+			msg:     &model.Message{Router: model.MessageRoute{Resource: "ns/device/name"}, Content: "not-bytes"},
+			wantErr: true,
+		},
+	}
+
+	dw := &DMIWorker{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := dw.dealMetaDeviceOperation(nil, "", test.msg)
+			if (err != nil) != test.wantErr {
+				t.Errorf("dealMetaDeviceOperation() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION


**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Four message handlers in `edge/pkg/devicetwin/dtmanager` converted `message.Content` to `[]byte` using the single-value type assertion (`message.Content.([]byte)`), which panics with an interface-conversion runtime error if the content is anything else:

- `device.go:83` — `dealDeviceStateUpdate`
- `device.go:161` — `dealDeviceAttrUpdate`
- `dmiworker.go:121` and `dmiworker.go:164` — `dealMetaDeviceOperation`

`model.Message.Content` is `interface{}`, and modules on the same process frequently fill it with structs or strings rather than raw bytes. Every handler already guards the outer `msg.(*model.Message)` assertion with the two-value form and returns a proper error, but then trusted `Content` blindly. A single malformed message on these hot paths could take down the whole edgecore process instead of being rejected with an error.

This PR switches all four sites to the two-value assertion form, returning an error instead of panicking matching the pattern already used for the `*model.Message` assertion in the same functions, and by
`dealTwinUpdate`/`dealMembershipDetail` elsewhere in the package.

**Which issue(s) this PR fixes**:

Fixes #7076

**Special notes for your reviewer**:

Same fix pattern applied at all four sites: two-value assertion + `errors.New("invalid message content")` return, consistent with the existing convention in `twin.go`/`membership.go`. In `dmiworker.go`, the two `Content.([]byte)` sites within `dealMetaDeviceOperation` share a single assertion placed before the `switch` on resource type, since both branches need identical content-type handling.

Unit tests were added to `device_test.go` and a new `dmiworker_test.go` covering the previously-panicking case (non-`[]byte` `Content`), which now returns an error instead of crashing.

**Does this PR introduce a user-facing change?**:

```release-note
edgecore: fix panic in devicetwin dtmanager when a message's Content field is not []byte
```
