### PR TITLE
[keadm] Fix missing -l flag shorthand and incorrect --show-events text in describe device

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/describe/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/device.go
@@ -74,9 +74,9 @@ func NewDescribeDeviceOptions() *DeviceDescribeOptions {
 
 func AddDescribeDeviceFlags(cmd *cobra.Command, options *DeviceDescribeOptions) {
 	cmd.Flags().StringVarP(&options.Namespace, common.FlagNameNamespace, "n", "default", "If present, the namespace scope for this CLI request")
-	cmd.Flags().StringVar(&options.LabelSelector, common.FlagNameLabelSelector, "", "Selector (label query) to filter on")
+	cmd.Flags().StringVarP(&options.LabelSelector, common.FlagNameLabelSelector, "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVarP(&options.AllNamespaces, common.FlagNameAllNamespaces, "A", false, "If present, list the requested object(s) across all namespaces")
-	cmd.Flags().BoolVar(&options.ShowEvents, common.FlagNameShowEvents, false, "If present, list the requested object(s) across all namespaces")
+	cmd.Flags().BoolVar(&options.ShowEvents, common.FlagNameShowEvents, false, "If present, display events related to the described object.")
 	cmd.Flags().Int64Var(&options.ChunkSize, common.FlagNameChunkSize, 500, "If non-zero, split output into chunks of this many bytes")
 }
 

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/device_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/device_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+func TestNewEdgeDescribeDevice(t *testing.T) {
+	cmd := NewEdgeDescribeDevice()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "device", cmd.Use)
+	assert.Equal(t, edgeDescribeDeviceShortDescription, cmd.Short)
+	assert.Contains(t, cmd.Aliases, "devices")
+
+	// Verify flag registration
+	flagNamespace := cmd.Flags().Lookup(common.FlagNameNamespace)
+	assert.NotNil(t, flagNamespace)
+	assert.Equal(t, "n", flagNamespace.Shorthand)
+	assert.Equal(t, "default", flagNamespace.DefValue)
+
+	flagSelector := cmd.Flags().Lookup(common.FlagNameLabelSelector)
+	assert.NotNil(t, flagSelector)
+	assert.Equal(t, "l", flagSelector.Shorthand)
+
+	flagAllNamespaces := cmd.Flags().Lookup(common.FlagNameAllNamespaces)
+	assert.NotNil(t, flagAllNamespaces)
+	assert.Equal(t, "A", flagAllNamespaces.Shorthand)
+
+	flagShowEvents := cmd.Flags().Lookup(common.FlagNameShowEvents)
+	assert.NotNil(t, flagShowEvents)
+	assert.Equal(t, "If present, display events related to the described object.", flagShowEvents.Usage)
+
+	flagChunkSize := cmd.Flags().Lookup(common.FlagNameChunkSize)
+	assert.NotNil(t, flagChunkSize)
+	assert.Equal(t, "500", flagChunkSize.DefValue)
+}
+
+func TestNewDescribeDeviceOptions(t *testing.T) {
+	opts := NewDescribeDeviceOptions()
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.In)
+	assert.NotNil(t, opts.Out)
+	assert.NotNil(t, opts.ErrOut)
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/describe/pod_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/describe/pod_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+func TestNewEdgeDescribePod(t *testing.T) {
+	cmd := NewEdgeDescribePod()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "pod", cmd.Use)
+	assert.Equal(t, edgeDescribePodShortDescription, cmd.Short)
+	assert.Contains(t, cmd.Aliases, "pods")
+	assert.Contains(t, cmd.Aliases, "po")
+
+	// Verify flag registration
+	flagNamespace := cmd.Flags().Lookup(common.FlagNameNamespace)
+	assert.NotNil(t, flagNamespace)
+	assert.Equal(t, "n", flagNamespace.Shorthand)
+	assert.Equal(t, "default", flagNamespace.DefValue)
+
+	flagSelector := cmd.Flags().Lookup(common.FlagNameLabelSelector)
+	assert.NotNil(t, flagSelector)
+	assert.Equal(t, "l", flagSelector.Shorthand)
+
+	flagAllNamespaces := cmd.Flags().Lookup(common.FlagNameAllNamespaces)
+	assert.NotNil(t, flagAllNamespaces)
+	assert.Equal(t, "A", flagAllNamespaces.Shorthand)
+
+	flagShowEvents := cmd.Flags().Lookup(common.FlagNameShowEvents)
+	assert.NotNil(t, flagShowEvents)
+	assert.Equal(t, "If present, display events related to the described object.", flagShowEvents.Usage)
+
+	flagChunkSize := cmd.Flags().Lookup(common.FlagNameChunkSize)
+	assert.NotNil(t, flagChunkSize)
+	assert.Equal(t, "500", flagChunkSize.DefValue)
+}
+
+func TestNewDescribePodOptions(t *testing.T) {
+	opts := NewDescribePodOptions()
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.In)
+	assert.NotNil(t, opts.Out)
+	assert.NotNil(t, opts.ErrOut)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes two flag registration issues in `keadm ctl describe device`:
1. Fixes the missing `-l` shorthand flag for `--label-selector` / `--selector` by switching `StringVar` to `StringVarP`.
2. Updates the `--show-events` help description string to `"If present, display events related to the described object."` (previously copy-pasted from `--all-namespaces`).
3. Adds unit test coverage for `keadm ctl describe device` and `keadm ctl describe pod` in `device_test.go` and `pod_test.go`.

**Which issue(s) this PR fixes**:

Fixes #7130

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix missing `-l` flag shorthand and incorrect `--show-events` description in `keadm ctl describe device`.
```
