### PR TITLE
fix: correct grammar in keadm reset command help text

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/reset_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/reset_others.go
@@ -54,7 +54,7 @@ func NewOtherEdgeReset() *cobra.Command {
 	step := common.NewStep()
 	var cmd = &cobra.Command{
 		Use:     "edge",
-		Short:   "Teardowns EdgeCore component",
+		Short:   "Tears down EdgeCore component",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(_ *cobra.Command, _ []string) error {

--- a/keadm/cmd/keadm/app/cmd/reset_others.go
+++ b/keadm/cmd/keadm/app/cmd/reset_others.go
@@ -59,7 +59,7 @@ func NewKubeEdgeReset() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "reset",
-		Short:   "Teardowns KubeEdge (cloud(helm installed) & edge) component",
+		Short:   "Tears down KubeEdge (cloud(helm installed) & edge) component",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(_ *cobra.Command, _ []string) error {

--- a/keadm/cmd/keadm/app/cmd/reset_windows.go
+++ b/keadm/cmd/keadm/app/cmd/reset_windows.go
@@ -54,7 +54,7 @@ func NewKubeEdgeReset() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "reset",
-		Short:   "Teardowns KubeEdge edge component in windows server",
+		Short:   "Tears down KubeEdge edge component in windows server",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

What this PR does / why we need it:

Corrects grammar in the `keadm reset` command help text by replacing "Teardowns" with "Tears down" in the reset command descriptions. This improves the user-facing CLI help text without changing any functionality.

Which issue(s) this PR fixes:

Fixes #7113

Special notes for your reviewer:

This is a help-text-only cleanup affecting the reset command descriptions. No functional or behavioral changes are introduced, and no tests are required.

Does this PR introduce a user-facing change?:

```release-note
Corrected grammar in the `keadm reset` command help text.
```