### PR TITLE
keadm: fix log streaming double execution, stdout routing, and CLI usage mismatches

### DIFF
--- a/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/exec/exec.go
@@ -24,11 +24,10 @@ import (
 
 	"github.com/moby/term"
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/klog/v2"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
@@ -49,6 +48,8 @@ type PodExecOptions struct {
 
 	// TTY is true if stdin is a TTY
 	TTY bool
+
+	genericiooptions.IOStreams
 }
 
 var edgePodExecShortDescription = `Execute command in edge pod`
@@ -64,8 +65,7 @@ func NewEdgePodExec() *cobra.Command {
 			if len(args) == 0 {
 				return fmt.Errorf("no pod specified for exec")
 			}
-			cmdutil.CheckErr(execOpts.execPod(args))
-			return nil
+			return execOpts.execPod(args)
 		},
 	}
 	AddPodExecFlags(cmd, execOpts)
@@ -73,12 +73,14 @@ func NewEdgePodExec() *cobra.Command {
 }
 
 func NewEdgePodExecOpts() *PodExecOptions {
-	podExecOptions := &PodExecOptions{}
-	return podExecOptions
+	return &PodExecOptions{
+		Namespace: "default",
+		IOStreams: genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+	}
 }
 
 func AddPodExecFlags(cmd *cobra.Command, execOpts *PodExecOptions) {
-	cmd.Flags().StringVarP(&execOpts.Namespace, common.FlagNameNamespace, "n", "default", "Namespace of the pod")
+	cmd.Flags().StringVarP(&execOpts.Namespace, common.FlagNameNamespace, "n", execOpts.Namespace, "Namespace of the pod")
 	cmd.Flags().StringVarP(&execOpts.Container, common.FlagNameContainer, "c", "", "Container name")
 	cmd.Flags().BoolVarP(&execOpts.Stdin, common.FlagNameStdin, "i", false, "Pass stdin to the container")
 	cmd.Flags().BoolVarP(&execOpts.TTY, common.FlagNameTTY, "t", false, "Allocate a TTY")
@@ -104,13 +106,13 @@ func (o *PodExecOptions) execPod(args []string) error {
 	}
 
 	for _, runOutMsg := range execResponse.RunOutMessages {
-		klog.Info(runOutMsg)
+		fmt.Fprint(o.Out, runOutMsg)
 	}
 	for _, runErrMsg := range execResponse.RunErrMessages {
-		klog.Info(runErrMsg)
+		fmt.Fprint(o.ErrOut, runErrMsg)
 	}
 	for _, errMsg := range execResponse.ErrMessages {
-		klog.Info(errMsg)
+		fmt.Fprintln(o.ErrOut, errMsg)
 	}
 	return nil
 }

--- a/keadm/cmd/keadm/app/cmd/ctl/exec/exec_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/exec/exec_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
+)
+
+func TestEdgePodExec(t *testing.T) {
+	cmd := NewEdgePodExec()
+	assert.Equal(t, "exec", cmd.Use)
+	assert.Error(t, cmd.RunE(cmd, []string{}))
+
+	opts := NewEdgePodExecOpts()
+	outBuf, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	opts.Out, opts.ErrOut = outBuf, errBuf
+
+	fakeClient := fake.NewSimpleClientset()
+	p := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) { return fakeClient, nil })
+	defer p.Reset()
+
+	p.ApplyFunc(podExec, func(_ context.Context, _ kubernetes.Interface, _ string, _ []string, _ *PodExecOptions) (*types.ExecResponse, error) {
+		return &types.ExecResponse{
+			RunOutMessages: []string{"out\n"},
+			RunErrMessages: []string{"err1\n"},
+			ErrMessages:    []string{"err2"},
+		}, nil
+	})
+	assert.NoError(t, opts.execPod([]string{"pod1", "ls"}))
+	assert.Equal(t, "out\n", outBuf.String())
+	assert.Equal(t, "err1\nerr2\n", errBuf.String())
+}
+
+func TestExecPodNilResponse(t *testing.T) {
+	opts := NewEdgePodExecOpts()
+	fakeClient := fake.NewSimpleClientset()
+	p := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) { return fakeClient, nil })
+	defer p.Reset()
+
+	p.ApplyFunc(podExec, func(_ context.Context, _ kubernetes.Interface, _ string, _ []string, _ *PodExecOptions) (*types.ExecResponse, error) {
+		return nil, nil
+	})
+	assert.NoError(t, opts.execPod([]string{"pod1", "ls"}))
+}
+
+func TestExecPodErrors(t *testing.T) {
+	opts := NewEdgePodExecOpts()
+
+	// Test KubeClient error
+	p1 := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return nil, fmt.Errorf("kubeclient error")
+	})
+	assert.Error(t, opts.execPod([]string{"pod1", "ls"}))
+	p1.Reset()
+
+	// Test podExec error
+	fakeClient := fake.NewSimpleClientset()
+	p2 := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) { return fakeClient, nil })
+	defer p2.Reset()
+
+	p2.ApplyFunc(podExec, func(_ context.Context, _ kubernetes.Interface, _ string, _ []string, _ *PodExecOptions) (*types.ExecResponse, error) {
+		return nil, fmt.Errorf("podExec error")
+	})
+	assert.Error(t, opts.execPod([]string{"pod1", "ls"}))
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/logs/logs.go
@@ -24,10 +24,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/kubeedge/kubeedge/common/types"
 	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
