### PR TITLE
build: update stale controller-gen version annotation in HA prepare manifest

### DIFF
--- a/build/cloud/ha/01-ha-prepare.yaml
+++ b/build/cloud/ha/01-ha-prepare.yaml
@@ -78,7 +78,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: devices.devices.kubeedge.io
 spec:
@@ -611,7 +611,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: devicemodels.devices.kubeedge.io
 spec:
@@ -774,7 +774,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: clusterobjectsyncs.reliablesyncs.kubeedge.io
 spec:
@@ -850,7 +850,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   creationTimestamp: null
   name: objectsyncs.reliablesyncs.kubeedge.io
 spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

`build/cloud/ha/01-ha-prepare.yaml` embeds four CRDs whose `controller-gen.kubebuilder.io/version` annotation was still `v0.6.2`, while `hack/generate-crds.sh` pins `controller-gen@v0.17.3` and every generated CRD under `manifests/charts/cloudcore/crds` carries `v0.17.3`. This updates the annotation in all four embedded CRDs (`devices`, `devicemodels`, `clusterobjectsyncs`, `objectsyncs`) to match the current toolchain version used elsewhere in the repo.

**Which issue(s) this PR fixes**:

Fixes #7152

**Special notes for your reviewer**:

This is a scoped, minimal change limited to the stale annotation value; it does not alter the CRD schema, structure, or any other content in the manifest. Verified `hack/verify-crds.sh` still passes and is unaffected, since it only checks `build/crds`, not `build/cloud/ha/01-ha-prepare.yaml`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
