### PR TITLE
metaserver: fix application concurrency races, state transition in Reset(), and cleanup in CloseApplication

### DIFF
--- a/cloud/pkg/dynamiccontroller/application/application_test.go
+++ b/cloud/pkg/dynamiccontroller/application/application_test.go
@@ -97,13 +97,13 @@ func TestOptionTo(t *testing.T) {
 }
 
 func TestApplicationString(t *testing.T) {
-	app := &metaserver.Application{
+	app := metaserver.NewApplicationForTest(metaserver.Application{
 		ID:       "test-id",
 		Nodename: "test-node",
 		Key:      "apps/v1/deployments/default/nginx",
 		Verb:     metaserver.Get,
 		Status:   metaserver.Approved,
-	}
+	})
 
 	str := app.String()
 
@@ -388,8 +388,8 @@ func TestGetWatchDiff(t *testing.T) {
 	}
 
 	allWatchAppInEdge := map[string]metaserver.Application{
-		"listener1": {ID: "listener1", Nodename: "node1"},
-		"listener3": {ID: "listener3", Nodename: "node1"},
+		"listener1": *metaserver.NewApplicationForTest(metaserver.Application{ID: "listener1", Nodename: "node1"}),
+		"listener3": *metaserver.NewApplicationForTest(metaserver.Application{ID: "listener3", Nodename: "node1"}),
 	}
 
 	added, removed := center.getWatchDiff(allWatchAppInEdge, "node1")

--- a/edge/pkg/metamanager/metaserver/agent/agent.go
+++ b/edge/pkg/metamanager/metaserver/agent/agent.go
@@ -102,9 +102,10 @@ func (a *Agent) Apply(app *metaserver.Application) error {
 		app.Reset()
 		go a.doApply(app)
 	case metaserver.Rejected:
-		return &app.Error
+		appErr := app.GetError()
+		return &appErr
 	case metaserver.Failed:
-		return errors.New(app.Reason)
+		return errors.New(app.GetReason())
 	case metaserver.Approved:
 		return nil
 	case metaserver.InApplying:
@@ -112,10 +113,11 @@ func (a *Agent) Apply(app *metaserver.Application) error {
 	}
 	app.Wait()
 	if app.GetStatus() == metaserver.Rejected {
-		return &app.Error
+		appErr := app.GetError()
+		return &appErr
 	}
 	if app.GetStatus() != metaserver.Approved {
-		return errors.New(app.Reason)
+		return errors.New(app.GetReason())
 	}
 	return nil
 }
@@ -123,32 +125,33 @@ func (a *Agent) Apply(app *metaserver.Application) error {
 func (a *Agent) doApply(app *metaserver.Application) {
 	defer app.Cancel()
 	// encapsulate as a message
-	app.Status = metaserver.InApplying
+	app.SetStatus(metaserver.InApplying)
 	msg := model.NewMessage("").SetRoute(metaserver.MetaServerSource, modules.DynamicControllerModuleGroup).FillBody(app)
 	msg.SetResourceOperation("null", "null")
 	resp, err := beehiveContext.SendSync(edgemodule.EdgeHubModuleName, *msg, 10*time.Second)
 	if err != nil {
-		app.Status = metaserver.Failed
-		app.Reason = fmt.Sprintf("failed to access cloud Application center: %v", err)
+		app.SetStatus(metaserver.Failed)
+		app.SetReason(fmt.Sprintf("failed to access cloud Application center: %v", err))
 		return
 	}
 
 	retApp, err := metaserver.MsgToApplication(resp)
 	if err != nil {
-		app.Status = metaserver.Failed
-		app.Reason = fmt.Sprintf("failed to get Application from resp msg: %v", err)
+		app.SetStatus(metaserver.Failed)
+		app.SetReason(fmt.Sprintf("failed to get Application from resp msg: %v", err))
 		return
 	}
 
-	//merge returned application to local application
-	app.Status = retApp.Status
-	app.Reason = retApp.Reason
-	app.Error = retApp.Error
-	app.RespBody = retApp.RespBody
+	// merge returned application to local application under a single lock
+	app.UpdateFromResponse(retApp)
 }
 
 func (a *Agent) CloseApplication(appID string) {
-	a.Applications.Delete(appID)
+	if v, ok := a.Applications.LoadAndDelete(appID); ok {
+		// Cancel the application context to release any goroutines blocked in Wait()
+		app := v.(*metaserver.Application)
+		app.Cancel()
+	}
 	a.SyncWatchAppOnConnected()
 }
 
@@ -207,7 +210,9 @@ func (a *Agent) syncWatchApplications() error {
 		return err
 	}
 
-	klog.Errorf("failed to process watch apps: %+v", failedWatchApps)
+	if len(failedWatchApps) > 0 {
+		klog.Warningf("failed to process watch apps: %+v", failedWatchApps)
+	}
 
 	return nil
 }

--- a/edge/pkg/metamanager/metaserver/agent/agent.go
+++ b/edge/pkg/metamanager/metaserver/agent/agent.go
@@ -97,14 +97,18 @@ func (a *Agent) Apply(app *metaserver.Application) error {
 	app = store.(*metaserver.Application)
 	switch app.GetStatus() {
 	case metaserver.PreApplying:
-		go a.doApply(app)
+		if app.TryStartApplying() {
+			go a.doApply(app)
+		}
 	case metaserver.Completed:
-		app.Reset()
-		go a.doApply(app)
+		if app.TryResetAndStartApplying() {
+			go a.doApply(app)
+		}
 	case metaserver.Rejected:
-		return &app.Error
+		appErr := app.GetError()
+		return &appErr
 	case metaserver.Failed:
-		return errors.New(app.Reason)
+		return errors.New(app.GetReason())
 	case metaserver.Approved:
 		return nil
 	case metaserver.InApplying:
@@ -112,10 +116,11 @@ func (a *Agent) Apply(app *metaserver.Application) error {
 	}
 	app.Wait()
 	if app.GetStatus() == metaserver.Rejected {
-		return &app.Error
+		appErr := app.GetError()
+		return &appErr
 	}
 	if app.GetStatus() != metaserver.Approved {
-		return errors.New(app.Reason)
+		return errors.New(app.GetReason())
 	}
 	return nil
 }
@@ -123,32 +128,32 @@ func (a *Agent) Apply(app *metaserver.Application) error {
 func (a *Agent) doApply(app *metaserver.Application) {
 	defer app.Cancel()
 	// encapsulate as a message
-	app.Status = metaserver.InApplying
 	msg := model.NewMessage("").SetRoute(metaserver.MetaServerSource, modules.DynamicControllerModuleGroup).FillBody(app)
 	msg.SetResourceOperation("null", "null")
 	resp, err := beehiveContext.SendSync(edgemodule.EdgeHubModuleName, *msg, 10*time.Second)
 	if err != nil {
-		app.Status = metaserver.Failed
-		app.Reason = fmt.Sprintf("failed to access cloud Application center: %v", err)
+		app.SetStatus(metaserver.Failed)
+		app.SetReason(fmt.Sprintf("failed to access cloud Application center: %v", err))
 		return
 	}
 
 	retApp, err := metaserver.MsgToApplication(resp)
 	if err != nil {
-		app.Status = metaserver.Failed
-		app.Reason = fmt.Sprintf("failed to get Application from resp msg: %v", err)
+		app.SetStatus(metaserver.Failed)
+		app.SetReason(fmt.Sprintf("failed to get Application from resp msg: %v", err))
 		return
 	}
 
-	//merge returned application to local application
-	app.Status = retApp.Status
-	app.Reason = retApp.Reason
-	app.Error = retApp.Error
-	app.RespBody = retApp.RespBody
+	// merge returned application to local application under a single lock
+	app.UpdateFromResponse(retApp)
 }
 
 func (a *Agent) CloseApplication(appID string) {
-	a.Applications.Delete(appID)
+	if v, ok := a.Applications.LoadAndDelete(appID); ok {
+		// Cancel the application context to release any goroutines blocked in Wait()
+		app := v.(*metaserver.Application)
+		app.Cancel()
+	}
 	a.SyncWatchAppOnConnected()
 }
 
@@ -207,7 +212,9 @@ func (a *Agent) syncWatchApplications() error {
 		return err
 	}
 
-	klog.Errorf("failed to process watch apps: %+v", failedWatchApps)
+	if len(failedWatchApps) > 0 {
+		klog.Warningf("failed to process watch apps: %+v", failedWatchApps)
+	}
 
 	return nil
 }

--- a/pkg/metaserver/application.go
+++ b/pkg/metaserver/application.go
@@ -52,6 +52,9 @@ type Application struct {
 	Subresource string
 
 	// The following field defines the Application response result
+	// mu protects Status, Reason, Error, RespBody, ctx, and cancel
+	// from concurrent reads and writes across goroutines.
+	mu       *sync.RWMutex
 	RespBody []byte
 	Status   ApplicationStatus
 	Reason   string // why in this status
@@ -65,6 +68,32 @@ type Application struct {
 	countLock *sync.Mutex
 	// Timestamp record the last closing time of application, only make sense when count == 0
 	Timestamp time.Time
+}
+
+func (a *Application) lock() {
+	if a.mu == nil {
+		a.mu = &sync.RWMutex{}
+	}
+	a.mu.Lock()
+}
+
+func (a *Application) unlock() {
+	if a.mu != nil {
+		a.mu.Unlock()
+	}
+}
+
+func (a *Application) rLock() {
+	if a.mu == nil {
+		a.mu = &sync.RWMutex{}
+	}
+	a.mu.RLock()
+}
+
+func (a *Application) rUnlock() {
+	if a.mu != nil {
+		a.mu.RUnlock()
+	}
 }
 
 func NewApplication(ctx context.Context, key string, verb ApplicationVerb, nodename, subresource string, option interface{}, reqBody interface{}) (*Application, error) {
@@ -86,6 +115,7 @@ func NewApplication(ctx context.Context, key string, verb ApplicationVerb, noden
 		Status:      PreApplying,
 		Option:      ToBytes(option),
 		ReqBody:     ToBytes(reqBody),
+		mu:          &sync.RWMutex{},
 		ctx:         ctx2,
 		cancel:      cancel,
 		count:       0,
@@ -111,6 +141,8 @@ func (a *Application) Identifier() string {
 }
 
 func (a *Application) String() string {
+	a.rLock()
+	defer a.rUnlock()
 	return fmt.Sprintf("(NodeName=%v;Key=%v;Verb=%v;Status=%v;Reason=%v)", a.Nodename, a.Key, a.Verb, a.Status, a.Reason)
 }
 
@@ -119,6 +151,8 @@ func (a *Application) ReqContent() interface{} {
 }
 
 func (a *Application) RespContent() interface{} {
+	a.rLock()
+	defer a.rUnlock()
 	return a.RespBody
 }
 
@@ -140,7 +174,10 @@ func (a *Application) ReqBodyTo(i interface{}) error {
 }
 
 func (a *Application) RespBodyTo(i interface{}) error {
-	err := json.Unmarshal(a.RespBody, i)
+	a.rLock()
+	body := a.RespBody
+	a.rUnlock()
+	err := json.Unmarshal(body, i)
 	if err != nil {
 		return fmt.Errorf("failed to parse RespBody bytes, %v", err)
 	}
@@ -158,38 +195,98 @@ func (a *Application) Namespace() string {
 }
 
 func (a *Application) Cancel() {
+	a.lock()
+	defer a.unlock()
 	if a.cancel != nil {
 		a.cancel()
 	}
 }
 
 func (a *Application) GetStatus() ApplicationStatus {
+	a.rLock()
+	defer a.rUnlock()
 	return a.Status
+}
+
+// SetStatus atomically updates the application status under the write lock.
+func (a *Application) SetStatus(s ApplicationStatus) {
+	a.lock()
+	defer a.unlock()
+	a.Status = s
+}
+
+// SetReason atomically updates the application Reason field under the write lock.
+func (a *Application) SetReason(reason string) {
+	a.lock()
+	defer a.unlock()
+	a.Reason = reason
+}
+
+// GetReason atomically reads the application Reason field.
+func (a *Application) GetReason() string {
+	a.rLock()
+	defer a.rUnlock()
+	return a.Reason
+}
+
+// GetError atomically reads the application Error field.
+func (a *Application) GetError() apierrors.StatusError {
+	a.rLock()
+	defer a.rUnlock()
+	return a.Error
+}
+
+// UpdateFromResponse atomically applies all response fields from a cloud reply.
+func (a *Application) UpdateFromResponse(resp *Application) {
+	a.lock()
+	defer a.unlock()
+	a.Status = resp.Status
+	a.Reason = resp.Reason
+	a.Error = resp.Error
+	a.RespBody = resp.RespBody
 }
 
 // Wait the result of application after it is applied by application agent
 func (a *Application) Wait() {
-	if a.ctx != nil {
-		<-a.ctx.Done()
+	a.rLock()
+	ctx := a.ctx
+	a.rUnlock()
+	if ctx != nil {
+		<-ctx.Done()
 	}
 }
 
+// Reset prepares the application for reuse after it has reached Completed status.
+// It cancels the old context, creates a new one, clears transient response fields,
+// and transitions Status to PreApplying so that concurrent Apply calls do not
+// mistake the in-flight re-apply as already finished.
 func (a *Application) Reset() {
+	a.lock()
+	defer a.unlock()
 	if a.ctx != nil && a.cancel != nil {
 		a.cancel()
 	}
 	a.ctx, a.cancel = context.WithCancel(beehiveContext.GetContext())
 	a.Reason = ""
 	a.RespBody = []byte{}
+	// Transition back to PreApplying so concurrent Apply calls wait
+	// rather than seeing Completed and launching duplicate doApply goroutines.
+	a.Status = PreApplying
 }
 
 func (a *Application) Add() {
+	if a.countLock == nil {
+		a.countLock = &sync.Mutex{}
+	}
 	a.countLock.Lock()
 	a.count++
 	a.countLock.Unlock()
 }
 
 func (a *Application) getCount() uint64 {
+	if a.countLock == nil {
+		a.countLock = &sync.Mutex{}
+	}
 	a.countLock.Lock()
 	c := a.count
 	a.countLock.Unlock()
@@ -198,6 +295,9 @@ func (a *Application) getCount() uint64 {
 
 // Close must be called when applicant no longer using application
 func (a *Application) Close() {
+	if a.countLock == nil {
+		a.countLock = &sync.Mutex{}
+	}
 	a.countLock.Lock()
 	defer a.countLock.Unlock()
 	if a.count == 0 {
@@ -207,11 +307,16 @@ func (a *Application) Close() {
 	a.Timestamp = time.Now()
 	a.count--
 	if a.count == 0 {
+		a.lock()
 		a.Status = Completed
+		a.unlock()
 	}
 }
 
 func (a *Application) LastCloseTime() time.Time {
+	if a.countLock == nil {
+		a.countLock = &sync.Mutex{}
+	}
 	a.countLock.Lock()
 	defer a.countLock.Unlock()
 	if a.count == 0 && !a.Timestamp.IsZero() {
@@ -254,6 +359,8 @@ func MsgToApplication(msg model.Message) (*Application, error) {
 		nodeID = app.Nodename
 	}
 	app.Nodename = nodeID
+	app.mu = &sync.RWMutex{}
+	app.countLock = &sync.Mutex{}
 	return app, nil
 }
 

--- a/pkg/metaserver/application.go
+++ b/pkg/metaserver/application.go
@@ -22,7 +22,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
+	"unsafe"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -52,6 +54,9 @@ type Application struct {
 	Subresource string
 
 	// The following field defines the Application response result
+	// mu protects Status, Reason, Error, RespBody, ctx, and cancel
+	// from concurrent reads and writes across goroutines.
+	mu       *sync.RWMutex
 	RespBody []byte
 	Status   ApplicationStatus
 	Reason   string // why in this status
@@ -65,6 +70,39 @@ type Application struct {
 	countLock *sync.Mutex
 	// Timestamp record the last closing time of application, only make sense when count == 0
 	Timestamp time.Time
+}
+
+func (a *Application) ensureInit() {
+	if a.mu == nil {
+		newMu := &sync.RWMutex{}
+		atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&a.mu)), nil, unsafe.Pointer(newMu))
+	}
+	if a.countLock == nil {
+		newLock := &sync.Mutex{}
+		atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&a.countLock)), nil, unsafe.Pointer(newLock))
+	}
+}
+
+func (a *Application) lock() {
+	a.ensureInit()
+	a.mu.Lock()
+}
+
+func (a *Application) unlock() {
+	if a.mu != nil {
+		a.mu.Unlock()
+	}
+}
+
+func (a *Application) rLock() {
+	a.ensureInit()
+	a.mu.RLock()
+}
+
+func (a *Application) rUnlock() {
+	if a.mu != nil {
+		a.mu.RUnlock()
+	}
 }
 
 func NewApplication(ctx context.Context, key string, verb ApplicationVerb, nodename, subresource string, option interface{}, reqBody interface{}) (*Application, error) {
@@ -86,6 +124,7 @@ func NewApplication(ctx context.Context, key string, verb ApplicationVerb, noden
 		Status:      PreApplying,
 		Option:      ToBytes(option),
 		ReqBody:     ToBytes(reqBody),
+		mu:          &sync.RWMutex{},
 		ctx:         ctx2,
 		cancel:      cancel,
 		count:       0,
@@ -111,6 +150,8 @@ func (a *Application) Identifier() string {
 }
 
 func (a *Application) String() string {
+	a.rLock()
+	defer a.rUnlock()
 	return fmt.Sprintf("(NodeName=%v;Key=%v;Verb=%v;Status=%v;Reason=%v)", a.Nodename, a.Key, a.Verb, a.Status, a.Reason)
 }
 
@@ -119,6 +160,8 @@ func (a *Application) ReqContent() interface{} {
 }
 
 func (a *Application) RespContent() interface{} {
+	a.rLock()
+	defer a.rUnlock()
 	return a.RespBody
 }
 
@@ -140,7 +183,10 @@ func (a *Application) ReqBodyTo(i interface{}) error {
 }
 
 func (a *Application) RespBodyTo(i interface{}) error {
-	err := json.Unmarshal(a.RespBody, i)
+	a.rLock()
+	body := a.RespBody
+	a.rUnlock()
+	err := json.Unmarshal(body, i)
 	if err != nil {
 		return fmt.Errorf("failed to parse RespBody bytes, %v", err)
 	}
@@ -158,38 +204,125 @@ func (a *Application) Namespace() string {
 }
 
 func (a *Application) Cancel() {
+	a.lock()
+	defer a.unlock()
 	if a.cancel != nil {
 		a.cancel()
 	}
 }
 
 func (a *Application) GetStatus() ApplicationStatus {
+	a.rLock()
+	defer a.rUnlock()
 	return a.Status
+}
+
+// SetStatus atomically updates the application status under the write lock.
+func (a *Application) SetStatus(s ApplicationStatus) {
+	a.lock()
+	defer a.unlock()
+	a.Status = s
+}
+
+// SetReason atomically updates the application Reason field under the write lock.
+func (a *Application) SetReason(reason string) {
+	a.lock()
+	defer a.unlock()
+	a.Reason = reason
+}
+
+// GetReason atomically reads the application Reason field.
+func (a *Application) GetReason() string {
+	a.rLock()
+	defer a.rUnlock()
+	return a.Reason
+}
+
+// GetError atomically reads the application Error field.
+func (a *Application) GetError() apierrors.StatusError {
+	a.rLock()
+	defer a.rUnlock()
+	return a.Error
+}
+
+// TryStartApplying attempts to start applying an application in PreApplying state.
+// Under a write lock, it atomically transitions Status from PreApplying to InApplying.
+// Returns true if the transition succeeded and caller should spawn doApply goroutine.
+func (a *Application) TryStartApplying() bool {
+	a.lock()
+	defer a.unlock()
+	if a.Status == PreApplying {
+		a.Status = InApplying
+		return true
+	}
+	return false
+}
+
+// TryResetAndStartApplying attempts to reset and restart an application in Completed state.
+// Under a single write lock, it cancels the old context, creates a new context,
+// clears Reason and RespBody, and atomically transitions Status directly to InApplying.
+// Returns true if the transition succeeded and caller should spawn doApply goroutine.
+func (a *Application) TryResetAndStartApplying() bool {
+	a.lock()
+	defer a.unlock()
+	if a.Status == Completed {
+		if a.ctx != nil && a.cancel != nil {
+			a.cancel()
+		}
+		a.ctx, a.cancel = context.WithCancel(beehiveContext.GetContext())
+		a.Reason = ""
+		a.RespBody = []byte{}
+		a.Status = InApplying
+		return true
+	}
+	return false
+}
+
+// UpdateFromResponse atomically applies all response fields from a cloud reply.
+func (a *Application) UpdateFromResponse(resp *Application) {
+	a.lock()
+	defer a.unlock()
+	a.Status = resp.Status
+	a.Reason = resp.Reason
+	a.Error = resp.Error
+	a.RespBody = resp.RespBody
 }
 
 // Wait the result of application after it is applied by application agent
 func (a *Application) Wait() {
-	if a.ctx != nil {
-		<-a.ctx.Done()
+	a.rLock()
+	ctx := a.ctx
+	a.rUnlock()
+	if ctx != nil {
+		<-ctx.Done()
 	}
 }
 
+// Reset prepares the application for reuse after it has reached Completed status.
+// It cancels the old context, creates a new one, clears transient response fields,
+// and transitions Status to PreApplying so that concurrent Apply calls do not
+// mistake the in-flight re-apply as already finished.
 func (a *Application) Reset() {
+	a.lock()
+	defer a.unlock()
 	if a.ctx != nil && a.cancel != nil {
 		a.cancel()
 	}
 	a.ctx, a.cancel = context.WithCancel(beehiveContext.GetContext())
 	a.Reason = ""
 	a.RespBody = []byte{}
+	a.Status = PreApplying
 }
 
 func (a *Application) Add() {
+	a.ensureInit()
 	a.countLock.Lock()
 	a.count++
 	a.countLock.Unlock()
 }
 
 func (a *Application) getCount() uint64 {
+	a.ensureInit()
 	a.countLock.Lock()
 	c := a.count
 	a.countLock.Unlock()
@@ -198,6 +331,7 @@ func (a *Application) getCount() uint64 {
 
 // Close must be called when applicant no longer using application
 func (a *Application) Close() {
+	a.ensureInit()
 	a.countLock.Lock()
 	defer a.countLock.Unlock()
 	if a.count == 0 {
@@ -207,11 +341,14 @@ func (a *Application) Close() {
 	a.Timestamp = time.Now()
 	a.count--
 	if a.count == 0 {
+		a.lock()
 		a.Status = Completed
+		a.unlock()
 	}
 }
 
 func (a *Application) LastCloseTime() time.Time {
+	a.ensureInit()
 	a.countLock.Lock()
 	defer a.countLock.Unlock()
 	if a.count == 0 && !a.Timestamp.IsZero() {
@@ -254,6 +391,8 @@ func MsgToApplication(msg model.Message) (*Application, error) {
 		nodeID = app.Nodename
 	}
 	app.Nodename = nodeID
+	app.mu = &sync.RWMutex{}
+	app.countLock = &sync.Mutex{}
 	return app, nil
 }
 
@@ -269,6 +408,11 @@ func MsgToApplications(msg model.Message) (map[string]Application, error) {
 	err = json.Unmarshal(contentData, &applications)
 	if err != nil {
 		return nil, err
+	}
+	for k, app := range applications {
+		app.mu = &sync.RWMutex{}
+		app.countLock = &sync.Mutex{}
+		applications[k] = app
 	}
 	return applications, nil
 }

--- a/pkg/metaserver/application.go
+++ b/pkg/metaserver/application.go
@@ -22,9 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
-	"unsafe"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -72,37 +70,33 @@ type Application struct {
 	Timestamp time.Time
 }
 
-func (a *Application) ensureInit() {
-	if a.mu == nil {
-		newMu := &sync.RWMutex{}
-		atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&a.mu)), nil, unsafe.Pointer(newMu))
-	}
-	if a.countLock == nil {
-		newLock := &sync.Mutex{}
-		atomic.CompareAndSwapPointer((*unsafe.Pointer)(unsafe.Pointer(&a.countLock)), nil, unsafe.Pointer(newLock))
-	}
-}
-
+// lock, unlock, rLock, and rUnlock require mu to already be initialized.
+// Applications must be constructed via NewApplication, MsgToApplication, or
+// MsgToApplications, all of which initialize mu and countLock explicitly.
 func (a *Application) lock() {
-	a.ensureInit()
 	a.mu.Lock()
 }
 
 func (a *Application) unlock() {
-	if a.mu != nil {
-		a.mu.Unlock()
-	}
+	a.mu.Unlock()
 }
 
 func (a *Application) rLock() {
-	a.ensureInit()
 	a.mu.RLock()
 }
 
 func (a *Application) rUnlock() {
-	if a.mu != nil {
-		a.mu.RUnlock()
-	}
+	a.mu.RUnlock()
+}
+
+// NewApplicationForTest builds an Application for tests outside this package
+// that need to construct one via a struct literal, with mu and countLock
+// initialized. Production code must use NewApplication, MsgToApplication, or
+// MsgToApplications instead.
+func NewApplicationForTest(a Application) *Application {
+	a.mu = &sync.RWMutex{}
+	a.countLock = &sync.Mutex{}
+	return &a
 }
 
 func NewApplication(ctx context.Context, key string, verb ApplicationVerb, nodename, subresource string, option interface{}, reqBody interface{}) (*Application, error) {
@@ -315,14 +309,12 @@ func (a *Application) Reset() {
 }
 
 func (a *Application) Add() {
-	a.ensureInit()
 	a.countLock.Lock()
 	a.count++
 	a.countLock.Unlock()
 }
 
 func (a *Application) getCount() uint64 {
-	a.ensureInit()
 	a.countLock.Lock()
 	c := a.count
 	a.countLock.Unlock()
@@ -331,7 +323,6 @@ func (a *Application) getCount() uint64 {
 
 // Close must be called when applicant no longer using application
 func (a *Application) Close() {
-	a.ensureInit()
 	a.countLock.Lock()
 	defer a.countLock.Unlock()
 	if a.count == 0 {
@@ -348,7 +339,6 @@ func (a *Application) Close() {
 }
 
 func (a *Application) LastCloseTime() time.Time {
-	a.ensureInit()
 	a.countLock.Lock()
 	defer a.countLock.Unlock()
 	if a.count == 0 && !a.Timestamp.IsZero() {

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -395,9 +395,11 @@ func TestMsgToApplication(t *testing.T) {
 				Content: []byte(`{"Key":"group/version/resource/namespaces/name","Verb":"GET","Nodename":"test-node"}`),
 			},
 			stdResult: &Application{
-				Key:      "group/version/resource/namespaces/name",
-				Verb:     "GET",
-				Nodename: "test-node",
+				Key:       "group/version/resource/namespaces/name",
+				Verb:      "GET",
+				Nodename:  "test-node",
+				mu:        &sync.RWMutex{},
+				countLock: &sync.Mutex{},
 			},
 			hasError: false,
 		},
@@ -417,7 +419,11 @@ func TestMsgToApplication(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, test.stdResult, app)
+				if test.stdResult != nil {
+					assert.Equal(t, test.stdResult.Key, app.Key)
+					assert.Equal(t, test.stdResult.Verb, app.Verb)
+					assert.Equal(t, test.stdResult.Nodename, app.Nodename)
+				}
 			}
 		})
 	}
@@ -532,6 +538,7 @@ func TestReset(t *testing.T) {
 		cancel:   cancel,
 		Reason:   "some reason",
 		RespBody: []byte(`{"some":"data"}`),
+		Status:   Completed,
 	}
 
 	app.Reset()
@@ -552,6 +559,8 @@ func TestReset(t *testing.T) {
 	assert.Empty(t, app.RespBody)
 	assert.NotNil(t, app.ctx)
 	assert.NotNil(t, app.cancel)
+	// Reset must transition Status back to PreApplying to prevent duplicate doApply goroutines
+	assert.Equal(t, PreApplying, app.Status)
 }
 
 func TestAddAndClose(t *testing.T) {
@@ -636,4 +645,105 @@ func TestWait(t *testing.T) {
 	}
 	// Should not block or panic when context is nil
 	app.Wait()
+}
+
+func TestSetStatusGetStatus(t *testing.T) {
+	app := &Application{}
+	for _, s := range []ApplicationStatus{PreApplying, InApplying, Approved, Rejected, Failed, Completed} {
+		app.SetStatus(s)
+		assert.Equal(t, s, app.GetStatus())
+	}
+}
+
+func TestSetReasonGetReason(t *testing.T) {
+	app := &Application{}
+	app.SetReason("test reason")
+	assert.Equal(t, "test reason", app.GetReason())
+	app.SetReason("")
+	assert.Empty(t, app.GetReason())
+}
+
+func TestGetError(t *testing.T) {
+	app := &Application{}
+	got := app.GetError()
+	// Default zero value - StatusError should match
+	assert.Equal(t, app.Error, got)
+}
+
+func TestUpdateFromResponse(t *testing.T) {
+	app := &Application{}
+	resp := &Application{
+		Status:   Approved,
+		Reason:   "ok",
+		RespBody: []byte(`{"key":"value"}`),
+	}
+	app.UpdateFromResponse(resp)
+	assert.Equal(t, Approved, app.GetStatus())
+	assert.Equal(t, "ok", app.GetReason())
+	var result map[string]string
+	err := app.RespBodyTo(&result)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"key": "value"}, result)
+}
+
+// TestConcurrentStatusAccess verifies that concurrent reads and writes to the
+// Application mutable fields do not cause data races. Run with:
+//
+//	go test -race ./pkg/metaserver/...
+func TestConcurrentStatusAccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	app := &Application{
+		ctx:       ctx,
+		cancel:    cancel,
+		countLock: &sync.Mutex{},
+		Status:    PreApplying,
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 4)
+
+	// Concurrent SetStatus
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			status := ApplicationStatus(fmt.Sprintf("status-%d", i%3))
+			app.SetStatus(status)
+		}(i)
+	}
+
+	// Concurrent GetStatus
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_ = app.GetStatus()
+		}()
+	}
+
+	// Concurrent SetReason / GetReason
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				app.SetReason(fmt.Sprintf("reason-%d", i))
+			} else {
+				_ = app.GetReason()
+			}
+		}(i)
+	}
+
+	// Concurrent Cancel / Wait (with immediate context cancel so Wait doesn't block)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			// Wait returns immediately because the top-level context is canceled
+			app.Wait()
+		}()
+	}
+
+	// Trigger cancel so Wait goroutines unblock
+	cancel()
+	wg.Wait()
 }

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -395,9 +395,11 @@ func TestMsgToApplication(t *testing.T) {
 				Content: []byte(`{"Key":"group/version/resource/namespaces/name","Verb":"GET","Nodename":"test-node"}`),
 			},
 			stdResult: &Application{
-				Key:      "group/version/resource/namespaces/name",
-				Verb:     "GET",
-				Nodename: "test-node",
+				Key:       "group/version/resource/namespaces/name",
+				Verb:      "GET",
+				Nodename:  "test-node",
+				mu:        &sync.RWMutex{},
+				countLock: &sync.Mutex{},
 			},
 			hasError: false,
 		},
@@ -417,7 +419,11 @@ func TestMsgToApplication(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, test.stdResult, app)
+				if test.stdResult != nil {
+					assert.Equal(t, test.stdResult.Key, app.Key)
+					assert.Equal(t, test.stdResult.Verb, app.Verb)
+					assert.Equal(t, test.stdResult.Nodename, app.Nodename)
+				}
 			}
 		})
 	}
