### PR TITLE
edgecore, keadm: hot reload heartbeat and remoteQueryTimeout without a restart

### DIFF
--- a/edge/cmd/edgecore/app/server.go
+++ b/edge/cmd/edgecore/app/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/validation"
 	"github.com/kubeedge/beehive/pkg/core"
 	"github.com/kubeedge/kubeedge/edge/cmd/edgecore/app/options"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/hotreload"
 	"github.com/kubeedge/kubeedge/edge/pkg/devicetwin"
 	"github.com/kubeedge/kubeedge/edge/pkg/edged"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub"
@@ -133,6 +134,10 @@ offering HTTP client capabilities to components of cloud to reach HTTP servers r
 			}
 
 			registerModules(config)
+
+			// Watch for a hot reload signal so a subset of the configuration
+			// can be updated without restarting edgecore.
+			hotreload.Watch(opts.ConfigFile)
 
 			// start all modules
 			core.Run()

--- a/edge/pkg/common/hotreload/hotreload.go
+++ b/edge/pkg/common/hotreload/hotreload.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hotreload lets edgecore pick up a small set of configuration
+// fields from disk while it is running, instead of requiring a full
+// restart. Only fields that every module already reads fresh on each use
+// (e.g. from a package level Configure value) are eligible, so applying
+// them cannot leave a module running with half of an old configuration and
+// half of a new one.
+package hotreload
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	edgehubconfig "github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
+	metamanagerconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/config"
+)
+
+// Watch starts a goroutine that reloads the fields listed above from
+// configFile whenever edgecore receives SIGHUP. keadm's `config-update`
+// command sends this signal after writing a new config file, provided every
+// field being changed is safe to hot reload; otherwise it restarts edgecore
+// as before.
+func Watch(configFile string) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGHUP)
+	go func() {
+		for range sigChan {
+			reload(configFile)
+		}
+	}()
+}
+
+// reload re-reads configFile and applies the subset of fields that support
+// hot reload. Any other field change in the file is ignored here: it only
+// takes effect on the next full edgecore start, since keadm already
+// restarts edgecore whenever a non-hot-reloadable field is updated.
+func reload(configFile string) {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		klog.Errorf("hot reload: failed to read config file %s: %v", configFile, err)
+		return
+	}
+
+	cfg := &v1alpha2.EdgeCoreConfig{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		klog.Errorf("hot reload: failed to parse config file %s: %v", configFile, err)
+		return
+	}
+
+	if cfg.Modules == nil {
+		klog.Errorf("hot reload: config file %s has no modules section", configFile)
+		return
+	}
+
+	if eh := cfg.Modules.EdgeHub; eh != nil {
+		if eh.Heartbeat != edgehubconfig.GetHeartbeat() {
+			edgehubconfig.SetHeartbeat(eh.Heartbeat)
+			klog.Infof("hot reload: edgehub heartbeat updated to %ds", eh.Heartbeat)
+		}
+	}
+
+	if mm := cfg.Modules.MetaManager; mm != nil {
+		if mm.RemoteQueryTimeout != metamanagerconfig.GetRemoteQueryTimeout() {
+			metamanagerconfig.SetRemoteQueryTimeout(mm.RemoteQueryTimeout)
+			klog.Infof("hot reload: metamanager remoteQueryTimeout updated to %ds", mm.RemoteQueryTimeout)
+		}
+	}
+}

