### PR TITLE
keadm: replace fmt.Print with klog in debug collect command

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/collect.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect.go
@@ -15,6 +15,8 @@ import (
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
 	"github.com/kubeedge/kubeedge/pkg/util/execs"
 	"github.com/kubeedge/kubeedge/pkg/util/files"
+
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -79,7 +81,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 		return err
 	}
 
-	fmt.Println("Start collecting data")
+	klog.Info("Start collecting data")
 	// create tmp direction
 	tmpName, timenow, err := makeDirTmp()
 	if err != nil {
@@ -89,7 +91,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 
 	err = collectSystemData(fmt.Sprintf("%s/system", tmpName))
 	if err != nil {
-		fmt.Printf("collect System data failed")
+		klog.Errorf("collect system data failed: %v", err)
 	}
 	printDetail("collect systemd data finish")
 
@@ -100,7 +102,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 	}
 	err = collectEdgecoreData(fmt.Sprintf("%s/edgecore", tmpName), edgeconfig, collectOptions)
 	if err != nil {
-		fmt.Printf("collect edgecore data failed")
+		klog.Errorf("collect edgecore data failed: %v", err)
 	}
 	printDetail("collect edgecore data finish")
 
@@ -121,7 +123,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 
 	printDetail("Remove tmp data finish")
 
-	fmt.Printf("Data collected successfully, path: %s\n", zipName)
+	klog.Infof("Data collected successfully, path: %s", zipName)
 	return nil
 }
 
@@ -301,6 +303,6 @@ func ExecuteShell(cmdStr string, tmpPath string) error {
 
 func printDetail(msg string) {
 	if printDeatilFlag {
-		fmt.Println(msg)
+		klog.Info(msg)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`GenerateAndRefreshToken` in `cloud/pkg/cloudhub/servers/httpserver/pre_server.go` starts a goroutine that periodically refreshes the node-join token using a `select` over the refresh ticker and `ctx.Done()`. In the `ctx.Done()` case, the code used a `break` statement, which in Go only exits the enclosing `select`, not the surrounding `for` loop. Once the context was cancelled, `ctx.Done()` returns an already-closed channel, so the `select` resolves immediately on every iteration and the goroutine spins in a tight busy loop for the remaining lifetime of the process, pinning a full CPU core. The ticker was also never stopped, leaking its resources.

This PR changes the `ctx.Done()` case to `return` (exiting the goroutine) and adds `defer t.Stop()` to release the ticker, so cancellation actually stops the refresh goroutine as intended.

**Which issue(s) this PR fixes**:

Fixes #7101

**Special notes for your reviewer**:

Added `TestGenerateAndRefreshToken_StopsOnContextCancel`, which fails against the original code (the goroutine never terminates after cancellation, so `runtime.NumGoroutine()` never drops back to baseline) and passes against the fix. Uses gomonkey to patch `client.GetKubeClient` with a fake clientset, following the existing pattern in `cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go`. Run with `go test -gcflags=all=-l ./cloud/pkg/cloudhub/servers/httpserver/...`.

**Does this PR introduce a user-facing change?**:

```
NONE
```