### PR TITLE
edgehub: return error from CertManager.Start instead of panicking

### DIFF
--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -74,12 +74,12 @@ func NewCertManager(edgehub v1alpha2.EdgeHub, nodename string) CertManager {
 }
 
 // Start starts the CertManager
-func (cm *CertManager) Start() {
+func (cm *CertManager) Start() error {
 	if _, err := cm.getCurrent(); err != nil {
 		klog.Warningf("unable to get the current edge certs, reason: %v", err)
 		klog.Info("Reuse the token to obtain the certificate")
 		if err = cm.applyCerts(); err != nil {
-			panic(fmt.Errorf("failed to apply the edge certs, err: %v", err))
+			return fmt.Errorf("failed to apply the edge certs, err: %v", err)
 		}
 		// inform to cleanup token in configuration edgecore.yaml
 		CleanupTokenChan <- struct{}{}
@@ -87,6 +87,7 @@ func (cm *CertManager) Start() {
 	if cm.RotateCertificates {
 		cm.rotate()
 	}
+	return nil
 }
 
 // getCurrent returns current edge certificate

--- a/edge/pkg/edgehub/certificate/certmanager_test.go
+++ b/edge/pkg/edgehub/certificate/certmanager_test.go
@@ -135,6 +135,26 @@ func TestGetEdgeCert(t *testing.T) {
 	})
 }
 
+func TestStart(t *testing.T) {
+	t.Run("returns error instead of panicking when cert provisioning fails", func(t *testing.T) {
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "missing-ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "missing-server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "missing-server.key"),
+			caURL:    "http://127.0.0.1:0/ca.crt",
+			certURL:  "http://127.0.0.1:0/edge.crt",
+		}
+
+		var err error
+		require.NotPanics(t, func() {
+			err = cm.Start()
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to apply the edge certs")
+	})
+}
+
 const (
 	fakeCertsDir = "fake-certs"
 )

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -91,7 +91,10 @@ func (eh *EdgeHub) RestartPolicy() *core.ModuleRestartPolicy {
 // Start sets context and starts the controller
 func (eh *EdgeHub) Start() {
 	eh.certManager = certificate.NewCertManager(config.Config.EdgeHub, config.Config.NodeName)
-	eh.certManager.Start()
+	if err := eh.certManager.Start(); err != nil {
+		klog.Exitf("failed to start cert manager: %v", err)
+		return
+	}
 	for _, v := range GetCertSyncChannel() {
 		v <- true
 		close(v)


### PR DESCRIPTION
## Summary
- `CertManager.Start()` panicked when initial certificate provisioning failed, crashing EdgeCore instead of returning a recoverable error.

## Linked Issue
Fixes #7165

## What Changed
- Changed `CertManager.Start()` to return an `error` instead of calling `panic()` on `applyCerts()` failure.
- Updated `EdgeHub.Start()` to handle the returned error and exit the module in a controlled way via `klog.Exitf`.
- Added a unit test verifying `Start()` returns an error instead of panicking when cert provisioning fails.

## Verification
- `gofmt -l` on changed files — passed
- `go build ./edge/pkg/edgehub/...` — passed
- `go vet ./edge/pkg/edgehub/...` — passed
- `make verify` — passed
- `make test WHAT=edge` — all `edge/pkg/edgehub/...` packages passed; two failures were observed in unrelated, unmodified packages (`edge/pkg/metamanager/client`, `edge/pkg/taskmanager`) that this change does not touch

## Scope
- Only `edge/pkg/edgehub/certificate/certmanager.go`, `edge/pkg/edgehub/certificate/certmanager_test.go`, and `edge/pkg/edgehub/edgehub.go` were changed; no unrelated files were modified.
