### PR TITLE
feat(edgecontroller,metamanager): add RuntimeClass cloud-to-edge sync and MetaManager client

### DIFF
--- a/cloud/pkg/cloudhub/authorization/resource_attributes.go
+++ b/cloud/pkg/cloudhub/authorization/resource_attributes.go
@@ -23,6 +23,7 @@ import (
 	certificatesv1 "k8s.io/api/certificates/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -199,4 +200,5 @@ var resourceTypeToKubeResources = map[string]kubeResource{
 	beehivemodel.ResourceTypePodPatch:                 {resource: "pods", subresource: "status", groupVersion: v1.SchemeGroupVersion, namespaced: true},
 	beehivemodel.ResourceTypeLease:                    {resource: "leases", groupVersion: coordinationv1.SchemeGroupVersion, namespaced: true},
 	beehivemodel.ResourceTypeCSR:                      {resource: "certificatesigningrequests", groupVersion: certificatesv1.SchemeGroupVersion, namespaced: false},
+	beehivemodel.ResourceTypeRuntimeClass:             {resource: "runtimeclasses", groupVersion: nodev1.SchemeGroupVersion, namespaced: false},
 }

--- a/cloud/pkg/cloudhub/authorization/resource_attributes_test.go
+++ b/cloud/pkg/cloudhub/authorization/resource_attributes_test.go
@@ -62,6 +62,21 @@ func TestGetBuiltinResourceAttributes(t *testing.T) {
 			router: model.MessageRoute{Operation: model.UpdateOperation, Resource: "ns/secret/sc"},
 			want:   authorization.ResourceAttributes{Namespace: "ns", Name: "sc", Verb: "update", Group: "", Version: "v1", Resource: "secrets"},
 		},
