### PR TITLE
devicetwin: guard nil twin value when adding twins

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/twin.go
+++ b/edge/pkg/devicetwin/dtmanager/twin.go
@@ -838,7 +838,7 @@ func dealTwinAdd(returnResult *dttype.DealTwinResult, deviceID string, key strin
 		}
 	}
 
-	if msgTwin.Expected != nil {
+	if msgTwin.Expected != nil && msgTwin.Expected.Value != nil {
 		version := &dttype.TwinVersion{}
 		var msgTwinExpectedVersion *dttype.TwinVersion
 		if dealType != RestDealType {
@@ -881,7 +881,7 @@ func dealTwinAdd(returnResult *dttype.DealTwinResult, deviceID string, key strin
 		}
 	}
 
-	if msgTwin.Actual != nil {
+	if msgTwin.Actual != nil && msgTwin.Actual.Value != nil {
 		version := &dttype.TwinVersion{}
 		var msgTwinActualVersion *dttype.TwinVersion
 		if dealType != RestDealType {

--- a/edge/pkg/devicetwin/dtmanager/twin_test.go
+++ b/edge/pkg/devicetwin/dtmanager/twin_test.go
@@ -1384,6 +1384,74 @@ func TestDealTwinAdd(t *testing.T) {
 	}
 }
 
+// TestDealTwinAddNilTwinValue is function to test dealTwinAdd when the expected
+// or the actual object of a twin carries no value
+func TestDealTwinAddNilTwinValue(t *testing.T) {
+	optionTrue := true
+	tests := []struct {
+		name     string
+		msgTwin  *dttype.MsgTwin
+		dealType int
+	}{
+		{
+			name: "TestDealTwinAddNilTwinValue(): Case 1: expected without value, updated from mqtt",
+			msgTwin: &dttype.MsgTwin{
+				Expected: &dttype.TwinValue{},
+				Optional: &optionTrue,
+				Metadata: &dttype.TypeMetadata{Type: typeString},
+			},
+			dealType: RestDealType,
+		},
+		{
+			name: "TestDealTwinAddNilTwinValue(): Case 2: actual without value, updated from mqtt",
+			msgTwin: &dttype.MsgTwin{
+				Actual:   &dttype.TwinValue{},
+				Optional: &optionTrue,
+				Metadata: &dttype.TypeMetadata{Type: typeString},
+			},
+			dealType: RestDealType,
+		},
+		{
+			name: "TestDealTwinAddNilTwinValue(): Case 3: expected and actual without value, synced from cloud",
+			msgTwin: &dttype.MsgTwin{
+				Expected:        &dttype.TwinValue{},
+				Actual:          &dttype.TwinValue{},
+				Optional:        &optionTrue,
+				Metadata:        &dttype.TypeMetadata{Type: typeString},
+				ExpectedVersion: &dttype.TwinVersion{},
+				ActualVersion:   &dttype.TwinVersion{},
+			},
+			dealType: SyncDealType,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			returnResult := &dttype.DealTwinResult{
+				Document:   make(map[string]*dttype.TwinDoc),
+				SyncResult: make(map[string]*dttype.MsgTwin),
+				Result:     make(map[string]*dttype.MsgTwin),
+			}
+			twins := make(map[string]*dttype.MsgTwin)
+			if err := dealTwinAdd(returnResult, deviceA, key1, twins, test.msgTwin, test.dealType); err != nil {
+				t.Errorf("DTManager.TestDealTwinAddNilTwinValue() case failed: got = %+v, Want = %+v", err, nil)
+			}
+			twin, exist := twins[key1]
+			if !exist {
+				t.Fatalf("DTManager.TestDealTwinAddNilTwinValue() case failed: twin %v was not added", key1)
+			}
+			if twin.Expected != nil {
+				t.Errorf("DTManager.TestDealTwinAddNilTwinValue() case failed: got expected = %+v, Want = %+v", twin.Expected, nil)
+			}
+			if twin.Actual != nil {
+				t.Errorf("DTManager.TestDealTwinAddNilTwinValue() case failed: got actual = %+v, Want = %+v", twin.Actual, nil)
+			}
+			if len(returnResult.Add) != 1 {
+				t.Errorf("DTManager.TestDealTwinAddNilTwinValue() case failed: got add = %v, Want = %v", len(returnResult.Add), 1)
+			}
+		})
+	}
+}
+
 // TestDealMsgTwin is function to test DealMsgTwin
 func TestDealMsgTwin(t *testing.T) {
 	value := valueType


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

`TwinValue.Value` is a `*string` tagged `json:"value,omitempty"`, so a twin
payload carrying an `expected` or `actual` object with no `value` field
unmarshals with the outer pointer set and the inner one nil. `dealTwinAdd`
validated only the outer pointer before dereferencing the value, so such a
payload caused a nil pointer dereference that took down the devicetwin
goroutine.

This checks the value pointer on both the expected and the actual branch,
the same guard `BuildDeviceTwinDelta` already uses. A twin that carries no
value is now added without one rather than crashing.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7126 

**Special notes for your reviewer**:

Added `TestDealTwinAddNilTwinValue`, covering an expected-only and an
actual-only payload from the mqtt path and both of them from the cloud sync
path. It panics on master and passes with this change. The existing
`TestDealTwinAdd` table only compares the returned error, so the new test
asserts the resulting state instead: the twin is added, its expected and
actual values are absent, and it is recorded in the add result.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
