### PR TITLE
build: remove stale GO111MODULE=off from image Dockerfiles

### DIFF
--- a/build/admission/Dockerfile
+++ b/build/admission/Dockerfile
@@ -4,7 +4,7 @@ ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/admission -ldflags="${GO_LDFLAGS} -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/admission -ldflags="${GO_LDFLAGS} -w -s" \
 github.com/kubeedge/kubeedge/cloud/cmd/admission
 
 

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -4,7 +4,7 @@ ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/cloudcore -ldflags "$GO_LDFLAGS -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/cloudcore -ldflags "$GO_LDFLAGS -w -s" \
     github.com/kubeedge/kubeedge/cloud/cmd/cloudcore
 
 

--- a/build/conformance/Dockerfile
+++ b/build/conformance/Dockerfile
@@ -25,9 +25,9 @@ RUN cp /go/src/github.com/kubeedge/kubeedge/build/conformance/kubernetes/kube_co
 
 RUN cd /go/src/github.com/kubeedge/kubeedge && GOWORK=off go mod vendor
 
-RUN CGO_ENABLED=0 GO111MODULE=off ginkgo build -ldflags "-w -s -extldflags -static" -r /go/src/github.com/kubeedge/kubeedge/tests/e2e
+RUN CGO_ENABLED=0 ginkgo build -ldflags "-w -s -extldflags -static" -r /go/src/github.com/kubeedge/kubeedge/tests/e2e
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
    /go/src/github.com/kubeedge/kubeedge/build/conformance/e2e-runner
 
 FROM alpine:3.21

--- a/build/conformance/nodeconformance.Dockerfile
+++ b/build/conformance/nodeconformance.Dockerfile
@@ -25,9 +25,9 @@ RUN cp /go/src/github.com/kubeedge/kubeedge/build/conformance/kubernetes/kube_no
 
 RUN cd /go/src/github.com/kubeedge/kubeedge && GOWORK=off go mod vendor
 
-RUN CGO_ENABLED=0 GO111MODULE=off ginkgo build -ldflags "-w -s -extldflags -static" -r /go/src/github.com/kubeedge/kubeedge/tests/e2e
+RUN CGO_ENABLED=0 ginkgo build -ldflags "-w -s -extldflags -static" -r /go/src/github.com/kubeedge/kubeedge/tests/e2e
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/node-e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/node-e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
    /go/src/github.com/kubeedge/kubeedge/build/conformance/node-e2e-runner
 
 FROM alpine:3.21

--- a/build/controllermanager/Dockerfile
+++ b/build/controllermanager/Dockerfile
@@ -4,7 +4,7 @@ ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/controllermanager -ldflags "$GO_LDFLAGS -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/controllermanager -ldflags "$GO_LDFLAGS -w -s" \
     github.com/kubeedge/kubeedge/cloud/cmd/controllermanager
 
 

--- a/build/csidriver/Dockerfile
+++ b/build/csidriver/Dockerfile
@@ -4,7 +4,7 @@ ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/csidriver -ldflags="${GO_LDFLAGS} -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/csidriver -ldflags="${GO_LDFLAGS} -w -s" \
 github.com/kubeedge/kubeedge/cloud/cmd/csidriver
 
 FROM alpine:3.21

--- a/build/edge/Dockerfile
+++ b/build/edge/Dockerfile
@@ -15,7 +15,7 @@ COPY . /go/src/github.com/kubeedge/kubeedge
 RUN apk --no-cache update && \
 apk --no-cache upgrade && \
 apk --no-cache add build-base linux-headers sqlite-dev binutils-gold && \
-CGO_ENABLED=1 GO111MODULE=off go build -v -o /usr/local/bin/edgecore -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
+CGO_ENABLED=1 go build -v -o /usr/local/bin/edgecore -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
 github.com/kubeedge/kubeedge/edge/cmd/edgecore
 
 FROM ${RUN_FROM}

