### PR TITLE
keadm: fix stale keys leaking between debug get pod/node records

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/get.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get.go
@@ -296,8 +296,6 @@ func (g *GetOptions) queryDataFromDatabase(resType string, resNames []string) ([
 
 func (g *GetOptions) getPodsFromDatabase(resNS string, resNames []string) ([]models.Meta, error) {
 	var results []models.Meta
-	podJSON := make(map[string]interface{})
-	podStatusJSON := make(map[string]interface{})
 
 	podRecords, err := ms.QueryAllMeta("type", model.ResourceTypePod)
 	if err != nil {
@@ -322,6 +320,8 @@ func (g *GetOptions) getPodsFromDatabase(resNS string, resNames []string) ([]mod
 			results = append(results, v)
 			continue
 		}
+		podJSON := make(map[string]interface{})
+		podStatusJSON := make(map[string]interface{})
 		if err := json.Unmarshal([]byte(v.Value), &podJSON); err != nil {
 			return nil, err
 		}
@@ -342,8 +342,6 @@ func (g *GetOptions) getPodsFromDatabase(resNS string, resNames []string) ([]mod
 
 func (g *GetOptions) getNodeFromDatabase(resNS string, resNames []string) ([]models.Meta, error) {
 	var results []models.Meta
-	nodeJSON := make(map[string]interface{})
-	nodeStatusJSON := make(map[string]interface{})
 
 	nodeRecords, err := ms.QueryAllMeta("type", model.ResourceTypeNode)
 	if err != nil {
@@ -368,6 +366,8 @@ func (g *GetOptions) getNodeFromDatabase(resNS string, resNames []string) ([]mod
 			results = append(results, v)
 			continue
 		}
+		nodeJSON := make(map[string]interface{})
+		nodeStatusJSON := make(map[string]interface{})
 		if err := json.Unmarshal([]byte(v.Value), &nodeJSON); err != nil {
 			return nil, err
 		}

--- a/keadm/cmd/keadm/app/cmd/debug/get_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
+)
+
+// TestGetPodsFromDatabaseNoStaleKeys guards against a regression where
+// json.Unmarshal reused the same map across loop iterations, leaking keys
+// from one record's JSON into the next record's output.
+func TestGetPodsFromDatabaseNoStaleKeys(t *testing.T) {
+	dao.Init(":memory:", &v1alpha2.MetaManager{Enable: true})
+	ms = dbclient.NewMetaService()
+
+	metas := []models.Meta{
+		{Key: "default/pod/pod1", Type: model.ResourceTypePod, Value: `{"metadata":{"name":"pod1"},"extra":"stale-value"}`},
+		{Key: "default/podstatus/pod1", Type: model.ResourceTypePodStatus, Value: `{"Status":{"phase":"Running"}}`},
+		{Key: "default/pod/pod2", Type: model.ResourceTypePod, Value: `{"metadata":{"name":"pod2"}}`},
+		{Key: "default/podstatus/pod2", Type: model.ResourceTypePodStatus, Value: `{"Status":{"phase":"Pending"}}`},
+	}
+	for i := range metas {
+		require.NoError(t, ms.SaveMeta(&metas[i]))
+	}
+
+	g := &GetOptions{AllNamespace: true}
+	results, err := g.getPodsFromDatabase("default", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	var pod2Result map[string]interface{}
+	for _, r := range results {
+		if r.Key == "default/pod/pod2" {
+			require.NoError(t, json.Unmarshal([]byte(r.Value), &pod2Result))
+		}
+	}
+	require.NotNil(t, pod2Result)
+	_, hasStaleKey := pod2Result["extra"]
+	assert.False(t, hasStaleKey, "pod2 output must not contain pod1's stale 'extra' key")
+}
+
+// TestGetNodeFromDatabaseNoStaleKeys is the node-side counterpart of
+// TestGetPodsFromDatabaseNoStaleKeys.
+func TestGetNodeFromDatabaseNoStaleKeys(t *testing.T) {
+	dao.Init(":memory:", &v1alpha2.MetaManager{Enable: true})
+	ms = dbclient.NewMetaService()
+
+	metas := []models.Meta{
+		{Key: "default/node/node1", Type: model.ResourceTypeNode, Value: `{"metadata":{"name":"node1"},"extra":"stale-value"}`},
+		{Key: "default/nodestatus/node1", Type: model.ResourceTypeNodeStatus, Value: `{"Status":{"phase":"Running"}}`},
+		{Key: "default/node/node2", Type: model.ResourceTypeNode, Value: `{"metadata":{"name":"node2"}}`},
+		{Key: "default/nodestatus/node2", Type: model.ResourceTypeNodeStatus, Value: `{"Status":{"phase":"Pending"}}`},
+	}
+	for i := range metas {
+		require.NoError(t, ms.SaveMeta(&metas[i]))
+	}
+
+	g := &GetOptions{AllNamespace: true}
+	results, err := g.getNodeFromDatabase("default", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	var node2Result map[string]interface{}
+	for _, r := range results {
+		if r.Key == "default/node/node2" {
+			require.NoError(t, json.Unmarshal([]byte(r.Value), &node2Result))
+		}
+	}
+	require.NotNil(t, node2Result)
+	_, hasStaleKey := node2Result["extra"]
+	assert.False(t, hasStaleKey, "node2 output must not contain node1's stale 'extra' key")
+}


### PR DESCRIPTION
Motivation:
keadm/cmd/keadm/app/cmd/debug/get.go declared the podJSON/podStatusJSON
(and nodeJSON/nodeStatusJSON) maps once outside the per-record loop in
getPodsFromDatabase and getNodeFromDatabase, then reused the same map
across json.Unmarshal calls for every record. json.Unmarshal into a
non-empty map only overwrites keys present in the new document; it does
not clear keys absent from it. So a key present in record N (e.g. an
extra top-level field, or "status") could persist into record N+1's
marshalled output if record N+1's JSON didn't redefine that key. This
is a data-correctness bug in `keadm debug get pods`/`get nodes` output,
not a crash: nothing panics or exits, but the emitted JSON/YAML for a
later record can silently contain stale fields carried over from an
earlier, unrelated record.

Approach:
Move the map allocations inside the loop body, right before the
json.Unmarshal calls, so every record gets a fresh map. Applied to both
getPodsFromDatabase and getNodeFromDatabase, matching the fix
suggested in the issue.

Validation:
Added TestGetPodsFromDatabaseNoStaleKeys and
TestGetNodeFromDatabaseNoStaleKeys, which spin up a real in-memory
sqlite DB via dao.Init, insert two records where the second omits a
key the first has, and assert the second record's output does not
contain the first record's stale key. Confirmed both tests fail
against the pre-fix code and pass against the fix.

  go build ./keadm/...
  go test ./keadm/cmd/keadm/app/cmd/debug/... -run 'TestGetPodsFromDatabaseNoStaleKeys|TestGetNodeFromDatabaseNoStaleKeys' -v

PASS (both tests), go vet ./keadm/cmd/keadm/app/cmd/debug/... clean.

/kind bug

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a data-correctness bug where `keadm debug get pods` and
`keadm debug get nodes` could emit stale fields from a previous
record's JSON in a later, unrelated record's output, because the
unmarshal target maps were reused across loop iterations instead of
being allocated fresh per record.

**Which issue(s) this PR fixes**:
Fixes #7086

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug in `keadm debug get pods`/`keadm debug get nodes` where stale fields from a previously processed record could leak into a later record's JSON output due to a reused json.Unmarshal target map.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