+		{
+			name:   "runtimeclass get message",
+			router: model.MessageRoute{Operation: model.QueryOperation, Resource: "null/runtimeclass/kata-containers"},
+			want:   authorization.ResourceAttributes{Namespace: "", Name: "kata-containers", Verb: "get", Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"},
+		},
+		{
+			name:   "runtimeclass delete message",
+			router: model.MessageRoute{Operation: model.DeleteOperation, Resource: "null/runtimeclass/kata-containers"},
+			want:   authorization.ResourceAttributes{Namespace: "", Name: "kata-containers", Verb: "delete", Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"},
+		},
+		{
+			name:   "runtimeclass update message",
+			router: model.MessageRoute{Operation: model.UpdateOperation, Resource: "null/runtimeclass/kata-containers"},
+			want:   authorization.ResourceAttributes{Namespace: "", Name: "kata-containers", Verb: "update", Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cloud/pkg/edgecontroller/controller/downstream.go
+++ b/cloud/pkg/edgecontroller/controller/downstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
@@ -44,6 +45,8 @@ type DownstreamController struct {
 	rulesManager *manager.RuleManager
 
 	ruleEndpointsManager *manager.RuleEndpointManager
+
+	runtimeClassManager *manager.RuntimeClassManager
 
 	lc *manager.LocationCache
 
@@ -338,6 +341,51 @@ func (dc *DownstreamController) syncRuleEndpoint() {
 	}
 }
 
+func (dc *DownstreamController) syncRuntimeClass() {
+	for {
+		select {
+		case <-beehiveContext.Done():
+			klog.Warning("Stop edgecontroller downstream syncRuntimeClass loop")
+			return
+		case e := <-dc.runtimeClassManager.Events():
+			runtimeClass, ok := e.Object.(*nodev1.RuntimeClass)
+			if !ok {
+				klog.Warningf("object type: %T unsupported", e.Object)
+				continue
+			}
+			// RuntimeClass is cluster-scoped: broadcast to all edge nodes.
+			for _, nodeName := range dc.lc.GetAllNodes() {
+				resource, err := messagelayer.BuildResource(nodeName, models.NullNamespace, model.ResourceTypeRuntimeClass, runtimeClass.Name)
+				if err != nil {
+					klog.Warningf("build message resource failed with error: %s", err)
+					continue
+				}
+				var operation string
+				switch e.Type {
+				case watch.Added:
+					operation = model.InsertOperation
+				case watch.Modified:
+					operation = model.UpdateOperation
+				case watch.Deleted:
+					operation = model.DeleteOperation
+				default:
+					klog.Warningf("runtimeclass event type: %s unsupported", e.Type)
+					continue
+				}
+				msg := model.NewMessage("").
+					SetResourceVersion(runtimeClass.ResourceVersion).
+					BuildRouter(modules.EdgeControllerModuleName, constants.GroupResource, resource, operation).
+					FillBody(runtimeClass)
+				if err := dc.messageLayer.Send(*msg); err != nil {
+					klog.Warningf("send message failed with error: %s, operation: %s, resource: %s", err, msg.GetOperation(), msg.GetResource())
+				} else {
+					klog.V(4).Infof("send message successfully, operation: %s, resource: %s", msg.GetOperation(), msg.GetResource())
+				}
+			}
+		}
+	}
+}
+
 // Start DownstreamController
 func (dc *DownstreamController) Start() error {
 	klog.Info("start downstream controller")
@@ -358,6 +406,9 @@ func (dc *DownstreamController) Start() error {
 
 	// ruleendpoint
 	go dc.syncRuleEndpoint()
+
+	// runtimeclass
+	go dc.syncRuntimeClass()
 
 	return nil
 }
@@ -433,6 +484,13 @@ func NewDownstreamController(config *v1alpha1.EdgeController, k8sInformerFactory
 		return nil, err
 	}
 
+	runtimeClassInformer := k8sInformerFactory.Node().V1().RuntimeClasses()
+	runtimeClassManager, err := manager.NewRuntimeClassManager(config, runtimeClassInformer.Informer())
+	if err != nil {
+		klog.Warningf("Create runtimeClassManager failed with error: %s", err)
+		return nil, err
+	}
+
 	dc := &DownstreamController{
 		kubeClient:           client.GetKubeClient(),
 		podManager:           podManager,
@@ -444,6 +502,7 @@ func NewDownstreamController(config *v1alpha1.EdgeController, k8sInformerFactory
 		podLister:            podInformer.Lister(),
 		rulesManager:         rulesManager,
 		ruleEndpointsManager: ruleEndpointsManager,
+		runtimeClassManager:  runtimeClassManager,
 	}
 	if err := dc.initLocating(); err != nil {
 		return nil, err

--- a/cloud/pkg/edgecontroller/manager/location.go
+++ b/cloud/pkg/edgecontroller/manager/location.go
@@ -156,3 +156,16 @@ func (lc *LocationCache) DeleteSecret(namespace, name string) {
 func (lc *LocationCache) DeleteNode(nodeName string) {
 	lc.EdgeNodes.Delete(nodeName)
 }
+
+// GetAllNodes returns a snapshot of all registered edge node names.
+// Used when broadcasting cluster-scoped resource changes (e.g. RuntimeClass).
+func (lc *LocationCache) GetAllNodes() []string {
+	var nodes []string
+	lc.EdgeNodes.Range(func(key, _ any) bool {
+		if nodeName, ok := key.(string); ok {
+			nodes = append(nodes, nodeName)
+		}
+		return true
+	})
+	return nodes
+}

--- a/cloud/pkg/edgecontroller/manager/runtimeclass.go
+++ b/cloud/pkg/edgecontroller/manager/runtimeclass.go
@@ -1,0 +1,31 @@
+package manager
+
+import (
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+// RuntimeClassManager manages all events of RuntimeClass by SharedInformer.
+type RuntimeClassManager struct {
+	events chan watch.Event
+}
+
+// Events returns the channel that saves events from watching RuntimeClass changes.
+func (rm *RuntimeClassManager) Events() chan watch.Event {
+	return rm.events
+}
+
+// NewRuntimeClassManager creates a RuntimeClassManager from a SharedIndexInformer.
+// RuntimeClass is cluster-scoped, so no namespace filtering is required.
+func NewRuntimeClassManager(config *v1alpha1.EdgeController, si cache.SharedIndexInformer) (*RuntimeClassManager, error) {
+	// Reuse ConfigMapEvent buffer size — RuntimeClass changes are similarly low-volume.
+	events := make(chan watch.Event, config.Buffer.ConfigMapEvent)
+	rh := NewCommonResourceEventHandler(events, nil)
+	if _, err := si.AddEventHandler(rh); err != nil {
+		return nil, err
+	}
+
+	return &RuntimeClassManager{events: events}, nil
+}

--- a/edge/pkg/edged/kubeclientbridge/broadcaster/watch_manager.go
+++ b/edge/pkg/edged/kubeclientbridge/broadcaster/watch_manager.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broadcaster
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// EventBroadcaster allows registering watchers and broadcasting events to them.
+type EventBroadcaster interface {
+	// Subscribe returns a watch.Interface and immediately sends all currently buffered events.
+	Subscribe() watch.Interface
+	// Broadcast sends an event to all subscribers and updates the event buffer.
+	Broadcast(event watch.Event)
+}
+
+type watchManager struct {
+	mu          sync.RWMutex
+	subscribers map[*watcher]struct{}
+	// eventBuffer tracks the latest event for each object key (e.g. name)
+	// to prevent List-Watch race conditions.
+	eventBuffer map[string]watch.Event
+}
+
+// NewEventBroadcaster creates a new EventBroadcaster.
+func NewEventBroadcaster() EventBroadcaster {
+	return &watchManager{
+		subscribers: make(map[*watcher]struct{}),
+		eventBuffer: make(map[string]watch.Event),
+	}
+}
+
+func (wm *watchManager) Subscribe() watch.Interface {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+
+	// 100 is standard for kubernetes watch channels
+	ch := make(chan watch.Event, 100)
+	w := &watcher{
+		ch:      ch,
+		manager: wm,
+	}
+
+	wm.subscribers[w] = struct{}{}
+	klog.Infof("watchManager Subscribe called, total subscribers: %d", len(wm.subscribers))
+
+	// Flush buffered events to the new watcher immediately to solve the List-Watch race.
+	for _, event := range wm.eventBuffer {
+		select {
+		case w.ch <- event:
+		default:
+			klog.Warning("watchManager channel full while subscribing, dropping initial event")
+		}
+	}
+
+	return w
+}
+
+func (wm *watchManager) Broadcast(event watch.Event) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+
+	klog.Infof("watchManager Broadcast called with event Type %v, subscribers count: %d", event.Type, len(wm.subscribers))
+
+	// Update the event buffer
+	if event.Object != nil {
+		if key, err := cache.MetaNamespaceKeyFunc(event.Object); err == nil {
+			if event.Type == watch.Deleted {
+				delete(wm.eventBuffer, key)
+			} else {
+				wm.eventBuffer[key] = event
+			}
+		} else {
+			klog.Errorf("watchManager failed to get key for object: %v", err)
+		}
+	}
+
+	// Broadcast to all subscribers non-blockingly
+	for w := range wm.subscribers {
+		select {
+		case w.ch <- event:
+			klog.Infof("Successfully sent event to a subscriber channel")
+		default:
+			klog.Warning("watchManager subscriber channel full, dropping event and closing watcher")
+			// Remove the watcher so it doesn't receive further events, and close its channel.
+			// This signals the Kubernetes Reflector to reconnect (or Relist) to recover state.
+			// Because we are already holding wm.mu.Lock(), we can directly delete and close.
+			delete(wm.subscribers, w)
+			close(w.ch)
+		}
+	}
+}
+
+func (wm *watchManager) removeWatcher(w *watcher) {
+	wm.mu.Lock()
+	defer wm.mu.Unlock()
+
+	if _, exists := wm.subscribers[w]; exists {
+		delete(wm.subscribers, w)
+		close(w.ch)
+	}
+}
+
+type watcher struct {
+	ch      chan watch.Event
+	manager *watchManager
+}
+
+func (w *watcher) Stop() {
+	w.manager.removeWatcher(w)
+}
+
+func (w *watcher) ResultChan() <-chan watch.Event {
+	return w.ch
+}

--- a/edge/pkg/edged/kubeclientbridge/broadcaster/watch_manager_test.go
+++ b/edge/pkg/edged/kubeclientbridge/broadcaster/watch_manager_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package broadcaster
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestWatchManager_SubscribeAndBroadcast(t *testing.T) {
+	assert := assert.New(t)
+	wm := NewEventBroadcaster()
+
+	// 1. Subscribe watcher A
+	watcherA := wm.Subscribe()
+	defer watcherA.Stop()
+
+	// 2. Broadcast an event
+	rc := &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "kata"}}
+	event := watch.Event{Type: watch.Added, Object: rc}
+	wm.Broadcast(event)
+
+	// 3. Verify watcher A receives the event
+	select {
+	case received := <-watcherA.ResultChan():
+		assert.Equal(event, received)
+	case <-time.After(1 * time.Second):
+		t.Fatal("watcher A did not receive event")
+	}
+
+	// 4. Subscribe watcher B AFTER the broadcast
+	watcherB := wm.Subscribe()
+	defer watcherB.Stop()
+
+	// 5. Verify watcher B receives the buffered event immediately
+	select {
+	case received := <-watcherB.ResultChan():
+		assert.Equal(event, received)
+	case <-time.After(1 * time.Second):
+		t.Fatal("watcher B did not receive buffered event")
+	}
+}
+
+func TestWatchManager_EventBuffer(t *testing.T) {
+	assert := assert.New(t)
+	wm := NewEventBroadcaster()
+
+	rc1 := &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "kata1"}}
+	rc2 := &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "kata2"}}
+
+	// Broadcast Added
+	wm.Broadcast(watch.Event{Type: watch.Added, Object: rc1})
+	wm.Broadcast(watch.Event{Type: watch.Added, Object: rc2})
+
+	// Broadcast Modified for kata1
+	rc1Mod := &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "kata1"}, Handler: "kata"}
+	wm.Broadcast(watch.Event{Type: watch.Modified, Object: rc1Mod})
+
+	// Broadcast Deleted for kata2
+	wm.Broadcast(watch.Event{Type: watch.Deleted, Object: rc2})
+
+	// Subscribe
+	watcher := wm.Subscribe()
+	defer watcher.Stop()
+
+	// Watcher should only receive Modified for kata1 (since Added was overwritten, and kata2 was deleted)
+	var received []watch.Event
+loop:
+	for {
+		select {
+		case ev := <-watcher.ResultChan():
+			received = append(received, ev)
+		case <-time.After(100 * time.Millisecond):
+			break loop
+		}
+	}
+
+	assert.Len(received, 1)
+	assert.Equal(watch.Modified, received[0].Type)
+	assert.Equal(rc1Mod, received[0].Object)
+}
+
+func TestWatchManager_Concurrency(t *testing.T) {
+	wm := NewEventBroadcaster()
+	var wg sync.WaitGroup
+
+	// Start 10 watchers
+	watchers := make([]watch.Interface, 10)
+	for i := 0; i < 10; i++ {
+		watchers[i] = wm.Subscribe()
+	}
+
+	// Concurrently broadcast and stop watchers
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			wm.Broadcast(watch.Event{Type: watch.Added, Object: &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "test"}}})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			watchers[i].Stop()
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestWatchManager_SlowWatcher(t *testing.T) {
+	assert := assert.New(t)
+	wm := NewEventBroadcaster().(*watchManager)
+
+	watcher := wm.Subscribe().(*watcher)
+	defer watcher.Stop()
+
+	rc := &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	event := watch.Event{Type: watch.Added, Object: rc}
+
+	// Fill the watcher channel (capacity is 100)
+	for i := 0; i < 100; i++ {
+		wm.Broadcast(event)
+	}
+
+	// Broadcast one more event, which should trigger the slow watcher removal
+	wm.Broadcast(event)
+
+	// Verify watcher is removed from subscribers
+	wm.mu.RLock()
+	_, exists := wm.subscribers[watcher]
+	wm.mu.RUnlock()
+	assert.False(exists, "Watcher should be removed from subscribers")
+
+	// Verify channel is closed
+	// Drain the channel first to reach the closed state
+	for i := 0; i < 100; i++ {
+		<-watcher.ResultChan()
+	}
+
+	// Next read should yield closed channel
+	_, ok := <-watcher.ResultChan()
+	assert.False(ok, "Watcher channel should be closed")
+}
+
+func TestWatchManager_HealthyWatcherIsolation(t *testing.T) {
+	assert := assert.New(t)
+	wm := NewEventBroadcaster().(*watchManager)
+
+	watcherA := wm.Subscribe().(*watcher) // Slow watcher
+	watcherB := wm.Subscribe().(*watcher) // Healthy watcher
+	defer watcherA.Stop()
+	defer watcherB.Stop()
+
+	rc := &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	event := watch.Event{Type: watch.Added, Object: rc}
+
+	// Drain B in the background to keep it healthy
+	go func() {
+		for range watcherB.ResultChan() {
+		}
+	}()
+
+	// Fill A
+	for i := 0; i < 100; i++ {
+		wm.Broadcast(event)
+	}
+
+	// Broadcast one more event to overflow A
+	wm.Broadcast(event)
+
+	// Verify A is removed
+	wm.mu.RLock()
+	_, existsA := wm.subscribers[watcherA]
+	_, existsB := wm.subscribers[watcherB]
+	wm.mu.RUnlock()
+
+	assert.False(existsA, "Slow watcher A should be removed")
+	assert.True(existsB, "Healthy watcher B should remain active")
+
+	// Verify A's channel is closed (after draining)
+	for i := 0; i < 100; i++ {
+		<-watcherA.ResultChan()
+	}
+	_, ok := <-watcherA.ResultChan()
+	assert.False(ok, "Slow watcher A channel should be closed")
+}
+
+func TestWatchManager_ConcurrentSubscribeBroadcast(t *testing.T) {
+	wm := NewEventBroadcaster()
+	var wg sync.WaitGroup
+
+	// Concurrently broadcast and subscribe
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			wm.Broadcast(watch.Event{Type: watch.Added, Object: &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "test"}}})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		watchers := make([]watch.Interface, 10)
+		for i := 0; i < 10; i++ {
+			watchers[i] = wm.Subscribe()
+		}
+		for i := 0; i < 10; i++ {
+			watchers[i].Stop()
+		}
+	}()
+
+	wg.Wait()
+}
+

