### PR TITLE
charts: fix misspelled annotations key in admission deployment

### DIFF
--- a/manifests/charts/cloudcore/templates/deployment_admission.yaml
+++ b/manifests/charts/cloudcore/templates/deployment_admission.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   {{- with .Values.admission.annotations }}
-  anntations: {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.admission.labels }}
   labels: {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The cloudcore admission Deployment Helm template renders `anntations` instead of `annotations`, so any value set in `.Values.admission.annotations` is silently dropped from the rendered Deployment metadata. This fixes the key spelling so user-supplied annotations are applied correctly.

**Which issue(s) this PR fixes**:
Fixes #7122

**Special notes for your reviewer**:

Verified with `helm template manifests/charts/cloudcore --set admission.enable=true --set admission.annotations.foo=bar` that `annotations: {foo: bar}` now renders correctly on the admission Deployment.

**Does this PR introduce a user-facing change?**:
```release-note
Fix a bug where `.Values.admission.annotations` was not applied to the cloudcore admission Deployment due to a misspelled `annotations` key in the Helm chart template.
```