--- a/build/edgemark/Dockerfile
+++ b/build/edgemark/Dockerfile
@@ -9,7 +9,7 @@ COPY . /go/src/github.com/kubeedge/kubeedge
 RUN apk --no-cache update && \
 apk --no-cache upgrade && \
 apk --no-cache add build-base linux-headers sqlite-dev binutils-gold && \
-CGO_ENABLED=1 GO111MODULE=off go build -v -o /usr/local/bin/edgemark -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
+CGO_ENABLED=1 go build -v -o /usr/local/bin/edgemark -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
 github.com/kubeedge/kubeedge/edge/cmd/edgemark
 
 FROM alpine:3.21

--- a/build/edgesite/agent-build.Dockerfile
+++ b/build/edgesite/agent-build.Dockerfile
@@ -6,7 +6,7 @@ COPY . /go/src/github.com/kubeedge/kubeedge
 
 # Build
 ARG ARCH
-RUN CGO_ENABLED=0 GO111MODULE=off GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o edgesite-agent github.com/kubeedge/kubeedge/edgesite/cmd/edgesite-agent
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o edgesite-agent github.com/kubeedge/kubeedge/edgesite/cmd/edgesite-agent
 
 # Copy the loader into a thin image
 FROM scratch

--- a/build/edgesite/server-build.Dockerfile
+++ b/build/edgesite/server-build.Dockerfile
@@ -8,7 +8,7 @@ COPY . /go/src/github.com/kubeedge/kubeedge
 
 # Build
 ARG ARCH
-RUN CGO_ENABLED=0 GO111MODULE=off GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o edgesite-server github.com/kubeedge/kubeedge/edgesite/cmd/edgesite-server
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o edgesite-server github.com/kubeedge/kubeedge/edgesite/cmd/edgesite-server
 
 # Copy the loader into a thin image
 FROM scratch

--- a/build/iptablesmanager/Dockerfile
+++ b/build/iptablesmanager/Dockerfile
@@ -4,7 +4,7 @@ ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
     github.com/kubeedge/kubeedge/cloud/cmd/iptablesmanager
 
 

--- a/build/iptablesmanager/iptablesmanager-nft.Dockerfile
+++ b/build/iptablesmanager/iptablesmanager-nft.Dockerfile
@@ -4,7 +4,7 @@ ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
     github.com/kubeedge/kubeedge/cloud/cmd/iptablesmanager
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Several image build Dockerfiles still compiled binaries with `GO111MODULE=off`, a leftover pre-modules setting that predates the repository's move to `go.mod`/`go.work`. This is inconsistent with the project's canonical build path in `hack/lib/golang.sh`, which explicitly unsets `GO111MODULE` and `GOWORK` because both are default-on for a module-based project, and with `build/docker/build-tools/build-tools.dockerfile`, which already sets `GO111MODULE=on`. This PR removes the stale `GO111MODULE=off` flag from all affected Dockerfiles so image builds are module-aware and consistent with the rest of the build tooling.

**Which issue(s) this PR fixes**:
Fixes #7154

**Special notes for your reviewer**:

Changed files are limited to the `GO111MODULE=off` occurrences in:
- `build/admission/Dockerfile`
- `build/cloud/Dockerfile`
- `build/controllermanager/Dockerfile`
- `build/csidriver/Dockerfile`
- `build/edge/Dockerfile`
- `build/edgemark/Dockerfile`
- `build/edgesite/agent-build.Dockerfile`
- `build/edgesite/server-build.Dockerfile`
- `build/iptablesmanager/Dockerfile`
- `build/iptablesmanager/iptablesmanager-nft.Dockerfile`
- `build/conformance/Dockerfile`
- `build/conformance/nodeconformance.Dockerfile`

Verified `go build` succeeds in module mode (without `GO111MODULE=off`) from the repo root for an affected binary (`cloud/cmd/admission`). A full `docker build` of an affected image could not be completed in this environment because the local Docker daemon's storage was exhausted (`no space left on device`); this is an environment limitation, not related to the change itself.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
