### PR TITLE
fix(metamanager): send error feedback on processVolume SendSync failure

### DIFF
--- a/edge/pkg/metamanager/metamanager_test.go
+++ b/edge/pkg/metamanager/metamanager_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeedge/beehive/pkg/common"
 	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/beehive/pkg/core/model"
 	commodule "github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 )
 
@@ -60,3 +61,14 @@ func TestNameAndGroup(t *testing.T) {
 		}
 	})
 }
+
+func TestProcessVolume(t *testing.T) {
+	m := &metaManager{enable: true}
+	msg := model.NewMessage("test-volume-msg-id").
+		BuildRouter(commodule.MetaManagerModuleName, commodule.MetaGroup, "volume", "createVolume")
+
+	t.Run("processVolume SendSync error handling", func(t *testing.T) {
+		m.processVolume(*msg)
+	})
+}
+

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -424,6 +424,8 @@ func (m *metaManager) processVolume(message model.Message) {
 	klog.Infof("process volume get: req[%+v], back[%+v], err[%+v]", message, back, err)
 	if err != nil {
 		klog.Errorf("process volume send to edged failed: %v", err)
+		feedbackError(err, message)
+		return
 	}
 
 	resp := message.NewRespByMessage(&message, back.GetContent())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
In `edge/pkg/metamanager/process.go`, `processVolume` handles CSI volume operations dispatched from CloudHub to `edged`. When `beehiveContext.SendSync` returned an error or timed out, `processVolume` logged the error but did not return or send an error response. Instead, it fell through to create a response message with `nil` content and sent it to CloudHub via `sendToCloud(resp)`, causing CloudHub to incorrectly treat a failed/timed-out volume operation as successful.

This PR adds `feedbackError(err, message)` and an early return when `beehiveContext.SendSync` fails in `processVolume`, ensuring failed volume operations are properly reported back to CloudHub.

**Which issue(s) this PR fixes**:
Fixes #7092

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
Fix a bug in metamanager where failed or timed-out CSI volume operations were incorrectly reported as successful to CloudHub.
