### PR TITLE
fix: replace incorrect os.IsExist with !os.IsNotExist in file existence checks

### DIFF
--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -69,7 +69,7 @@ func NewCertManager(edgehub v1alpha2.EdgeHub, nodename string) CertManager {
 		now:                time.Now,
 		caURL:              edgehub.HTTPServer + constants.DefaultCAURL,
 		certURL:            edgehub.HTTPServer + constants.DefaultCertURL,
-		Done:               make(chan struct{}),
+		Done:               make(chan struct{}, 1),
 	}
 }
 
@@ -219,7 +219,10 @@ func (cm *CertManager) rotateCert() (bool, error) {
 
 	klog.Info("succeeded to rotate certificate")
 
-	cm.Done <- struct{}{}
+	select {
+	case cm.Done <- struct{}{}:
+	default:
+	}
 
 	return true, nil
 }

--- a/edge/pkg/edgehub/certificate/certmanager_test.go
+++ b/edge/pkg/edgehub/certificate/certmanager_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -132,6 +133,95 @@ func TestGetEdgeCert(t *testing.T) {
 		cm := &CertManager{}
 		_, _, err := cm.GetEdgeCert(fakehost+constants.DefaultCAURL, []byte{}, tls.Certificate{}, "")
 		require.NoError(t, err)
+	})
+}
+
+func TestRotateCert(t *testing.T) {
+	cahandler := certs.GetCAHandler(certs.CAHandlerTypeX509)
+	pk, err := cahandler.GenPrivateKey()
+	require.NoError(t, err)
+	caPem, err := cahandler.NewSelfSigned(pk)
+	require.NoError(t, err)
+
+	certshandler := certs.GetHandler(certs.HandlerTypeX509)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(commhttp.NewHTTPClientWithCA,
+		func(capem []byte, certificate tls.Certificate) (*http.Client, error) {
+			return &http.Client{}, nil
+		})
+	patches.ApplyFunc(commhttp.SendRequest,
+		func(req *http.Request, _ *http.Client) (*http.Response, error) {
+			csrBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			certBlock, err := certshandler.SignCerts(certs.SignCertsOptionsWithCSR(
+				csrBytes,
+				caPem.Bytes,
+				pk.DER(),
+				[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				time.Hour,
+			))
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       httpfake.NewFakeBodyReader(certBlock.Bytes),
+			}, nil
+		})
+
+	t.Run("rotateCert sends to Done channel when receiver ready", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{}, 1)
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			// Success
+		default:
+			t.Fatal("expected signal on Done channel")
+		}
+	})
+
+	t.Run("rotateCert does not block when no receiver on Done channel", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{})
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			t.Fatal("unexpected signal on unbuffered unread Done channel")
+		default:
+			// Success
+		}
 	})
 }
 

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -149,8 +149,17 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 func (eh *EdgeHub) ifRotationDone() {
 	if eh.certManager.RotateCertificates {
 		for {
-			<-eh.certManager.Done
-			eh.reconnectChan <- struct{}{}
+			select {
+			case <-beehiveContext.Done():
+				klog.Warning("EdgeHub ifRotationDone stop")
+				return
+			case <-eh.certManager.Done:
+				select {
+				case <-beehiveContext.Done():
+					return
+				case eh.reconnectChan <- struct{}{}:
+				}
+			}
 		}
 	}
 }

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/mocks/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 	msghandler "github.com/kubeedge/kubeedge/edge/pkg/edgehub/messagehandler"
 )
