### PR TITLE
docs(pkg/jsonpatch): add godoc comments to exported identifiers

### DIFF
--- a/pkg/jsonpatch/jsonpatch.go
+++ b/pkg/jsonpatch/jsonpatch.go
@@ -28,6 +28,7 @@ const (
 	OpReplace Operation = "replace"
 )
 
+// Operation represents a single JSON patch operation type (e.g., add, remove, replace).
 type Operation string
 
 // Items maps the json expression of jsonpatch.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds missing godoc comments to exported identifiers in `pkg/jsonpatch/`:

- `Operation`

No logic is changed; this is a pure documentation improvement that makes `go doc` and IDE hover docs accurate.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
All comments follow the Go convention of starting with the exported identifier name.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