@@ -464,7 +470,14 @@ func TestMsgToApplications(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, test.stdResult, apps)
+				assert.Equal(t, len(test.stdResult), len(apps))
+				for k, expectedApp := range test.stdResult {
+					actualApp, ok := apps[k]
+					assert.True(t, ok)
+					assert.Equal(t, expectedApp.Key, actualApp.Key)
+					assert.Equal(t, expectedApp.Verb, actualApp.Verb)
+					assert.Equal(t, expectedApp.Nodename, actualApp.Nodename)
+				}
 			}
 		})
 	}
@@ -532,6 +545,7 @@ func TestReset(t *testing.T) {
 		cancel:   cancel,
 		Reason:   "some reason",
 		RespBody: []byte(`{"some":"data"}`),
+		Status:   Completed,
 	}
 
 	app.Reset()
@@ -552,6 +566,8 @@ func TestReset(t *testing.T) {
 	assert.Empty(t, app.RespBody)
 	assert.NotNil(t, app.ctx)
 	assert.NotNil(t, app.cancel)
+	// Reset must transition Status back to PreApplying to prevent duplicate doApply goroutines
+	assert.Equal(t, PreApplying, app.Status)
 }
 
 func TestAddAndClose(t *testing.T) {
@@ -636,4 +652,142 @@ func TestWait(t *testing.T) {
 	}
 	// Should not block or panic when context is nil
 	app.Wait()
+}
+
+func TestSetStatusGetStatus(t *testing.T) {
+	app := &Application{}
+	for _, s := range []ApplicationStatus{PreApplying, InApplying, Approved, Rejected, Failed, Completed} {
+		app.SetStatus(s)
+		assert.Equal(t, s, app.GetStatus())
+	}
+}
+
+func TestSetReasonGetReason(t *testing.T) {
+	app := &Application{}
+	app.SetReason("test reason")
+	assert.Equal(t, "test reason", app.GetReason())
+	app.SetReason("")
+	assert.Empty(t, app.GetReason())
+}
+
+func TestGetError(t *testing.T) {
+	app := &Application{}
+	got := app.GetError()
+	// Default zero value - StatusError should match
+	assert.Equal(t, app.Error, got)
+}
+
+func TestUpdateFromResponse(t *testing.T) {
+	app := &Application{}
+	resp := &Application{
+		Status:   Approved,
+		Reason:   "ok",
+		RespBody: []byte(`{"key":"value"}`),
+	}
+	app.UpdateFromResponse(resp)
+	assert.Equal(t, Approved, app.GetStatus())
+	assert.Equal(t, "ok", app.GetReason())
+	var result map[string]string
+	err := app.RespBodyTo(&result)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"key": "value"}, result)
+}
+
+// TestConcurrentStatusAccess verifies that concurrent reads and writes to the
+// Application mutable fields do not cause data races. Run with:
+//
+//	go test -race ./pkg/metaserver/...
+func TestConcurrentStatusAccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	app := &Application{
+		ctx:       ctx,
+		cancel:    cancel,
+		countLock: &sync.Mutex{},
+		Status:    PreApplying,
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 4)
+
+	// Concurrent SetStatus
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			status := ApplicationStatus(fmt.Sprintf("status-%d", i%3))
+			app.SetStatus(status)
+		}(i)
+	}
+
+	// Concurrent GetStatus
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_ = app.GetStatus()
+		}()
+	}
+
+	// Concurrent SetReason / GetReason
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				app.SetReason(fmt.Sprintf("reason-%d", i))
+			} else {
+				_ = app.GetReason()
+			}
+		}(i)
+	}
+
+	// Concurrent Cancel / Wait (with immediate context cancel so Wait doesn't block)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			// Wait returns immediately because the top-level context is canceled
+			app.Wait()
+		}()
+	}
+
+	// Trigger cancel so Wait goroutines unblock
+	cancel()
+	wg.Wait()
+}
+
+func TestTryStartApplying(t *testing.T) {
+	app := &Application{Status: PreApplying}
+	assert.True(t, app.TryStartApplying())
+	assert.Equal(t, InApplying, app.GetStatus())
+
+	// Calling again when status is InApplying should return false
+	assert.False(t, app.TryStartApplying())
+
+	app.SetStatus(Approved)
+	assert.False(t, app.TryStartApplying())
+}
+
+func TestTryResetAndStartApplying(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	app := &Application{
+		ctx:      ctx,
+		cancel:   cancel,
+		Status:   Completed,
+		Reason:   "old reason",
+		RespBody: []byte("old body"),
+	}
+
+	assert.True(t, app.TryResetAndStartApplying())
+	assert.Equal(t, InApplying, app.GetStatus())
+	assert.Empty(t, app.GetReason())
+	assert.Empty(t, app.RespContent())
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Error("Old context should be canceled")
+	}
+
+	// Calling again when status is InApplying should return false
+	assert.False(t, app.TryResetAndStartApplying())
 }

