### PR TITLE
Fix race condition in dtmanager callback initialization

### DIFF
--- a/edge/pkg/devicetwin/dtmanager/device.go
+++ b/edge/pkg/devicetwin/dtmanager/device.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -21,7 +22,8 @@ import (
 
 var (
 	//deviceActionCallBack map for action to callback
-	deviceActionCallBack map[string]CallBack
+	deviceActionCallBack         map[string]CallBack
+	initDeviceActionCallBackOnce sync.Once
 
 	// DeviceServiceFactory is a function variable that can be mocked in tests
 	DeviceServiceFactory = func() interface {
@@ -69,9 +71,11 @@ func (dw DeviceWorker) Start() {
 }
 
 func initDeviceActionCallBack() {
-	deviceActionCallBack = make(map[string]CallBack)
-	deviceActionCallBack[dtcommon.DeviceUpdated] = dealDeviceAttrUpdate
-	deviceActionCallBack[dtcommon.DeviceStateUpdate] = dealDeviceStateUpdate
+	initDeviceActionCallBackOnce.Do(func() {
+		deviceActionCallBack = make(map[string]CallBack)
+		deviceActionCallBack[dtcommon.DeviceUpdated] = dealDeviceAttrUpdate
+		deviceActionCallBack[dtcommon.DeviceStateUpdate] = dealDeviceStateUpdate
+	})
 }
 
 func dealDeviceStateUpdate(context *dtcontext.DTContext, resource string, msg interface{}) error {

--- a/edge/pkg/devicetwin/dtmanager/membership.go
+++ b/edge/pkg/devicetwin/dtmanager/membership.go
@@ -21,7 +21,8 @@ import (
 
 var (
 	//memActionCallBack map for action to callback
-	memActionCallBack map[string]CallBack
+	memActionCallBack         map[string]CallBack
+	initMemActionCallBackOnce sync.Once
 
 	// MembershipServiceFactory is a function variable that can be mocked in tests
 	MembershipServiceFactory = func() interface {
@@ -73,10 +74,12 @@ func (mw MemWorker) Start() {
 }
 
 func initMemActionCallBack() {
-	memActionCallBack = make(map[string]CallBack)
-	memActionCallBack[dtcommon.MemGet] = dealMembershipGet
-	memActionCallBack[dtcommon.MemUpdated] = dealMembershipUpdate
-	memActionCallBack[dtcommon.MemDetailResult] = dealMembershipDetail
+	initMemActionCallBackOnce.Do(func() {
+		memActionCallBack = make(map[string]CallBack)
+		memActionCallBack[dtcommon.MemGet] = dealMembershipGet
+		memActionCallBack[dtcommon.MemUpdated] = dealMembershipUpdate
+		memActionCallBack[dtcommon.MemDetailResult] = dealMembershipDetail
+	})
 }
 func getRemoveList(context *dtcontext.DTContext, devices []dttype.Device) []dttype.Device {
 	var toRemove []dttype.Device


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR fixes a potential map race condition in the `dtmanager` package. Currently, `initTwinActionCallBack()` in `twin.go` uses `sync.Once` to prevent re-initialization. However, `initDeviceActionCallBack()` and `initMemActionCallBack()` execute `make(map[string]CallBack)` directly every time `DeviceWorker.Start()` or `MemWorker.Start()` is called (e.g., during module restarts). 

This PR adds `sync.Once` for the initialization of `deviceActionCallBack` and `memActionCallBack` to ensure thread-safe, single initialization across the `dtmanager` package, matching the existing pattern in `twin.go`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7167