### PR TITLE
router: fix EventBus/ServiceBus Forward ignoring GetContentData error

### DIFF
--- a/cloud/pkg/router/provider/eventbus/eventbus.go
+++ b/cloud/pkg/router/provider/eventbus/eventbus.go
@@ -103,7 +103,7 @@ func (*EventBus) Forward(target provider.Target, data interface{}) (response int
 	}
 	res := make(map[string]interface{})
 	content, err := message.GetContentData()
-	if !ok {
+	if err != nil {
 		klog.Errorf("get message %s content err: %v", message.GetID(), err)
 		return nil, fmt.Errorf("get message %s content err: %v", message.GetID(), err)
 	}

--- a/cloud/pkg/router/provider/eventbus/eventbus_test.go
+++ b/cloud/pkg/router/provider/eventbus/eventbus_test.go
@@ -263,3 +263,31 @@ func TestBuildAndLogError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "test-key")
 }
+
+// fakeTarget is a provider.Target that records the data it is given and always
+// succeeds, so any error returned by Forward can only come from extracting the
+// message content.
+type fakeTarget struct {
+	received map[string]interface{}
+}
+
+func (f *fakeTarget) Name() string { return "fake" }
+
+func (f *fakeTarget) GoToTarget(data map[string]interface{}, _ chan struct{}) (interface{}, error) {
+	f.received = data
+	return nil, nil
+}
+
+func TestForwardContentDataError(t *testing.T) {
+	eb := &EventBus{}
+	msg := model.NewMessage("")
+	// A channel value cannot be marshaled to JSON, so GetContentData returns an error.
+	msg.Content = make(chan int)
+
+	target := &fakeTarget{}
+	resp, err := eb.Forward(target, msg)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, target.received, "message should not be forwarded when its content cannot be extracted")
+}

--- a/cloud/pkg/router/provider/servicebus/servicebus.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus.go
@@ -89,7 +89,7 @@ func (sb *ServiceBus) Forward(target provider.Target, data interface{}) (respons
 	}
 	res := make(map[string]interface{})
 	content, err := message.GetContentData()
-	if !ok {
+	if err != nil {
 		klog.Errorf("get message %s content err: %v", message.GetID(), err)
 		return nil, fmt.Errorf("get message %s content err: %v", message.GetID(), err)
 	}

--- a/cloud/pkg/router/provider/servicebus/servicebus_test.go
+++ b/cloud/pkg/router/provider/servicebus/servicebus_test.go
@@ -1,0 +1,37 @@
+package servicebus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+)
+
+// fakeTarget is a provider.Target that records the data it is given and always
+// succeeds, so any error returned by Forward can only come from extracting the
+// message content.
+type fakeTarget struct {
+	received map[string]interface{}
+}
+
+func (f *fakeTarget) Name() string { return "fake" }
+
+func (f *fakeTarget) GoToTarget(data map[string]interface{}, _ chan struct{}) (interface{}, error) {
+	f.received = data
+	return nil, nil
+}
+
+func TestForwardContentDataError(t *testing.T) {
+	sb := &ServiceBus{}
+	msg := model.NewMessage("")
+	// A channel value cannot be marshaled to JSON, so GetContentData returns an error.
+	msg.Content = make(chan int)
+
+	target := &fakeTarget{}
+	resp, err := sb.Forward(target, msg)
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Nil(t, target.received, "message should not be forwarded when its content cannot be extracted")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`EventBus.Forward` and `ServiceBus.Forward` check the wrong variable after
extracting the message content. After `content, err := message.GetContentData()`,
the code checks `if !ok`, but `ok` is bound by the earlier
`data.(*model.Message)` type assertion and is never reassigned. So `if !ok` is
always false and the branch is unreachable: the error from `GetContentData()` is
discarded, and when content extraction fails an empty payload is forwarded to the
target while the call still reports success.

This changes the check to `if err != nil` in both providers, matching the pattern
already used by `Rest.Forward` (`cloud/pkg/router/provider/rest/rest.go:150`).
Regression tests are added for both `EventBus.Forward` and `ServiceBus.Forward`.

**Which issue(s) this PR fixes**:

Fixes #7083 

**Special notes for your reviewer**:

Scope is intentionally limited to the two Forward methods named in the issue. I
noticed `ServiceBus.GoToTarget` reuses `ok` across several type assertions in a
similar way; happy to address that in a separate PR if you'd like.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
