### PR TITLE
docs(cloud/synccontroller): add godoc comments to exported identifiers

### DIFF
--- a/cloud/pkg/synccontroller/config/config.go
+++ b/cloud/pkg/synccontroller/config/config.go
@@ -9,10 +9,13 @@ import (
 var Config Configure
 var once sync.Once
 
+// Configure holds the configuration for the synccontroller module.
 type Configure struct {
 	SyncController *configv1alpha1.SyncController
 }
 
+// InitConfigure initializes the global Config variable based on the provided
+// SyncController configuration. It is safe to call multiple times.
 func InitConfigure(sc *configv1alpha1.SyncController) {
 	once.Do(func() {
 		Config = Configure{

--- a/cloud/pkg/synccontroller/synccontroller.go
+++ b/cloud/pkg/synccontroller/synccontroller.go
@@ -89,6 +89,8 @@ func newSyncController(enable bool) *SyncController {
 	return sctl
 }
 
+// Register initializes the synccontroller configuration and registers the
+// module to the core framework.
 func Register(ec *configv1alpha1.SyncController) {
 	config.InitConfigure(ec)
 	core.Register(newSyncController(ec.Enable))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to exported identifiers in `cloud/pkg/synccontroller/`:

- `Register` — documents module registration
- `Configure` (config.go) — documents the configuration struct
- `InitConfigure` (config.go) — documents the initialization logic

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