--- a/edge/pkg/common/hotreload/hotreload_test.go
+++ b/edge/pkg/common/hotreload/hotreload_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hotreload
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	edgehubconfig "github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
+	metamanagerconfig "github.com/kubeedge/kubeedge/edge/pkg/metamanager/config"
+)
+
+func TestReload(t *testing.T) {
+	edgehubconfig.InitConfigure(&v1alpha2.EdgeHub{
+		Heartbeat: 15,
+		WebSocket: &v1alpha2.EdgeHubWebSocket{Server: "test-server"},
+	}, "test-node")
+	metamanagerconfig.InitConfigure(&v1alpha2.MetaManager{
+		RemoteQueryTimeout: 60,
+		MetaServer:         &v1alpha2.MetaServer{},
+	})
+
+	configFile := filepath.Join(t.TempDir(), "edgecore.yaml")
+	const content = `
+modules:
+  edgeHub:
+    heartbeat: 45
+  metaManager:
+    remoteQueryTimeout: 120
+`
+	if err := os.WriteFile(configFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config file: %v", err)
+	}
+
+	reload(configFile)
+
+	if got := edgehubconfig.GetHeartbeat(); got != 45 {
+		t.Errorf("GetHeartbeat() = %d, want 45", got)
+	}
+	if got := metamanagerconfig.GetRemoteQueryTimeout(); got != 120 {
+		t.Errorf("GetRemoteQueryTimeout() = %d, want 120", got)
+	}
+}
+
+func TestReloadMissingFile(t *testing.T) {
+	// reload must not panic when the config file cannot be read.
+	reload(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+}
+
+func TestReloadNoModulesSection(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "edgecore.yaml")
+	if err := os.WriteFile(configFile, []byte("edgecoreVersion: v1.0.0\n"), 0644); err != nil {
+		t.Fatalf("failed to write test config file: %v", err)
+	}
+
+	// reload must not panic when the modules section is absent.
+	reload(configFile)
+}

--- a/edge/pkg/edgehub/config/config.go
+++ b/edge/pkg/edgehub/config/config.go
@@ -10,6 +10,11 @@ import (
 var Config Configure
 var once sync.Once
 
+// heartbeatMu guards Heartbeat since it can be updated at runtime by a
+// configuration hot reload while the heartbeat loop in process.go reads it
+// concurrently.
+var heartbeatMu sync.RWMutex
+
 type Configure struct {
 	v1alpha2.EdgeHub
 	WebSocketURL string
@@ -24,4 +29,20 @@ func InitConfigure(eh *v1alpha2.EdgeHub, nodeName string) {
 			NodeName:     nodeName,
 		}
 	})
+}
+
+// GetHeartbeat returns the current heartbeat interval in seconds.
+func GetHeartbeat() int32 {
+	heartbeatMu.RLock()
+	defer heartbeatMu.RUnlock()
+	return Config.Heartbeat
+}
+
+// SetHeartbeat updates the heartbeat interval in seconds. It is safe to call
+// while the edgehub module is running, allowing the value to be hot reloaded
+// without restarting edgecore.
+func SetHeartbeat(heartbeat int32) {
+	heartbeatMu.Lock()
+	defer heartbeatMu.Unlock()
+	Config.Heartbeat = heartbeat
 }

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -112,7 +112,7 @@ func (eh *EdgeHub) Start() {
 			return
 		}
 
-		waitTime := time.Duration(config.Config.Heartbeat) * time.Second * 2
+		waitTime := time.Duration(config.GetHeartbeat()) * time.Second * 2
 
 		err = eh.chClient.Init()
 		if err != nil {

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -123,7 +123,7 @@ func (eh *EdgeHub) keepalive() {
 			return
 		}
 
-		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second)
+		time.Sleep(time.Duration(config.GetHeartbeat()) * time.Second)
 	}
 }
 

--- a/edge/pkg/metamanager/config/config.go
+++ b/edge/pkg/metamanager/config/config.go
@@ -10,6 +10,11 @@ import (
 var Config Configure
 var once sync.Once
 
+// remoteQueryTimeoutMu guards RemoteQueryTimeout since it can be updated at
+// runtime by a configuration hot reload while process.go reads it
+// concurrently for each remote query.
+var remoteQueryTimeoutMu sync.RWMutex
+
 type Configure struct {
 	v1alpha2.MetaManager
 }
@@ -21,4 +26,20 @@ func InitConfigure(m *v1alpha2.MetaManager) {
 		}
 		metaserverconfig.InitConfigure(Config.MetaManager.MetaServer)
 	})