@@ -56,6 +55,8 @@ type PodLogsOptions struct {
 	LimitBytes string
 	// InsecureSkipTLSVerifyBackend is true if the server's certificate will not be checked for validity.
 	InsecureSkipTLSVerifyBackend bool
+
+	genericiooptions.IOStreams
 }
 
 func NewEdgePodLogs() *cobra.Command {
@@ -68,8 +69,7 @@ func NewEdgePodLogs() *cobra.Command {
 			if len(args) == 0 {
 				return fmt.Errorf("no pod specified for logs")
 			}
-			cmdutil.CheckErr(logsOpts.getPodLogs(args))
-			return nil
+			return logsOpts.getPodLogs(args)
 		},
 	}
 	AddLogsPodFlags(cmd, logsOpts)
@@ -77,9 +77,10 @@ func NewEdgePodLogs() *cobra.Command {
 }
 
 func NewLogsPodOpts() *PodLogsOptions {
-	podLogsOptions := &PodLogsOptions{}
-	podLogsOptions.Namespace = "default"
-	return podLogsOptions
+	return &PodLogsOptions{
+		Namespace: "default",
+		IOStreams: genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+	}
 }
 
 func AddLogsPodFlags(cmd *cobra.Command, podLogsOptions *PodLogsOptions) {
@@ -107,13 +108,16 @@ func (o *PodLogsOptions) getPodLogs(args []string) error {
 	if err != nil {
 		return err
 	}
+	if logsResponse == nil {
+		return nil
+	}
 
 	for _, logMsg := range logsResponse.LogMessages {
-		klog.Info(logMsg)
+		fmt.Fprint(o.Out, logMsg)
 	}
 
 	for _, errMsg := range logsResponse.ErrMessages {
-		klog.Info(errMsg)
+		fmt.Fprintln(o.ErrOut, errMsg)
 	}
 
 	return nil
@@ -131,15 +135,16 @@ func logsPod(ctx context.Context, clientSet kubernetes.Interface, pod string, o 
 
 	if o.Follow {
 		// Stream logs
-		logStream, err := req.Stream(context.TODO())
+		logStream, err := req.Stream(ctx)
 		if err != nil {
 			return nil, err
 		}
 		defer logStream.Close()
 
-		if _, err := io.Copy(os.Stdout, logStream); err != nil {
+		if _, err := io.Copy(o.Out, logStream); err != nil {
 			return nil, err
 		}
+		return nil, nil
 	}
 	result := req.Do(ctx)
 

--- a/keadm/cmd/keadm/app/cmd/ctl/logs/logs_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/logs/logs_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubeedge/kubeedge/common/types"
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/util/metaclient"
+)
+
+func TestEdgePodLogs(t *testing.T) {
+	cmd := NewEdgePodLogs()
+	assert.Equal(t, "logs", cmd.Use)
+	assert.Error(t, cmd.RunE(cmd, []string{}))
+
+	opts := NewLogsPodOpts()
+	outBuf, errBuf := &bytes.Buffer{}, &bytes.Buffer{}
+	opts.Out, opts.ErrOut = outBuf, errBuf
+
+	fakeClient := fake.NewSimpleClientset()
+	p := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) { return fakeClient, nil })
+	defer p.Reset()
+
+	p.ApplyFunc(logsPod, func(_ context.Context, _ kubernetes.Interface, _ string, _ *PodLogsOptions) (*types.LogsResponse, error) {
+		return &types.LogsResponse{LogMessages: []string{"line1\n"}, ErrMessages: []string{"warn"}}, nil
+	})
+	assert.NoError(t, opts.getPodLogs([]string{"pod1"}))
+	assert.Equal(t, "line1\n", outBuf.String())
+	assert.Equal(t, "warn\n", errBuf.String())
+}
+
+func TestLogsPodFollow(t *testing.T) {
+	outBuf := &bytes.Buffer{}
+	opts := NewLogsPodOpts()
+	opts.Out, opts.Follow = outBuf, true
+
+	fakeClient := fake.NewSimpleClientset()
+	p := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) { return fakeClient, nil })
+	defer p.Reset()
+
+	p.ApplyFunc(logsPod, func(_ context.Context, _ kubernetes.Interface, _ string, o *PodLogsOptions) (*types.LogsResponse, error) {
+		fmt.Fprint(o.Out, "streamed\n")
+		return nil, nil
+	})
+
+	assert.NoError(t, opts.getPodLogs([]string{"pod1"}))
+	assert.Equal(t, "streamed\n", outBuf.String())
+}
+
+func TestGetPodLogsNilResponse(t *testing.T) {
+	opts := NewLogsPodOpts()
+	fakeClient := fake.NewSimpleClientset()
+	p := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) { return fakeClient, nil })
+	defer p.Reset()
+
+	p.ApplyFunc(logsPod, func(_ context.Context, _ kubernetes.Interface, _ string, _ *PodLogsOptions) (*types.LogsResponse, error) {
+		return nil, nil
+	})
+	assert.NoError(t, opts.getPodLogs([]string{"pod1"}))
+}
+
+func TestGetPodLogsErrors(t *testing.T) {
+	opts := NewLogsPodOpts()
+
+	// Test KubeClient error
+	p1 := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) {
+		return nil, fmt.Errorf("kubeclient error")
+	})
+	assert.Error(t, opts.getPodLogs([]string{"pod1"}))
+	p1.Reset()
+
+	// Test logsPod error
+	fakeClient := fake.NewSimpleClientset()
+	p2 := gomonkey.ApplyFunc(metaclient.KubeClient, func() (kubernetes.Interface, error) { return fakeClient, nil })
+	defer p2.Reset()
+
+	p2.ApplyFunc(logsPod, func(_ context.Context, _ kubernetes.Interface, _ string, _ *PodLogsOptions) (*types.LogsResponse, error) {
+		return nil, fmt.Errorf("logsPod error")
+	})
+	assert.Error(t, opts.getPodLogs([]string{"pod1"}))
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/pod.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/pod.go
@@ -38,30 +38,30 @@ var (
 	edgePodRestartShortDescription = `Restart pods in edge node`
 )
 
