### PR TITLE
docs(cloud/controllermanager): add godoc comments to exported identifiers

### DIFF
--- a/cloud/cmd/controllermanager/app/controllermanager.go
+++ b/cloud/cmd/controllermanager/app/controllermanager.go
@@ -19,6 +19,8 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/version/verflag"
 )
 
+// NewControllerManagerCommand creates a *cobra.Command object with default
+// parameters and registry setup.
 func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	log.SetLogger(klog.FromContext(ctx))
 	opts := options.NewControllerManagerOptions()

--- a/cloud/cmd/controllermanager/app/options/options.go
+++ b/cloud/cmd/controllermanager/app/options/options.go
@@ -4,12 +4,15 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 )
 
+// ControllerManagerOptions holds the configuration for the controller manager.
 type ControllerManagerOptions struct {
 	UseServerSideApply     bool
 	HealthProbeBindAddress string
 	FeatureGates           []string
 }
 
+// NewControllerManagerOptions creates a new ControllerManagerOptions with
+// default configuration values.
 func NewControllerManagerOptions() *ControllerManagerOptions {
 	return &ControllerManagerOptions{}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to exported identifiers in `cloud/cmd/controllermanager/`:

- `NewControllerManagerCommand`
- `ControllerManagerOptions` (options.go)
- `NewControllerManagerOptions` (options.go)

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
