### PR TITLE
taskmanager: secure node upgrade task logs

### DIFF
--- a/edge/pkg/taskmanager/actions/nodeupgradejob.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/containers"
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
+	"github.com/kubeedge/kubeedge/pkg/nodetask/tasklog"
 	upgradeedge "github.com/kubeedge/kubeedge/pkg/upgrade/edge"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 	"github.com/kubeedge/kubeedge/pkg/util/validation"
@@ -81,6 +82,8 @@ type nodeUpgradeJobActionHandler struct {
 	backupFiles []string
 	logger      logr.Logger
 }
+
+var openNodeUpgradeJobLog = tasklog.OpenKeadmLog
 
 func (nodeUpgradeJobActionHandler) preRun(
 	_ctx context.Context,
@@ -242,7 +245,7 @@ func (h *nodeUpgradeJobActionHandler) backup(
 
 func (h *nodeUpgradeJobActionHandler) upgrade(
 	_ctx context.Context,
-	_jobname, _nodename string,
+	jobname, nodename string,
 	specser SpecSerializer,
 ) ActionResponse {
 	resp := new(nodeUpgradeJobActionResponse)
@@ -263,9 +266,9 @@ func (h *nodeUpgradeJobActionHandler) upgrade(
 		return resp
 	}
 
-	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	logFile, err := openNodeUpgradeJobLog(nodeUpgradeJobLogName("upgrade", jobname, nodename), os.O_APPEND)
 	if err != nil {
-		resp.err = fmt.Errorf("failed to open keadm log file: %w", err)
+		resp.err = err
 		resp.interrupt = true // No upgrade yet, no need to roll back.
 		return resp
 	}
@@ -291,16 +294,38 @@ func buildNodeUpgradeJobCommandArgs(spec *operationsv1alpha2.NodeUpgradeJobSpec)
 
 func (h *nodeUpgradeJobActionHandler) rollback(
 	_ctx context.Context,
-	_jobname, _nodename string,
+	jobname, nodename string,
 	specser SpecSerializer,
 ) ActionResponse {
 	resp := new(nodeUpgradeJobActionResponse)
-	// Roll back to the previous version
-	cmdline := "keadm rollback edge >> /tmp/keadm.log 2>&1"
-	cmd := execs.NewCommand(cmdline)
-	h.logger.V(2).Info("run rollback cmd", "cmd", cmdline)
-	resp.err = cmd.Exec()
+	logFile, err := openNodeUpgradeJobLog(nodeUpgradeJobLogName("rollback", jobname, nodename), os.O_APPEND)
+	if err != nil {
+		resp.err = err
+		return resp
+	}
+	defer logFile.Close()
+
+	args := []string{"rollback", "edge"}
+	cmd := exec.Command("keadm", args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	h.logger.V(2).Info("run rollback cmd", "cmd", "keadm", "args", args)
+	resp.err = cmd.Run()
 	return resp
+}
+
+func nodeUpgradeJobLogName(action, jobname, nodename string) string {
+	return fmt.Sprintf("keadm-%s-%s-%s.log",
+		tasklog.SafeName(action),
+		tasklog.SafeName(defaultLogNamePart(jobname)),
+		tasklog.SafeName(defaultLogNamePart(nodename)))
+}
+
+func defaultLogNamePart(part string) string {
+	if part == "" {
+		return "unknown"
+	}
+	return part
 }
 
 func (nodeUpgradeJobActionHandler) getSpecSerializer(specData []byte) (SpecSerializer, error) {

--- a/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob_test.go
@@ -19,6 +19,8 @@ package actions
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -35,6 +37,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
 	"github.com/kubeedge/kubeedge/pkg/containers"
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
+	"github.com/kubeedge/kubeedge/pkg/nodetask/tasklog"
 	upgradeedge "github.com/kubeedge/kubeedge/pkg/upgrade/edge"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 )
@@ -313,17 +316,33 @@ func TestNodeUpgradeJobRollback(t *testing.T) {
 		logger: klog.Background(),
 	}
 
-	patches := gomonkey.NewPatches()
-	defer patches.Reset()
+	binDir := t.TempDir()
+	logDir := t.TempDir()
+	keadmPath := filepath.Join(binDir, "keadm")
+	if err := os.WriteFile(keadmPath, []byte("#!/bin/sh\necho \"$@\"\n"), 0755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("PATH", binDir)
 
-	patches.ApplyMethod(reflect.TypeOf((*execs.Command)(nil)), "Exec",
-		func(cmd *execs.Command) error {
-			assert.Equal(t, "bash -c keadm rollback edge >> /tmp/keadm.log 2>&1", cmd.GetCommand())
-			return nil
-		})
+	oldOpenLog := openNodeUpgradeJobLog
+	t.Cleanup(func() {
+		openNodeUpgradeJobLog = oldOpenLog
+	})
+	openNodeUpgradeJobLog = func(name string, flag int) (*os.File, error) {
+		return tasklog.OpenKeadmLogAt(logDir, name, flag)
+	}
 
-	resp := h.rollback(ctx, "", "", specser)
+	resp := h.rollback(ctx, "job-1", "node-1", specser)
 	require.NoError(t, resp.Error())
+
+	got, err := os.ReadFile(filepath.Join(logDir, "keadm-rollback-job-1-node-1.log"))
+	require.NoError(t, err)
+	assert.Equal(t, "rollback edge\n", string(got))
+}
+
+func TestNodeUpgradeJobLogName(t *testing.T) {
+	assert.Equal(t, "keadm-upgrade-job_1-node_1.log", nodeUpgradeJobLogName("upgrade", "job 1", "node/1"))
+	assert.Equal(t, "keadm-rollback-unknown-unknown.log", nodeUpgradeJobLogName("rollback", "", ""))
 }
 
 func TestNodeUpgradeJobReportActionStatus(t *testing.T) {

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_rollback.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_rollback.go
@@ -18,6 +18,7 @@ package taskexecutor
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	"k8s.io/klog/v2"
@@ -56,17 +57,24 @@ func rollbackNode(taskReq commontypes.NodeTaskRequest) (event fsm.Event) {
 
 func rollback(upgradeReq *commontypes.NodeUpgradeJobRequest) error {
 	klog.Infof("Begin to run rollback command")
-	rollBackCmd := fmt.Sprintf("keadm rollback edge --name %s --history %s >> /tmp/keadm.log 2>&1",
-		upgradeReq.UpgradeID, version.Get())
+	logFile, err := openKeadmTaskLog(v1alpha1KeadmLogName("rollback", upgradeReq.UpgradeID, version.Get().String()), os.O_APPEND)
+	if err != nil {
+		return err
+	}
 
 	// run upgrade cmd to upgrade edge node
 	// use nohup command to start a child progress
-	command := fmt.Sprintf("nohup %s &", rollBackCmd)
-	cmd := exec.Command("bash", "-c", command)
-	s, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("run rollback command %s failed: %v, %s", command, err, s)
+	args := []string{"keadm", "rollback", "edge", "--name", upgradeReq.UpgradeID, "--history", version.Get().String()}
+	cmd := exec.Command("nohup", args...)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		if cerr := logFile.Close(); cerr != nil {
+			klog.Warningf("failed to close keadm rollback log file %s: %v", logFile.Name(), cerr)
+		}
+		return fmt.Errorf("failed to start keadm rollback command: %w", err)
 	}
+	go waitKeadmTaskCommand(cmd, logFile)
 	klog.Infof("!!! Finish rollback ")
 	return nil
 }

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
 	"github.com/kubeedge/kubeedge/pkg/containers"
+	"github.com/kubeedge/kubeedge/pkg/nodetask/tasklog"
 	"github.com/kubeedge/kubeedge/pkg/util/fsm"
 	"github.com/kubeedge/kubeedge/pkg/version"
 )
@@ -45,6 +46,8 @@ const (
 type Upgrade struct {
 	*BaseExecutor
 }
+
+var openKeadmTaskLog = tasklog.OpenKeadmLog
 
 func (u *Upgrade) Name() string {
 	return u.name
@@ -193,11 +196,10 @@ func upgrade(taskReq types.NodeTaskRequest) (event fsm.Event) {
 func keadmUpgrade(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) error {
 	klog.Infof("Begin to run upgrade command")
 
-	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	logFile, err := openKeadmTaskLog(v1alpha1KeadmLogName("upgrade", upgradeReq.UpgradeID, upgradeReq.HistoryID), os.O_TRUNC)
 	if err != nil {
-		return fmt.Errorf("failed to open keadm log file: %w", err)
+		return err
 	}
-	defer logFile.Close()
 
 	args := buildKeadmUpgradeArgs(upgradeReq, opts)
 
@@ -206,14 +208,42 @@ func keadmUpgrade(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.Ed
 	cmd.Stderr = logFile
 
 	if err := cmd.Start(); err != nil {
+		if cerr := logFile.Close(); cerr != nil {
+			klog.Warningf("failed to close keadm upgrade log file %s: %v", logFile.Name(), cerr)
+		}
 		return fmt.Errorf("failed to start keadm upgrade command: %w", err)
 	}
-	if err := cmd.Process.Release(); err != nil {
-		return fmt.Errorf("failed to release keadm upgrade process: %w", err)
-	}
+	go waitKeadmTaskCommand(cmd, logFile)
 
 	klog.Infof("Started keadm upgrade from Version %s to %s ...", version.Get().String(), upgradeReq.Version)
 	return nil
+}
+
+// waitKeadmTaskCommand reaps a detached keadm task process so it does not
+// linger as a zombie, and closes the log file once the process exits.
+func waitKeadmTaskCommand(cmd *exec.Cmd, logFile *os.File) {
+	defer func() {
+		if cerr := logFile.Close(); cerr != nil {
+			klog.Warningf("failed to close keadm task log file %s: %v", logFile.Name(), cerr)
+		}
+	}()
+	if err := cmd.Wait(); err != nil {
+		klog.Errorf("keadm task command %v failed: %v", cmd.Args, err)
+	}
+}
+
+func v1alpha1KeadmLogName(action, upgradeID, historyID string) string {
+	return fmt.Sprintf("keadm-%s-%s-%s.log",
+		tasklog.SafeName(action),
+		tasklog.SafeName(defaultKeadmLogNamePart(upgradeID)),
+		tasklog.SafeName(defaultKeadmLogNamePart(historyID)))
+}
+
+func defaultKeadmLogNamePart(part string) string {
+	if part == "" {
+		return "unknown"
+	}
+	return part
 }
 
 func buildKeadmUpgradeArgs(upgradeReq commontypes.NodeUpgradeJobRequest, opts *options.EdgeCoreOptions) []string {

--- a/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
+++ b/edge/pkg/taskmanager/v1alpha1/taskexecutor/node_upgrade_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package taskexecutor
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	commontypes "github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
+	"github.com/kubeedge/kubeedge/pkg/nodetask/tasklog"
 	"github.com/kubeedge/kubeedge/pkg/version"
 )
 
@@ -56,6 +59,14 @@ func TestBuildKeadmUpgradeArgsDoesNotUseShell(t *testing.T) {
 
 func TestKeadmUpgradeReturnsErrorWhenCommandMissing(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
+	logDir := t.TempDir()
+	oldOpenLog := openKeadmTaskLog
+	t.Cleanup(func() {
+		openKeadmTaskLog = oldOpenLog
+	})
+	openKeadmTaskLog = func(name string, flag int) (*os.File, error) {
+		return tasklog.OpenKeadmLogAt(logDir, name, flag)
+	}
 
 	err := keadmUpgrade(commontypes.NodeUpgradeJobRequest{
 		UpgradeID: "upgrade-1",
@@ -71,5 +82,53 @@ func TestKeadmUpgradeReturnsErrorWhenCommandMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to start keadm upgrade command") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestV1alpha1KeadmLogName(t *testing.T) {
+	got := v1alpha1KeadmLogName("upgrade", "upgrade 1", "history/1")
+	want := "keadm-upgrade-upgrade_1-history_1.log"
+	if got != want {
+		t.Fatalf("v1alpha1KeadmLogName() = %q, want %q", got, want)
+	}
+}
+
+func TestKeadmUpgradeWritesPrivateTaskLog(t *testing.T) {
+	binDir := t.TempDir()
+	logDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "nohup"), []byte("#!/bin/sh\n\"$@\"\n"), 0755); err != nil {
+		t.Fatalf("WriteFile(nohup) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "keadm"), []byte("#!/bin/sh\necho \"$@\"\n"), 0755); err != nil {
+		t.Fatalf("WriteFile(keadm) error = %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	oldOpenLog := openKeadmTaskLog
+	t.Cleanup(func() {
+		openKeadmTaskLog = oldOpenLog
+	})
+	openKeadmTaskLog = func(name string, flag int) (*os.File, error) {
+		return tasklog.OpenKeadmLogAt(logDir, name, flag)
+	}
+
+	err := keadmUpgrade(commontypes.NodeUpgradeJobRequest{
+		UpgradeID: "upgrade-1",
+		HistoryID: "history-1",
+		Version:   "v1.23.1",
+		Image:     "kubeedge/installation-package:v1.23.1",
+	}, &options.EdgeCoreOptions{
+		ConfigFile: "/etc/kubeedge/config/edgecore.yaml",
+	})
+	if err != nil {
+		t.Fatalf("keadmUpgrade() error = %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(logDir, "keadm-upgrade-upgrade-1-history-1.log"))
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("log mode = %o, want 0600", got)
 	}
 }

--- a/pkg/nodetask/tasklog/log.go
+++ b/pkg/nodetask/tasklog/log.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasklog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/kubeedge/api/apis/common/constants"
+)
+
+const (
+	dirMode  os.FileMode = 0750
+	fileMode os.FileMode = 0600
+)
+
+// OpenKeadmLog opens a Keadm task log in the KubeEdge-owned log directory.
+func OpenKeadmLog(name string, flag int) (*os.File, error) {
+	return OpenKeadmLogAt(constants.KubeEdgeLogPath, name, flag)
+}
+
+// OpenKeadmLogAt opens a Keadm task log under logDir.
+func OpenKeadmLogAt(logDir, name string, flag int) (*os.File, error) {
+	name = SafeName(name)
+	if name == "" || name == "." {
+		return nil, fmt.Errorf("invalid keadm log file name %q", name)
+	}
+	if err := os.MkdirAll(logDir, dirMode); err != nil {
+		return nil, fmt.Errorf("failed to create keadm log directory: %w", err)
+	}
+	// MkdirAll does not change the mode of a directory that already exists,
+	// so an existing dir created with permissive bits would otherwise stay that way.
+	if err := os.Chmod(logDir, dirMode); err != nil {
+		return nil, fmt.Errorf("failed to chmod keadm log directory: %w", err)
+	}
+
+	path := filepath.Join(logDir, name)
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refuse to open symlinked keadm log file %s", path)
+	} else if err == nil {
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("refuse to open non-regular keadm log file %s", path)
+		}
+		// os.OpenFile only applies fileMode when creating a new file, so an existing
+		// file with permissive bits needs an explicit chmod to be corrected.
+		if err := os.Chmod(path, fileMode); err != nil {
+			return nil, fmt.Errorf("failed to chmod keadm log file %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to inspect keadm log file %s: %w", path, err)
+	}
+
+	logFile, err := openFileNoFollow(path, os.O_CREATE|os.O_WRONLY|flag, fileMode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open keadm log file %s: %w", path, err)
+	}
+	return logFile, nil
+}
+
+// SafeName returns a path-safe filename component suitable for task log names.
+func SafeName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '.' || r == '-' || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return strings.Trim(b.String(), "._-")
+}

--- a/pkg/nodetask/tasklog/log_test.go
+++ b/pkg/nodetask/tasklog/log_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasklog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenKeadmLogAtCreatesPrivateLog(t *testing.T) {
+	dir := t.TempDir()
+	logFile, err := OpenKeadmLogAt(dir, "keadm-upgrade-job-1.log", os.O_TRUNC)
+	if err != nil {
+		t.Fatalf("OpenKeadmLogAt() error = %v", err)
+	}
+	if _, err := logFile.WriteString("test"); err != nil {
+		t.Fatalf("WriteString() error = %v", err)
+	}
+	if err := logFile.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "keadm-upgrade-job-1.log"))
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != fileMode {
+		t.Fatalf("log mode = %o, want %o", got, fileMode)
+	}
+}
+
+func TestOpenKeadmLogAtTightensExistingPermissions(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0777); err != nil {
+		t.Fatalf("Chmod(dir) error = %v", err)
+	}
+	name := "keadm-upgrade-job-1.log"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("stale"), 0666); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	logFile, err := OpenKeadmLogAt(dir, name, os.O_APPEND)
+	if err != nil {
+		t.Fatalf("OpenKeadmLogAt() error = %v", err)
+	}
+	if err := logFile.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat(dir) error = %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != dirMode {
+		t.Fatalf("existing dir mode = %o, want %o", got, dirMode)
+	}
+
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(file) error = %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != fileMode {
+		t.Fatalf("existing file mode = %o, want %o", got, fileMode)
+	}
+}
+
+func TestOpenKeadmLogAtRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("target"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	link := filepath.Join(dir, "keadm-upgrade-job-1.log")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	logFile, err := OpenKeadmLogAt(dir, filepath.Base(link), os.O_APPEND)
+	if err == nil {
+		_ = logFile.Close()
+		t.Fatal("OpenKeadmLogAt() succeeded for a symlink")
+	}
+}
+
+func TestOpenKeadmLogAtRejectsNonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	name := "keadm-upgrade-job-1.log"
+	subdir := filepath.Join(dir, name)
+	if err := os.Mkdir(subdir, 0700); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+
+	logFile, err := OpenKeadmLogAt(dir, name, os.O_APPEND)
+	if err == nil {
+		_ = logFile.Close()
+		t.Fatal("OpenKeadmLogAt() succeeded for a directory")
+	}
+}
+
+func TestSafeName(t *testing.T) {
+	got := SafeName("../job/upgrade 1:$history.log")
+	want := "job_upgrade_1__history.log"
+	if got != want {
+		t.Fatalf("SafeName() = %q, want %q", got, want)
+	}
+}

--- a/pkg/nodetask/tasklog/log_unix.go
+++ b/pkg/nodetask/tasklog/log_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasklog
+
+import (
+	"os"
+	"syscall"
+)
+
+func openFileNoFollow(path string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, flag|syscall.O_NOFOLLOW, perm)
+}

--- a/pkg/nodetask/tasklog/log_windows.go
+++ b/pkg/nodetask/tasklog/log_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasklog
+
+import "os"
+
+func openFileNoFollow(path string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(path, flag, perm)
+}


### PR DESCRIPTION
## Summary
- Move keadm upgrade and rollback logs from the shared `/tmp/keadm.log` path to private KubeEdge log files.
- Add symlink rejection and restrictive log file permissions for node task logs.

## Linked Issue
Fixes #7097

## What Changed
- Added `pkg/nodetask/tasklog` for safe Keadm task log creation under `constants.KubeEdgeLogPath`.
- Updated v1alpha1 and v1alpha2 node upgrade/rollback paths to use per-task log filenames.
- Replaced rollback shell redirection to `/tmp/keadm.log` with explicit command argv and attached stdout/stderr.
- Added focused regression tests for private log creation, symlink rejection, log naming, and changed upgrade/rollback paths.

## Verification
- `go test ./pkg/nodetask/tasklog` — passed
- `go test ./edge/pkg/taskmanager/actions -run '^(TestNodeUpgradeJobUpgrade|TestNodeUpgradeJobRollback|TestNodeUpgradeJobLogName)$'` — passed\n- `go test ./edge/pkg/taskmanager/v1alpha1/taskexecutor` — passed\n- `go test ./pkg/nodetask/tasklog ./edge/pkg/taskmanager/v1alpha1/taskexecutor ./edge/pkg/taskmanager/actions -run '^(TestOpenKeadmLogAt|TestSafeName|TestBuildKeadmUpgradeArgsDoesNotUseShell|TestKeadmUpgradeReturnsErrorWhenCommandMissing|TestV1alpha1KeadmLogName|TestKeadmUpgradeWritesPrivateTaskLog|TestNodeUpgradeJobUpgrade|TestNodeUpgradeJobRollback|TestNodeUpgradeJobLogName)$'` — passed\n- `make verify` — passed\n- `make lint` — not completed: installed required `golangci-lint` v1.64.5 and passed whitespace checking after staging intended files, but the root `golangci-lint` process hung after reporting 12m execution time and was interrupted.\n- `PATH="$HOME/go/bin:$PATH" golangci-lint run --timeout=3m ./pkg/nodetask/tasklog ./edge/pkg/taskmanager/actions ./edge/pkg/taskmanager/v1alpha1/taskexecutor` — not completed: focused lint also hung past the requested timeout and was interrupted.\n- `make edge_test` — not run: target is not defined in this Makefile.\n- `make test WHAT=edge` — failed: unrelated existing/local failures in `edge/pkg/metamanager/client` runtime crash and `edge/pkg/taskmanager/actions` imageprepull/pre-check tests; changed `taskexecutor` package passed in this run.\n- `make edge_integration_test` — not run: target is not defined in this Makefile.\n- `make integrationtest WHAT=edge` — failed: local environment lacks passwordless `sudo` and `pidof`; `edgecore` build step completed before script failure.\n\n## Scope\n- Only node upgrade task log handling and focused tests were changed; unrelated files, audit files, and issue-list files were not modified.\n\n**What type of PR is this?**\n/kind bug\n\n**What this PR does / why we need it**:\nKeadm upgrade and rollback task output should not use a predictable shared log file in `/tmp`. This change writes task logs under the KubeEdge log directory with restrictive permissions and isolated task-specific filenames, and rejects symlinked log paths.\n\n**Which issue(s) this PR fixes**:\nFixes #7097\n\n**Special notes for your reviewer**:\nThe broader edge test and integration targets were attempted locally. Failures were outside the changed code path or due to local macOS environment prerequisites, as listed in Verification.\n\n**Does this PR introduce a user-facing change?**:\n```release-note\nKubeEdge now writes node upgrade and rollback keadm task logs to private per-task files under the KubeEdge log directory instead of a shared `/tmp/keadm.log` path.\n```