### PR TITLE
docs(cloud/csidriver): add godoc comments to exported identifiers

### DIFF
--- a/cloud/pkg/csidriver/server.go
+++ b/cloud/pkg/csidriver/server.go
@@ -24,6 +24,8 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/cmd/csidriver/app/options"
 )
 
+// CSIDriver implements the CSI driver server components, handling both
+// identity and controller GRPC endpoints.
 type CSIDriver struct {
 	options.CSIDriverOptions
 
@@ -31,6 +33,8 @@ type CSIDriver struct {
 	cs  *controllerServer
 }
 
+// NewCSIDriver creates a new CSIDriver with the given options. It validates
+// that all required endpoint and identification fields are provided.
 func NewCSIDriver(opts *options.CSIDriverOptions) (*CSIDriver, error) {
 	if opts.Endpoint == "" {
 		return nil, fmt.Errorf("no driver endpoint provided")
@@ -52,6 +56,8 @@ func NewCSIDriver(opts *options.CSIDriverOptions) (*CSIDriver, error) {
 	}, nil
 }
 
+// Run starts the GRPC servers for the CSI driver (identity and controller)
+// and blocks until they finish.
 func (cd *CSIDriver) Run() {
 	klog.Infof("driver information: %v", cd)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to exported identifiers in `cloud/pkg/csidriver/`:

- `CSIDriver` — documents the server component struct
- `NewCSIDriver` — documents the initialization and validation logic
- `Run` — documents the GRPC server startup behavior

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
