### PR TITLE
Bug: Fix silent discard of patched updates in MergePatchedResource

### DIFF
--- a/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
+++ b/edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go
@@ -184,7 +184,7 @@ func MergePatchedResource(ctx context.Context, originalObj *unstructured.Unstruc
 		if err = patchutil.StrategicPatchObject(ctx, defaulter, originalObj, []byte((*metas)[0]), updatedResource, schemaReferenceObj, ""); err != nil {
 			return err
 		}
-		originalObj = updatedResource
+		*originalObj = *updatedResource
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #7171

In `edge/pkg/metamanager/metaserver/kubernetes/storage/sqlite/store.go`, the `MergePatchedResource` function reassigns the `originalObj` pointer locally instead of dereferencing it. As a result, the patched resource is silently discarded and the caller receives the original stale object.

This PR simply dereferences the pointers so the actual underlying object in memory is updated:
`*originalObj = *updatedResource`