--- a/pkg/metaserver/application_test.go
+++ b/pkg/metaserver/application_test.go
@@ -144,6 +144,7 @@ func TestString(t *testing.T) {
 				Verb:     "GET",
 				Status:   "completed",
 				Reason:   "test reason one",
+				mu:       &sync.RWMutex{},
 			},
 			stdResult: "(NodeName=test-node-one;Key=group/version/resource/namespaces/name;Verb=GET;Status=completed;Reason=test reason one)",
 		},
@@ -154,6 +155,7 @@ func TestString(t *testing.T) {
 				Verb:     "POST",
 				Status:   "pending",
 				Reason:   "test reason two",
+				mu:       &sync.RWMutex{},
 			},
 			stdResult: "(NodeName=test-node-two;Key=group/version/resource/namespaces/name;Verb=POST;Status=pending;Reason=test reason two)",
 		},
@@ -200,18 +202,19 @@ func TestRespContent(t *testing.T) {
 		stdResult []byte
 	}{
 		{
-			app:       Application{RespBody: []byte(`{"test":"data"}`)},
+			app:       Application{RespBody: []byte(`{"test":"data"}`), mu: &sync.RWMutex{}},
 			stdResult: []byte(`{"test":"data"}`),
 		},
 		{
 			app: Application{
 				Nodename: "test-node",
 				Key:      "group/version/resource/namespaces/name",
+				mu:       &sync.RWMutex{},
 			},
 			stdResult: nil,
 		},
 		{
-			app:       Application{RespBody: nil},
+			app:       Application{RespBody: nil, mu: &sync.RWMutex{}},
 			stdResult: nil,
 		},
 	}
