### PR TITLE
edgehub: enforce WebSocket read deadline to detect unresponsive cloud…

### DIFF
--- a/edge/pkg/edgehub/clients/wsclient/websocket.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket.go
@@ -118,6 +118,12 @@ func (wsc *WebSocketClient) Send(message model.Message) error {
 // Receive reads the binary message through the connection
 func (wsc *WebSocketClient) Receive() (model.Message, error) {
 	message := model.Message{}
+	if wsc.config.ReadDeadline > 0 {
+		err := wsc.connection.SetReadDeadline(time.Now().Add(wsc.config.ReadDeadline))
+		if err != nil {
+			return message, err
+		}
+	}
 	err := wsc.connection.ReadMessage(&message)
 	return message, err
 }

--- a/edge/pkg/edgehub/clients/wsclient/websocket_test.go
+++ b/edge/pkg/edgehub/clients/wsclient/websocket_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +36,8 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/server"
 )
 
+var serverOnce sync.Once
+
 func handleServer(container *mux.MessageContainer, writer mux.ResponseWriter) {
 	klog.Infof("receive message: %s", container.Message.GetContent())
 	writer.WriteResponse(&model.Message{}, container.Message.GetContent())
@@ -46,6 +49,14 @@ func connNotify(conn.Connection) {
 
 // newTestServer() starts a fake server for testing
 func newTestServer() error {
+	var err error
+	serverOnce.Do(func() {
+		err = startTestServer()
+	})
+	return err
+}
+
+func startTestServer() error {
 	if err := util.GenerateTestCertificate("/tmp/", "edge", "edge"); err != nil {
 		return err
 	}
@@ -201,6 +212,39 @@ func TestSend(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReceiveTimeout checks that Receive() returns an error when the cloud
+// server does not respond within the configured read deadline, instead of
+// blocking forever. This verifies the read timeout is enforced.
+func TestReceiveTimeout(t *testing.T) {
+	if err := newTestServer(); err != nil {
+		t.Errorf("failed to start server, err: %v", err)
+	}
+
+	wcc := newTestWebSocketClient("timeout", "/tmp/edge.crt", "/tmp/edge.key")
+	wcc.config.ReadDeadline = 1 * time.Second
+
+	if err := wcc.Init(); err != nil {
+		t.Fatalf("failed to init, err: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := wcc.Receive()
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Errorf("WebSocketClient.Receive() should return error after read timeout, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Errorf("WebSocketClient.Receive() did not time out within the expected period")
+	}
+
+	wcc.UnInit()
 }
 
 // TestReceive sends the message through send function then calls receive function to see same message is received or not

--- a/pkg/viaduct/pkg/conn/ws.go
+++ b/pkg/viaduct/pkg/conn/ws.go
@@ -102,13 +102,25 @@ func (conn *WSConnection) handleRawData() {
 func (conn *WSConnection) handleMessage() {
 	for {
 		msg := &model.Message{}
-		err := lane.NewLane(api.ProtocolTypeWS, conn.wsConn).ReadMessage(msg)
+		wsLane := lane.NewLane(api.ProtocolTypeWS, conn.wsConn)
+
+		conn.locker.Lock()
+		readDeadline := conn.ReadDeadline
+		conn.locker.Unlock()
+		if !readDeadline.IsZero() {
+			_ = wsLane.SetReadDeadline(readDeadline)
+		}
+
+		err := wsLane.ReadMessage(msg)
 		if err != nil {
 			if !errors.Is(err, io.EOF) {
 				klog.Errorf("failed to read message, error: %+v", err)
 			}
 			conn.state.State = api.StatDisconnected
 			_ = conn.wsConn.Close()
+			// close the message fifo to unblock the blocked readers,
+			// so that the caller can be aware of the connection error
+			conn.messageFifo.Close()
 
 			if conn.OnReadTransportErr != nil {
 				conn.OnReadTransportErr(conn.state.Headers.Get("node_id"),
@@ -150,6 +162,8 @@ func (conn *WSConnection) handleMessage() {
 }
 
 func (conn *WSConnection) SetReadDeadline(t time.Time) error {
+	conn.locker.Lock()
+	defer conn.locker.Unlock()
 	conn.ReadDeadline = t
 	return nil
 }


### PR DESCRIPTION
… hub

The WebSocket read deadline configured in edgecore.yaml was never enforced, so when the cloud hub failed to respond, the edge node's WebSocket connection would hang indefinitely without triggering any recovery mechanism.

Set the read deadline on the connection before reading in wsclient.Receive(), apply it to the underlying websocket connection in viaduct handleMessage(), and close the message fifo when a read error occurs so blocked readers unblock and edgehub can reconnect.

Fixes #6412

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
