### PR TITLE
fix(util): check Close errors in FileCopy and Compress to prevent silent data loss

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -269,7 +269,9 @@ func DecompressTarGz(gzFilePath, dest string) error {
 				writer.Close() // Close the file explicitly here in case of an error
 				return err
 			}
-			writer.Close() // Close the file explicitly after successful write
+			if err := writer.Close(); err != nil {
+				return fmt.Errorf("failed to close destination file %s: %v", target, err)
+			}
 		}
 	}
 }
@@ -279,10 +281,10 @@ func Compress(tarName string, paths []string) error {
 	if err != nil {
 		return err
 	}
+	closed := false
 	defer func() {
-		err := tarFile.Close()
-		if err != nil {
-			fmt.Printf("failed to close tar file, path: %v, error: %v \n", tarName, err)
+		if !closed {
+			tarFile.Close()
 		}
 	}()
 
@@ -292,13 +294,23 @@ func Compress(tarName string, paths []string) error {
 	}
 
 	// enable compression if file ends in .gz
-	tw := tar.NewWriter(tarFile)
+	var tw *tar.Writer
+	var gz *gzip.Writer
 	if strings.HasSuffix(tarName, ".gz") || strings.HasSuffix(tarName, ".gzip") {
-		gz := gzip.NewWriter(tarFile)
-		defer gz.Close()
+		gz = gzip.NewWriter(tarFile)
 		tw = tar.NewWriter(gz)
+	} else {
+		tw = tar.NewWriter(tarFile)
 	}
-	defer tw.Close()
+
+	defer func() {
+		if !closed {
+			tw.Close()
+			if gz != nil {
+				gz.Close()
+			}
+		}
+	}()
 
 	// walk each specified path and add encountered file to tar
 	for _, path := range paths {
@@ -353,12 +365,7 @@ func Compress(tarName string, paths []string) error {
 				return err
 			}
 
-			defer func() {
-				err := srcFile.Close()
-				if err != nil {
-					fmt.Printf("failed to close file, path: %v, error: %v \n", file, err)
-				}
-			}()
+			defer srcFile.Close()
 
 			_, err = io.Copy(tw, srcFile)
 			if err != nil {
@@ -369,10 +376,26 @@ func Compress(tarName string, paths []string) error {
 
 		// build tar
 		if err := filepath.Walk(path, walker); err != nil {
-			fmt.Printf("failed to add %s to tar: %s\n", path, err)
+			return fmt.Errorf("failed to add %s to tar: %v", path, err)
 		}
 	}
-	return nil
+
+	closed = true
+
+	var firstErr error
+	if err := tw.Close(); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("failed to close tar writer: %v", err)
+	}
+	if gz != nil {
+		if err := gz.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("failed to close gzip writer: %v", err)
+		}
+	}
+	if err := tarFile.Close(); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("failed to close tar file %s: %v", tarName, err)
+	}
+
+	return firstErr
 }
 
 // keadmVersion returns the version of the client without metadata.

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -567,6 +567,16 @@ func TestDecompressAndCompress(t *testing.T) {
 	assert.FileExists(t, extractedFile1)
 	assert.FileExists(t, extractedFile2)
 
+	// Test uncompressed tar archive
+	testTar := filepath.Join(testDir, "archive.tar")
+	err = Compress(testTar, []string{testFile1, testFile2})
+	assert.NoError(t, err)
+	assert.FileExists(t, testTar)
+
+	// Test error when input path does not exist
+	err = Compress(filepath.Join(testDir, "error.tar.gz"), []string{filepath.Join(testDir, "nonexistent_source")})
+	assert.Error(t, err)
+
 	badPath := filepath.Join(os.TempDir(), "invalid/path/test.tar.gz")
 	err = Compress(badPath, []string{testFile1})
 	assert.Error(t, err)

--- a/keadm/cmd/keadm/app/cmd/util/idempotency/idempotency.go
+++ b/keadm/cmd/keadm/app/cmd/util/idempotency/idempotency.go
@@ -36,8 +36,12 @@ func Occupy() (bool, error) {
 	if IsOccupied() {
 		return true, nil
 	}
-	if _, err := os.Create(idempotencyRecord); err != nil {
+	f, err := os.Create(idempotencyRecord)
+	if err != nil {
 		return true, fmt.Errorf("failed to create idempotency_record file, err: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		return true, fmt.Errorf("failed to close idempotency_record file, err: %v", err)
 	}
 	return false, nil
 }

--- a/pkg/util/files/files.go
+++ b/pkg/util/files/files.go
@@ -48,10 +48,23 @@ func FileCopy(src, dst string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open or create destination file %s, err: %v", dst, err)
 	}
-	defer destination.Close()
+	closed := false
+	defer func() {
+		if !closed {
+			destination.Close()
+		}
+	}()
 
-	_, err = io.Copy(destination, source)
-	return err
+	if _, err = io.Copy(destination, source); err != nil {
+		return err
+	}
+
+	closed = true
+	if err := destination.Close(); err != nil {
+		return fmt.Errorf("failed to close destination file %s, err: %v", dst, err)
+	}
+
+	return nil
 }
 
 func FileExists(path string) bool {

--- a/pkg/util/files/files_test.go
+++ b/pkg/util/files/files_test.go
@@ -26,41 +26,38 @@ import (
 )
 
 func TestFileCopy(t *testing.T) {
+	dir := t.TempDir()
+
 	t.Run("source file not exists", func(t *testing.T) {
-		err := FileCopy("a.txt", "b.txt")
-		assert.ErrorContains(t, err, "failed to get source file a.txt sta")
+		err := FileCopy(filepath.Join(dir, "nonexistent.txt"), filepath.Join(dir, "b.txt"))
+		assert.ErrorContains(t, err, "failed to get source file")
 	})
 
 	t.Run("source file is a directory", func(t *testing.T) {
-		const src = "a"
-		var err error
-		err = os.Mkdir(src, os.ModePerm)
+		src := filepath.Join(dir, "dir_a")
+		err := os.Mkdir(src, os.ModePerm)
 		assert.NoError(t, err)
 
-		defer func() {
-			err := os.Remove(src)
-			assert.NoError(t, err)
-		}()
-
-		err = FileCopy(src, "b.txt")
-		assert.ErrorContains(t, err, "source file a is not a regular file")
+		err = FileCopy(src, filepath.Join(dir, "b.txt"))
+		assert.ErrorContains(t, err, "is not a regular file")
 	})
 
 	t.Run("copy file successfully", func(t *testing.T) {
-		const src, dest = "a.txt", "b.txt"
-		var err error
-		_, err = os.Create(src)
+		src := filepath.Join(dir, "a.txt")
+		dest := filepath.Join(dir, "b.txt")
+
+		f, err := os.Create(src)
+		assert.NoError(t, err)
+		_, err = f.WriteString("hello world")
+		assert.NoError(t, err)
+		assert.NoError(t, f.Close())
+
+		err = FileCopy(src, dest)
 		assert.NoError(t, err)
 
-		defer func() {
-			err = os.Remove(src)
-			assert.NoError(t, err)
-			err = os.Remove(dest)
-			assert.NoError(t, err)
-		}()
-
-		err = FileCopy(src, "b.txt")
+		content, err := os.ReadFile(dest)
 		assert.NoError(t, err)
+		assert.Equal(t, "hello world", string(content))
 	})
 }
 
@@ -69,6 +66,7 @@ func TestFileExists(t *testing.T) {
 
 	ef, err := os.CreateTemp(dir, "FileExist")
 	if err == nil {
+		ef.Close()
 		if !FileExists(ef.Name()) {
 			t.Fatalf("file %v should exist", ef.Name())
 		}

--- a/pkg/util/validation/check_test.go
+++ b/pkg/util/validation/check_test.go
@@ -11,6 +11,7 @@ func TestFileIsExist(t *testing.T) {
 
 	ef, err := os.CreateTemp(dir, "CheckFileIsExist")
 	if err == nil {
+		ef.Close()
 		if !FileIsExist(ef.Name()) {
 			t.Fatalf("file %v should exist", ef.Name())
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes an issue where `FileCopy` in `pkg/util/files/files.go` and `Compress` / `DecompressTarGz` in `keadm/cmd/keadm/app/cmd/util/common.go` silently ignore errors returned by `Close()` on destination file descriptors and archive stream writers (`tar.Writer`, `gzip.Writer`).

Because kernel writes and archive formatters (gzip footers, tar end-of-archive blocks) buffer data in memory, write errors (such as `ENOSPC` / no space left on device) frequently manifest when `Close()` is invoked. Ignoring `Close()` errors causes `keadm backup`, `upgrade`, and `rollback` operations to falsely report success when backup files or compressed archives are actually truncated or corrupted.

Changes included:
- `pkg/util/files/files.go`: Explicitly check and return error from `destination.Close()` in `FileCopy`.
- `keadm/cmd/keadm/app/cmd/util/common.go`:
  - Explicitly close and check errors for `tw.Close()`, `gz.Close()`, and `tarFile.Close()` in `Compress`.
  - Return error from `filepath.Walk` in `Compress`.
  - Check error from `writer.Close()` in `DecompressTarGz`.
- `pkg/util/files/files_test.go` & `keadm/cmd/keadm/app/cmd/util/common_test.go`: Updated unit tests for `FileCopy`, `Compress`, and `DecompressTarGz`.

**Which issue(s) this PR fixes**:

Fixes #7145

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