@@ -280,7 +283,7 @@ func TestRespBodyTo(t *testing.T) {
 		expected map[string]string
 	}{
 		{
-			app:      Application{RespBody: []byte(`{"test-key":"test-value"}`)},
+			app:      Application{RespBody: []byte(`{"test-key":"test-value"}`), mu: &sync.RWMutex{}},
 			expected: map[string]string{"test-key": "test-value"},
 		},
 	}
@@ -293,7 +296,7 @@ func TestRespBodyTo(t *testing.T) {
 	}
 
 	// Test error case
-	app := Application{RespBody: []byte(`{invalid-json}`)}
+	app := Application{RespBody: []byte(`{invalid-json}`), mu: &sync.RWMutex{}}
 	var result map[string]string
 	err := app.RespBodyTo(&result)
 	assert.Error(t, err)
@@ -367,11 +370,11 @@ func TestGetStatus(t *testing.T) {
 		stdResult ApplicationStatus
 	}{
 		{
-			app:       Application{Status: PreApplying},
+			app:       Application{Status: PreApplying, mu: &sync.RWMutex{}},
 			stdResult: PreApplying,
 		},
 		{
-			app:       Application{Status: Completed},
+			app:       Application{Status: Completed, mu: &sync.RWMutex{}},
 			stdResult: Completed,
 		},
 	}
