### PR TITLE
charts: derive admission webhook namespace and service name from release

### DIFF
--- a/manifests/charts/cloudcore/templates/deployment_admission.yaml
+++ b/manifests/charts/cloudcore/templates/deployment_admission.yaml
@@ -41,8 +41,8 @@ spec:
             - --tls-private-key-file=/admission.local.config/certificates/tls.key
             - --ca-cert-file=/admission.local.config/certificates/ca.crt
             {{- end }}
-            - --webhook-namespace=kubeedge
-            - --webhook-service-name=kubeedge-admission-service
+            - --webhook-namespace={{ .Release.Namespace }}
+            - --webhook-service-name={{ .Values.admission.serviceName | default "kubeedge-admission-service" }}
             - --port=443
             - -v=4
             - 2>&1

--- a/manifests/charts/cloudcore/templates/service_admission.yaml
+++ b/manifests/charts/cloudcore/templates/service_admission.yaml
@@ -5,7 +5,7 @@ metadata:
   {{- with .Values.admission.labels }}
   labels: {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: kubeedge-admission-service
+  name: {{ .Values.admission.serviceName | default "kubeedge-admission-service" }}
 spec:
   ports:
     - port: 443

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -147,6 +147,7 @@ admission:
   enable: false
   replicaCount: 1
   certsSecretName: ""
+  serviceName: "kubeedge-admission-service"
   image:
     repository: "kubeedge/admission"
     tag: "v1.23.0"


### PR DESCRIPTION
## Summary
- Fix the cloudcore admission Helm chart so the webhook namespace and service name are no longer hardcoded

## Linked Issue
Fixes #7132

## What Changed
- `manifests/charts/cloudcore/templates/deployment_admission.yaml`: derive `--webhook-namespace` from `.Release.Namespace` and `--webhook-service-name` from a new `admission.serviceName` value, instead of hardcoded `kubeedge` / `kubeedge-admission-service`
- `manifests/charts/cloudcore/templates/service_admission.yaml`: use the same `admission.serviceName` value for the Service name so it stays consistent with the Deployment args
- `manifests/charts/cloudcore/values.yaml`: add `admission.serviceName` default value `kubeedge-admission-service`

## Verification
- `make verify` — passed
- `helm lint manifests/charts/cloudcore --set admission.enable=true` — passed
- `helm template demo manifests/charts/cloudcore -n custom-edge --set admission.enable=true | grep -- '--webhook-'` — passed, confirms `--webhook-namespace=custom-edge` is now rendered instead of the previous hardcoded `kubeedge`

## Scope
- Only the three files listed above were changed; no unrelated files were modified