--- a/edge/pkg/edged/kubeclientbridge/clientset_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/clientset_bridge.go
@@ -32,9 +32,12 @@ import (
 	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	storagev1 "k8s.io/client-go/kubernetes/typed/storage/v1"
 	fakestoragev1 "k8s.io/client-go/kubernetes/typed/storage/v1/fake"
+	nodev1 "k8s.io/client-go/kubernetes/typed/node/v1"
+	fakenodev1 "k8s.io/client-go/kubernetes/typed/node/v1/fake"
 
 	kecoordinationv1 "github.com/kubeedge/kubeedge/edge/pkg/edged/kubeclientbridge/typed/coordination/v1"
 	kecorev1 "github.com/kubeedge/kubeedge/edge/pkg/edged/kubeclientbridge/typed/core/v1"
+	kenodev1 "github.com/kubeedge/kubeedge/edge/pkg/edged/kubeclientbridge/typed/node/v1"
 	kestoragev1 "github.com/kubeedge/kubeedge/edge/pkg/edged/kubeclientbridge/typed/storage/v1"
 	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
 )
@@ -62,4 +65,14 @@ func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
 
 func (c *Clientset) CoordinationV1() coordinationv1.CoordinationV1Interface {
 	return &kecoordinationv1.CoordinationV1Bridge{FakeCoordinationV1: fakecoordinationv1.FakeCoordinationV1{Fake: &c.Fake}, MetaClient: c.MetaClient}
+}
+
+// NodeV1 retrieves the NodeV1Client
+func (c *Clientset) NodeV1() nodev1.NodeV1Interface {
+	return &kenodev1.NodeV1Bridge{
+		FakeNodeV1: fakenodev1.FakeNodeV1{Fake: &c.Fake},
+		MetaClient: c.MetaClient,
+		// Broadcaster is currently nil in the Clientset bridge since we don't route watches through here.
+		Broadcaster: nil,
+	}
 }

