### PR TITLE
cloudhub: cleanup ackMessageCache when sendMessageWithRetry exits

### DIFF
--- a/cloud/pkg/cloudhub/session/node_session.go
+++ b/cloud/pkg/cloudhub/session/node_session.go
@@ -338,10 +338,14 @@ func (ns *NodeSession) syncAckMessage() (bool, error) {
 func (ns *NodeSession) sendMessageWithRetry(copyMsg, msg *beehivemodel.Message) error {
 	ackChan := make(chan struct{})
 	ns.ackMessageCache.Store(copyMsg.GetID(), ackChan)
+	// Delete the ack channel from the cache on every return path.
+	// This prevents a leak when the edge node never acknowledges the message.
+	defer ns.ackMessageCache.Delete(copyMsg.GetID())
 
 	// initialize retry count and timer for sending message
 	retryCount := 0
 	ticker := time.NewTimer(sendRetryInterval)
+	defer ticker.Stop()
 
 	err := ns.connection.WriteMessageAsync(copyMsg)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

CloudHub's `sendMessageWithRetry` function tracks each message it sends to an edge node and waits for an acknowledgement. When the edge node confirms a message, CloudHub removes the tracking entry. This cleanup happens only on acknowledgement.

Two situations skip that cleanup:

1. Sending the message fails.
2. The edge node never acknowledges the message, and the retry limit runs out.

In both cases, the tracking entry stays in memory forever. A busy edge node with many failed or unacknowledged messages slowly builds up memory that is never freed.

This PR makes sure the tracking entry is removed no matter how the send attempt ends. It also stops the retry timer when the attempt ends.

Messages that time out still get retried later, exactly as before. The fix only stops the leftover memory growth.

**Which issue(s) this PR fixes**:

Fixes #6175

**Special notes for your reviewer**:

The change is small and contained to the message-sending path. A late acknowledgement after cleanup does not cause a problem. The system simply ignores it.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