@@ -376,4 +377,121 @@ func TestKeepalive(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIfRotationDone(t *testing.T) {
+	t.Run("RotateCertificates disabled", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: false,
+			},
+		}
+		hub.ifRotationDone()
+	})
+
+	t.Run("Successful send to reconnectChan when receiver ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		recChan := make(chan struct{})
+		go func() {
+			<-hub.reconnectChan
+			close(recChan)
+		}()
+
+		time.Sleep(20 * time.Millisecond)
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-recChan:
+			// Success: reconnectChan received signal
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
+	t.Run("Sends to reconnectChan when receiver becomes ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}, 1),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-hub.reconnectChan:
+			// Success: reconnectChan received signal when receiver read from it
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
+	t.Run("Stopped by outer beehiveContext.Done", func(t *testing.T) {
+		beehiveContext.InitContext([]string{"channel"})
+		defer beehiveContext.InitContext([]string{"channel"})
+		beehiveContext.Cancel()
+
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}),
+			},
+		}
+
+		done := make(chan struct{})
+		go func() {
+			hub.ifRotationDone()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Success: exited when beehiveContext.Done closed
+		case <-time.After(2 * time.Second):
+			t.Fatal("ifRotationDone did not exit on beehiveContext.Done")
+		}
+	})
+
+	t.Run("Stopped by inner beehiveContext.Done", func(t *testing.T) {
+		beehiveContext.InitContext([]string{"channel"})
+		defer beehiveContext.InitContext([]string{"channel"})
+
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}, 1),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		done := make(chan struct{})
+		go func() {
+			hub.ifRotationDone()
+			close(done)
+		}()
+
+		hub.certManager.Done <- struct{}{}
+
+		time.Sleep(50 * time.Millisecond)
+		beehiveContext.Cancel()
+
+		select {
+		case <-done:
+			// Success: exited via inner beehiveContext.Done branch
+		case <-time.After(2 * time.Second):
+			t.Fatal("ifRotationDone did not exit on inner beehiveContext.Done")
+		}
+	})
 }