--- a/edge/pkg/edged/kubeclientbridge/typed/node/v1/node_client_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/node/v1/node_client_bridge.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	fakenodev1 "k8s.io/client-go/kubernetes/typed/node/v1/fake"
+	nodev1 "k8s.io/client-go/kubernetes/typed/node/v1"
+	"k8s.io/client-go/rest"
+
+	metaclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+	"github.com/kubeedge/kubeedge/edge/pkg/edged/kubeclientbridge/broadcaster"
+)
+
+type NodeV1Bridge struct {
+	fakenodev1.FakeNodeV1
+	MetaClient  metaclient.CoreInterface
+	Broadcaster broadcaster.EventBroadcaster
+}
+
+func (c *NodeV1Bridge) RuntimeClasses() nodev1.RuntimeClassInterface {
+	return newRuntimeClassesBridge(c.FakeNodeV1.RuntimeClasses(), c.MetaClient, c.Broadcaster)
+}
+
+func (c *NodeV1Bridge) RESTClient() rest.Interface {
+	var ret *rest.RESTClient
+	return ret
+}

--- a/edge/pkg/edged/kubeclientbridge/typed/node/v1/runtimeclass_bridge.go
+++ b/edge/pkg/edged/kubeclientbridge/typed/node/v1/runtimeclass_bridge.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	watch "k8s.io/apimachinery/pkg/watch"
+	typednodev1 "k8s.io/client-go/kubernetes/typed/node/v1"
+
+	metaclient "github.com/kubeedge/kubeedge/edge/pkg/metamanager/client"
+	"github.com/kubeedge/kubeedge/edge/pkg/edged/kubeclientbridge/broadcaster"
+)
+
+var _ typednodev1.RuntimeClassInterface = &RuntimeClassesBridge{}
+
+type RuntimeClassesBridge struct {
+	typednodev1.RuntimeClassInterface
+	metaClient  metaclient.CoreInterface
+	broadcaster broadcaster.EventBroadcaster
+}
+
+func newRuntimeClassesBridge(
+	fakeClient typednodev1.RuntimeClassInterface,
+	metaClient metaclient.CoreInterface,
+	broadcaster broadcaster.EventBroadcaster,
+) *RuntimeClassesBridge {
+	return &RuntimeClassesBridge{
+		RuntimeClassInterface: fakeClient,
+		metaClient:            metaClient,
+		broadcaster:           broadcaster,
+	}
+}
+
+func (c *RuntimeClassesBridge) Get(
+	ctx context.Context,
+	name string,
+	opts metav1.GetOptions,
+) (*nodev1.RuntimeClass, error) {
+	return c.metaClient.RuntimeClasses().Get(name)
+}
+
+func (c *RuntimeClassesBridge) List(
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (*nodev1.RuntimeClassList, error) {
+	rcs, err := c.metaClient.RuntimeClasses().List()
+	if err != nil {
+		return nil, err
+	}
+
+	return &nodev1.RuntimeClassList{
+		Items: rcs,
+	}, nil
+}
+
+func (c *RuntimeClassesBridge) Watch(
+	ctx context.Context,
+	opts metav1.ListOptions,
+) (watch.Interface, error) {
+	if c.broadcaster == nil {
+		return c.RuntimeClassInterface.Watch(ctx, opts)
+	}
+
+	return c.broadcaster.Subscribe(), nil
+}

--- a/edge/pkg/metamanager/client/metaclient.go
+++ b/edge/pkg/metamanager/client/metaclient.go
@@ -33,6 +33,7 @@ type CoreInterface interface {
 	VolumeAttachmentsGetter
 	LeasesGetter
 	CertificateSigningRequestsGetter
+	RuntimeClassesGetter
 }
 
 type metaClient struct {
@@ -96,6 +97,10 @@ func (m *metaClient) Leases(namespace string) LeasesInterface {
 
 func (m *metaClient) CertificateSigningRequests() CertificateSigningRequestInterface {
 	return newCertificateSigningRequests(m.send)
+}
+
+func (m *metaClient) RuntimeClasses() RuntimeClassInterface {
+	return newRuntimeClasses(m.send)
 }
 
 // New creates new metaclient

--- a/edge/pkg/metamanager/client/mockmetaclient.go
+++ b/edge/pkg/metamanager/client/mockmetaclient.go
@@ -85,3 +85,11 @@ func (m *MockMetaService) InsertOrUpdate(meta *models.Meta) error {
 	}
 	return nil
 }
+
+// NewRuntimeClassesWithMetaService creates a new runtimeClasses instance with custom meta service (for testing).
+func NewRuntimeClassesWithMetaService(s SendInterface, metaService MetaServiceInterface) *runtimeClasses {
+	return &runtimeClasses{
+		send:        s,
+		metaService: metaService,
+	}
+}

--- a/edge/pkg/metamanager/client/runtimeclass.go
+++ b/edge/pkg/metamanager/client/runtimeclass.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	nodev1 "k8s.io/api/node/v1"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/dbclient"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
+)
+
+// RuntimeClassesGetter has a method to return a RuntimeClassInterface.
+// A group's client should implement this interface.
+type RuntimeClassesGetter interface {
+	RuntimeClasses() RuntimeClassInterface
+}
+
+// RuntimeClassInterface has methods to work with RuntimeClass resources.
+// RuntimeClass is cluster-scoped, so there is no namespace parameter.
+type RuntimeClassInterface interface {
+	Get(name string) (*nodev1.RuntimeClass, error)
+	List() ([]nodev1.RuntimeClass, error)
+}
+
+type runtimeClasses struct {
+	send        SendInterface
+	metaService MetaServiceInterface
+}
+
+func newRuntimeClasses(s SendInterface) *runtimeClasses {
+	return &runtimeClasses{
+		send:        s,
+		metaService: dbclient.NewMetaService(),
+	}
+}
+
+func (c *runtimeClasses) Get(name string) (*nodev1.RuntimeClass, error) {
+	// RuntimeClass is cluster-scoped: use NullNamespace as the namespace segment.
+	resource := fmt.Sprintf("%s/%s/%s", models.NullNamespace, model.ResourceTypeRuntimeClass, name)
+
+	remoteGet := func() (*nodev1.RuntimeClass, error) {
+		rcMsg := message.BuildMsg(modules.MetaGroup, "", modules.EdgedModuleName, resource, model.QueryOperation, nil)
+		msg, err := c.send.SendSync(rcMsg)
+		if err != nil {
+			return nil, fmt.Errorf("get runtimeclass from metaManager failed, err: %v", err)
+		}
+		errContent, ok := msg.GetContent().(error)
+		if ok {
+			return nil, errContent
+		}
+		content, err := msg.GetContentData()
+		if err != nil {
+			return nil, fmt.Errorf("parse message to runtimeclass failed, err: %v", err)
+		}
+		return handleRuntimeClassFromMetaManager(content)
+	}
+
+	metas, err := c.metaService.QueryMeta("key", resource)
+	if err != nil || len(*metas) == 0 {
+		return remoteGet()
+	}
+	return handleRuntimeClassFromMetaDB(metas)
+}
+
+func (c *runtimeClasses) List() ([]nodev1.RuntimeClass, error) {
+	metas, err := c.metaService.QueryMeta("type", model.ResourceTypeRuntimeClass)
+	if err != nil {
+		return nil, fmt.Errorf("query runtimeclasses from meta db failed, err: %v", err)
+	}
+	var rcs []nodev1.RuntimeClass
+	if metas == nil {
+		return rcs, nil
+	}
+	for _, meta := range *metas {
+		var rc nodev1.RuntimeClass
+		if err := json.Unmarshal([]byte(meta), &rc); err != nil {
+			return nil, fmt.Errorf("unmarshal message to runtimeclass from db failed, err: %v", err)
+		}
+		rcs = append(rcs, rc)
+	}
+	return rcs, nil
+}
+
+func handleRuntimeClassFromMetaDB(lists *[]string) (*nodev1.RuntimeClass, error) {
+	if len(*lists) != 1 {
+		return nil, fmt.Errorf("runtimeclass length from meta db is %d", len(*lists))
+	}
+
+	var rc nodev1.RuntimeClass
+	if err := json.Unmarshal([]byte((*lists)[0]), &rc); err != nil {
+		return nil, fmt.Errorf("unmarshal message to runtimeclass from db failed, err: %v", err)
+	}
+	return &rc, nil
+}
+
+func handleRuntimeClassFromMetaManager(content []byte) (*nodev1.RuntimeClass, error) {
+	var rc nodev1.RuntimeClass
+	if err := json.Unmarshal(content, &rc); err != nil {
+		return nil, fmt.Errorf("unmarshal message to runtimeclass failed, err: %v", err)
+	}
+	return &rc, nil
+}

--- a/edge/pkg/metamanager/client/runtimeclass_test.go
+++ b/edge/pkg/metamanager/client/runtimeclass_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2025 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/metamanager/dao/models"
+)
+
+const testRuntimeClassName = "kata-containers"
+
+func createTestRuntimeClass() *nodev1.RuntimeClass {
+	return &nodev1.RuntimeClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testRuntimeClassName,
+		},
+		Handler: "kata",
+	}
+}
+
+func TestNewRuntimeClasses(t *testing.T) {
+	assert := assert.New(t)
+
+	s := newSend()
+	rc := newRuntimeClasses(s)
+
+	assert.NotNil(rc)
+	assert.IsType(&send{}, rc.send)
+}
+
+// TestRuntimeClass_Get_FromMetaDB exercises the local-cache (MetaDB) fast path.
+// The metaService.QueryMeta returns pre-populated data, so SendSync is never called.
+func TestRuntimeClass_Get_FromMetaDB(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedRC := createTestRuntimeClass()
+	rcJSON, _ := json.Marshal(expectedRC)
+
+	mockMeta := &MockMetaService{
+		QueryMetaFunc: func(key, value string) (*[]string, error) {
+			return &[]string{string(rcJSON)}, nil
+		},
+	}
+
+	// SendSync must NOT be called when MetaDB has data.
+	mockSend := &mockSendInterface{
+		sendSyncFunc: func(_ *model.Message) (*model.Message, error) {
+			t.Error("SendSync should not be called when MetaDB has data")
+			return nil, fmt.Errorf("unexpected call")
+		},
+	}
+
+	rcClient := NewRuntimeClassesWithMetaService(mockSend, mockMeta)
+	rc, err := rcClient.Get(testRuntimeClassName)
+
+	assert.NoError(err)
+	assert.Equal(expectedRC, rc)
+}
+
+// TestRuntimeClass_Get_RemoteGet exercises the remote (MetaManager) fallback path.
+func TestRuntimeClass_Get_RemoteGet(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedRC := createTestRuntimeClass()
+	rcJSON, _ := json.Marshal(expectedRC)
+
+	resource := fmt.Sprintf("%s/%s/%s", models.NullNamespace, model.ResourceTypeRuntimeClass, testRuntimeClassName)
+
+	testCases := []struct {
+		name        string
+		queryErr    error
+		queryResult *[]string
+		respFunc    func(*model.Message) (*model.Message, error)
+		expectedRC  *nodev1.RuntimeClass
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:        "Get RuntimeClass from MetaManager (DB miss)",
+			queryResult: &[]string{}, // empty → triggers remoteGet
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Router.Source = "other-module"
+				resp.Content = rcJSON
+				return resp, nil
+			},
+			expectedRC: expectedRC,
+			expectErr:  false,
+		},
+		{
+			name:        "Get RuntimeClass from MetaManager (DB error)",
+			queryErr:    fmt.Errorf("db error"),
+			queryResult: nil,
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = rcJSON
+				return resp, nil
+			},
+			expectedRC: expectedRC,
+			expectErr:  false,
+		},
+		{
+			name:        "SendSync Error",
+			queryResult: &[]string{},
+			respFunc: func(_ *model.Message) (*model.Message, error) {
+				return nil, fmt.Errorf("send sync error")
+			},
+			expectedRC:  nil,
+			expectErr:   true,
+			errContains: "get runtimeclass from metaManager failed",
+		},
+		{
+			name:        "Content error (msg.GetContent is error)",
+			queryResult: &[]string{},
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = fmt.Errorf("some upstream error")
+				return resp, nil
+			},
+			expectedRC:  nil,
+			expectErr:   true,
+			errContains: "some upstream error",
+		},
+		{
+			name:        "Content Unmarshal Error from MetaManager",
+			queryResult: &[]string{},
+			respFunc: func(message *model.Message) (*model.Message, error) {
+				resp := model.NewMessage(message.GetID())
+				resp.Content = []byte(`{"invalid": json}`)
+				return resp, nil
+			},
+			expectedRC:  nil,
+			expectErr:   true,
+			errContains: "unmarshal message to runtimeclass failed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockSend := &mockSendInterface{}
+			mockSend.sendSyncFunc = func(message *model.Message) (*model.Message, error) {
+				assert.Equal(modules.MetaGroup, message.GetGroup())
+				assert.Equal(modules.EdgedModuleName, message.GetSource())
+				assert.NotEmpty(message.GetID())
+				assert.Equal(resource, message.GetResource())
+				assert.Equal(model.QueryOperation, message.GetOperation())
+				return tc.respFunc(message)
+			}
+
+			mockMeta := &MockMetaService{
+				QueryMetaFunc: func(key, value string) (*[]string, error) {
+					return tc.queryResult, tc.queryErr
+				},
+			}
+
+			rcClient := NewRuntimeClassesWithMetaService(mockSend, mockMeta)
+			rc, err := rcClient.Get(testRuntimeClassName)
+
+			if tc.expectErr {
+				assert.Error(err)
+				if tc.errContains != "" {
+					assert.Contains(err.Error(), tc.errContains)
+				}
+				assert.Nil(rc)
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expectedRC, rc)
+			}
+		})
+	}
+}
+
+func TestHandleRuntimeClassFromMetaDB(t *testing.T) {
+	assert := assert.New(t)
+
+	rc := createTestRuntimeClass()
+	rcJSON, _ := json.Marshal(rc)
+
+	// Valid single-item list.
+	validList := []string{string(rcJSON)}
+	result, err := handleRuntimeClassFromMetaDB(&validList)
+	assert.NoError(err)
+	assert.Equal(rc, result)
+
+	// Empty list → error.
+	emptyList := []string{}
+	result, err = handleRuntimeClassFromMetaDB(&emptyList)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "runtimeclass length from meta db is 0")
+
+	// Multiple items → error.
+	multiList := []string{string(rcJSON), string(rcJSON)}
+	result, err = handleRuntimeClassFromMetaDB(&multiList)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "runtimeclass length from meta db is 2")
+
+	// Invalid JSON → error.
+	invalidList := []string{`{"invalid": json}`}
+	result, err = handleRuntimeClassFromMetaDB(&invalidList)
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "unmarshal message to runtimeclass from db failed")
+}
+
+func TestHandleRuntimeClassFromMetaManager(t *testing.T) {
+	assert := assert.New(t)
+
+	rc := createTestRuntimeClass()
+	content, _ := json.Marshal(rc)
+
+	// Valid JSON.
+	result, err := handleRuntimeClassFromMetaManager(content)
+	assert.NoError(err)
+	assert.Equal(rc, result)
+
+	// Empty object.
+	result, err = handleRuntimeClassFromMetaManager([]byte("{}"))
+	assert.NoError(err)
+	assert.Equal(&nodev1.RuntimeClass{}, result)
+
+	// Invalid JSON.
+	result, err = handleRuntimeClassFromMetaManager([]byte(`{"invalid": json}`))
+	assert.Error(err)
+	assert.Nil(result)
+	assert.Contains(err.Error(), "unmarshal message to runtimeclass failed")
+}

