### PR TITLE
fix: correct grammar in keadm join command help text

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/join.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join.go
@@ -59,7 +59,7 @@ func NewEdgeJoin() *cobra.Command {
 	step := common.NewStep()
 	cmd := &cobra.Command{
 		Use:          "join",
-		Short:        "Bootstraps edge component. Checks and install (if required) the pre-requisites. Execute it on any edge node machine you wish to join",
+		Short:        "Bootstraps edge component. Checks and installs (if required) the pre-requisites. Execute it on any edge node machine you wish to join",
 		Long:         edgeJoinDescription,
 		Example:      edgeJoinExample,
 		SilenceUsage: true,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Corrects a grammar error in the `keadm join` command help text by changing "Checks and install" to "Checks and installs". This improves the user-facing CLI help text without changing any functionality.

**Which issue(s) this PR fixes**:

Fixes #7110

**Special notes for your reviewer**:

This is a help-text-only cleanup affecting a single line in `keadm/cmd/keadm/app/cmd/edge/join.go`. No functional or behavioral changes are introduced, and no tests are required.

**Does this PR introduce a user-facing change?**:

```release-note
Corrected a grammar error in the `keadm join` command help text.
```