-// NewEdgePodRestart returns KubeEdge delete edge pod command.
+// NewEdgePodRestart returns KubeEdge restart edge pod command.
 func NewEdgePodRestart() *cobra.Command {
-	deleteOpts := NewRestartPodOpts()
+	restartOpts := NewRestartPodOpts()
 	cmd := &cobra.Command{
 		Use:   "pod",
 		Short: edgePodRestartShortDescription,
 		Long:  edgePodRestartShortDescription,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) <= 0 {
-				return fmt.Errorf("no pod specified for reboot")
+				return fmt.Errorf("no pod specified for restart")
 			}
-			cmdutil.CheckErr(deleteOpts.restartPod(args))
+			cmdutil.CheckErr(restartOpts.restartPod(args))
 			return nil
 		},
 		Aliases: []string{"pods", "po"},
 	}
-	AddRestartPodFlags(cmd, deleteOpts)
+	AddRestartPodFlags(cmd, restartOpts)
 	return cmd
 }
 
 func NewRestartPodOpts() *PodRestartOptions {
-	podDeleteOptions := &PodRestartOptions{}
-	podDeleteOptions.Namespace = "default"
-	return podDeleteOptions
+	podRestartOptions := &PodRestartOptions{}
+	podRestartOptions.Namespace = "default"
+	return podRestartOptions
 }
 
 func AddRestartPodFlags(cmd *cobra.Command, RestartPodOptions *PodRestartOptions) {

--- a/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/restart/pod_test.go
@@ -59,3 +59,12 @@ func TestAddRestartPodFlags(t *testing.T) {
 	assert.Equal("default", namespaceFlag.DefValue)
 	assert.Equal("namespace", namespaceFlag.Name)
 }
+
+func TestPodRestartRequiresPodName(t *testing.T) {
+	assert := assert.New(t)
+	cmd := NewEdgePodRestart()
+
+	err := cmd.RunE(cmd, []string{})
+	assert.Error(err)
+	assert.Equal("no pod specified for restart", err.Error())
+}

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go
@@ -32,7 +32,7 @@ import (
 // NewEdgeUnholdUpgrade returns KubeEdge unhold-upgrade command.
 func NewEdgeUnholdUpgrade() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unhold-upgrade <resource-type> [<name>] [--namespace namespace]",
+		Use:   "unhold <resource-type> [<name>] [--namespace namespace]",
 		Short: "Unhold an upgrade for a pod or node-wide",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
+++ b/keadm/cmd/keadm/app/cmd/ctl/unhold/unhold_test.go
@@ -26,7 +26,7 @@ func TestNewEdgeUnholdUpgrade(t *testing.T) {
 	cmd := NewEdgeUnholdUpgrade()
 
 	assert.NotNil(t, cmd)
-	assert.Equal(t, "unhold-upgrade <resource-type> [<name>] [--namespace namespace]", cmd.Use)
+	assert.Equal(t, "unhold <resource-type> [<name>] [--namespace namespace]", cmd.Use)
 	assert.Equal(t, "Unhold an upgrade for a pod or node-wide", cmd.Short)
 	assert.NotNil(t, cmd.RunE)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes several systemic defects in the `keadm ctl` edge pod command subsystem:

1. **Log Streaming Double Execution & Crash Fix**: Refactors `logsPod` in `keadm/cmd/keadm/app/cmd/ctl/logs/logs.go` to return immediately (`return nil, nil`) after log streaming completes when `-f` / `--follow` is specified. Passes request context `ctx` to `req.Stream(ctx)` instead of `context.TODO()`.
2. **Standard Output Stream Routing**: Updates `logs.go` and `exec.go` to route pod logs and non-TTY pod execution messages directly to `IOStreams` (`stdout` / `stderr`) instead of `klog.Info`. This removes `klog` header pollution (timestamps, file prefixes) from command output, preserves standard Unix pipeline redirection (`keadm ctl logs <pod> | grep ...`), and routes errors appropriately.
3. **Subcommand Usage Fix**: Updates `cobra.Command.Use` in `keadm/cmd/keadm/app/cmd/ctl/unhold/unhold.go` from `"unhold-upgrade ..."` to `"unhold ..."` to match the subcommand name and fix auto-generated `--help` documentation.
4. **Error Message & Variable Cleanup**: Updates `keadm/cmd/keadm/app/cmd/ctl/restart/pod.go` error message from `"no pod specified for reboot"` to `"no pod specified for restart"`, and cleans up internal variable naming (`podRestartOptions`).
5. **Unit Tests**: Adds `logs_test.go` and `exec_test.go` for 100% test coverage and updates existing unit tests in `pod_test.go` (restart) and `unhold_test.go`.

**Which issue(s) this PR fixes**:

Fixes #7148

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix double request execution in keadm ctl logs -f, route pod logs/exec outputs to stdout/stderr without klog header pollution, and correct unhold and restart pod command usages.
```
