### PR TITLE
certs: restrict cert file and directory permissions

### DIFF
--- a/pkg/security/certs/io.go
+++ b/pkg/security/certs/io.go
@@ -36,13 +36,23 @@ func ReadPEMFile(file string) (*pem.Block, error) {
 
 func WriteDERToPEMFile(file, t string, der []byte) (*pem.Block, error) {
 	dir := filepath.Dir(file)
-	if err := os.MkdirAll(dir, 0722); err != nil {
+	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create dir %s, err: %v", dir, err)
+	}
+	// MkdirAll does not change the mode of a directory that already exists,
+	// so an existing dir created with permissive bits would otherwise stay that way.
+	if err := os.Chmod(dir, 0700); err != nil {
+		return nil, fmt.Errorf("failed to chmod dir %s, err: %v", dir, err)
 	}
 	block := &pem.Block{Type: t, Bytes: der}
 	bff := pem.EncodeToMemory(block)
-	if err := os.WriteFile(file, bff, 0622); err != nil {
+	if err := os.WriteFile(file, bff, 0600); err != nil {
 		return nil, fmt.Errorf("failed to write file %s, err: %v", file, err)
+	}
+	// WriteFile only applies the mode when creating a new file, so an existing
+	// file with permissive bits needs an explicit chmod to be corrected.
+	if err := os.Chmod(file, 0600); err != nil {
+		return nil, fmt.Errorf("failed to chmod file %s, err: %v", file, err)
 	}
 	return block, nil
 }

--- a/pkg/security/certs/io_test.go
+++ b/pkg/security/certs/io_test.go
@@ -24,6 +24,62 @@ func TestReadWrite(t *testing.T) {
 	}
 }
 
+func TestWriteDERToPEMFilePermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "certs")
+	file := filepath.Join(dir, "edge.key")
+	if _, err := WriteDERToPEMFile(file, "test data", []byte("test")); err != nil {
+		t.Fatal(err)
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0700 {
+		t.Fatalf("want dir permissions %o, actual %o", 0700, perm)
+	}
+
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0600 {
+		t.Fatalf("want file permissions %o, actual %o", 0600, perm)
+	}
+}
+
+func TestWriteDERToPEMFileTightensExistingPermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "certs")
+	file := filepath.Join(dir, "edge.key")
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := WriteDERToPEMFile(file, "test data", []byte("test")); err != nil {
+		t.Fatal(err)
+	}
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0700 {
+		t.Fatalf("want dir permissions %o, actual %o", 0700, perm)
+	}
+
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0600 {
+		t.Fatalf("want file permissions %o, actual %o", 0600, perm)
+	}
+}
+
 func TestReadPEMFileNoBlock(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "invalid.crt")
 	if err := os.WriteFile(file, []byte("not a pem block"), 0600); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
`WriteDERToPEMFile` in `pkg/security/certs/io.go` created certificate directories with mode `0722` and PEM files with mode `0622`. These modes are group/world writable, which allows non-owner users on the host to modify or overwrite private key and certificate material written during certificate bootstrap and rotation (used by `edge/pkg/edgehub/certificate/certmanager.go`). This PR restricts directory creation to `0700` and file creation to `0600` so only the owner can write these artifacts.

**Which issue(s) this PR fixes**:
Fixes #7120

**Special notes for your reviewer**:
Added `TestWriteDERToPEMFilePermissions` in `pkg/security/certs/io_test.go` to assert the created directory and file have the expected restrictive permissions. Existing tests in the package continue to pass.

**Does this PR introduce a user-facing change?**:
```release-note
Restrict permissions on certificate files and directories written by WriteDERToPEMFile to 0600/0700 to prevent non-owner write access to private key material.
```
