### PR TITLE
keadm: fix goroutine leak in GenerateAndRefreshToken due to break in select

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/check.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shirou/gopsutil/disk"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/spf13/cobra"
+	klog "k8s.io/klog/v2"
 	utilruntime "k8s.io/kubernetes/cmd/kubeadm/app/util/runtime"
 
 	"github.com/kubeedge/api/apis/common/constants"
@@ -146,7 +147,7 @@ func (co *CheckObject) ExecuteCheck(use string, ob *common.CheckOptions) {
 	}
 
 	if err != nil {
-		fmt.Println(err)
+		klog.Errorf("%v", err)
 		util.PrintFail(use, common.StrCheck)
 	} else {
 		util.PrintSucceed(use, common.StrCheck)
@@ -202,8 +203,8 @@ func CheckCPU() error {
 		return err
 	}
 
-	fmt.Printf("CPU total: %v core, Allowed > %v core\n", cpuNum, common.AllowedValueCPU)
-	fmt.Printf("CPU usage rate: %.2f, Allowed rate < %v\n", percent[0]/100, common.AllowedCurrentValueCPURate)
+	klog.Infof("CPU total: %v core, Allowed > %v core", cpuNum, common.AllowedValueCPU)
+	klog.Infof("CPU usage rate: %.2f, Allowed rate < %v", percent[0]/100, common.AllowedCurrentValueCPURate)
 
 	if cpuNum < common.AllowedValueCPU || percent[0]/100 > common.AllowedCurrentValueCPURate {
 		return errors.New("cpu check failed")
@@ -217,9 +218,9 @@ func CheckMemory() error {
 		return err
 	}
 
-	fmt.Printf("Memory total: %.2f MB, Allowed > %v MB\n", float32(memoryInfo.Total)/common.MB, common.AllowedValueMemory/common.MB)
-	fmt.Printf("Memory Free total: %.2f MB, Allowed > %v MB\n", float32(memoryInfo.Free)/common.MB, common.AllowedCurrentValueMem/common.MB)
-	fmt.Printf("Memory usage rate: %.2f, Allowed rate < %v\n", memoryInfo.UsedPercent/100,
+	klog.Infof("Memory total: %.2f MB, Allowed > %v MB", float32(memoryInfo.Total)/common.MB, common.AllowedValueMemory/common.MB)
+	klog.Infof("Memory Free total: %.2f MB, Allowed > %v MB", float32(memoryInfo.Free)/common.MB, common.AllowedCurrentValueMem/common.MB)
+	klog.Infof("Memory usage rate: %.2f, Allowed rate < %v", memoryInfo.UsedPercent/100,
 		common.AllowedCurrentValueMemRate)
 
 	if memoryInfo.Total < common.AllowedValueMemory ||
@@ -242,9 +243,9 @@ func CheckDisk() error {
 		return err
 	}
 
-	fmt.Printf("Disk total: %.2f MB, Allowed > %v MB\n", float32(diskInfo.Total)/common.MB, common.AllowedValueDisk/common.MB)
-	fmt.Printf("Disk Free total: %.2f MB, Allowed > %vMB\n", float32(diskInfo.Free)/common.MB, common.AllowedCurrentValueDisk/common.MB)
-	fmt.Printf("Disk usage rate: %.2f, Allowed rate < %v\n", diskInfo.UsedPercent/100, common.AllowedCurrentValueDiskRate)
+	klog.Infof("Disk total: %.2f MB, Allowed > %v MB", float32(diskInfo.Total)/common.MB, common.AllowedValueDisk/common.MB)
+	klog.Infof("Disk Free total: %.2f MB, Allowed > %vMB", float32(diskInfo.Free)/common.MB, common.AllowedCurrentValueDisk/common.MB)
+	klog.Infof("Disk usage rate: %.2f, Allowed rate < %v", diskInfo.UsedPercent/100, common.AllowedCurrentValueDiskRate)
 
 	if diskInfo.Total < common.AllowedValueDisk ||
 		diskInfo.Free < common.AllowedCurrentValueDisk ||
@@ -261,9 +262,9 @@ func CheckDNS(domain string) error {
 		return fmt.Errorf("dns resolution failed, domain: %s err: %s", domain, err)
 	}
 	if len(r) > 0 {
-		fmt.Printf("dns resolution success, domain: %s ip: %s\n", domain, r[0])
+		klog.Infof("dns resolution success, domain: %s ip: %s", domain, r[0])
 	} else {
-		fmt.Printf("dns resolution success, domain: %s ip: null\n", domain)
+		klog.Infof("dns resolution success, domain: %s ip: null", domain)
 	}
 	return err
 }
@@ -314,7 +315,7 @@ func CheckNetWork(IP string, timeout int, cloudhubServer string, edgecoreServer 
 		if result != "0%" {
 			return fmt.Errorf("ping %s timeout", IP)
 		}
-		fmt.Printf("ping %s success\n", IP)
+		klog.Infof("ping %s success", IP)
 	}
 
 	if cloudhubServer != "" {
@@ -322,7 +323,7 @@ func CheckNetWork(IP string, timeout int, cloudhubServer string, edgecoreServer 
 		if err != nil {
 			return fmt.Errorf("check cloudhubServer %s failed, %v", cloudhubServer, err)
 		}
-		fmt.Printf("check cloudhubServer %s success\n", cloudhubServer)
+		klog.Infof("check cloudhubServer %s success", cloudhubServer)
 	}
 
 	if edgecoreServer != "" {
@@ -330,7 +331,7 @@ func CheckNetWork(IP string, timeout int, cloudhubServer string, edgecoreServer 
 		if err != nil {
 			return fmt.Errorf("check edgecoreServer %s failed, %v", edgecoreServer, err)
 		}
-		fmt.Printf("check edgecoreServer %s success\n", edgecoreServer)
+		klog.Infof("check edgecoreServer %s success", edgecoreServer)
 	}
 
 	return nil
@@ -368,7 +369,7 @@ func checkRuntimeEndpoint(endpoint string, containerRuntime runtimeStatusChecker
 	if err := containerRuntime.IsRunning(); err != nil {
 		return err
 	}
-	fmt.Printf("check runtime endpoint %s success\n", endpoint)
+	klog.Infof("check runtime endpoint %s success", endpoint)
 	return nil
 }
 
@@ -414,7 +415,7 @@ func CheckPid() error {
 	v, err := strconv.ParseFloat(r, 32)
 	rate := (1 - v/vMax)
 	if rate > common.AllowedValuePIDRate {
-		fmt.Printf("Maximum PIDs: %s; Running processes: %s\n", rMax, r)
+		klog.Infof("Maximum PIDs: %s; Running processes: %s", rMax, r)
 		return nil
 	}
 	return fmt.Errorf("Maximum PIDs: %s; Running processes: %s", rMax, r)

--- a/keadm/cmd/keadm/app/cmd/debug/collect.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	klog "k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/common/constants"
 	apiconsts "github.com/kubeedge/api/apis/common/constants"
@@ -26,7 +27,7 @@ keadm debug collect --output-path .
 `
 )
 
-var printDeatilFlag = false
+var printDetailFlag = false
 
 // NewCollect returns KubeEdge collect command.
 func NewCollect() *cobra.Command {
@@ -40,7 +41,7 @@ func NewCollect() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := ExecuteCollect(collectOptions)
 			if err != nil {
-				fmt.Println(err)
+				klog.Errorf("collect failed: %v", err)
 			}
 		},
 	}
@@ -79,7 +80,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 		return err
 	}
 
-	fmt.Println("Start collecting data")
+	klog.Infof("Start collecting data")
 	// create tmp direction
 	tmpName, timenow, err := makeDirTmp()
 	if err != nil {
@@ -89,7 +90,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 
 	err = collectSystemData(fmt.Sprintf("%s/system", tmpName))
 	if err != nil {
-		fmt.Printf("collect System data failed")
+		klog.Warningf("collect System data failed")
 	}
 	printDetail("collect systemd data finish")
 
@@ -100,7 +101,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 	}
 	err = collectEdgecoreData(fmt.Sprintf("%s/edgecore", tmpName), edgeconfig, collectOptions)
 	if err != nil {
-		fmt.Printf("collect edgecore data failed")
+		klog.Warningf("collect edgecore data failed")
 	}
 	printDetail("collect edgecore data finish")
 
@@ -121,7 +122,7 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 
 	printDetail("Remove tmp data finish")
 
-	fmt.Printf("Data collected successfully, path: %s\n", zipName)
+	klog.Infof("Data collected successfully, path: %s", zipName)
 	return nil
 }
 
@@ -141,7 +142,7 @@ func VerificationParameters(collectOptions *common.CollectOptions) error {
 	collectOptions.OutputPath = path
 
 	if collectOptions.Detail {
-		printDeatilFlag = true
+		printDetailFlag = true
 	}
 
 	return nil
@@ -300,7 +301,7 @@ func ExecuteShell(cmdStr string, tmpPath string) error {
 }
 
 func printDetail(msg string) {
-	if printDeatilFlag {
-		fmt.Println(msg)
+	if printDetailFlag {
+		klog.V(4).Infof("%s", msg)
 	}
 }

--- a/keadm/cmd/keadm/app/cmd/debug/collect_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect_test.go
@@ -19,6 +19,7 @@ package debug
 import (
 	"bytes"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
+	klog "k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
@@ -73,23 +75,27 @@ func setupCopyFilePatch(shouldSucceed bool) *gomonkey.Patches {
 
 func TestPrintDetail(t *testing.T) {
 	assert := assert.New(t)
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	assert.NoError(err)
-	os.Stdout = w
 
-	printDeatilFlag = false
+	// Redirect klog output to a buffer for testing
+	var buf bytes.Buffer
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	_ = fs.Set("v", "4")
+	_ = fs.Set("logtostderr", "false")
+	klog.SetOutput(&buf)
+	defer func() {
+		klog.SetOutput(os.Stderr)
+		_ = fs.Set("v", "0")
+		_ = fs.Set("logtostderr", "true")
+	}()
+
+	printDetailFlag = false
 	printDetail("This should not be printed")
 
-	printDeatilFlag = true
+	printDetailFlag = true
 	printDetail("This should be printed")
 
-	w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	_, err = buf.ReadFrom(r)
-	assert.NoError(err)
+	klog.Flush()
 
 	assert.NotContains(buf.String(), "This should not be printed")
 	assert.Contains(buf.String(), "This should be printed")
@@ -232,9 +238,9 @@ func TestVerificationParameters(t *testing.T) {
 	opts.Detail = true
 	err = VerificationParameters(opts)
 	assert.NoError(err)
-	assert.True(printDeatilFlag)
+	assert.True(printDetailFlag)
 
-	printDeatilFlag = false
+	printDetailFlag = false
 }
 
 func TestCollectSystemData(t *testing.T) {
@@ -484,23 +490,24 @@ func TestExecuteCollect(t *testing.T) {
 	})
 	defer removeAllPatch.Reset()
 
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
+	// Redirect klog output to a buffer to verify logging
+	var klogBuf bytes.Buffer
+	fs := flag.NewFlagSet("test-exec", flag.ContinueOnError)
+	klog.InitFlags(fs)
+	_ = fs.Set("logtostderr", "false")
+	klog.SetOutput(&klogBuf)
+	defer func() {
+		klog.SetOutput(os.Stderr)
+		_ = fs.Set("logtostderr", "true")
+	}()
+
+	err := ExecuteCollect(opts)
 	assert.NoError(err)
-	os.Stdout = w
 
-	err = ExecuteCollect(opts)
-	assert.NoError(err)
+	klog.Flush()
 
-	w.Close()
-	os.Stdout = oldStdout
-
-	var buf bytes.Buffer
-	_, err = buf.ReadFrom(r)
-	assert.NoError(err)
-
-	assert.Contains(buf.String(), "Start collecting data")
-	assert.Contains(buf.String(), "Data collected successfully")
+	assert.Contains(klogBuf.String(), "Start collecting data")
+	assert.Contains(klogBuf.String(), "Data collected successfully")
 
 	verifyPatch.Reset()
 	verifyErrorPatch := gomonkey.ApplyFunc(VerificationParameters, func(collectOptions *common.CollectOptions) error {
@@ -540,21 +547,14 @@ func TestExecuteCollect(t *testing.T) {
 	})
 	defer collectSystemErrorPatch.Reset()
 
-	r, w, err = os.Pipe()
-	assert.NoError(err)
-	os.Stdout = w
+	klogBuf.Reset()
 
 	err = ExecuteCollect(opts)
 	assert.NoError(err)
 
-	w.Close()
-	os.Stdout = oldStdout
+	klog.Flush()
 
-	buf.Reset()
-	_, err = buf.ReadFrom(r)
-	assert.NoError(err)
-
-	assert.Contains(buf.String(), "collect System data failed")
+	assert.Contains(klogBuf.String(), "collect System data failed")
 
 	collectSystemErrorPatch.Reset()
 	collectSystemSuccessPatch := gomonkey.ApplyFunc(collectSystemData, func(tmpPath string) error {

--- a/keadm/cmd/keadm/app/cmd/debug/diagnose.go
+++ b/keadm/cmd/keadm/app/cmd/debug/diagnose.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
+	klog "k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/common/constants"
 	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
@@ -95,7 +96,7 @@ func (da Diagnose) ExecuteDiagnose(use string, ops *common.DiagnoseOptions, args
 		err = DiagnoseNode(ops)
 	case common.ArgDiagnosePod:
 		if len(args) == 0 {
-			fmt.Println("error: You must specify a pod name")
+			klog.Errorf("you must specify a pod name")
 			return
 		}
 		// diagnose Pod, first diagnose node
@@ -108,7 +109,7 @@ func (da Diagnose) ExecuteDiagnose(use string, ops *common.DiagnoseOptions, args
 	}
 
 	if err != nil {
-		fmt.Println(err.Error())
+		klog.Errorf("%v", err)
 		util.PrintFail(use, common.StrDiagnose)
 	} else {
 		util.PrintSucceed(use, common.StrDiagnose)
@@ -125,13 +126,13 @@ func DiagnoseNode(ops *common.DiagnoseOptions) error {
 	if !isEdgeRunning {
 		return fmt.Errorf("edgecore is not running")
 	}
-	fmt.Println("edgecore is running")
+	klog.Infof("edgecore is running")
 
 	isFileExists := files.FileExists(ops.Config)
 	if !isFileExists {
 		return fmt.Errorf("edge config is not exists")
 	}
-	fmt.Printf("edge config is exists: %v\n", ops.Config)
+	klog.Infof("edge config is exists: %v", ops.Config)
 
 	edgeconfig, err := util.ParseEdgecoreConfig(ops.Config)
 	if err != nil {
@@ -148,7 +149,7 @@ func DiagnoseNode(ops *common.DiagnoseOptions) error {
 	if !isFileExists {
 		return fmt.Errorf("dataSource is not exists")
 	}
-	fmt.Printf("dataSource is exists: %v\n", dataSource)
+	klog.Infof("dataSource is exists: %v", dataSource)
 
 	//CheckNetWork
 	if !edgeconfig.Modules.EdgeHub.WebSocket.Enable {
@@ -160,7 +161,7 @@ func DiagnoseNode(ops *common.DiagnoseOptions) error {
 	if err != nil {
 		return fmt.Errorf("cloudcore websocket connection failed")
 	}
-	fmt.Printf("cloudcore websocket connection success")
+	klog.Infof("cloudcore websocket connection success")
 
 	return nil
 }
@@ -174,13 +175,13 @@ func DiagnosePod(ops *common.DiagnoseOptions, podName string) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize database: %v ", err)
 	}
-	fmt.Printf("Database %s is exist \n", v1alpha2.DataBaseDataSource)
+	klog.Infof("Database %s is exist", v1alpha2.DataBaseDataSource)
 	podStatus, err := QueryPodFromDatabase(ops.Namespace, podName)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("pod %v phase is %v \n", podName, podStatus.Phase)
+	klog.Infof("pod %v phase is %v", podName, podStatus.Phase)
 	if podStatus.Phase != "Running" {
 		ready = false
 	}
@@ -194,7 +195,7 @@ func DiagnosePod(ops *common.DiagnoseOptions, podName string) error {
 			ready = true
 		}
 		if v.Status != "True" {
-			fmt.Printf("conditions is not true, type: %v ,message: %v ,reason: %v \n",
+			klog.Warningf("conditions is not true, type: %v ,message: %v ,reason: %v",
 				v.Type, v.Message, v.Reason)
 		}
 	}
@@ -202,20 +203,20 @@ func DiagnosePod(ops *common.DiagnoseOptions, podName string) error {
 	for _, v := range containerConditions {
 		if !v.Ready {
 			if v.State.Waiting != nil {
-				fmt.Printf("containerConditions %v Waiting, message: %v, reason: %v, RestartCount: %v \n", v.Name,
+				klog.Warningf("containerConditions %v Waiting, message: %v, reason: %v, RestartCount: %v", v.Name,
 					v.State.Waiting.Message, v.State.Waiting.Reason, v.RestartCount)
 			} else if v.State.Terminated != nil {
-				fmt.Printf("containerConditions %v Terminated, message: %v, reason: %v, RestartCount: %v \n", v.Name,
+				klog.Warningf("containerConditions %v Terminated, message: %v, reason: %v, RestartCount: %v", v.Name,
 					v.State.Terminated.Message, v.State.Terminated.Reason, v.RestartCount)
 			} else {
-				fmt.Printf("containerConditions %v is not ready\n", v.Name)
+				klog.Warningf("containerConditions %v is not ready", v.Name)
 			}
 		} else {
-			fmt.Printf("containerConditions %v is ready\n", v.Name)
+			klog.Infof("containerConditions %v is ready", v.Name)
 		}
 	}
 	if ready {
-		fmt.Printf("Pod %s is Ready", podName)
+		klog.Infof("Pod %s is Ready", podName)
 	} else {
 		return fmt.Errorf("pod %s is not Ready", podName)
 	}
@@ -234,7 +235,7 @@ func QueryPodFromDatabase(resNamePaces string, podName string) (*v1.PodStatus, e
 	if len(*resultPod) == 0 {
 		return nil, fmt.Errorf("not find %v in database", conditionsPod)
 	}
-	fmt.Printf("Pod %s is exist \n", podName)
+	klog.Infof("Pod %s is exist", podName)
 
 	conditionsStatus := fmt.Sprintf("%v/podstatus/%v",
 		resNamePaces,
@@ -244,7 +245,7 @@ func QueryPodFromDatabase(resNamePaces string, podName string) (*v1.PodStatus, e
 		return nil, fmt.Errorf("read database fail: %s", err.Error())
 	}
 	if len(*resultStatus) == 0 {
-		fmt.Printf("not find %v in database\n", conditionsStatus)
+		klog.Warningf("not find %v in database", conditionsStatus)
 		r := *resultPod
 		pod := &v1.Pod{}
 		err = json.Unmarshal([]byte(r[0]), pod)
@@ -253,7 +254,7 @@ func QueryPodFromDatabase(resNamePaces string, podName string) (*v1.PodStatus, e
 		}
 		return &pod.Status, nil
 	}
-	fmt.Printf("PodStatus %s is exist \n", podName)
+	klog.Infof("PodStatus %s is exist", podName)
 
 	r := *resultStatus
 	podStatus := &types.PodStatusRequest{}

--- a/keadm/cmd/keadm/app/cmd/debug/get.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
+	klog "k8s.io/klog/v2"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	k8s_v1_api "k8s.io/kubernetes/pkg/apis/core/v1"
 	k8sprinters "k8s.io/kubernetes/pkg/printers"
@@ -194,9 +195,7 @@ func (g *GetOptions) Run(args []string) error {
 	}
 
 	if len(results) == 0 {
-		if _, err := fmt.Printf("No resources found in %v namespace.\n", g.Namespace); err != nil {
-			return err
-		}
+		klog.Infof("No resources found in %v namespace.", g.Namespace)
 		return nil
 	}
 	if *g.PrintFlags.OutputFormat == "" || *g.PrintFlags.OutputFormat == FormatTypeWIDE {
@@ -227,7 +226,7 @@ func (g *GetOptions) Validate(args []string) error {
 		return fmt.Errorf("unrecognized resource type: %v. ", args[0])
 	}
 	if len(g.DataPath) == 0 {
-		fmt.Printf("not specified the EdgeCore database path, use the default path: %v. ", g.DataPath)
+		klog.Infof("not specified the EdgeCore database path, use the default path: %v.", g.DataPath)
 	}
 	if !isFileExist(g.DataPath) {
 		return fmt.Errorf("edgeCore database file %v not exist. ", g.DataPath)


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
`GenerateAndRefreshToken` in `cloud/pkg/cloudhub/servers/httpserver/pre_server.go` starts a goroutine that periodically refreshes the node-join token using a `select` over the refresh ticker and `ctx.Done()`. In the `ctx.Done()` case, the code used a `break` statement, which in Go only exits the enclosing `select`, not the surrounding `for` loop. Once the context was cancelled, `ctx.Done()` returns an already-closed channel, so the `select` resolves immediately on every iteration and the goroutine spins in a tight busy loop for the remaining lifetime of the process, pinning a full CPU core. The ticker was also never stopped, leaking its resources.

This PR changes the `ctx.Done()` case to `return` (exiting the goroutine) and adds `defer t.Stop()` to release the ticker, so cancellation actually stops the refresh goroutine as intended.

Which issue(s) this PR fixes:
Fixes #7101

Special notes for your reviewer:
Added `TestGenerateAndRefreshToken_StopsOnContextCancel`, which fails against the original code (the goroutine never terminates after cancellation, so `runtime.NumGoroutine()` never drops back to baseline) and passes against the fix. Uses gomonkey to patch `client.GetKubeClient` with a fake clientset, following the existing pattern in `cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go`. Run with `go test -gcflags=all=-l ./cloud/pkg/cloudhub/servers/httpserver/...`.

Does this PR introduce a user-facing change?: