### PR TITLE
edgehub: requeue message when sending to cloud fails

### DIFF
--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -97,6 +97,9 @@ func (eh *EdgeHub) routeToCloud() {
 		err = eh.sendToCloud(message)
 		if err != nil {
 			klog.Errorf("failed to send message to cloud: %v", err)
+			// Requeue the message so it is sent again after reconnection.
+			// Otherwise the message is lost when the connection drops.
+			beehiveContext.Send(modules.EdgeHubModuleName, message)
 			eh.reconnectChan <- struct{}{}
 			return
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

EdgeHub sends messages from the edge to the cloud over one connection. When the connection breaks, the message that is being sent at that moment is lost. EdgeHub then closes the connection and starts reconnecting. The failed message is not put back into the queue.

This PR puts the failed message back into EdgeHub's queue before reconnecting. After the new connection is established, EdgeHub sends the message again. No message is lost when the connection breaks.

Messages published while the connection is down are already buffered. They are sent after reconnection. This change covers the one message that is in flight when the connection breaks.

**Which issue(s) this PR fixes**:

Fixes #6615

**Special notes for your reviewer**:

The change is one line in the message-routing loop, plus a short comment. It reuses the existing queue, so no new state is added.

I validated the change on a live single-machine KubeEdge setup:

- The full path works end to end: MQTT topic to EventBus to EdgeHub to CloudCore router to a REST sink.
- I cut the connection and confirmed that EdgeHub detects the break and enters the reconnect loop.
- Messages published during the outage wait in the queue and are not dropped.


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
