### PR TITLE
executor: fix RemoveExecutor evicting a newer executor via stale reference

### DIFF
--- a/cloud/pkg/taskmanager/downstream/config_update.go
+++ b/cloud/pkg/taskmanager/downstream/config_update.go
@@ -93,7 +93,7 @@ func (h *ConfigUpdateJobHandler) InterruptExecutor(obj any) {
 	}
 	if exec != nil {
 		exec.Interrupt()
-		executor.RemoveExecutor(operationsv1alpha2.ResourceConfigUpdateJob, job.Name)
+		executor.RemoveExecutor(operationsv1alpha2.ResourceConfigUpdateJob, job.Name, exec)
 	}
 }
 

--- a/cloud/pkg/taskmanager/downstream/image_prepull.go
+++ b/cloud/pkg/taskmanager/downstream/image_prepull.go
@@ -93,7 +93,7 @@ func (h *ImagePrePullJobHandler) InterruptExecutor(obj any) {
 	}
 	if exec != nil {
 		exec.Interrupt()
-		executor.RemoveExecutor(operationsv1alpha2.ResourceImagePrePullJob, job.Name)
+		executor.RemoveExecutor(operationsv1alpha2.ResourceImagePrePullJob, job.Name, exec)
 	}
 }
 

--- a/cloud/pkg/taskmanager/downstream/node_upgrade.go
+++ b/cloud/pkg/taskmanager/downstream/node_upgrade.go
@@ -93,7 +93,7 @@ func (h *NodeUpgradeJobHandler) InterruptExecutor(obj any) {
 	}
 	if exec != nil {
 		exec.Interrupt()
-		executor.RemoveExecutor(operationsv1alpha2.ResourceNodeUpgradeJob, job.Name)
+		executor.RemoveExecutor(operationsv1alpha2.ResourceNodeUpgradeJob, job.Name, exec)
 	}
 }
 

