### PR TITLE
admissioncontroller: handle NodeUpgradeJob v1alpha2 webhooks

### DIFF
--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/devices/v1beta1"
+	operationsv1alpha1 "github.com/kubeedge/api/apis/operations/v1alpha1"
+	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 	v1 "github.com/kubeedge/api/apis/rules/v1"
 	"github.com/kubeedge/api/client/clientset/versioned"
 	"github.com/kubeedge/kubeedge/cloud/cmd/admission/app/options"
@@ -51,6 +53,11 @@ var codecs = serializer.NewCodecFactory(scheme)
 
 var controller = &AdmissionController{}
 
+var nodeUpgradeJobWebhookVersions = []string{
+	operationsv1alpha1.Version,
+	operationsv1alpha2.Version,
+}
+
 func init() {
 	addToScheme(scheme)
 }
@@ -60,6 +67,8 @@ func addToScheme(scheme *runtime.Scheme) {
 	utilruntime.Must(admissionv1.AddToScheme(scheme))
 	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(v1beta1.AddDeviceCrds(scheme))
+	utilruntime.Must(operationsv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(operationsv1alpha2.AddToScheme(scheme))
 }
 
 // AdmissionController implements the admission webhook for validation of configuration.
@@ -287,7 +296,7 @@ func (ac *AdmissionController) registerWebhooks(opt *options.AdmissionOptions, c
 					},
 					Rule: admissionregistrationv1.Rule{
 						APIGroups:   []string{"operations.kubeedge.io"},
-						APIVersions: []string{"v1alpha1"},
+						APIVersions: nodeUpgradeJobWebhookVersions,
 						Resources:   []string{"nodeupgradejobs"},
 					},
 				}},
@@ -362,7 +371,7 @@ func (ac *AdmissionController) registerWebhooks(opt *options.AdmissionOptions, c
 
 			Rule: admissionregistrationv1.Rule{
 				APIGroups:   []string{"operations.kubeedge.io"},
-				APIVersions: []string{"v1alpha1"},
+				APIVersions: nodeUpgradeJobWebhookVersions,
 				Resources:   []string{"nodeupgradejobs"},
 			},
 		}},

--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob.go
@@ -27,7 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
-	"github.com/kubeedge/api/apis/operations/v1alpha1"
+	operationsv1alpha1 "github.com/kubeedge/api/apis/operations/v1alpha1"
+	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/util/validation"
 )
 
@@ -42,32 +43,29 @@ func serveMutatingNodeUpgradeJob(w http.ResponseWriter, r *http.Request) {
 func admitNodeUpgradeJob(review admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	switch review.Request.Operation {
 	case admissionv1.Create:
-		raw := review.Request.Object.Raw
-		upgrade := v1alpha1.NodeUpgradeJob{}
-		deserializer := codecs.UniversalDeserializer()
-		if _, _, err := deserializer.Decode(raw, nil, &upgrade); err != nil {
+		upgrade, err := decodeNodeUpgradeJob(review.Request.Object.Raw)
+		if err != nil {
 			return admissionResponse(fmt.Errorf("validation failed with error: %v", err))
 		}
-		return admissionResponse(validateNodeUpgradeJob(&upgrade))
+		return admissionResponse(validateNodeUpgradeJob(upgrade))
 
 	case admissionv1.Update:
-		newUpgrade := v1alpha1.NodeUpgradeJob{}
-		deserializer := codecs.UniversalDeserializer()
-		if _, _, err := deserializer.Decode(review.Request.Object.Raw, nil, &newUpgrade); err != nil {
+		newUpgrade, err := decodeNodeUpgradeJob(review.Request.Object.Raw)
+		if err != nil {
 			return admissionResponse(fmt.Errorf("validation failed with error: %v", err))
 		}
-		oldUpgrade := v1alpha1.NodeUpgradeJob{}
-		if _, _, err := deserializer.Decode(review.Request.OldObject.Raw, nil, &oldUpgrade); err != nil {
+		oldUpgrade, err := decodeNodeUpgradeJob(review.Request.OldObject.Raw)
+		if err != nil {
 			return admissionResponse(fmt.Errorf("validation failed with error: %v", err))
 		}
 
 		// For update, we don't allow update spec fields once an Upgrade is created.
-		if !reflect.DeepEqual(oldUpgrade.Spec, newUpgrade.Spec) {
+		if !reflect.DeepEqual(oldUpgrade, newUpgrade) {
 			err := errors.New("spec fields are not allowed to update once it's created")
 			return admissionResponse(err)
 		}
 
-		return admissionResponse(validateNodeUpgradeJob(&newUpgrade))
+		return admissionResponse(validateNodeUpgradeJob(newUpgrade))
 
 	case admissionv1.Delete:
 		//no rule defined for above operations, greenlight for all of above.
@@ -78,19 +76,75 @@ func admitNodeUpgradeJob(review admissionv1.AdmissionReview) *admissionv1.Admiss
 	}
 }
 
-func validateNodeUpgradeJob(upgrade *v1alpha1.NodeUpgradeJob) error {
-	if !validation.ValidateVersion(upgrade.Spec.Version) {
-		return fmt.Errorf("invalid version %s", upgrade.Spec.Version)
+type nodeUpgradeJobSpec struct {
+	Version        string
+	TimeoutSeconds *uint32
+	NodeNames      []string
+	LabelSelector  *metav1.LabelSelector
+	Image          string
+	Concurrency    int32
+}
+
+func decodeNodeUpgradeJob(raw []byte) (*nodeUpgradeJobSpec, error) {
+	deserializer := codecs.UniversalDeserializer()
+	obj, gvk, err := deserializer.Decode(raw, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case gvk.Group == operationsv1alpha1.GroupName && gvk.Version == operationsv1alpha1.Version && gvk.Kind == "NodeUpgradeJob":
+		upgrade, ok := obj.(*operationsv1alpha1.NodeUpgradeJob)
+		if !ok {
+			return nil, fmt.Errorf("decoded object is %T, want *v1alpha1.NodeUpgradeJob", obj)
+		}
+		return nodeUpgradeJobSpecFromV1Alpha1(upgrade.Spec), nil
+	case gvk.Group == operationsv1alpha2.GroupName && gvk.Version == operationsv1alpha2.Version && gvk.Kind == "NodeUpgradeJob":
+		upgrade, ok := obj.(*operationsv1alpha2.NodeUpgradeJob)
+		if !ok {
+			return nil, fmt.Errorf("decoded object is %T, want *v1alpha2.NodeUpgradeJob", obj)
+		}
+		return nodeUpgradeJobSpecFromV1Alpha2(upgrade.Spec), nil
+	default:
+		return nil, fmt.Errorf("unsupported NodeUpgradeJob GVK %s", gvk.String())
+	}
+}
+
+func nodeUpgradeJobSpecFromV1Alpha1(spec operationsv1alpha1.NodeUpgradeJobSpec) *nodeUpgradeJobSpec {
+	return &nodeUpgradeJobSpec{
+		Version:        spec.Version,
+		TimeoutSeconds: spec.TimeoutSeconds,
+		NodeNames:      spec.NodeNames,
+		LabelSelector:  spec.LabelSelector,
+		Image:          spec.Image,
+		Concurrency:    spec.Concurrency,
+	}
+}
+
+func nodeUpgradeJobSpecFromV1Alpha2(spec operationsv1alpha2.NodeUpgradeJobSpec) *nodeUpgradeJobSpec {
+	return &nodeUpgradeJobSpec{
+		Version:        spec.Version,
+		TimeoutSeconds: spec.TimeoutSeconds,
+		NodeNames:      spec.NodeNames,
+		LabelSelector:  spec.LabelSelector,
+		Image:          spec.Image,
+		Concurrency:    spec.Concurrency,
+	}
+}
+
+func validateNodeUpgradeJob(upgrade *nodeUpgradeJobSpec) error {
+	if !validation.ValidateVersion(upgrade.Version) {
+		return fmt.Errorf("invalid version %s", upgrade.Version)
 	}
 	// Image is a optional field.
-	if upgrade.Spec.Image != "" && !validation.ValidateImageRepo(upgrade.Spec.Image) {
-		return fmt.Errorf("invalid image repo %s", upgrade.Spec.Image)
+	if upgrade.Image != "" && !validation.ValidateImageRepo(upgrade.Image) {
+		return fmt.Errorf("invalid image repo %s", upgrade.Image)
 	}
 	// we must specify NodeNames or LabelSelector, and we can only specify only one
-	if len(upgrade.Spec.NodeNames) == 0 && upgrade.Spec.LabelSelector == nil {
+	if len(upgrade.NodeNames) == 0 && upgrade.LabelSelector == nil {
 		return fmt.Errorf("both NodeNames and LabelSelector are NOT specified")
 	}
-	if len(upgrade.Spec.NodeNames) != 0 && upgrade.Spec.LabelSelector != nil {
+	if len(upgrade.NodeNames) != 0 && upgrade.LabelSelector != nil {
 		return fmt.Errorf("both NodeNames and LabelSelector are specified")
 	}
 
@@ -117,13 +171,13 @@ func mutatingNodeUpgradeJob(review admissionv1.AdmissionReview) *admissionv1.Adm
 		Allowed: true,
 	}
 
-	var upgrade v1alpha1.NodeUpgradeJob
-	if err := json.Unmarshal(review.Request.Object.Raw, &upgrade); err != nil {
-		klog.Errorf("Could not unmarshal raw object: %v", err)
+	upgrade, err := decodeNodeUpgradeJob(review.Request.Object.Raw)
+	if err != nil {
+		klog.Errorf("Could not decode raw object: %v", err)
 		return toAdmissionResponse(err)
 	}
 
-	payload := generateNodeUpgradeJobPatch(upgrade.Spec)
+	payload := generateNodeUpgradeJobPatch(upgrade)
 	if len(payload) == 0 {
 		return &reviewResponse
 	}
@@ -139,7 +193,7 @@ func mutatingNodeUpgradeJob(review admissionv1.AdmissionReview) *admissionv1.Adm
 	return &reviewResponse
 }
 
-func generateNodeUpgradeJobPatch(spec v1alpha1.NodeUpgradeJobSpec) []patchValue {
+func generateNodeUpgradeJobPatch(spec *nodeUpgradeJobSpec) []patchValue {
 	patch := make([]patchValue, 0)
 
 	// mutate .spec.concurrency to default value 1 if not specified

--- a/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
+++ b/cloud/pkg/admissioncontroller/admit_nodeupgradejob_test.go
@@ -26,7 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/kubeedge/api/apis/operations/v1alpha1"
+	operationsv1alpha1 "github.com/kubeedge/api/apis/operations/v1alpha1"
+	operationsv1alpha2 "github.com/kubeedge/api/apis/operations/v1alpha2"
 )
 
 func TestAdmitNodeUpgradeJob(t *testing.T) {
@@ -35,16 +36,20 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 	testCases := []struct {
 		name            string
 		operation       admissionv1.Operation
-		upgrade         *v1alpha1.NodeUpgradeJob
-		oldUpgrade      *v1alpha1.NodeUpgradeJob
+		upgrade         runtime.Object
+		oldUpgrade      runtime.Object
 		expectedAllowed bool
 		expectedError   string
 	}{
 		{
 			name:      "Valid Create",
 			operation: admissionv1.Create,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version:   "v1.0.0",
 					NodeNames: []string{"node1", "node2"},
 				},
@@ -54,8 +59,12 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 		{
 			name:      "Invalid Version",
 			operation: admissionv1.Create,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version:   "1.0.0",
 					NodeNames: []string{"node1"},
 				},
@@ -66,8 +75,12 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 		{
 			name:      "Invalid Semver",
 			operation: admissionv1.Create,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version:   "v1.0",
 					NodeNames: []string{"node1"},
 				},
@@ -78,8 +91,12 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 		{
 			name:      "Invalid image",
 			operation: admissionv1.Create,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version: "v1.0.0",
 					Image:   "invalid-image",
 				},
@@ -90,8 +107,12 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 		{
 			name:      "No NodeNames and LabelSelector",
 			operation: admissionv1.Create,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version: "v1.0.0",
 				},
 			},
@@ -101,8 +122,12 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 		{
 			name:      "Both NodeNames and LabelSelector",
 			operation: admissionv1.Create,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version:       "v1.0.0",
 					NodeNames:     []string{"node1"},
 					LabelSelector: &metav1.LabelSelector{},
@@ -112,16 +137,39 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 			expectedError:   "both NodeNames and LabelSelector are specified",
 		},
 		{
-			name:      "Valid Update",
-			operation: admissionv1.Update,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			name:      "Valid Create v1alpha2",
+			operation: admissionv1.Create,
+			upgrade: &operationsv1alpha2.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha2",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha2.NodeUpgradeJobSpec{
 					Version:   "v1.0.0",
 					NodeNames: []string{"node1", "node2"},
 				},
 			},
-			oldUpgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			expectedAllowed: true,
+		},
+		{
+			name:      "Valid Update",
+			operation: admissionv1.Update,
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
+					Version:   "v1.0.0",
+					NodeNames: []string{"node1", "node2"},
+				},
+			},
+			oldUpgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version:   "v1.0.0",
 					NodeNames: []string{"node1", "node2"},
 				},
@@ -131,14 +179,48 @@ func TestAdmitNodeUpgradeJob(t *testing.T) {
 		{
 			name:      "Invalid Update - Spec Change",
 			operation: admissionv1.Update,
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			upgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 					Version:   "v1.0.1",
 					NodeNames: []string{"node1", "node2"},
 				},
 			},
-			oldUpgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
+			oldUpgrade: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
+					Version:   "v1.0.0",
+					NodeNames: []string{"node1", "node2"},
+				},
+			},
+			expectedAllowed: false,
+			expectedError:   "spec fields are not allowed to update once it's created",
+		},
+		{
+			name:      "Invalid Update - Spec Change v1alpha2",
+			operation: admissionv1.Update,
+			upgrade: &operationsv1alpha2.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha2",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha2.NodeUpgradeJobSpec{
+					Version:   "v1.0.1",
+					NodeNames: []string{"node1", "node2"},
+				},
+			},
+			oldUpgrade: &operationsv1alpha2.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha2",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha2.NodeUpgradeJobSpec{
 					Version:   "v1.0.0",
 					NodeNames: []string{"node1", "node2"},
 				},
@@ -188,76 +270,62 @@ func TestValidateNodeUpgradeJob(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		upgrade     *v1alpha1.NodeUpgradeJob
+		upgrade     *nodeUpgradeJobSpec
 		expectedErr string
 	}{
 		{
 			name: "Valid upgrade job",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version:   "v1.0.0",
-					NodeNames: []string{"node1", "node2"},
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version:   "v1.0.0",
+				NodeNames: []string{"node1", "node2"},
 			},
 			expectedErr: "",
 		},
 		{
 			name: "Invalid version",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version:   "1.0.0",
-					NodeNames: []string{"node1"},
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version:   "1.0.0",
+				NodeNames: []string{"node1"},
 			},
 			expectedErr: "invalid version 1.0.0",
 		},
 		{
 			name: "Invalid image",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version: "v1.0.0",
-					Image:   "invalid-image",
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version: "v1.0.0",
+				Image:   "invalid-image",
 			},
 			expectedErr: "invalid image repo invalid-image",
 		},
 		{
 			name: "Invalid version (not semver compatible)",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version:   "v1.0",
-					NodeNames: []string{"node1"},
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version:   "v1.0",
+				NodeNames: []string{"node1"},
 			},
 			expectedErr: "invalid version v1.0",
 		},
 		{
 			name: "Missing both NodeNames and LabelSelector",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version: "v1.0.0",
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version: "v1.0.0",
 			},
 			expectedErr: "both NodeNames and LabelSelector are NOT specified",
 		},
 		{
 			name: "Both NodeNames and LabelSelector specified",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version:       "v1.0.0",
-					NodeNames:     []string{"node1"},
-					LabelSelector: &metav1.LabelSelector{},
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version:       "v1.0.0",
+				NodeNames:     []string{"node1"},
+				LabelSelector: &metav1.LabelSelector{},
 			},
 			expectedErr: "both NodeNames and LabelSelector are specified",
 		},
 		{
-			name: "Valid upgrade job",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version:       "v1.0.0",
-					LabelSelector: &metav1.LabelSelector{},
-				},
+			name: "Valid upgrade job with label selector",
+			upgrade: &nodeUpgradeJobSpec{
+				Version:       "v1.0.0",
+				LabelSelector: &metav1.LabelSelector{},
 			},
 			expectedErr: "",
 		},
