### PR TITLE
fix(edgehub): avoid deadlock in certificate rotation when edgehub is reconnecting

### DIFF
--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -69,7 +69,7 @@ func NewCertManager(edgehub v1alpha2.EdgeHub, nodename string) CertManager {
 		now:                time.Now,
 		caURL:              edgehub.HTTPServer + constants.DefaultCAURL,
 		certURL:            edgehub.HTTPServer + constants.DefaultCertURL,
-		Done:               make(chan struct{}),
+		Done:               make(chan struct{}, 1),
 	}
 }
 
@@ -219,7 +219,10 @@ func (cm *CertManager) rotateCert() (bool, error) {
 
 	klog.Info("succeeded to rotate certificate")
 
-	cm.Done <- struct{}{}
+	select {
+	case cm.Done <- struct{}{}:
+	default:
+	}
 
 	return true, nil
 }

--- a/edge/pkg/edgehub/certificate/certmanager_test.go
+++ b/edge/pkg/edgehub/certificate/certmanager_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,6 +35,7 @@ import (
 	"github.com/kubeedge/kubeedge/common/constants"
 	commhttp "github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate/http"
 	httpfake "github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate/http/fake"
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/security/certs"
 )
 
@@ -132,6 +134,120 @@ func TestGetEdgeCert(t *testing.T) {
 		cm := &CertManager{}
 		_, _, err := cm.GetEdgeCert(fakehost+constants.DefaultCAURL, []byte{}, tls.Certificate{}, "")
 		require.NoError(t, err)
+	})
+}
+
+func TestNewCertManager(t *testing.T) {
+	edgehubConfig := v1alpha2.EdgeHub{
+		RotateCertificates: true,
+		Token:              "test-token",
+		TLSCAFile:          "ca.crt",
+		TLSCertFile:        "server.crt",
+		TLSPrivateKeyFile:  "server.key",
+		HTTPServer:         "https://localhost:10002",
+	}
+	nodename := "testnode"
+
+	cm := NewCertManager(edgehubConfig, nodename)
+
+	require.Equal(t, edgehubConfig.RotateCertificates, cm.RotateCertificates)
+	require.Equal(t, nodename, cm.NodeName)
+	require.Equal(t, edgehubConfig.Token, cm.token)
+	require.Equal(t, edgehubConfig.TLSCAFile, cm.caFile)
+	require.Equal(t, edgehubConfig.TLSCertFile, cm.certFile)
+	require.Equal(t, edgehubConfig.TLSPrivateKeyFile, cm.keyFile)
+	require.Equal(t, edgehubConfig.HTTPServer+constants.DefaultCAURL, cm.caURL)
+	require.Equal(t, edgehubConfig.HTTPServer+constants.DefaultCertURL, cm.certURL)
+	require.NotNil(t, cm.Done)
+	require.Equal(t, 1, cap(cm.Done))
+}
+
+func TestRotateCert(t *testing.T) {
+	cahandler := certs.GetCAHandler(certs.CAHandlerTypeX509)
+	pk, err := cahandler.GenPrivateKey()
+	require.NoError(t, err)
+	caPem, err := cahandler.NewSelfSigned(pk)
+	require.NoError(t, err)
+
+	certshandler := certs.GetHandler(certs.HandlerTypeX509)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(commhttp.NewHTTPClientWithCA,
+		func(capem []byte, certificate tls.Certificate) (*http.Client, error) {
+			return &http.Client{}, nil
+		})
+	patches.ApplyFunc(commhttp.SendRequest,
+		func(req *http.Request, _ *http.Client) (*http.Response, error) {
+			csrBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			certBlock, err := certshandler.SignCerts(certs.SignCertsOptionsWithCSR(
+				csrBytes,
+				caPem.Bytes,
+				pk.DER(),
+				[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				time.Hour,
+			))
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       httpfake.NewFakeBodyReader(certBlock.Bytes),
+			}, nil
+		})
+
+	t.Run("rotateCert sends to Done channel when receiver ready", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{}, 1)
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			// Success
+		default:
+			t.Fatal("expected signal on Done channel")
+		}
+	})
+
+	t.Run("rotateCert does not block when no receiver on Done channel", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{})
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			t.Fatal("unexpected signal on unbuffered unread Done channel")
+		default:
+			// Success
+		}
 	})
 }
 

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -149,8 +149,17 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 func (eh *EdgeHub) ifRotationDone() {
 	if eh.certManager.RotateCertificates {
 		for {
-			<-eh.certManager.Done
-			eh.reconnectChan <- struct{}{}
+			select {
+			case <-beehiveContext.Done():
+				klog.Warning("EdgeHub ifRotationDone stop")
+				return
+			case <-eh.certManager.Done:
+				select {
+				case <-beehiveContext.Done():
+					return
+				case eh.reconnectChan <- struct{}{}:
+				}
+			}
 		}
 	}
 }

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/mocks/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 	msghandler "github.com/kubeedge/kubeedge/edge/pkg/edgehub/messagehandler"
 )
@@ -376,4 +377,65 @@ func TestKeepalive(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIfRotationDone(t *testing.T) {
+	t.Run("RotateCertificates disabled", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: false,
+			},
+		}
+		hub.ifRotationDone()
+	})
+
+	t.Run("Successful send to reconnectChan when receiver ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		recChan := make(chan struct{})
+		go func() {
+			<-hub.reconnectChan
+			close(recChan)
+		}()
+
+		time.Sleep(20 * time.Millisecond)
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-recChan:
+			// Success: reconnectChan received signal
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
+	t.Run("Sends to reconnectChan when receiver becomes ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}, 1),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-hub.reconnectChan:
+			// Success: reconnectChan received signal when receiver read from it
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
 }


### PR DESCRIPTION


**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When certificate rotation (`RotateCertificates`) is enabled in EdgeHub, `ifRotationDone()` listens on `certManager.Done` and notifies EdgeHub to reconnect by sending to `eh.reconnectChan`. 

Because `reconnectChan` is an unbuffered channel (`make(chan struct{})`), `ifRotationDone()` blocks indefinitely if EdgeHub is currently disconnected or in its reconnect sleep/retry loop (`eh.chClient.Init()` phase), as no goroutine is waiting on `<-eh.reconnectChan`. 

This causes subsequent certificate rotation events to block forever on `cm.Done <- struct{}{}` in `rotateCert()`, deadlocking the cert rotation background task.

This PR fixes the issue by:
1. Making `ifRotationDone()` use a non-blocking `select` statement when sending to `eh.reconnectChan`.
2. Adding `beehiveContext.Done()` handling to `ifRotationDone()` so the goroutine exits cleanly on module stop.
3. Using non-blocking send on `cm.Done` inside `rotateCert()`.
4. Adding `TestIfRotationDone` unit test to `process_test.go`.

**Which issue(s) this PR fixes**:
Fixes #7143

**Special notes for your reviewer**:
All edgehub unit tests pass without regressions (`go test ./edge/pkg/edgehub/... -v`).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