--- a/cloud/pkg/taskmanager/executor/executor.go
+++ b/cloud/pkg/taskmanager/executor/executor.go
@@ -92,8 +92,8 @@ func GetExecutor(resourceType, jobName string) (*NodeTaskExecutor, error) {
 
 // RemoveExecutor removes the executor from the nodeTaskExecutors,
 // found by resource type and job name.
-func RemoveExecutor(resourceType, jobName string) {
-	nodeTaskExecutors.Delete(executorsKey(resourceType, jobName))
+func RemoveExecutor(resourceType, jobName string, executor *NodeTaskExecutor) {
+	nodeTaskExecutors.CompareAndDelete(executorsKey(resourceType, jobName), executor)
 }
 
 type NodeTaskExecutor struct {
@@ -121,7 +121,7 @@ type UpdateNodeTaskStatus func(ctx context.Context, job wrap.NodeJob, task wrap.
 // will execute tasks.
 func (executor *NodeTaskExecutor) Execute(ctx context.Context, connectedNodes []string) {
 	// All node tasks of the node job have been executed, delete the executor.
-	defer RemoveExecutor(executor.job.ResourceType(), executor.job.Name())
+	defer RemoveExecutor(executor.job.ResourceType(), executor.job.Name(), executor)
 
 	tasks := executor.job.Tasks()
 	for i := range tasks {

--- a/cloud/pkg/taskmanager/executor/executor_test.go
+++ b/cloud/pkg/taskmanager/executor/executor_test.go
@@ -69,11 +69,66 @@ func TestExecutorOperation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, exec)
 
-	RemoveExecutor(job.ResourceType(), job.Name())
+	RemoveExecutor(job.ResourceType(), job.Name(), exec)
 
 	exec, err = GetExecutor(job.ResourceType(), job.Name())
 	assert.Equal(t, ErrExecutorNotExists, err)
 	assert.Nil(t, exec)
+}
+
+func TestRemoveExecutor_DoesNotEvictNewerExecutor(t *testing.T) {
+	job, err := wrap.WithEventObj(&operationsv1alpha2.ImagePrePullJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stale-evict-test-job",
+		},
+		Spec: operationsv1alpha2.ImagePrePullJobSpec{
+			ImagePrePullTemplate: operationsv1alpha2.ImagePrePullTemplate{
+				Concurrency: 2,
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	updateFun := func(_ctx context.Context, _job wrap.NodeJob, _task wrap.NodeJobTask) {}
+	ctx := context.TODO()
+
+	// Simulate executor A being created, then interrupted and removed early,
+	// before its Execute() goroutine has actually finished running.
+	execA, loaded, err := NewNodeTaskExecutor(ctx, job, updateFun)
+	assert.NoError(t, err)
+	assert.False(t, loaded)
+	assert.NotNil(t, execA)
+
+	RemoveExecutor(job.ResourceType(), job.Name(), execA)
+
+	check, err := GetExecutor(job.ResourceType(), job.Name())
+	assert.Equal(t, ErrExecutorNotExists, err)
+	assert.Nil(t, check)
+
+	// Simulate the job being re-triggered while A's goroutine is still winding
+	// down: a new executor B gets registered under the same key.
+	execB, loaded, err := NewNodeTaskExecutor(ctx, job, updateFun)
+	assert.NoError(t, err)
+	assert.False(t, loaded)
+	assert.NotNil(t, execB)
+	assert.NotSame(t, execA, execB)
+
+	// A's goroutine finally finishes and fires its own deferred RemoveExecutor
+	// with its own (now stale) reference. Before the fix, this deleted B's
+	// entry purely by key. After the fix, CompareAndDelete refuses because
+	// the stored value is execB, not execA.
+	RemoveExecutor(job.ResourceType(), job.Name(), execA)
+
+	// B must still be discoverable — it's the executor actually running now.
+	check, err = GetExecutor(job.ResourceType(), job.Name())
+	assert.NoError(t, err)
+	assert.Same(t, execB, check)
+
+	// B removes itself correctly when it's actually done.
+	RemoveExecutor(job.ResourceType(), job.Name(), execB)
+	check, err = GetExecutor(job.ResourceType(), job.Name())
+	assert.Equal(t, ErrExecutorNotExists, err)
+	assert.Nil(t, check)
 }
 
 func TestExecute(t *testing.T) {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

RemoveExecutor in cloud/pkg/taskmanager/executor/executor.go deleted an entry from the nodeTaskExecutors sync.Map by key only, not by executor identity. InterruptExecutor (in node_upgrade.go, config_update.go, and image_prepull.go) calls Interrupt() and then immediately RemoveExecutor(), before the executor's own Execute() goroutine has actually finished, since Execute() only checks the interrupted flag between task iterations.

If the same job was re-triggered while the old executor's goroutine was still winding down, a new executor got registered under the same key. When the old executor's goroutine finally finished and its own deferred RemoveExecutor call fired, it deleted by key, removing the newer executor that had since taken that slot, even though it was still actively running.

This PR changes RemoveExecutor to take the executor being removed as an argument and use sync.Map.CompareAndDelete, so an entry is only removed if it still matches the executor being removed. A stale executor finishing late can no longer evict a different, newer executor occupying its old key. This also updates the three call sites in the downstream package and the self-cleanup call inside Execute() to pass the executor reference.

**Which issue(s) this PR fixes**:

Fixes #7127

**Special notes for your reviewer**:

Added TestRemoveExecutor_DoesNotEvictNewerExecutor, which simulates the exact sequence from the issue: create executor A, remove A, create executor B under the same key, then call RemoveExecutor again with the stale A reference. Before the fix this deleted B's entry (assert.Same on the recovered executor failed with a nil result); after the fix B remains discoverable via GetExecutor. Verified this by temporarily reverting RemoveExecutor to the old key-only Delete and confirming the new test fails at that exact assertion, then reverting back and confirming the full package passes.

Run with `go test ./cloud/pkg/taskmanager/executor/... -v`.

**Does this PR introduce a user-facing change?**:

```
NONE
```