### PR TITLE
[keadm] Fix misleading argument error and YAML unmarshaling in keadm ctl edit device

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/edit/device.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/device.go
@@ -85,6 +85,13 @@ func NewEditDeviceOpts() *DeviceEditOptions {
 }
 
 func (o *DeviceEditOptions) editDevice(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("device name is required")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("too many args, edit one device at once")
+	}
+
 	config, err := util.ParseEdgecoreConfig(constants.EdgecoreConfigPath)
 	if err != nil {
 		return fmt.Errorf("get edge config failed with err:%v", err)
@@ -93,27 +100,23 @@ func (o *DeviceEditOptions) editDevice(args []string) error {
 
 	ctx := context.Background()
 
-	if len(args) == 1 {
-		deviceRequest := &client.DeviceRequest{
-			Namespace:  o.Namespace,
-			DeviceName: args[0],
-		}
+	deviceRequest := &client.DeviceRequest{
+		Namespace:  o.Namespace,
+		DeviceName: args[0],
+	}
 
-		device, err := deviceRequest.GetDevice(ctx)
-		if err != nil {
+	device, err := deviceRequest.GetDevice(ctx)
+	if err != nil {
+		return err
+	}
+
+	if device.Spec.NodeName == nodeName {
+		if err = o.edit(device); err != nil {
 			return err
 		}
-
-		if device.Spec.NodeName == nodeName {
-			if err = o.edit(device); err != nil {
-				return err
-			}
-			klog.Infof("Send update message to DeviceTwin")
-		} else {
-			klog.Errorf("Can't query device: \"%s\" for node: \"%s\"", device.Name, device.Spec.NodeName)
-		}
+		klog.Infof("Send update message to DeviceTwin")
 	} else {
-		return fmt.Errorf("too many args, edit one device at once")
+		klog.Errorf("Can't query device: \"%s\" for node: \"%s\"", device.Name, device.Spec.NodeName)
 	}
 
 	return nil
@@ -160,7 +163,7 @@ func (o *DeviceEditOptions) edit(dl *v1beta1.Device) error {
 	jsonEdited := cmdutil.StripComments(edited)
 
 	var editedDevice v1beta1.Device
-	err = json.Unmarshal(jsonEdited, &editedDevice)
+	err = yaml.Unmarshal(jsonEdited, &editedDevice)
 	if err != nil {
 		return preservedFile(err, file)
 	}

--- a/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/edit/device_test.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
+
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
+	"github.com/kubeedge/api/apis/devices/v1beta1"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/ctl/client"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util"
+)
+
+const (
+	deviceTestNodeName = "test-node"
+	testDeviceName     = "test-device"
+	testTempFile       = "temp-file"
+)
+
+func setupEditDeviceTest() (*DeviceEditOptions, *v1alpha2.EdgeCoreConfig, *gomonkey.Patches) {
+	opts := NewEditDeviceOpts()
+
+	edgeCoreConfig := v1alpha2.NewDefaultEdgeCoreConfig()
+	edgeCoreConfig.Modules.Edged.HostnameOverride = deviceTestNodeName
+
+	patches := gomonkey.ApplyFunc(util.ParseEdgecoreConfig,
+		func(configPath string) (*v1alpha2.EdgeCoreConfig, error) {
+			return edgeCoreConfig, nil
+		})
+
+	return opts, edgeCoreConfig, patches
+}
+
+func TestNewEdgeEdit(t *testing.T) {
+	cmd := NewEdgeEdit()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "edit", cmd.Use)
+	assert.Equal(t, edgeEditShortDescription, cmd.Short)
+}
+
+func TestNewEdgeEditDevice(t *testing.T) {
+	cmd := NewEdgeEditDevice()
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "device", cmd.Use)
+	assert.Equal(t, edgeEditDeviceShortDescription, cmd.Short)
+
+	// Verify namespace flag
+	flagNamespace := cmd.Flags().Lookup(common.FlagNameNamespace)
+	assert.NotNil(t, flagNamespace)
+	assert.Equal(t, "n", flagNamespace.Shorthand)
+	assert.Equal(t, "default", flagNamespace.DefValue)
+}
+
+func TestNewEditDeviceOpts(t *testing.T) {
+	opts := NewEditDeviceOpts()
+	assert.NotNil(t, opts)
+	assert.NotNil(t, opts.In)
+	assert.NotNil(t, opts.Out)
+	assert.NotNil(t, opts.ErrOut)
+	assert.NotNil(t, opts.editPrinterOptions)
+}
+
+func TestEditDeviceArgumentValidation(t *testing.T) {
+	opts, _, patches := setupEditDeviceTest()
+	defer patches.Reset()
+
+	// Case 1: 0 arguments passed
+	err := opts.editDevice([]string{})
+	assert.Error(t, err)
+	assert.Equal(t, "device name is required", err.Error())
+
+	// Case 2: >1 arguments passed
+	err = opts.editDevice([]string{"dev1", "dev2"})
+	assert.Error(t, err)
+	assert.Equal(t, "too many args, edit one device at once", err.Error())
+}
+
+func TestEditDeviceZeroArgsDoesNotParseConfig(t *testing.T) {
+	opts := NewEditDeviceOpts()
+
+	called := false
+	patches := gomonkey.ApplyFunc(util.ParseEdgecoreConfig,
+		func(configPath string) (*v1alpha2.EdgeCoreConfig, error) {
+			called = true
+			return nil, errors.New("failed to parse config")
+		})
+	defer patches.Reset()
+
+	err := opts.editDevice([]string{})
+	assert.Error(t, err)
+	assert.Equal(t, "device name is required", err.Error())
+	assert.False(t, called, "ParseEdgecoreConfig should not be called before argument validation")
+}
+
+func TestEditDeviceErrorConfig(t *testing.T) {
+	opts := NewEditDeviceOpts()
+	patches := gomonkey.ApplyFunc(util.ParseEdgecoreConfig,
+		func(configPath string) (*v1alpha2.EdgeCoreConfig, error) {
+			return nil, errors.New("failed to parse config")
+		})
+	defer patches.Reset()
+
+	err := opts.editDevice([]string{testDeviceName})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get edge config failed")
+}
+
+func TestEditDeviceGetDeviceError(t *testing.T) {
+	opts, _, patches := setupEditDeviceTest()
+	defer patches.Reset()
+
+	patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "GetDevice",
+		func(_ *client.DeviceRequest, _ context.Context) (*v1beta1.Device, error) {
+			return nil, errors.New("device not found")
+		})
+
+	err := opts.editDevice([]string{testDeviceName})
+	assert.Error(t, err)
+	assert.Equal(t, "device not found", err.Error())
+}
+
+func TestEditDeviceNodeMismatch(t *testing.T) {
+	opts, _, patches := setupEditDeviceTest()
+	defer patches.Reset()
+
+	patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "GetDevice",
+		func(_ *client.DeviceRequest, _ context.Context) (*v1beta1.Device, error) {
+			return &v1beta1.Device{
+				ObjectMeta: metav1.ObjectMeta{Name: testDeviceName, Namespace: "default"},
+				Spec: v1beta1.DeviceSpec{
+					NodeName: "other-node",
+				},
+			}, nil
+		})
+
+	err := opts.editDevice([]string{testDeviceName})
+	assert.NoError(t, err)
+}
+
+func TestPrintObj(t *testing.T) {
+	opts := NewEditDeviceOpts()
+	device := &v1beta1.Device{
+		ObjectMeta: metav1.ObjectMeta{Name: testDeviceName, Namespace: "default"},
+		Spec: v1beta1.DeviceSpec{
+			NodeName: deviceTestNodeName,
+		},
+	}
+
+	buf := &bytes.Buffer{}
+	err := opts.editPrinterOptions.PrintObj(device, buf)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), testDeviceName)
+}
+
+func TestEditDeviceSuccess(t *testing.T) {
+	opts, _, patches := setupEditDeviceTest()
+	defer patches.Reset()
+
+	device := &v1beta1.Device{
+		ObjectMeta: metav1.ObjectMeta{Name: testDeviceName, Namespace: "default"},
+		Spec: v1beta1.DeviceSpec{
+			NodeName: deviceTestNodeName,
+		},
+	}
+
+	patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "GetDevice",
+		func(_ *client.DeviceRequest, _ context.Context) (*v1beta1.Device, error) {
+			return device, nil
+		})
+
+	modifiedYAML := []byte("apiVersion: devices.kubeedge.io/v1beta1\nkind: Device\nmetadata:\n  name: test-device\n  namespace: default\nspec:\n  nodeName: test-node\n  description: updated-device\n")
+
+	patches.ApplyMethod(reflect.TypeOf(editor.NewDefaultEditor([]string{})), "LaunchTempFile",
+		func(_ editor.Editor, _ string, _ string, _ io.Reader) ([]byte, string, error) {
+			return modifiedYAML, testTempFile, nil
+		})
+
+	patches.ApplyFunc(os.Remove, func(name string) error {
+		return nil
+	})
+
+	patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "UpdateDevice",
+		func(_ *client.DeviceRequest, _ context.Context, _ *v1beta1.Device) (*rest.Result, error) {
+			return &rest.Result{}, nil
+		})
+
+	err := opts.editDevice([]string{testDeviceName})
+	assert.NoError(t, err)
+}
+
+func TestEditDeviceCancelled(t *testing.T) {
+	opts, _, patches := setupEditDeviceTest()
+	defer patches.Reset()
+
+	device := &v1beta1.Device{
+		ObjectMeta: metav1.ObjectMeta{Name: testDeviceName, Namespace: "default"},
+		Spec: v1beta1.DeviceSpec{
+			NodeName: deviceTestNodeName,
+		},
+	}
+
+	patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "GetDevice",
+		func(_ *client.DeviceRequest, _ context.Context) (*v1beta1.Device, error) {
+			return device, nil
+		})
+
+	patches.ApplyMethod(reflect.TypeOf(editor.NewDefaultEditor([]string{})), "LaunchTempFile",
+		func(_ editor.Editor, _ string, _ string, r io.Reader) ([]byte, string, error) {
+			buf := new(bytes.Buffer)
+			_, _ = buf.ReadFrom(r)
+			return buf.Bytes(), testTempFile, nil
+		})
+
+	patches.ApplyFunc(os.Remove, func(name string) error {
+		return nil
+	})
+
+	err := opts.editDevice([]string{testDeviceName})
+	assert.Error(t, err)
+	assert.Equal(t, "no changes made", err.Error())
+}
+
+func TestEditDeviceUnmarshalError(t *testing.T) {
+	opts, _, patches := setupEditDeviceTest()
+	defer patches.Reset()
+
+	device := &v1beta1.Device{
+		ObjectMeta: metav1.ObjectMeta{Name: testDeviceName, Namespace: "default"},
+		Spec: v1beta1.DeviceSpec{
+			NodeName: deviceTestNodeName,
+		},
+	}
+
+	patches.ApplyMethod(reflect.TypeOf(&client.DeviceRequest{}), "GetDevice",
+		func(_ *client.DeviceRequest, _ context.Context) (*v1beta1.Device, error) {
+			return device, nil
+		})
+
+	invalidYAML := []byte("invalid_yaml: [unclosed_bracket")
+
+	patches.ApplyMethod(reflect.TypeOf(editor.NewDefaultEditor([]string{})), "LaunchTempFile",
+		func(_ editor.Editor, _ string, _ string, _ io.Reader) ([]byte, string, error) {
+			return invalidYAML, testTempFile, nil
+		})
+
+	patches.ApplyFunc(os.Remove, func(name string) error {
+		return nil
+	})
+
+	err := opts.editDevice([]string{testDeviceName})
+	assert.Error(t, err)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR addresses argument validation and YAML unmarshaling issues in `keadm ctl edit device`:
1. Refactors argument count validation in `editDevice` so running `keadm ctl edit device` with 0 arguments returns `Error: device name is required` instead of `Error: too many args, edit one device at once`.
2. Replaces `json.Unmarshal` with `yaml.Unmarshal` (`sigs.k8s.io/yaml`) when parsing saved temporary YAML device files in `edit()` to avoid JSON syntax parsing failures on YAML content.
3. Adds unit test coverage for `keadm ctl edit device` in `device_test.go`.

**Which issue(s) this PR fixes**:

Fixes #7136

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix misleading argument error message and YAML unmarshaling failure in `keadm ctl edit device`.
```
