### PR TITLE
keadm: wait for kubeedge namespace to fully terminate during reset

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/kubeclient.go
+++ b/keadm/cmd/keadm/app/cmd/util/kubeclient.go
@@ -3,13 +3,24 @@ package util
 import (
 	"context"
 	"fmt"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubeedge/kubeedge/common/constants"
+)
+
+// namespaceDeleteTimeout/namespaceDeletePollInterval bound how long CleanNameSpace
+// waits for a namespace to actually disappear after the delete call is accepted.
+// Declared as vars (not consts) so tests can shrink them.
+var (
+	namespaceDeleteTimeout      = 2 * time.Minute
+	namespaceDeletePollInterval = 2 * time.Second
 )
 
 func kubeConfig(kubeconfigPath string) (conf *rest.Config, err error) {
@@ -33,12 +44,50 @@ func KubeClient(kubeConfigPath string) (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(kubeConfig)
 }
 
+// CleanNameSpace deletes the given namespace and waits for it to be fully
+// removed. Namespace deletion in Kubernetes is asynchronous: the API server
+// marks the namespace as Terminating and returns immediately, while the
+// actual removal only completes once every object inside it (and any
+// pending finalizers) is cleaned up. Returning as soon as the delete call is
+// accepted, without waiting for the namespace to actually disappear, made
+// `keadm reset` report success while the "kubeedge" namespace was still
+// stuck in Terminating, which then caused a subsequent `keadm init`/`keadm
+// join` to fail or hang while recreating it.
 func (co *Common) CleanNameSpace(ns, kubeConfigPath string) error {
 	cli, err := KubeClient(kubeConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to create KubeClient, error: %s", err)
 	}
-	return cli.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+
+	if err := cli.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	err = wait.PollUntilContextTimeout(context.Background(), namespaceDeletePollInterval, namespaceDeleteTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			_, err := cli.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("namespace %s was not fully terminated within %s, it may be stuck in Terminating state "+
+			"because some resources in it still have pending finalizers; please check with "+
+			"`kubectl api-resources --verbs=list --namespaced -o name | xargs -n 1 kubectl get -n %s --ignore-not-found` "+
+			"and `kubectl describe ns %s` to find any remaining namespaced resources (including PVCs, config objects, "+
+			"or custom resources not covered by `kubectl get all`), and remove any blocking finalizers manually: %v",
+			ns, namespaceDeleteTimeout, ns, ns, err)
+	}
+
+	return nil
 }
 
 // IsCloudcoreContainerRunning judge whether cloudcore pod is running

--- a/keadm/cmd/keadm/app/cmd/util/kubeclient_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/kubeclient_test.go
@@ -17,11 +17,17 @@ limitations under the License.
 package util
 
 import (
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -113,6 +119,124 @@ func TestCleanNameSpaceErrorPath(t *testing.T) {
 	err := co.CleanNameSpace("test-namespace", "fake/path")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create KubeClient")
+}
+
+func newFakeKubeClient(t *testing.T, handler http.HandlerFunc) *kubernetes.Clientset {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cli, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	assert.NoError(t, err)
+	return cli
+}
+
+func writeNamespace(t *testing.T, w http.ResponseWriter, name string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+	}
+	assert.NoError(t, json.NewEncoder(w).Encode(ns))
+}
+
+func writeNotFound(w http.ResponseWriter, name string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	status := &metav1.Status{
+		Status:  metav1.StatusFailure,
+		Reason:  metav1.StatusReasonNotFound,
+		Code:    http.StatusNotFound,
+		Message: "namespaces \"" + name + "\" not found",
+	}
+	_ = json.NewEncoder(w).Encode(status)
+}
+
+func TestCleanNameSpace_WaitsForActualDeletion(t *testing.T) {
+	origTimeout, origInterval := namespaceDeleteTimeout, namespaceDeletePollInterval
+	namespaceDeleteTimeout, namespaceDeletePollInterval = 5*time.Second, 10*time.Millisecond
+	defer func() { namespaceDeleteTimeout, namespaceDeletePollInterval = origTimeout, origInterval }()
+
+	const ns = "kubeedge"
+	var getCalls int
+
+	cli := newFakeKubeClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			writeNamespace(t, w, ns)
+		case http.MethodGet:
+			getCalls++
+			if getCalls < 3 {
+				writeNamespace(t, w, ns)
+				return
+			}
+			writeNotFound(w, ns)
+		}
+	})
+
+	p := gomonkey.ApplyFunc(KubeClient, func(string) (*kubernetes.Clientset, error) {
+		return cli, nil
+	})
+	defer p.Reset()
+
+	co := &Common{}
+	err := co.CleanNameSpace(ns, "fake/path")
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, getCalls, 3)
+}
+
+func TestCleanNameSpace_TimesOutWhenStuckTerminating(t *testing.T) {
+	origTimeout, origInterval := namespaceDeleteTimeout, namespaceDeletePollInterval
+	namespaceDeleteTimeout, namespaceDeletePollInterval = 30*time.Millisecond, 10*time.Millisecond
+	defer func() { namespaceDeleteTimeout, namespaceDeletePollInterval = origTimeout, origInterval }()
+
+	const ns = "kubeedge"
+
+	cli := newFakeKubeClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			writeNamespace(t, w, ns)
+		case http.MethodGet:
+			writeNamespace(t, w, ns)
+		}
+	})
+
+	p := gomonkey.ApplyFunc(KubeClient, func(string) (*kubernetes.Clientset, error) {
+		return cli, nil
+	})
+	defer p.Reset()
+
+	co := &Common{}
+	err := co.CleanNameSpace(ns, "fake/path")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "was not fully terminated")
+}
+
+func TestCleanNameSpace_AlreadyDeleted(t *testing.T) {
+	const ns = "kubeedge"
+	var getCalls int
+
+	cli := newFakeKubeClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			writeNotFound(w, ns)
+		case http.MethodGet:
+			getCalls++
+			writeNotFound(w, ns)
+		}
+	})
+
+	p := gomonkey.ApplyFunc(KubeClient, func(string) (*kubernetes.Clientset, error) {
+		return cli, nil
+	})
+	defer p.Reset()
+
+	co := &Common{}
+	err := co.CleanNameSpace(ns, "fake/path")
+	assert.NoError(t, err)
+	assert.Zero(t, getCalls)
 }
 
 func TestIsCloudcoreContainerRunningErrorPath(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`keadm reset cloud` tears down CloudCore by deleting the `kubeedge` namespace, but it only issues the delete call and returns immediately once the API server accepts it. Namespace deletion in Kubernetes is asynchronous: the namespace is marked `Terminating` and only disappears once every object inside it (and any pending finalizers) has actually been cleaned up.

Because `keadm reset` never waited for that to finish, it could report success while the `kubeedge` namespace was still stuck in `Terminating`. Running `keadm init` again right after then fails or hangs while trying to recreate the namespace, since the old one hasn't gone away yet - matching the symptom in the linked issue where the namespace stays `Terminating` and a following `keadm init` fails with `client rate limiter Wait returned an error: context deadline exceeded`.

This PR makes `CleanNameSpace` poll for the namespace to actually be gone (bounded by a timeout) before returning. If the namespace is genuinely stuck due to pending finalizers on resources inside it, `keadm reset` now surfaces a clear, actionable error instead of silently moving on and leaving the caller to hit a confusing failure later.

**Which issue(s) this PR fixes**:
Fixes #6009

**Special notes for your reviewer**:

Added unit tests in `kubeclient_test.go` that exercise the real polling logic against an `httptest` server (not just mocked error paths), covering: namespace deleted after a few polls, namespace stuck past the timeout, and namespace already gone by the time delete is issued.

**Does this PR introduce a user-facing change?**:
```release-note
`keadm reset` now waits for the `kubeedge` namespace to be fully terminated before returning, instead of reporting success as soon as deletion is requested. If the namespace is stuck in `Terminating` due to pending finalizers, it now returns a clear error explaining how to investigate instead of leaving the node in an inconsistent state.
```