### PR TITLE
Fix grammatical error in keadm reset command help text

### DIFF
--- a/keadm/cmd/keadm/app/cmd/cloud/reset.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/reset.go
@@ -46,7 +46,7 @@ func NewCloudReset() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "cloud",
-		Short:   "Teardowns CloudCore component",
+		Short:   "Tears down CloudCore component",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/keadm/cmd/keadm/app/cmd/cloud/reset_test.go
+++ b/keadm/cmd/keadm/app/cmd/cloud/reset_test.go
@@ -37,7 +37,7 @@ func TestNewCloudReset(t *testing.T) {
 	cmd := NewCloudReset()
 
 	assert.Equal("cloud", cmd.Use)
-	assert.Equal("Teardowns CloudCore component", cmd.Short)
+	assert.Equal("Tears down CloudCore component", cmd.Short)
 	assert.Equal(resetLongDescription, cmd.Long)
 	assert.Equal(resetExample, cmd.Example)
 

--- a/keadm/cmd/keadm/app/cmd/deprecated/reset.go
+++ b/keadm/cmd/keadm/app/cmd/deprecated/reset.go
@@ -60,7 +60,7 @@ func NewDeprecatedKubeEdgeReset() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "reset",
-		Short:   "Deprecated: Teardowns KubeEdge (cloud & edge) component",
+		Short:   "Deprecated: Tears down KubeEdge (cloud & edge) component",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/keadm/cmd/keadm/app/cmd/edge/reset_others.go
+++ b/keadm/cmd/keadm/app/cmd/edge/reset_others.go
@@ -54,7 +54,7 @@ func NewOtherEdgeReset() *cobra.Command {
 	step := common.NewStep()
 	var cmd = &cobra.Command{
 		Use:     "edge",
-		Short:   "Teardowns EdgeCore component",
+		Short:   "Tears down EdgeCore component",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(_ *cobra.Command, _ []string) error {

--- a/keadm/cmd/keadm/app/cmd/reset_others.go
+++ b/keadm/cmd/keadm/app/cmd/reset_others.go
@@ -59,7 +59,7 @@ func NewKubeEdgeReset() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "reset",
-		Short:   "Teardowns KubeEdge (cloud(helm installed) & edge) component",
+		Short:   "Tears down KubeEdge (cloud(helm installed) & edge) component",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(_ *cobra.Command, _ []string) error {

--- a/keadm/cmd/keadm/app/cmd/reset_windows.go
+++ b/keadm/cmd/keadm/app/cmd/reset_windows.go
@@ -54,7 +54,7 @@ func NewKubeEdgeReset() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:     "reset",
-		Short:   "Teardowns KubeEdge edge component in windows server",
+		Short:   "Tears down KubeEdge edge component in windows server",
 		Long:    resetLongDescription,
 		Example: resetExample,
 		PreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Fixes #7169

Corrected the grammatical error where `Teardowns` was used instead of `Tears down` in the `keadm reset` command help texts.