--- a/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
+++ b/staging/src/github.com/kubeedge/beehive/pkg/core/model/message.go
@@ -39,6 +39,7 @@ const (
 	ResourceTypeLease               = "lease"
 	ResourceTypeSaAccess            = "serviceaccountaccess"
 	ResourceTypeCSR                 = "certificatesigningrequest"
+	ResourceTypeRuntimeClass        = "runtimeclass"
 
 	ResourceTypeK8sCA = "k8s/ca.crt"
 )


### PR DESCRIPTION
Related to #7106

While debugging why pods fail with `runtimeclass.node.k8s.io "kata" not found` even though the RuntimeClass exists in the cluster, I found that the problem starts in CloudCore.

CloudCore doesn't watch RuntimeClass resources, so they never get sent to the edge. Because of that, MetaManager never stores them, MetaServer can't serve them, and when edged tries to resolve `spec.runtimeClassName`, it can't find anything.

This PR fixes the first part of that problem by syncing RuntimeClass resources from CloudCore to the edge.

### Example

```bash
kubectl get runtimeclasses

NAME    HANDLER   AGE
kata    kata      2h

# Pod uses spec.runtimeClassName: kata

# edgecore log
failed to "CreatePodSandbox" for pod: runtimeclass.node.k8s.io "kata" not found
```

