### PR TITLE
docs(cloud/router): add godoc comments to exported identifiers

### DIFF
--- a/cloud/pkg/router/config/config.go
+++ b/cloud/pkg/router/config/config.go
@@ -9,10 +9,13 @@ import (
 var Config Configure
 var once sync.Once
 
+// Configure holds the configuration for the router module.
 type Configure struct {
 	v1alpha1.Router
 }
 
+// InitConfigure initializes the global Config variable based on the provided
+// Router configuration. It is safe to call multiple times (only executes once).
 func InitConfigure(router *v1alpha1.Router) {
 	once.Do(func() {
 		Config = Configure{

--- a/cloud/pkg/router/router.go
+++ b/cloud/pkg/router/router.go
@@ -26,6 +26,8 @@ func newRouter(enable bool) *router {
 	}
 }
 
+// Register initializes the router configuration and registers the router
+// module to the core framework.
 func Register(router *v1alpha1.Router) {
 	routerconfig.InitConfigure(router)
 	core.Register(newRouter(router.Enable))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to exported identifiers in `cloud/pkg/router/`:

- `Register` — documents module registration
- `Configure` (config.go) — documents the configuration struct
- `InitConfigure` (config.go) — documents the initialization logic

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
