### PR TITLE
Fixed potential slice index out of bounds panic in CheckDisk()

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/check.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check.go
@@ -236,6 +236,9 @@ func CheckDisk() error {
 	if err != nil {
 		return err
 	}
+	if len(parts) == 0 {
+		return errors.New("no disk partitions found")
+	}
 
 	diskInfo, err := disk.Usage(parts[0].Mountpoint)
 	if err != nil {
@@ -243,7 +246,7 @@ func CheckDisk() error {
 	}
 
 	fmt.Printf("Disk total: %.2f MB, Allowed > %v MB\n", float32(diskInfo.Total)/common.MB, common.AllowedValueDisk/common.MB)
-	fmt.Printf("Disk Free total: %.2f MB, Allowed > %vMB\n", float32(diskInfo.Free)/common.MB, common.AllowedCurrentValueDisk/common.MB)
+	fmt.Printf("Disk Free total: %.2f MB, Allowed > %v MB\n", float32(diskInfo.Free)/common.MB, common.AllowedCurrentValueDisk/common.MB)
 	fmt.Printf("Disk usage rate: %.2f, Allowed rate < %v\n", diskInfo.UsedPercent/100, common.AllowedCurrentValueDiskRate)
 
 	if diskInfo.Total < common.AllowedValueDisk ||

--- a/keadm/cmd/keadm/app/cmd/debug/check_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/check_test.go
@@ -361,3 +361,11 @@ func TestCheckRuntimeEndpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckDisk(t *testing.T) {
+	err := CheckDisk()
+	if err != nil {
+		assert.Contains(t, []string{"disk check failed", "no disk partitions found"}, err.Error())
+	}
+}
+


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR prevents a potential runtime panic in `keadm debug check disk` (`CheckDisk()`). Previously, `disk.Partitions(false)` results were indexed via `parts[0]` without validating `len(parts) > 0`. On systems or restricted environments where no disk partitions are returned, this caused a slice index out of bounds panic.

This PR:
- Adds a length check `if len(parts) == 0` before accessing `parts[0]`.
- Standardizes output string formatting consistency in `fmt.Printf`.
- Adds unit test coverage (`TestCheckDisk`) in `check_test.go`.

**Which issue(s) this PR fixes**:
Fixes #7139

**Special notes for your reviewer**:
NONE