### PR TITLE
docs(cloud/devicecontroller): add godoc comments to exported identifiers

### DIFF
--- a/cloud/pkg/devicecontroller/config/config.go
+++ b/cloud/pkg/devicecontroller/config/config.go
@@ -9,10 +9,13 @@ import (
 var Config Configure
 var once sync.Once
 
+// Configure holds the configuration for the devicecontroller module.
 type Configure struct {
 	v1alpha1.DeviceController
 }
 
+// InitConfigure initializes the global Config variable based on the provided
+// DeviceController configuration. It is safe to call multiple times.
 func InitConfigure(dc *v1alpha1.DeviceController) {
 	once.Do(func() {
 		Config = Configure{

--- a/cloud/pkg/devicecontroller/devicecontroller.go
+++ b/cloud/pkg/devicecontroller/devicecontroller.go
@@ -41,6 +41,8 @@ func newDeviceController(enable bool) *DeviceController {
 	}
 }
 
+// Register initializes the devicecontroller configuration and registers the
+// module to the core framework.
 func Register(dc *v1alpha1.DeviceController) {
 	config.InitConfigure(dc)
 	core.Register(newDeviceController(dc.Enable))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to exported identifiers in `cloud/pkg/devicecontroller/`:

- `Register` — documents module registration
- `Configure` (config.go) — documents the configuration struct
- `InitConfigure` (config.go) — documents the initialization logic

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
