### PR TITLE
dynamiccontroller: avoid EndpointSlice filter panic when nodeName is omitted

### DIFF
--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
@@ -89,6 +89,9 @@ func filterEndpointSlice(targetNode string, obj runtime.Object) {
 	}
 	var epsTmp []discovery.Endpoint
 	for _, ep := range epSlice.Endpoints {
+		if ep.NodeName == nil {
+			continue
+		}
 		if filter.IsBelongToSameGroup(targetNode, *ep.NodeName) {
 			epsTmp = append(epsTmp, ep)
 		}

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
@@ -198,6 +198,10 @@ func TestFilterEndpointSlice(t *testing.T) {
 				Addresses: []string{"192.168.1.2"},
 				NodeName:  &n2,
 			},
+			{
+				Addresses: []string{"192.168.1.3"},
+				NodeName:  nil,
+			},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds a nil check for endpoint `NodeName` in `filterEndpointSlice` before dereferencing `*ep.NodeName`. In `cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go`, `ep.NodeName` was dereferenced directly as `*ep.NodeName` without checking for `nil`. When processing `EndpointSlice` updates containing unassigned or transitioning endpoints where `NodeName` is `nil` (e.g. during pod updates or restarts), this caused nil pointer dereference panics in `filterEndpointSlice`, dropping the `EndpointSlice` event and preventing updated endpoint IPs from reaching edge nodes.

#### Which issue(s) this PR fixes:

Fixes #6464

#### Special notes for your reviewer:

Targeted unit test verification completed:
```bash
go test -v ./cloud/pkg/dynamiccontroller/filter/endpointresource/...
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
