### PR TITLE
docs(cloud/cloudhub): add godoc comments to exported identifiers

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -74,6 +74,8 @@ func newCloudHub(enable bool) *cloudHub {
 	return ch
 }
 
+// Register initializes the cloudhub configuration and registers the cloudhub
+// module to the core framework.
 func Register(hub *v1alpha1.CloudHub) {
 	hubconfig.InitConfigure(hub)
 	core.Register(newCloudHub(hub.Enable))
@@ -164,6 +166,8 @@ func getAuthConfig() authorization.Config {
 	}
 }
 
+// GetSessionManager returns the global session manager for cloudhub. It
+// returns an error if cloudhub has not been initialized.
 func GetSessionManager() (*session.Manager, error) {
 	if sessionMgr != nil {
 		return sessionMgr, nil

--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -12,6 +12,8 @@ import (
 var Config Configure
 var once sync.Once
 
+// Configure holds the configuration for cloudhub, including the TLS
+// certificates and keys required for secure communication.
 type Configure struct {
 	v1alpha1.CloudHub
 	KubeAPIConfig *v1alpha1.KubeAPIConfig
@@ -21,6 +23,9 @@ type Configure struct {
 	Key           []byte
 }
 
+// InitConfigure initializes the global Config variable based on the provided
+// CloudHub configuration. It ensures that the required certificates and keys
+// are loaded and is safe to call multiple times (only executes once).
 func InitConfigure(hub *v1alpha1.CloudHub) {
 	once.Do(func() {
 		if len(hub.AdvertiseAddress) == 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to exported identifiers in `cloud/pkg/cloudhub/`:

- `Register` — documents module registration
- `GetSessionManager` — documents session manager retrieval
- `Configure` (config.go) — documents the configuration struct
- `InitConfigure` (config.go) — documents the initialization logic

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
