### PR TITLE
fix(edgehub): make certificate rotation notification non-blocking to prevent deadlock

### DIFF
--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -69,7 +69,7 @@ func NewCertManager(edgehub v1alpha2.EdgeHub, nodename string) CertManager {
 		now:                time.Now,
 		caURL:              edgehub.HTTPServer + constants.DefaultCAURL,
 		certURL:            edgehub.HTTPServer + constants.DefaultCertURL,
-		Done:               make(chan struct{}),
+		Done:               make(chan struct{}, 1),
 	}
 }
 
@@ -219,7 +219,10 @@ func (cm *CertManager) rotateCert() (bool, error) {
 
 	klog.Info("succeeded to rotate certificate")
 
-	cm.Done <- struct{}{}
+	select {
+	case cm.Done <- struct{}{}:
+	default:
+	}
 
 	return true, nil
 }

--- a/edge/pkg/edgehub/certificate/certmanager_test.go
+++ b/edge/pkg/edgehub/certificate/certmanager_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -132,6 +133,95 @@ func TestGetEdgeCert(t *testing.T) {
 		cm := &CertManager{}
 		_, _, err := cm.GetEdgeCert(fakehost+constants.DefaultCAURL, []byte{}, tls.Certificate{}, "")
 		require.NoError(t, err)
+	})
+}
+
+func TestRotateCert(t *testing.T) {
+	cahandler := certs.GetCAHandler(certs.CAHandlerTypeX509)
+	pk, err := cahandler.GenPrivateKey()
+	require.NoError(t, err)
+	caPem, err := cahandler.NewSelfSigned(pk)
+	require.NoError(t, err)
+
+	certshandler := certs.GetHandler(certs.HandlerTypeX509)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(commhttp.NewHTTPClientWithCA,
+		func(capem []byte, certificate tls.Certificate) (*http.Client, error) {
+			return &http.Client{}, nil
+		})
+	patches.ApplyFunc(commhttp.SendRequest,
+		func(req *http.Request, _ *http.Client) (*http.Response, error) {
+			csrBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			certBlock, err := certshandler.SignCerts(certs.SignCertsOptionsWithCSR(
+				csrBytes,
+				caPem.Bytes,
+				pk.DER(),
+				[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				time.Hour,
+			))
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       httpfake.NewFakeBodyReader(certBlock.Bytes),
+			}, nil
+		})
+
+	t.Run("rotateCert sends to Done channel when receiver ready", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{}, 1)
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			// Success
+		default:
+			t.Fatal("expected signal on Done channel")
+		}
+	})
+
+	t.Run("rotateCert does not block when no receiver on Done channel", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{})
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			t.Fatal("unexpected signal on unbuffered unread Done channel")
+		default:
+			// Success
+		}
 	})
 }
 

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -149,8 +149,17 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 func (eh *EdgeHub) ifRotationDone() {
 	if eh.certManager.RotateCertificates {
 		for {
-			<-eh.certManager.Done
-			eh.reconnectChan <- struct{}{}
+			select {
+			case <-beehiveContext.Done():
+				klog.Warning("EdgeHub ifRotationDone stop")
+				return
+			case <-eh.certManager.Done:
+				select {
+				case <-beehiveContext.Done():
+					return
+				case eh.reconnectChan <- struct{}{}:
+				}
+			}
 		}
 	}
 }

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/mocks/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 	msghandler "github.com/kubeedge/kubeedge/edge/pkg/edgehub/messagehandler"
 )
@@ -376,4 +377,121 @@ func TestKeepalive(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIfRotationDone(t *testing.T) {
+	t.Run("RotateCertificates disabled", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: false,
+			},
+		}
+		hub.ifRotationDone()
+	})
+
+	t.Run("Successful send to reconnectChan when receiver ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		recChan := make(chan struct{})
+		go func() {
+			<-hub.reconnectChan
+			close(recChan)
+		}()
+
+		time.Sleep(20 * time.Millisecond)
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-recChan:
+			// Success: reconnectChan received signal
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
+	t.Run("Sends to reconnectChan when receiver becomes ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}, 1),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-hub.reconnectChan:
+			// Success: reconnectChan received signal when receiver read from it
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
+	t.Run("Stopped by outer beehiveContext.Done", func(t *testing.T) {
+		beehiveContext.InitContext([]string{"channel"})
+		defer beehiveContext.InitContext([]string{"channel"})
+		beehiveContext.Cancel()
+
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}),
+			},
+		}
+
+		done := make(chan struct{})
+		go func() {
+			hub.ifRotationDone()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Success: exited when beehiveContext.Done closed
+		case <-time.After(2 * time.Second):
+			t.Fatal("ifRotationDone did not exit on beehiveContext.Done")
+		}
+	})
+
+	t.Run("Stopped by inner beehiveContext.Done", func(t *testing.T) {
+		beehiveContext.InitContext([]string{"channel"})
+		defer beehiveContext.InitContext([]string{"channel"})
+
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}, 1),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		done := make(chan struct{})
+		go func() {
+			hub.ifRotationDone()
+			close(done)
+		}()
+
+		hub.certManager.Done <- struct{}{}
+
+		time.Sleep(50 * time.Millisecond)
+		beehiveContext.Cancel()
+
+		select {
+		case <-done:
+			// Success: exited via inner beehiveContext.Done branch
+		case <-time.After(2 * time.Second):
+			t.Fatal("ifRotationDone did not exit on inner beehiveContext.Done")
+		}
+	})
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When certificate rotation (`RotateCertificates`) is enabled in EdgeHub, `ifRotationDone()` listens on `certManager.Done` and notifies `EdgeHub` to reconnect by sending to `eh.reconnectChan`.

Because `eh.reconnectChan` is an unbuffered channel (`make(chan struct{})`), if `EdgeHub` is currently in the middle of a reconnection retry (e.g. `chClient.Init()` failed and it is executing `time.Sleep`), no goroutine is receiving on `<-eh.reconnectChan`. Consequently, `ifRotationDone()` blocks indefinitely on `eh.reconnectChan <- struct{}{}`.

This leads to two critical issues:
1. Subsequent certificate rotations block forever on `cm.Done <- struct{}{}` in `rotateCert()`, permanently hanging the certificate rotation background task.
2. When `EdgeHub` finishes its sleep and returns to `<-eh.reconnectChan`, it consumes the stale reconnect signal sent by the older rotation, triggering an extra unwanted reconnect cycle.

This PR updates `ifRotationDone()` to use a non-blocking `select` when sending to `eh.reconnectChan` and listens to `beehiveContext.Done()` for module shutdown. If `EdgeHub` is not waiting on `reconnectChan`, the send is safely skipped because `EdgeHub` will read the updated certificate files on disk during its next `chClient.Init()` call.

**Which issue(s) this PR fixes**:

Fixes #7142

**Special notes for your reviewer**:

- Updated `ifRotationDone()` in `edge/pkg/edgehub/process.go`.
- Added unit tests in `edge/pkg/edgehub/process_test.go` (`TestIfRotationDone`) covering normal signal delivery, non-blocking behavior when EdgeHub is not listening, and clean shutdown.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