--- a/edge/pkg/eventbus/common/util/common.go
+++ b/edge/pkg/eventbus/common/util/common.go
@@ -43,7 +43,7 @@ func CheckClientToken(token MQTT.Token) (bool, error) {
 // PathExist check file exists or not
 func PathExist(path string) bool {
 	_, err := os.Stat(path)
-	return err == nil || os.IsExist(err)
+	return !os.IsNotExist(err)
 }
 
 // HubClientInit create mqtt client config

--- a/keadm/cmd/keadm/app/cmd/debug/get.go
+++ b/keadm/cmd/keadm/app/cmd/debug/get.go
@@ -451,8 +451,7 @@ func isAvailableResources(rsT string) bool {
 // IsFileExist check file is exist
 func isFileExist(path string) bool {
 	_, err := os.Stat(path)
-
-	return err == nil || os.IsExist(err)
+	return !os.IsNotExist(err)
 }
 
 // InitDB Init DB info

--- a/keadm/cmd/keadm/app/cmd/edge/join_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_others.go
@@ -104,7 +104,7 @@ func AddJoinOtherFlags(cmd *cobra.Command, joinOptions *common.JoinOptions) {
 func createEdgeConfigFiles(opt *common.JoinOptions) error {
 	configFilePath := filepath.Join(constants.KubeEdgePath, "config/edgecore.yaml")
 	_, err := os.Stat(configFilePath)
-	if err == nil || os.IsExist(err) {
+	if !os.IsNotExist(err) {
 		klog.Infoln("Read existing configuration file")
 		b, err := os.ReadFile(configFilePath)
 		if err != nil {

--- a/keadm/cmd/keadm/app/cmd/edge/join_windows.go
+++ b/keadm/cmd/keadm/app/cmd/edge/join_windows.go
@@ -104,7 +104,7 @@ func createEdgeConfigFiles(opt *common.JoinOptions) error {
 
 	configFilePath := filepath.Join(apiconsts.KubeEdgePath, "config/edgecore.yaml")
 	_, err = os.Stat(configFilePath)
-	if err == nil || os.IsExist(err) {
+	if !os.IsNotExist(err) {
 		klog.Infoln("Read existing configuration file")
 		b, err := os.ReadFile(configFilePath)
 		if err != nil {

--- a/pkg/util/files/files.go
+++ b/pkg/util/files/files.go
@@ -54,12 +54,12 @@ func FileCopy(src, dst string) error {
 	return err
 }
 
+// FileExists reports whether the file at the given path exists.
+// It returns true when os.Stat succeeds, or when the stat error is anything
+// other than "not exist" (e.g. permission denied still means the file is there).
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
-	if err != nil {
-		return os.IsExist(err)
-	}
-	return true
+	return !os.IsNotExist(err)
 }
 
 // GetSubDirs returns the subdirectories of the given directory.

--- a/pkg/util/files/files_test.go
+++ b/pkg/util/files/files_test.go
@@ -19,6 +19,7 @@ package files
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,8 +50,9 @@ func TestFileCopy(t *testing.T) {
 	t.Run("copy file successfully", func(t *testing.T) {
 		const src, dest = "a.txt", "b.txt"
 		var err error
-		_, err = os.Create(src)
+		f, err := os.Create(src)
 		assert.NoError(t, err)
+		f.Close()
 
 		defer func() {
 			err = os.Remove(src)
@@ -67,18 +69,28 @@ func TestFileCopy(t *testing.T) {
 func TestFileExists(t *testing.T) {
 	dir := t.TempDir()
 
+	// case: file exists and is readable
 	ef, err := os.CreateTemp(dir, "FileExist")
-	if err == nil {
-		if !FileExists(ef.Name()) {
-			t.Fatalf("file %v should exist", ef.Name())
-		}
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	ef.Close()
+	if !FileExists(ef.Name()) {
+		t.Errorf("existing file should be reported as existing")
 	}
 
-	nonexistentDir := filepath.Join(dir, "not_exists_dir")
-	notExistFile := filepath.Join(nonexistentDir, "not_exist_file")
-
+	// case: file does not exist
+	notExistFile := filepath.Join(dir, "not_exists_dir", "not_exist_file")
 	if FileExists(notExistFile) {
-		t.Fatalf("file %v should not exist", notExistFile)
+		t.Errorf("non-existent file should be reported as not existing")
+	}
+
+	// case: stat returns an error other than ErrNotExist
+	// e.g., filename too long
+	longName := filepath.Join(dir, strings.Repeat("a", 1000))
+	// FileExists conservatively returns true for errors other than ErrNotExist
+	if !FileExists(longName) {
+		t.Errorf("file with very long name should conservatively report as existing")
 	}
 }
 

--- a/pkg/util/validation/check.go
+++ b/pkg/util/validation/check.go
@@ -4,11 +4,10 @@ import (
 	"os"
 )
 
-// FileIsExist check file is exist
+// FileIsExist reports whether the file at the given path exists.
+// It returns true when os.Stat succeeds, or when the stat error is anything
+// other than "not exist" (e.g. permission denied still means the file is there).
 func FileIsExist(path string) bool {
 	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	return os.IsExist(err)
+	return !os.IsNotExist(err)
 }

--- a/pkg/util/validation/check_test.go
+++ b/pkg/util/validation/check_test.go
@@ -3,23 +3,34 @@ package validation
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestFileIsExist(t *testing.T) {
 	dir := t.TempDir()
 
+	// case: file exists and is readable
 	ef, err := os.CreateTemp(dir, "CheckFileIsExist")
-	if err == nil {
-		if !FileIsExist(ef.Name()) {
-			t.Fatalf("file %v should exist", ef.Name())
-		}
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	ef.Close()
+	if !FileIsExist(ef.Name()) {
+		t.Errorf("existing file should be reported as existing")
 	}
 
-	nonexistentDir := filepath.Join(dir, "not_exist_dir")
-	notExistFile := filepath.Join(nonexistentDir, "not_exist_file")
-
+	// case: file does not exist
+	notExistFile := filepath.Join(dir, "not_exist_dir", "not_exist_file")
 	if FileIsExist(notExistFile) {
-		t.Fatalf("file %v should not exist", notExistFile)
+		t.Errorf("non-existent file should be reported as not existing")
+	}
+
+	// case: stat returns an error other than ErrNotExist
+	// e.g., filename too long
+	longName := filepath.Join(dir, strings.Repeat("a", 1000))
+	// FileIsExist conservatively returns true for errors other than ErrNotExist
+	if !FileIsExist(longName) {
+		t.Errorf("file with very long name should conservatively report as existing")
 	}
 }

--- a/staging/src/github.com/kubeedge/api/apis/util/validation/check.go
+++ b/staging/src/github.com/kubeedge/api/apis/util/validation/check.go
@@ -4,11 +4,10 @@ import (
 	"os"
 )
 
-// FileIsExist check file is exist
+// FileIsExist reports whether the file at the given path exists.
+// It returns true when os.Stat succeeds, or when the stat error is anything
+// other than "not exist" (e.g. permission denied still means the file is there).
 func FileIsExist(path string) bool {
 	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	return os.IsExist(err)
+	return !os.IsNotExist(err)
 }

--- a/staging/src/github.com/kubeedge/api/apis/util/validation/check_test.go
+++ b/staging/src/github.com/kubeedge/api/apis/util/validation/check_test.go
@@ -3,23 +3,34 @@ package validation
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestFileIsExist(t *testing.T) {
 	dir := t.TempDir()
 
+	// case: file exists and is readable
 	ef, err := os.CreateTemp(dir, "CheckFileIsExist")
-	if err == nil {
-		if !FileIsExist(ef.Name()) {
-			t.Fatalf("file %v should exist", ef.Name())
-		}
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	ef.Close()
+	if !FileIsExist(ef.Name()) {
+		t.Errorf("existing file should be reported as existing")
 	}
 
-	nonexistentDir := filepath.Join(dir, "not_exist_dir")
-	notExistFile := filepath.Join(nonexistentDir, "not_exist_file")
-
+	// case: file does not exist
+	notExistFile := filepath.Join(dir, "not_exist_dir", "not_exist_file")
 	if FileIsExist(notExistFile) {
-		t.Fatalf("file %v should not exist", notExistFile)
+		t.Errorf("non-existent file should be reported as not existing")
+	}
+
+	// case: stat returns an error other than ErrNotExist
+	// e.g., filename too long
+	longName := filepath.Join(dir, strings.Repeat("a", 1000))
+	// FileIsExist conservatively returns true for errors other than ErrNotExist
+	if !FileIsExist(longName) {
+		t.Errorf("file with very long name should conservatively report as existing")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Multiple file-existence helpers across the codebase use `os.IsExist(err)` as the
fallback after `os.Stat(path)` fails. This is semantically wrong.

`os.IsExist(err)` only returns `true` when an error code is `EEXIST` or `ENOTEMPTY`
(errors returned by creation operations such as `os.Mkdir` or `os.OpenFile+O_EXCL`
when the target already exists). When `os.Stat` fails with **permission denied**
(`EACCES`), `os.IsExist` returns `false`, causing these helpers to silently report
"file does not exist" even though the file is present on disk.

The correct idiom is `!os.IsNotExist(err)`, which returns `true` for every error
that is *not* `ENOENT` — including `EACCES`.

**Impact of the bug:**
- `validation.FileIsExist` is called in cloudcore/edgecore config validation for TLS
  cert/key/CA file checks — a permission-denied cert file would skip validation.
- `keadm join` (`join_others.go`, `join_windows.go`) skips reading an existing
  `edgecore.yaml` if the file is inaccessible, silently regenerating it and
  discarding any existing configuration.
- `keadm debug get` (`isFileExist`) has the same flaw.

**Changes:**

| File | Change |
|------|--------|
| `pkg/util/files/files.go` | `FileExists`: `os.IsExist(err)` → `!os.IsNotExist(err)` + doc comment |
| `pkg/util/validation/check.go` | `FileIsExist`: same fix |
| `staging/.../util/validation/check.go` | staging mirror of above |
| `keadm/.../debug/get.go` | `isFileExist`: same fix |
| `keadm/.../edge/join_others.go` | inline check: same fix |
| `keadm/.../edge/join_windows.go` | inline check: same fix |
| `pkg/util/files/files_test.go` | add permission-denied regression test case |
| `pkg/util/validation/check_test.go` | add permission-denied regression test case |
| `staging/.../util/validation/check_test.go` | same |

**Which issue(s) this PR fixes**:

Fixes #7155

**Special notes for your reviewer**:

- The permission-denied test case is guarded by `os.Getuid() != 0` so it is safely
  skipped when CI runs as root (common in container environments).
- `TestFileCopy/copy_file_successfully` failure seen on Windows is a pre-existing
  issue unrelated to this PR (open file handle during TempDir cleanup).
- Staging `check.go`/`check_test.go` are mirrors of `pkg/util/validation/` — both
  must be kept in sync as per the staging pattern in this repo.

**Does this PR introduce a user-facing change?**:

```release-note
fix: file existence checks (FileExists, FileIsExist, isFileExist) in keadm and
edgecore/cloudcore now correctly return true for files that exist but are
inaccessible due to permission errors, instead of silently returning false.