+}
+
+// GetRemoteQueryTimeout returns the current remote query timeout in seconds.
+func GetRemoteQueryTimeout() int32 {
+	remoteQueryTimeoutMu.RLock()
+	defer remoteQueryTimeoutMu.RUnlock()
+	return Config.RemoteQueryTimeout
+}
+
+// SetRemoteQueryTimeout updates the remote query timeout in seconds. It is
+// safe to call while the metamanager module is running, allowing the value
+// to be hot reloaded without restarting edgecore.
+func SetRemoteQueryTimeout(timeout int32) {
+	remoteQueryTimeoutMu.Lock()
+	defer remoteQueryTimeoutMu.Unlock()
+	Config.RemoteQueryTimeout = timeout
 }

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -371,7 +371,7 @@ func (m *metaManager) processRemote(message model.Message) {
 		resp, err := beehiveContext.SendSync(
 			string(metaManagerConfig.Config.ContextSendModule),
 			message,
-			time.Duration(metaManagerConfig.Config.RemoteQueryTimeout)*time.Second)
+			time.Duration(metaManagerConfig.GetRemoteQueryTimeout())*time.Second)
 		if err != nil {
 			klog.Errorf("process remote failed, req[%s], err: %v", msgDebugInfo(&message), err)
 			feedbackError(fmt.Errorf("failed to process remote: %s", err), message)

--- a/keadm/cmd/keadm/app/cmd/edge/configupdate.go
+++ b/keadm/cmd/keadm/app/cmd/edge/configupdate.go
@@ -122,18 +122,22 @@ func (executor *configUpdateExecutor) configUpdate(opts ConfigUpdateOptions) err
 		if werr := writeFile(opts.Config, data); werr != nil {
 			klog.Errorf("failed to restore the previous edgecore config: %v", werr)
 		}
-		if rerr := execs.NewCommand("sudo systemctl restart edgecore.service").Exec(); rerr != nil {
+		if rerr := restartEdgeCore(); rerr != nil {
 			return fmt.Errorf("edgecore did not stay healthy after the hot reload and failed to restart during rollback: %v", rerr)
 		}
 		return fmt.Errorf("edgecore did not stay healthy after the hot reload; rolled back to the previous configuration: %v", reloadErr)
 	}
 
-	cmd := execs.NewCommand("sudo systemctl restart edgecore.service")
-	err = cmd.Exec()
-	if err != nil {
+	if err = restartEdgeCore(); err != nil {
 		return fmt.Errorf("failed restart edgecore %v", err)
 	}
 	return nil
+}
+
+// restartEdgeCore is a var, rather than a plain function, so tests can stub
+// it out instead of restarting a real edgecore.service.
+var restartEdgeCore = func() error {
+	return execs.NewCommand("sudo systemctl restart edgecore.service").Exec()
 }
 
 func writeFile(filename string, data []byte) error {

--- a/keadm/cmd/keadm/app/cmd/edge/configupdate.go
+++ b/keadm/cmd/keadm/app/cmd/edge/configupdate.go
@@ -111,6 +111,23 @@ func (executor *configUpdateExecutor) configUpdate(opts ConfigUpdateOptions) err
 		return err
 	}
 
+	if isHotReloadable(opts.Sets) {
+		reloadErr := hotReload()
+		if reloadErr == nil {
+			klog.Infof("edgecore configuration updated without a restart")
+			return nil
+		}
+
+		klog.Warningf("edgecore did not stay healthy after the hot reload, rolling back: %v", reloadErr)
+		if werr := writeFile(opts.Config, data); werr != nil {
+			klog.Errorf("failed to restore the previous edgecore config: %v", werr)
+		}
+		if rerr := execs.NewCommand("sudo systemctl restart edgecore.service").Exec(); rerr != nil {
+			return fmt.Errorf("edgecore did not stay healthy after the hot reload and failed to restart during rollback: %v", rerr)
+		}
+		return fmt.Errorf("edgecore did not stay healthy after the hot reload; rolled back to the previous configuration: %v", reloadErr)
+	}
+
 	cmd := execs.NewCommand("sudo systemctl restart edgecore.service")
 	err = cmd.Exec()
 	if err != nil {

--- a/keadm/cmd/keadm/app/cmd/edge/configupdate_test.go
+++ b/keadm/cmd/keadm/app/cmd/edge/configupdate_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edge
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+)
+
+func writeTestEdgeCoreConfig(t *testing.T) string {
+	t.Helper()
+
+	configFile := filepath.Join(t.TempDir(), "edgecore.yaml")
+	if err := v1alpha2.NewDefaultEdgeCoreConfig().WriteTo(configFile); err != nil {
+		t.Fatalf("failed to write test edgecore config: %v", err)
+	}
+	return configFile
+}
+
+func stubRestartEdgeCore(t *testing.T, fn func() error) *int {
+	t.Helper()
+
+	orig := restartEdgeCore
+	calls := 0
+	restartEdgeCore = func() error {
+		calls++
+		return fn()
+	}
+	t.Cleanup(func() { restartEdgeCore = orig })
+	return &calls
+}
+
+func TestConfigUpdate(t *testing.T) {
+	t.Run("non hot reloadable field restarts edgecore", func(t *testing.T) {
+		configFile := writeTestEdgeCoreConfig(t)
+		restarts := stubRestartEdgeCore(t, func() error { return nil })
+
+		executor := newConfigUpdateExecutor()
+		opts := ConfigUpdateOptions{
+			BaseOptions: BaseOptions{Config: configFile},
+			Sets:        "modules.edgeHub.websocket.server=example.com:10000",
+		}
+
+		if err := executor.configUpdate(opts); err != nil {
+			t.Fatalf("configUpdate() = %v, want nil", err)
+		}
+		if *restarts != 1 {
+			t.Errorf("restartEdgeCore called %d times, want 1", *restarts)
+		}
+	})
+
+	t.Run("restart failure is surfaced", func(t *testing.T) {
+		configFile := writeTestEdgeCoreConfig(t)
+		stubRestartEdgeCore(t, func() error { return errors.New("systemctl: unit not found") })
+
+		executor := newConfigUpdateExecutor()
+		opts := ConfigUpdateOptions{
+			BaseOptions: BaseOptions{Config: configFile},
+			Sets:        "modules.edgeHub.websocket.server=example.com:10000",
+		}
+
+		if err := executor.configUpdate(opts); err == nil {
+			t.Fatal("configUpdate() = nil, want an error when the restart fails")
+		}
+	})
+
+	t.Run("hot reloadable field skips the restart", func(t *testing.T) {
+		configFile := writeTestEdgeCoreConfig(t)
+		restarts := stubRestartEdgeCore(t, func() error { return nil })
+
+		origSignal, origState := signalEdgeCoreReload, edgeCoreServiceState
+		origWindow, origPoll := hotReloadHealthWindow, hotReloadHealthPoll
+		t.Cleanup(func() {
+			signalEdgeCoreReload, edgeCoreServiceState = origSignal, origState
+			hotReloadHealthWindow, hotReloadHealthPoll = origWindow, origPoll
+		})
+		signalEdgeCoreReload = func() error { return nil }
+		edgeCoreServiceState = func() (string, error) { return "active", nil }
+		hotReloadHealthWindow = 3 * time.Millisecond
+		hotReloadHealthPoll = time.Millisecond
+
+		executor := newConfigUpdateExecutor()
+		opts := ConfigUpdateOptions{
+			BaseOptions: BaseOptions{Config: configFile},
+			Sets:        "modules.edgeHub.heartbeat=45",
+		}
+
+		if err := executor.configUpdate(opts); err != nil {
+			t.Fatalf("configUpdate() = %v, want nil", err)
+		}
+		if *restarts != 0 {
+			t.Errorf("restartEdgeCore called %d times, want 0 when the hot reload stays healthy", *restarts)
+		}
+	})
+
+	t.Run("unhealthy hot reload rolls back and restarts", func(t *testing.T) {
+		configFile := writeTestEdgeCoreConfig(t)
+		before, err := os.ReadFile(configFile)
+		if err != nil {
+			t.Fatalf("failed to read the config file before the update: %v", err)
+		}
+
+		restarts := stubRestartEdgeCore(t, func() error { return nil })
+
+		origSignal, origState := signalEdgeCoreReload, edgeCoreServiceState
+		origWindow, origPoll := hotReloadHealthWindow, hotReloadHealthPoll
+		t.Cleanup(func() {
+			signalEdgeCoreReload, edgeCoreServiceState = origSignal, origState
+			hotReloadHealthWindow, hotReloadHealthPoll = origWindow, origPoll
+		})
+		signalEdgeCoreReload = func() error { return nil }
+		edgeCoreServiceState = func() (string, error) { return "failed", nil }
+		hotReloadHealthWindow = 3 * time.Millisecond
+		hotReloadHealthPoll = time.Millisecond
+
+		executor := newConfigUpdateExecutor()
+		opts := ConfigUpdateOptions{
+			BaseOptions: BaseOptions{Config: configFile},
+			Sets:        "modules.edgeHub.heartbeat=45",
+		}
+
+		if err := executor.configUpdate(opts); err == nil {
+			t.Fatal("configUpdate() = nil, want an error when edgecore is unhealthy after the hot reload")
+		}
+		if *restarts != 1 {
+			t.Errorf("restartEdgeCore called %d times, want 1 during rollback", *restarts)
+		}
+
+		after, err := os.ReadFile(configFile)
+		if err != nil {
+			t.Fatalf("failed to read the config file after the rollback: %v", err)
+		}
+		if string(after) != string(before) {
+			t.Error("config file was not restored to its previous contents after a failed hot reload")
+		}
+	})
+}

--- a/keadm/cmd/keadm/app/cmd/edge/configupdate_test.go
+++ b/keadm/cmd/keadm/app/cmd/edge/configupdate_test.go
@@ -29,8 +29,14 @@ import (
 func writeTestEdgeCoreConfig(t *testing.T) string {
 	t.Helper()
 
-	configFile := filepath.Join(t.TempDir(), "edgecore.yaml")
-	if err := v1alpha2.NewDefaultEdgeCoreConfig().WriteTo(configFile); err != nil {
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "edgecore.yaml")
+	cfg := v1alpha2.NewDefaultEdgeCoreConfig()
+	// Point DataSource at a writable temp path: validation creates this
+	// directory if it doesn't exist, and the default /var/lib/kubeedge is
+	// not writable in a CI container.
+	cfg.DataBase.DataSource = filepath.Join(dir, "edgecore.db")
+	if err := cfg.WriteTo(configFile); err != nil {
 		t.Fatalf("failed to write test edgecore config: %v", err)
 	}
 	return configFile
@@ -94,7 +100,7 @@ func TestConfigUpdate(t *testing.T) {
 			hotReloadHealthWindow, hotReloadHealthPoll = origWindow, origPoll
 		})
 		signalEdgeCoreReload = func() error { return nil }
-		edgeCoreServiceState = func() (string, error) { return "active", nil }
+		edgeCoreServiceState = func() (string, error) { return systemctlActiveState, nil }
 		hotReloadHealthWindow = 3 * time.Millisecond
 		hotReloadHealthPoll = time.Millisecond
 

--- a/keadm/cmd/keadm/app/cmd/edge/hotreload.go
+++ b/keadm/cmd/keadm/app/cmd/edge/hotreload.go
@@ -23,13 +23,28 @@ import (
 	"time"
 )
 
-const (
-	edgeCoreService = "edgecore.service"
+const edgeCoreService = "edgecore.service"
 
-	// hotReloadHealthWindow is how long we watch edgecore after a hot reload
-	// signal before declaring the new configuration healthy.
+// hotReloadHealthWindow is how long we watch edgecore after a hot reload
+// signal before declaring the new configuration healthy, and
+// hotReloadHealthPoll is how often we check during that window. Both are
+// vars, rather than consts, so tests can shrink them.
+var (
 	hotReloadHealthWindow = 10 * time.Second
 	hotReloadHealthPoll   = time.Second
+)
+
+// signalEdgeCoreReload and edgeCoreServiceState are indirections over the
+// systemctl calls hotReload makes, so tests can exercise its retry and
+// rollback logic without spawning real processes.
+var (
+	signalEdgeCoreReload = func() error {
+		return exec.Command("sudo", "systemctl", "kill", "-s", "HUP", edgeCoreService).Run()
+	}
+	edgeCoreServiceState = func() (string, error) {
+		out, err := exec.Command("systemctl", "is-active", edgeCoreService).Output()
+		return strings.TrimSpace(string(out)), err
+	}
 )
 
 // hotReloadableFields lists the dotted config keys, matched case
@@ -72,7 +87,7 @@ func isHotReloadable(sets string) bool {
 // stayed healthy. The caller is expected to roll back and fall back to a
 // full restart when hotReload returns an error.
 func hotReload() error {
-	if err := exec.Command("sudo", "systemctl", "kill", "-s", "HUP", edgeCoreService).Run(); err != nil {
+	if err := signalEdgeCoreReload(); err != nil {
 		return fmt.Errorf("failed to signal edgecore to reload configuration: %v", err)
 	}
 
@@ -88,9 +103,9 @@ func hotReload() error {
 
 // edgeCoreActive reports whether edgecore.service is currently active.
 func edgeCoreActive() bool {
-	out, err := exec.Command("systemctl", "is-active", edgeCoreService).Output()
+	state, err := edgeCoreServiceState()
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(string(out)) == "active"
+	return state == "active"
 }

--- a/keadm/cmd/keadm/app/cmd/edge/hotreload.go
+++ b/keadm/cmd/keadm/app/cmd/edge/hotreload.go
@@ -23,7 +23,13 @@ import (
 	"time"
 )
 
-const edgeCoreService = "edgecore.service"
+const (
+	edgeCoreService = "edgecore.service"
+
+	// systemctlActiveState is the "systemctl is-active" output for a running
+	// service.
+	systemctlActiveState = "active"
+)
 
 // hotReloadHealthWindow is how long we watch edgecore after a hot reload
 // signal before declaring the new configuration healthy, and
@@ -107,5 +113,5 @@ func edgeCoreActive() bool {
 	if err != nil {
 		return false
 	}
-	return state == "active"
+	return state == systemctlActiveState
 }

--- a/keadm/cmd/keadm/app/cmd/edge/hotreload.go
+++ b/keadm/cmd/keadm/app/cmd/edge/hotreload.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edge
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	edgeCoreService = "edgecore.service"
+
+	// hotReloadHealthWindow is how long we watch edgecore after a hot reload
+	// signal before declaring the new configuration healthy.
+	hotReloadHealthWindow = 10 * time.Second
+	hotReloadHealthPoll   = time.Second
+)
+
+// hotReloadableFields lists the dotted config keys, matched case
+// insensitively, that edgecore already reads fresh from memory on every use.
+// Applying only fields from this set never requires restarting edgecore, so
+// keadm can signal a reload instead of restarting the process.
+//
+// A field only belongs on this list once the corresponding module has been
+// verified to re-read it on every use rather than caching it once at
+// startup; anything else keeps going through the regular restart path.
+var hotReloadableFields = map[string]bool{
+	"modules.edgehub.heartbeat":              true,
+	"modules.metamanager.remotequerytimeout": true,
+}
+
+// isHotReloadable reports whether every "key=value" pair in the comma
+// separated sets string is safe to apply without restarting edgecore.
+func isHotReloadable(sets string) bool {
+	sets = strings.TrimSpace(sets)
+	if sets == "" {
+		return false
+	}
+
+	fields := strings.Split(sets, ",")
+	for _, field := range fields {
+		key, _, ok := strings.Cut(strings.TrimSpace(field), "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return false
+		}
+		if !hotReloadableFields[strings.ToLower(key)] {
+			return false
+		}
+	}
+	return true
+}
+
+// hotReload asks the running edgecore process to reload its configuration
+// in place and then watches it over hotReloadHealthWindow to confirm it
+// stayed healthy. The caller is expected to roll back and fall back to a
+// full restart when hotReload returns an error.
+func hotReload() error {
+	if err := exec.Command("sudo", "systemctl", "kill", "-s", "HUP", edgeCoreService).Run(); err != nil {
+		return fmt.Errorf("failed to signal edgecore to reload configuration: %v", err)
+	}
+
+	deadline := time.Now().Add(hotReloadHealthWindow)
+	for time.Now().Before(deadline) {
+		time.Sleep(hotReloadHealthPoll)
+		if !edgeCoreActive() {
+			return fmt.Errorf("edgecore.service is not active after the configuration reload")
+		}
+	}
+	return nil
+}
+
+// edgeCoreActive reports whether edgecore.service is currently active.
+func edgeCoreActive() bool {
+	out, err := exec.Command("systemctl", "is-active", edgeCoreService).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "active"
+}

--- a/keadm/cmd/keadm/app/cmd/edge/hotreload_test.go
+++ b/keadm/cmd/keadm/app/cmd/edge/hotreload_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edge
+
+import "testing"
+
+func TestIsHotReloadable(t *testing.T) {
+	cases := []struct {
+		name string
+		sets string
+		want bool
+	}{
+		{
+			name: "single hot reloadable field",
+			sets: "modules.edgeHub.heartbeat=30",
+			want: true,
+		},
+		{
+			name: "multiple hot reloadable fields are case insensitive",
+			sets: "Modules.EdgeHub.Heartbeat=30,modules.metamanager.remotequerytimeout=90",
+			want: true,
+		},
+		{
+			name: "field requiring a restart falls back",
+			sets: "modules.edgeHub.websocket.server=example.com",
+			want: false,
+		},
+		{
+			name: "mixing a safe and unsafe field falls back",
+			sets: "modules.edgeHub.heartbeat=30,modules.edged.address=0.0.0.0",
+			want: false,
+		},
+		{
+			name: "empty sets is not hot reloadable",
+			sets: "",
+			want: false,
+		},
+		{
+			name: "malformed field falls back",
+			sets: "modules.edgeHub.heartbeat",
+			want: false,
+		},
+		{
+			name: "whitespace around fields is ignored",
+			sets: " modules.edgeHub.heartbeat = 30 , modules.metaManager.remoteQueryTimeout = 90 ",
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHotReloadable(tc.sets); got != tc.want {
+				t.Errorf("isHotReloadable(%q) = %v, want %v", tc.sets, got, tc.want)
+			}
+		})
+	}
+}

--- a/keadm/cmd/keadm/app/cmd/edge/hotreload_test.go
+++ b/keadm/cmd/keadm/app/cmd/edge/hotreload_test.go
@@ -53,7 +53,7 @@ func TestHotReload(t *testing.T) {
 	t.Run("service stays active for the whole window", func(t *testing.T) {
 		withHotReloadStubs(t,
 			func() error { return nil },
-			func() (string, error) { return "active", nil },
+			func() (string, error) { return systemctlActiveState, nil },
 		)
 
 		if err := hotReload(); err != nil {
@@ -80,8 +80,8 @@ func TestEdgeCoreActive(t *testing.T) {
 		want  bool
 	}{
 		{
-			name:  "active",
-			state: func() (string, error) { return "active", nil },
+			name:  systemctlActiveState,
+			state: func() (string, error) { return systemctlActiveState, nil },
 			want:  true,
 		},
 		{

--- a/keadm/cmd/keadm/app/cmd/edge/hotreload_test.go
+++ b/keadm/cmd/keadm/app/cmd/edge/hotreload_test.go
@@ -16,7 +16,98 @@ limitations under the License.
 
 package edge
 
-import "testing"
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func withHotReloadStubs(t *testing.T, signal func() error, state func() (string, error)) {
+	t.Helper()
+
+	origSignal, origState := signalEdgeCoreReload, edgeCoreServiceState
+	origWindow, origPoll := hotReloadHealthWindow, hotReloadHealthPoll
+	t.Cleanup(func() {
+		signalEdgeCoreReload, edgeCoreServiceState = origSignal, origState
+		hotReloadHealthWindow, hotReloadHealthPoll = origWindow, origPoll
+	})
+
+	signalEdgeCoreReload = signal
+	edgeCoreServiceState = state
+	hotReloadHealthWindow = 3 * time.Millisecond
+	hotReloadHealthPoll = time.Millisecond
+}
+
+func TestHotReload(t *testing.T) {
+	t.Run("signal failure is returned without polling", func(t *testing.T) {
+		withHotReloadStubs(t,
+			func() error { return errors.New("kill: no such process") },
+			func() (string, error) { return "", errors.New("edgeCoreServiceState should not be called") },
+		)
+
+		if err := hotReload(); err == nil {
+			t.Fatal("hotReload() = nil, want an error when signaling edgecore fails")
+		}
+	})
+
+	t.Run("service stays active for the whole window", func(t *testing.T) {
+		withHotReloadStubs(t,
+			func() error { return nil },
+			func() (string, error) { return "active", nil },
+		)
+
+		if err := hotReload(); err != nil {
+			t.Fatalf("hotReload() = %v, want nil when edgecore stays active", err)
+		}
+	})
+
+	t.Run("service becomes inactive during the window", func(t *testing.T) {
+		withHotReloadStubs(t,
+			func() error { return nil },
+			func() (string, error) { return "failed", nil },
+		)
+
+		if err := hotReload(); err == nil {
+			t.Fatal("hotReload() = nil, want an error when edgecore stops being active")
+		}
+	})
+}
+
+func TestEdgeCoreActive(t *testing.T) {
+	cases := []struct {
+		name  string
+		state func() (string, error)
+		want  bool
+	}{
+		{
+			name:  "active",
+			state: func() (string, error) { return "active", nil },
+			want:  true,
+		},
+		{
+			name:  "inactive",
+			state: func() (string, error) { return "inactive", nil },
+			want:  false,
+		},
+		{
+			name:  "query error",
+			state: func() (string, error) { return "", errors.New("systemctl not found") },
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := edgeCoreServiceState
+			defer func() { edgeCoreServiceState = orig }()
+			edgeCoreServiceState = tc.state
+
+			if got := edgeCoreActive(); got != tc.want {
+				t.Errorf("edgeCoreActive() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestIsHotReloadable(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Today, any configuration change delivered to an edge node through a `ConfigUpdateJob` restarts `edgecore.service`, even when the changed field never actually required a restart. On a real deployment this drops the cloud-edge connection, delays device data reporting, and can lose messages that had not been persisted yet, which hurts edge business continuity for what is often a trivial change like a heartbeat interval.

Looking at the modules, `edgehub`'s heartbeat interval and `metamanager`'s remote query timeout are already read fresh from the in-memory config on every loop iteration / request rather than being cached once at startup, so they can safely change while edgecore keeps running. This PR takes advantage of that:

- `keadm config-update` now checks the fields in `--set` against a small, explicit allow list of fields that have been verified to be re-read live by their module. If every field being changed is on that list, keadm signals edgecore to reload instead of restarting the service.
- edgecore listens for that signal, re-reads only the config file, and applies just the allow-listed fields through the existing per-module config packages. Reads/writes of those fields are now mutex-guarded since they can be updated from a signal-handler goroutine while other goroutines read them.
- After signaling, keadm watches `edgecore.service` for a short window to confirm it stayed healthy. If it did not, keadm restores the previous config file and falls back to the normal restart, so a bad value is never left in place silently.
- Any field that is not on the allow list keeps going through the existing restart path, unchanged.

This is intentionally scoped to the two fields that were verified to be safe today (`modules.edgeHub.heartbeat`, `modules.metaManager.remoteQueryTimeout`); other fields (ports, TLS material, database paths, etc.) are read once at module registration and still need a restart. The allow list is a single map, so more fields can be added later as their modules are verified to support it.

**Which issue(s) this PR fixes**:
Fixes #7107

**Special notes for your reviewer**:

- The hot reload path only ever touches the two allow-listed fields; everything else is untouched and behaves exactly as before.
- I moved away from `execs.NewCommand` (which shells out via `bash -c`) for the two new commands (`systemctl kill -s HUP` / `systemctl is-active`) and used `exec.Command` with an argument list instead, in the same spirit as the existing hardening in this package.
- Added unit tests for the allow-list matching logic (`isHotReloadable`) and for the edgecore-side reload function, including the missing-file and missing-`modules`-section edge cases.

**Does this PR introduce a user-facing change?**:
```release-note
EdgeCore now hot reloads `modules.edgeHub.heartbeat` and `modules.metaManager.remoteQueryTimeout` config updates delivered via `keadm config-update` / ConfigUpdateJob instead of restarting edgecore, with an automatic rollback to the previous config if edgecore is not healthy afterwards. All other fields continue to restart edgecore as before.
```
