### PR TITLE
admission: remove invalid 2>&1 argv entry

### DIFF
--- a/build/admission/deployment.yaml
+++ b/build/admission/deployment.yaml
@@ -32,7 +32,6 @@ spec:
             - --webhook-service-name=kubeedge-admission-service
             - --port=443
             - -v=4
-            - 2>&1
           image: kubeedge/admission:latest
           imagePullPolicy: IfNotPresent
           name: admission

--- a/manifests/charts/cloudcore/templates/deployment_admission.yaml
+++ b/manifests/charts/cloudcore/templates/deployment_admission.yaml
@@ -45,7 +45,6 @@ spec:
             - --webhook-service-name=kubeedge-admission-service
             - --port=443
             - -v=4
-            - 2>&1
           image: {{ .Values.admission.image.repository }}:{{ .Values.admission.image.tag }}
           imagePullPolicy:  {{ .Values.admission.image.pullPolicy }}
           name: admission


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The admission Deployment manifests (Helm template and static manifest) appended `2>&1` as a standalone item in the container `args` list. Kubernetes passes `args` directly to the container entrypoint, not through a shell, so `2>&1` was passed literally to the `admission` binary instead of acting as shell redirection. This PR removes the invalid token from both manifests so only valid CLI flags are passed.

**Which issue(s) this PR fixes**:

Fixes #7124

**Special notes for your reviewer**:

Verified with `helm lint manifests/charts/cloudcore --set admission.enable=true` and `make verify`.

**Does this PR introduce a user-facing change?**:

```release-note

```