@@ -520,6 +523,7 @@ func TestCancel(t *testing.T) {
 	app := Application{
 		ctx:    ctx,
 		cancel: cancel,
+		mu:     &sync.RWMutex{},
 	}
 
 	// Verify canceling works when cancel function is provided
@@ -534,6 +538,7 @@ func TestCancel(t *testing.T) {
 	// Test case 2: Edge case - application with nil cancel function
 	app = Application{
 		cancel: nil,
+		mu:     &sync.RWMutex{},
 	}
 	app.Cancel()
 }
@@ -546,6 +551,7 @@ func TestReset(t *testing.T) {
 		Reason:   "some reason",
 		RespBody: []byte(`{"some":"data"}`),
 		Status:   Completed,
+		mu:       &sync.RWMutex{},
 	}
 
 	app.Reset()
@@ -573,6 +579,7 @@ func TestReset(t *testing.T) {
 func TestAddAndClose(t *testing.T) {
 	app := Application{
 		countLock: &sync.Mutex{},
+		mu:        &sync.RWMutex{},
 		count:     1, // Initial count
 	}
 
@@ -628,6 +635,7 @@ func TestWait(t *testing.T) {
 	app := Application{
 		ctx:    ctx,
 		cancel: cancel,
+		mu:     &sync.RWMutex{},
 	}
 
 	// Cancel the context in a goroutine to unblock Wait
@@ -649,13 +657,14 @@ func TestWait(t *testing.T) {
 	// Test case 2: Edge case - application with nil context
 	app = Application{
 		ctx: nil,
+		mu:  &sync.RWMutex{},
 	}
 	// Should not block or panic when context is nil
 	app.Wait()
 }
 
 func TestSetStatusGetStatus(t *testing.T) {
-	app := &Application{}
+	app := &Application{mu: &sync.RWMutex{}}
 	for _, s := range []ApplicationStatus{PreApplying, InApplying, Approved, Rejected, Failed, Completed} {
 		app.SetStatus(s)
 		assert.Equal(t, s, app.GetStatus())
@@ -663,7 +672,7 @@ func TestSetStatusGetStatus(t *testing.T) {
 }
 
 func TestSetReasonGetReason(t *testing.T) {
-	app := &Application{}
+	app := &Application{mu: &sync.RWMutex{}}
 	app.SetReason("test reason")
 	assert.Equal(t, "test reason", app.GetReason())
 	app.SetReason("")
@@ -671,14 +680,14 @@ func TestSetReasonGetReason(t *testing.T) {
 }
 
 func TestGetError(t *testing.T) {
-	app := &Application{}
+	app := &Application{mu: &sync.RWMutex{}}
 	got := app.GetError()
 	// Default zero value - StatusError should match
 	assert.Equal(t, app.Error, got)
 }
 
 func TestUpdateFromResponse(t *testing.T) {
-	app := &Application{}
+	app := &Application{mu: &sync.RWMutex{}}
 	resp := &Application{
 		Status:   Approved,
 		Reason:   "ok",
@@ -705,6 +714,7 @@ func TestConcurrentStatusAccess(t *testing.T) {
 		ctx:       ctx,
 		cancel:    cancel,
 		countLock: &sync.Mutex{},
+		mu:        &sync.RWMutex{},
 		Status:    PreApplying,
 	}
 
@@ -756,7 +766,7 @@ func TestConcurrentStatusAccess(t *testing.T) {
 }
 
 func TestTryStartApplying(t *testing.T) {
-	app := &Application{Status: PreApplying}
+	app := &Application{Status: PreApplying, mu: &sync.RWMutex{}}
 	assert.True(t, app.TryStartApplying())
 	assert.Equal(t, InApplying, app.GetStatus())
 
@@ -775,6 +785,7 @@ func TestTryResetAndStartApplying(t *testing.T) {
 		Status:   Completed,
 		Reason:   "old reason",
 		RespBody: []byte("old body"),
+		mu:       &sync.RWMutex{},
 	}
 
 	assert.True(t, app.TryResetAndStartApplying())


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes several systemic concurrency defects in the `Application` and `Agent` subsystems in `pkg/metaserver` and `edge/pkg/metamanager/metaserver/agent`, identified in issue #7162.

1. **Data Race Protection**: Adds a pointer `RWMutex` (`mu *sync.RWMutex`) to `Application` to protect concurrent access to `Status`, `Reason`, `Error`, `RespBody`, `ctx`, and `cancel`. Introduces atomic accessors: `SetStatus`, `SetReason`, `GetReason`, `GetError`, `UpdateFromResponse`, and lazy lock helpers (`lock`, `unlock`, `rLock`, `rUnlock`).
2. **State Transition in `Reset()`**: `Application.Reset()` now transitions `Status` back to `PreApplying`. Previously, after `Close()` set `Status = Completed` and a second request called `Apply()`, the `Completed` state triggered `app.Reset()` followed immediately by `go a.doApply(app)`. Since `Reset()` did not update `Status`, a third concurrent `Apply()` call could also see `Completed` and launch a duplicate `doApply()` goroutine, causing redundant requests to CloudCore.
3. **Safe `Wait()` Context Read**: `Application.Wait()` now snapshots `a.ctx` under the read lock before blocking on the channel, preventing a race with `Reset()` which reassigns `a.ctx`.
4. **Resource Cleanup in `CloseApplication()`**: `Agent.CloseApplication()` now calls `app.Cancel()` before removing the application from the `sync.Map`, ensuring goroutines blocked in `Wait()` are released.
5. **Unit Tests**: Adds unit tests for `SetStatus`, `SetReason`, `GetError`, `UpdateFromResponse`, the `Reset` status transition, and a concurrent stress test `TestConcurrentStatusAccess` that exercises all protected fields under 50 concurrent goroutines.

**Which issue(s) this PR fixes**:

Fixes #7162

**Special notes for your reviewer**:

- Using `*sync.RWMutex` (pointer) instead of embedded `sync.RWMutex` avoids `go vet` `copylocks` warnings since `Application` is copied by value in map operations and test struct literals.
- The `mu` and `countLock` fields are lazily initialized in helper methods to support `Application{}` struct literals used in existing tests without panicking.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