@@ -319,8 +387,12 @@ func TestAdmissionResponse(t *testing.T) {
 func TestMutatingNodeUpgradeJob(t *testing.T) {
 	assert := assert.New(t)
 
-	upgrade := &v1alpha1.NodeUpgradeJob{
-		Spec: v1alpha1.NodeUpgradeJobSpec{
+	upgrade := &operationsv1alpha1.NodeUpgradeJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operations.kubeedge.io/v1alpha1",
+			Kind:       "NodeUpgradeJob",
+		},
+		Spec: operationsv1alpha1.NodeUpgradeJobSpec{
 			Version:   "v1.0.0",
 			NodeNames: []string{"node1", "node2"},
 		},
@@ -339,7 +411,6 @@ func TestMutatingNodeUpgradeJob(t *testing.T) {
 	assert.NotNil(response.Patch)
 	assert.Equal(admissionv1.PatchTypeJSONPatch, *response.PatchType)
 
-	// Unmarshal and check the patch
 	var patch []map[string]interface{}
 	err = json.Unmarshal(response.Patch, &patch)
 	assert.NoError(err)
@@ -352,17 +423,45 @@ func TestMutatingNodeUpgradeJob(t *testing.T) {
 	assert.Equal(float64(300), patch[1]["value"])
 }
 
+func TestMutatingNodeUpgradeJobSupportsV1Alpha2(t *testing.T) {
+	assert := assert.New(t)
+
+	upgrade := &operationsv1alpha2.NodeUpgradeJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operations.kubeedge.io/v1alpha2",
+			Kind:       "NodeUpgradeJob",
+		},
+		Spec: operationsv1alpha2.NodeUpgradeJobSpec{
+			Version:   "v1.0.0",
+			NodeNames: []string{"node1"},
+		},
+	}
+	raw, err := json.Marshal(upgrade)
+	assert.NoError(err)
+
+	review := admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Object: runtime.RawExtension{Raw: raw},
+		},
+	}
+	response := mutatingNodeUpgradeJob(review)
+
+	assert.True(response.Allowed)
+	assert.NotNil(response.Patch)
+	assert.Equal(admissionv1.PatchTypeJSONPatch, *response.PatchType)
+}
+
 func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 	assert := assert.New(t)
 
 	testCases := []struct {
 		name          string
-		spec          v1alpha1.NodeUpgradeJobSpec
+		spec          *nodeUpgradeJobSpec
 		expectedPatch []patchValue
 	}{
 		{
 			name: "Concurrency and TimeoutSeconds both specified",
-			spec: v1alpha1.NodeUpgradeJobSpec{
+			spec: &nodeUpgradeJobSpec{
 				Version:        "v1.0.0",
 				NodeNames:      []string{"node1"},
 				Concurrency:    2,
@@ -372,7 +471,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 		},
 		{
 			name: "None specified",
-			spec: v1alpha1.NodeUpgradeJobSpec{
+			spec: &nodeUpgradeJobSpec{
 				Version:   "v1.0.0",
 				NodeNames: []string{"node1"},
 			},
@@ -391,7 +490,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 		},
 		{
 			name: "Concurrency specified",
-			spec: v1alpha1.NodeUpgradeJobSpec{
+			spec: &nodeUpgradeJobSpec{
 				Version:        "v1.0.0",
 				NodeNames:      []string{"node1"},
 				TimeoutSeconds: func() *uint32 { v := uint32(600); return &v }(),
@@ -406,7 +505,7 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 		},
 		{
 			name: "TimeoutSeconds specified",
-			spec: v1alpha1.NodeUpgradeJobSpec{
+			spec: &nodeUpgradeJobSpec{
 				Version:     "v1.0.0",
 				NodeNames:   []string{"node1"},
 				Concurrency: 2,
@@ -432,25 +531,21 @@ func TestGenerateNodeUpgradeJobPatch(t *testing.T) {
 func TestValidateNodeUpgradeJobAllowsOptionalAndValidImage(t *testing.T) {
 	cases := []struct {
 		name    string
-		upgrade *v1alpha1.NodeUpgradeJob
+		upgrade *nodeUpgradeJobSpec
 	}{
 		{
 			name: "empty image is allowed",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version:   "v1.0.0",
-					NodeNames: []string{"node1"},
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version:   "v1.0.0",
+				NodeNames: []string{"node1"},
 			},
 		},
 		{
 			name: "valid image repo is allowed",
-			upgrade: &v1alpha1.NodeUpgradeJob{
-				Spec: v1alpha1.NodeUpgradeJobSpec{
-					Version:   "v1.0.0",
-					Image:     "kubeedge/installation-package:v1.23.1",
-					NodeNames: []string{"node1"},
-				},
+			upgrade: &nodeUpgradeJobSpec{
+				Version:   "v1.0.0",
+				Image:     "kubeedge/installation-package:v1.23.1",
+				NodeNames: []string{"node1"},
 			},
 		},
 	}
@@ -466,7 +561,7 @@ func TestValidateNodeUpgradeJobAllowsOptionalAndValidImage(t *testing.T) {
 
 func TestGenerateNodeUpgradeJobPatchReturnsEmptyWhenDefaultsSpecified(t *testing.T) {
 	timeoutSeconds := uint32(600)
-	patch := generateNodeUpgradeJobPatch(v1alpha1.NodeUpgradeJobSpec{
+	patch := generateNodeUpgradeJobPatch(&nodeUpgradeJobSpec{
 		Version:        "v1.0.0",
 		NodeNames:      []string{"node1"},
 		Concurrency:    2,
@@ -475,5 +570,57 @@ func TestGenerateNodeUpgradeJobPatchReturnsEmptyWhenDefaultsSpecified(t *testing
 
 	if len(patch) != 0 {
 		t.Fatalf("expected empty patch, got %#v", patch)
+	}
+}
+
+func TestDecodeNodeUpgradeJobSupportsServedVersions(t *testing.T) {
+	testCases := []struct {
+		name string
+		obj  runtime.Object
+	}{
+		{
+			name: "v1alpha1",
+			obj: &operationsv1alpha1.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha1",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha1.NodeUpgradeJobSpec{
+					Version:   "v1.0.0",
+					NodeNames: []string{"node1"},
+				},
+			},
+		},
+		{
+			name: "v1alpha2",
+			obj: &operationsv1alpha2.NodeUpgradeJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operations.kubeedge.io/v1alpha2",
+					Kind:       "NodeUpgradeJob",
+				},
+				Spec: operationsv1alpha2.NodeUpgradeJobSpec{
+					Version:   "v1.0.0",
+					NodeNames: []string{"node1"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.obj)
+			if err != nil {
+				t.Fatalf("marshal object: %v", err)
+			}
+
+			spec, err := decodeNodeUpgradeJob(raw)
+			if err != nil {
+				t.Fatalf("decode object: %v", err)
+			}
+
+			if spec.Version != "v1.0.0" || len(spec.NodeNames) != 1 || spec.NodeNames[0] != "node1" {
+				t.Fatalf("unexpected decoded spec: %#v", spec)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

## Summary
- register the NodeUpgradeJob admission webhooks for both served API versions
- decode `operations.kubeedge.io/v1alpha1` and `v1alpha2` requests through one validation/defaulting path
- add admission tests covering `v1alpha2` validation, mutation, and decode support

## Linked Issue
Fixes #7116

**What this PR does / why we need it**:

`NodeUpgradeJob` admission currently only matches `operations.kubeedge.io/v1alpha1`, even though the CRD also serves `v1alpha2`. This change keeps validation and mutating defaults consistent for both served versions.

## What Changed
- expanded the validating and mutating webhook rules to include `v1alpha2`
- added both operations API versions to the admission controller scheme
- normalized NodeUpgradeJob admission decoding so `v1alpha1` and `v1alpha2` share the same validation and patch generation logic
- extended admission tests to cover the `v1alpha2` path

## Verification
- `go test ./cloud/pkg/admissioncontroller/...` — passed
- `make verify` — passed
- `make test WHAT=cloud PROFILE=y` — failed: unrelated macOS socket binding failure in `cloud/pkg/csidriver` (`listen unix .../csidriver.sock: bind: invalid argument`)
- `make integrationtest` — failed: integration script requires `sudo` and `pidof`, which are unavailable in this non-interactive macOS environment
- `make lint` — not completed: full-repo `golangci-lint` did not finish within the available session after the whitespace precheck was satisfied

## Scope
- unrelated files were not changed; the diff is limited to the NodeUpgradeJob admission controller and its tests

**Which issue(s) this PR fixes**:
Fixes #7116

**Special notes for your reviewer**:
- The change is intentionally scoped to admission webhook registration and shared NodeUpgradeJob decoding for served API versions.

**Does this PR introduce a user-facing change?**:
```release-note
Fix NodeUpgradeJob admission webhooks so served `operations.kubeedge.io/v1alpha2` requests receive the same validation and defaulting as `v1alpha1`.
```
