### PR TITLE
keadm batch: return an error when node processing fails

### DIFF
--- a/keadm/cmd/keadm/app/cmd/edge/batch.go
+++ b/keadm/cmd/keadm/app/cmd/edge/batch.go
@@ -235,8 +235,15 @@ func batchProcessNodes(cfg *common.Config, logWriter *bufio.Writer) error {
 	if cfg.MaxRunNum == 0 {
 		cfg.MaxRunNum = defaultMaxRunNum
 	}
+	type batchNodeResult struct {
+		nodeName string
+		message  string
+		err      error
+	}
+
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, cfg.MaxRunNum)
+	results := make(chan batchNodeResult, len(cfg.Nodes))
 	for _, node := range cfg.Nodes {
 		wg.Add(1)
 		go func(node common.Node) {
@@ -244,23 +251,37 @@ func batchProcessNodes(cfg *common.Config, logWriter *bufio.Writer) error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			var result string
+			result := batchNodeResult{nodeName: node.NodeName}
 			if err := processNode(&node, cfg); err != nil {
-				result = fmt.Sprintf("Failed to process node %s: %v", node.NodeName, err)
-				klog.Error(result)
+				result.err = err
+				result.message = fmt.Sprintf("Failed to process node %s: %v", node.NodeName, err)
+				klog.Error(result.message)
 			} else {
-				result = fmt.Sprintf("Successfully processed node %s", node.NodeName)
-				klog.Info(result)
+				result.message = fmt.Sprintf("Successfully processed node %s", node.NodeName)
+				klog.Info(result.message)
 			}
-
-			// Log result to file
-			_, err := logWriter.WriteString(result + "\n")
-			if err != nil {
-				klog.Errorf("Failed to write log entry for node %s: %v", node.NodeName, err)
-			}
+			results <- result
 		}(node)
 	}
+
 	wg.Wait()
+	close(results)
+
+	failedNodes := 0
+	for result := range results {
+		if result.err != nil {
+			failedNodes++
+		}
+
+		// Log result to file from a single goroutine.
+		if _, err := logWriter.WriteString(result.message + "\n"); err != nil {
+			klog.Errorf("Failed to write log entry for node %s: %v", result.nodeName, err)
+		}
+	}
+
+	if failedNodes > 0 {
+		return errors.Errorf("%d node(s) failed", failedNodes)
+	}
 	return nil
 }
 

--- a/keadm/cmd/keadm/app/cmd/edge/batch_test.go
+++ b/keadm/cmd/keadm/app/cmd/edge/batch_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package edge
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/keadm/cmd/keadm/app/cmd/common"
+)
+
+func newBatchTestConfig(names ...string) *common.Config {
+	nodes := make([]common.Node, len(names))
+	for i, name := range names {
+		nodes[i].NodeName = name
+	}
+	return &common.Config{Nodes: nodes, MaxRunNum: len(names)}
+}
+
+func runBatchProcessNodesTest(t *testing.T, cfg *common.Config) (error, string) {
+	t.Helper()
+	var output bytes.Buffer
+	logWriter := bufio.NewWriter(&output)
+	err := batchProcessNodes(cfg, logWriter)
+	assert.NoError(t, logWriter.Flush())
+	return err, output.String()
+}
+
+func TestBatchProcessNodes(t *testing.T) {
+	var processNodeMock func(*common.Node) error
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(processNode, func(node *common.Node, _cfg *common.Config) error {
+		return processNodeMock(node)
+	})
+
+	t.Run("all nodes succeed", func(t *testing.T) {
+		processNodeMock = func(_node *common.Node) error {
+			return nil
+		}
+
+		cfg := newBatchTestConfig("node-1", "node-2")
+		err, output := runBatchProcessNodesTest(t, cfg)
+
+		assert.NoError(t, err)
+		for _, node := range cfg.Nodes {
+			assert.Contains(t, output, "Successfully processed node "+node.NodeName)
+		}
+	})
+
+	t.Run("failed nodes return an error", func(t *testing.T) {
+		processNodeMock = func(_node *common.Node) error {
+			return errors.New("test node failure")
+		}
+
+		cfg := newBatchTestConfig("failed-node")
+		err, output := runBatchProcessNodesTest(t, cfg)
+
+		assert.EqualError(t, err, "1 node(s) failed")
+		assert.Contains(t, output, "Failed to process node failed-node: test node failure")
+	})
+
+	t.Run("all nodes run before returning an error", func(t *testing.T) {
+		var calls int32
+		processNodeMock = func(node *common.Node) error {
+			atomic.AddInt32(&calls, 1)
+			if node.NodeName == "failed-node" {
+				return errors.New("test node failure")
+			}
+			return nil
+		}
+
+		cfg := newBatchTestConfig("failed-node", "successful-node-1", "successful-node-2")
+		err, output := runBatchProcessNodesTest(t, cfg)
+
+		assert.Equal(t, int32(len(cfg.Nodes)), atomic.LoadInt32(&calls))
+		assert.EqualError(t, err, "1 node(s) failed")
+		assert.Contains(t, output, "Failed to process node failed-node: test node failure")
+		assert.Contains(t, output, "Successfully processed node successful-node-1")
+		assert.Contains(t, output, "Successfully processed node successful-node-2")
+	})
+
+	t.Run("writes one log line per node", func(t *testing.T) {
+		processNodeMock = func(_node *common.Node) error {
+			return nil
+		}
+
+		cfg := newBatchTestConfig("node-1", "node-2", "node-3", "node-4")
+		err, output := runBatchProcessNodesTest(t, cfg)
+
+		assert.NoError(t, err)
+		assert.Len(t, strings.Split(strings.TrimSpace(output), "\n"), len(cfg.Nodes))
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`keadm batch` currently logs errors returned by `processNode`, but `batchProcessNodes` always returns `nil` after all node-processing goroutines complete. As a result, SSH failures, unreachable nodes, file-transfer failures, and remote command failures are not propagated to the CLI exit code.

This PR:

1. Collects the result of each node through a buffered channel.
2. Serializes writes to the shared batch log writer.
3. Aggregates node failures after all nodes have finished processing.
4. Returns an error when one or more nodes fail, causing `keadm batch` to exit with a non-zero status.
5. Preserves the existing best-effort behavior: remaining nodes continue to be processed after an individual node fails.

No fail-fast behavior, global cancellation, or automatic rollback is introduced.

**Which issue(s) this PR fixes**:

Fixes #7150

**Special notes for your reviewer**:

- The result channel is sized for all configured nodes so workers cannot block while the caller waits for completion.
- Regression tests mock `processNode` and do not require SSH connectivity or user configuration.
- The tests cover:
  - all nodes succeeding;
  - a single failed node;
  - mixed successful and failed nodes;
  - processing all nodes before returning the aggregated error;
  - one log line per processed node.

Validation:

- Targeted batch tests pass with the repository's `-gcflags "all=-N -l"` test configuration.
- The invalid SSH authentication reproduction now exits with code `1`.
- `git diff --check` passes.
- `make test WHAT=keadm` runs the new batch tests successfully, but the overall command is affected by unrelated platform-dependent tests involving cloud, debug, edge, Helm, and system utilities.

**Does this PR introduce a user-facing change?**:

Yes. `keadm batch` now returns a non-zero exit code when one or more nodes fail, while continuing to process the remaining nodes.

```release-note
keadm batch now returns a non-zero exit code when one or more nodes fail, while continuing to process the remaining nodes.
```