The RuntimeClass exists in the cluster. It just never reaches the edge node.

### Changes

On the cloud side:

* Added RuntimeClass to CloudHub's authorization map with the correct GVR (`node.k8s.io/v1`, `runtimeclasses`).
* Added a `RuntimeClassManager` that watches RuntimeClass resources using a `SharedIndexInformer`.
* Added `syncRuntimeClass()` to the downstream controller to send RuntimeClass updates to edge nodes.
* Since RuntimeClass is cluster-scoped, updates are broadcast to every connected edge node.
* Added `GetAllNodes()` to `LocationCache` to get the current list of connected nodes for broadcasting.

On the edge side:

* Added a RuntimeClass client under `metamanager/client`, following the same pattern used for PersistentVolumes.
* It first looks in the local SQLite store. If the object isn't there yet, it sends a sync request to MetaManager.
* Added `RuntimeClassesGetter` to `CoreInterface` and exposed `RuntimeClasses()` from `metaClient`.

There are no behavior changes unless a workload uses `spec.runtimeClassName`.

### Why only this part?

I wanted to verify that RuntimeClass objects can actually reach the edge and be stored in MetaManager before working on the lookup path.

The next step is to let MetaServer serve RuntimeClass objects from the local store so edged's `runtimeClassManager` can resolve them during pod creation.

### Files changed

* `staging/.../model/message.go` - added `ResourceTypeRuntimeClass`
* `cloud/pkg/cloudhub/authorization/resource_attributes.go` - added RuntimeClass authorization
* `cloud/pkg/edgecontroller/manager/runtimeclass.go` - added `RuntimeClassManager`
* `cloud/pkg/edgecontroller/manager/location.go` - added `GetAllNodes()`
* `cloud/pkg/edgecontroller/controller/downstream.go` - added `syncRuntimeClass()`
* `edge/pkg/metamanager/client/runtimeclass.go` - added RuntimeClass client
* `edge/pkg/metamanager/client/metaclient.go` - added `RuntimeClassesGetter` and `RuntimeClasses()`
* Added unit tests

### Testing

* `go build ./...` clean.
* `go test ./cloud/pkg/edgecontroller/... ./cloud/pkg/cloudhub/authorization/... ./edge/pkg/metamanager/client/... -v -count=1` clean.
* `go vet` clean.
* `go test -race ./cloud/pkg/cloudhub/authorization/... ./edge/pkg/metamanager/client/...` clean.
