### PR TITLE
Fix: handle CompareResourceVersion error gracefully to prevent cloudcore panic

### DIFF
--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -266,10 +266,17 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 	item, exist, _ := nodeStore.GetByKey(messageKey)
 	if exist {
 		msgInStore := item.(*beehivemodel.Message)
-		if isDeleteMessage(msgInStore) ||
-			synccontroller.CompareResourceVersion(msg.GetResourceVersion(), msgInStore.GetResourceVersion()) <= 0 {
-			// If the message resource version is older than the message in store or the operation
-			// for the message in store is delete, The message will be discarded directly.
+		if isDeleteMessage(msgInStore) {
+			// If the operation for the message in store is delete, The message will be discarded directly.
+			return
+		}
+		cmp, err := synccontroller.CompareResourceVersion(msg.GetResourceVersion(), msgInStore.GetResourceVersion())
+		if err != nil {
+			klog.Errorf("Failed to compare resource version for message %s: %v", msg.Header.ID, err)
+			return
+		}
+		if cmp <= 0 {
+			// If the message resource version is older than the message in store, The message will be discarded directly.
 			return
 		}
 		shouldEnqueue = true
@@ -299,7 +306,12 @@ func (md *messageDispatcher) enqueueNonNamespacedResource(nodeID string, msg *be
 
 	switch {
 	case err == nil && clusterObjectSync.Status.ObjectResourceVersion != "":
-		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion) > 0 {
+		cmp, parseErr := synccontroller.CompareResourceVersion(msg.GetResourceVersion(), clusterObjectSync.Status.ObjectResourceVersion)
+		if parseErr != nil {
+			klog.Errorf("Failed to compare resource version for message %s: %v", msg.Header.ID, parseErr)
+			return false
+		}
+		if cmp > 0 {
 			return true
 		}
 
@@ -363,7 +375,12 @@ func (md *messageDispatcher) enqueueNamespacedResource(nodeID string, msg *beehi
 
 	switch {
 	case err == nil && objectSync.Status.ObjectResourceVersion != "":
-		if synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion) > 0 {
+		cmp, parseErr := synccontroller.CompareResourceVersion(msg.GetResourceVersion(), objectSync.Status.ObjectResourceVersion)
+		if parseErr != nil {
+			klog.Errorf("Failed to compare resource version for message %s: %v", msg.Header.ID, parseErr)
+			return false
+		}
+		if cmp > 0 {
 			return true
 		}
 

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher_test.go
@@ -161,6 +161,9 @@ func TestEnqueueAckMessage(t *testing.T) {
 	respMsg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "5"), "response")
 	invalidMsg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, ""), "update")
 
+	// Create a message with an invalid resource version that will fail in CompareResourceVersion
+	invalidVersionMsg := tf.NewPodMessage(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "abc"), "update")
+
 	tests := []tf.TestCase{
 		{
 			Name:                 "invalid message arrives",
@@ -286,6 +289,32 @@ func TestEnqueueAckMessage(t *testing.T) {
 				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestDiffPodUID, "0"), "Pod"),
 			},
 			ExpectedStoreMessage: normalMsg3,
+		},
+		{
+			Name: "message with invalid resource version fails comparison with store",
+			InitialObjectSyncs: []*v1alpha1.ObjectSync{
+				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
+			},
+			ReactorErrors:        tf.NoErrors,
+			InitialMessages:      []*beehivemodel.Message{normalMsg1},
+			CurrentArriveMessage: invalidVersionMsg,
+			ExpectedObjectSyncs: []*v1alpha1.ObjectSync{
+				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
+			},
+			ExpectedStoreMessage: normalMsg1,
+		},
+		{
+			Name: "message with invalid resource version fails comparison with objectsync",
+			InitialObjectSyncs: []*v1alpha1.ObjectSync{
+				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
+			},
+			ReactorErrors:        tf.NoErrors,
+			InitialMessages:      []*beehivemodel.Message{},
+			CurrentArriveMessage: invalidVersionMsg,
+			ExpectedObjectSyncs: []*v1alpha1.ObjectSync{
+				tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
+			},
+			ExpectedStoreMessage: nil,
 		},
 	}
 

--- a/cloud/pkg/synccontroller/clusterobjectsync.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync.go
@@ -122,7 +122,12 @@ func sendClusterObjectSyncEvent(nodeName string, sync *v1alpha1.ClusterObjectSyn
 		return
 	}
 
-	if compareResourceVersionFunc(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
+	cmp, err := compareResourceVersionFunc(objectResourceVersion, sync.Status.ObjectResourceVersion)
+	if err != nil {
+		klog.Errorf("Failed to compare resource version for %s: %v", sync.Name, err)
+		return
+	}
+	if cmp > 0 {
 		// trigger the update event
 		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
 		msg := buildEdgeControllerMessageFunc(nodeName, models.NullNamespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)

--- a/cloud/pkg/synccontroller/clusterobjectsync_test.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync_test.go
@@ -43,7 +43,7 @@ type testFuncBackup struct {
 	originalBuildEdgeControllerMessageFunc func(string, string, string, string, string, interface{}) *model.Message
 	originalGetNodeNameFunc                func(string) string
 	originalGetObjectUIDFunc               func(string) string
-	originalCompareResourceVersionFunc     func(string, string) int
+	originalCompareResourceVersionFunc     func(string, string) (int, error)
 	originalGcFunc                         func(*SyncController, *v1alpha1.ClusterObjectSync)
 	originalDeleteFunc                     func(*SyncController, string) error
 }
@@ -87,17 +87,17 @@ func mockGetObjectUID(syncName string) string {
 	return ""
 }
 
-func mockCompareResourceVersion(rv1, rv2 string) int {
+func mockCompareResourceVersion(rv1, rv2 string) (int, error) {
 	if rv1 == "1000" && rv2 == "500" {
-		return 1
+		return 1, nil
 	}
 	if rv1 == rv2 {
-		return 0
+		return 0, nil
 	}
 	if rv1 > rv2 {
-		return 1
+		return 1, nil
 	}
-	return -1
+	return -1, nil
 }
 
 type MockLister struct {
@@ -294,7 +294,7 @@ func TestReconcileClusterObjectSync(t *testing.T) {
 			ctrl.reconcileClusterObjectSync(tt.sync)
 
 			if tt.name == "Object found with newer resource version" {
-				result := compareResourceVersionFunc("1000", "500")
+				result, _ := compareResourceVersionFunc("1000", "500")
 				if result <= 0 {
 					t.Errorf("Mock compareResourceVersionFunc returned unexpected result %d for 1000 vs 500", result)
 				}
@@ -401,11 +401,11 @@ func TestSendClusterObjectSyncEventDirect(t *testing.T) {
 	backup := setupTest()
 	defer backup.restore()
 
-	compareResourceVersionFunc = func(rv1, rv2 string) int {
+	compareResourceVersionFunc = func(rv1, rv2 string) (int, error) {
 		if rv1 == "1000" && rv2 == "500" {
-			return 1
+			return 1, nil
 		}
-		return 0
+		return 0, nil
 	}
 
 	sendCalled := false
@@ -427,6 +427,31 @@ func TestSendClusterObjectSyncEventDirect(t *testing.T) {
 	sendClusterObjectSyncEvent(nodeName, sync, resourceType, objectResourceVersion, obj)
 
 	assert.True(t, sendCalled, "Send should have been called")
+}
+
+func TestSendClusterObjectSyncEventDirectCompareError(t *testing.T) {
+	backup := setupTest()
+	defer backup.restore()
+
+	compareResourceVersionFunc = func(rv1, rv2 string) (int, error) {
+		return -1, errors.New("mock error")
+	}
+
+	sendCalled := false
+
+	sendToEdge = func(module string, msg model.Message) {
+		sendCalled = true
+	}
+
+	nodeName := "node1"
+	resourceType := "pod"
+	objectResourceVersion := "1000"
+	obj := createTestPod("test-pod", "12345", "1000")
+	sync := createTestSync("node1-pod-12345", "test-pod", "Pod", "v1", "500")
+
+	sendClusterObjectSyncEvent(nodeName, sync, resourceType, objectResourceVersion, obj)
+
+	assert.False(t, sendCalled, "Send should not have been called on compare error")
 }
 
 func TestDeleteClusterObjectSyncFunc(t *testing.T) {

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -94,7 +94,12 @@ func sendEvents(nodeName string, sync *v1alpha1.ObjectSync, resourceType string,
 		return
 	}
 
-	if CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
+	cmp, err := CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion)
+	if err != nil {
+		klog.Errorf("Failed to compare resource version for %s: %v", sync.Name, err)
+		return
+	}
+	if cmp > 0 {
 		// trigger the update event
 		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
 		msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
@@ -138,23 +143,21 @@ func GetObjectResourceVersion(obj interface{}) string {
 // CompareResourceVersion compares resourceversions, resource versions are actually
 // ints, so we can easily compare them.
 // If rva>rvb, return 1; rva=rvb, return 0; rva<rvb, return -1
-func CompareResourceVersion(rva, rvb string) int {
+func CompareResourceVersion(rva, rvb string) (int, error) {
 	a, err := strconv.ParseUint(rva, 10, 64)
 	if err != nil {
-		// coder error
-		panic(err)
+		return -1, err
 	}
 	b, err := strconv.ParseUint(rvb, 10, 64)
 	if err != nil {
-		// coder error
-		panic(err)
+		return -1, err
 	}
 
 	if a > b {
-		return 1
+		return 1, nil
 	}
 	if a == b {
-		return 0
+		return 0, nil
 	}
-	return -1
+	return -1, nil
 }

--- a/cloud/pkg/synccontroller/objectsync_test.go
+++ b/cloud/pkg/synccontroller/objectsync_test.go
@@ -44,26 +44,46 @@ func TestCompareResourceVersion(t *testing.T) {
 		name       string
 		testNumber []string
 		want       int
+		wantErr    bool
 	}{
 		{
 			name:       "test greater than",
 			testNumber: []string{"123", "124"},
 			want:       -1,
+			wantErr:    false,
 		},
 		{
 			name:       "test less than",
 			testNumber: []string{"124", "123"},
 			want:       1,
+			wantErr:    false,
 		},
 		{
 			name:       "test equal",
 			testNumber: []string{"123", "123"},
 			want:       0,
+			wantErr:    false,
+		},
+		{
+			name:       "test invalid string",
+			testNumber: []string{"123", "abc"},
+			want:       -1,
+			wantErr:    true,
+		},
+		{
+			name:       "test empty string",
+			testNumber: []string{"", "123"},
+			want:       -1,
+			wantErr:    true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CompareResourceVersion(tt.testNumber[0], tt.testNumber[1])
+			got, err := CompareResourceVersion(tt.testNumber[0], tt.testNumber[1])
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CompareResourceVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 			if !reflect.DeepEqual(tt.want, got) {
 				t.Errorf("CompareResourceVersion() = %v, want %v", got, tt.want)
 			}
@@ -174,6 +194,14 @@ func TestSendEvents(t *testing.T) {
 			}
 		})
 	}
+
+	// Test error path for CompareResourceVersion
+	t.Run("test sendEvents compare error", func(t *testing.T) {
+		sync := tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod")
+		// synchronous call, if it doesn't return early due to error, it might block on send or panic.
+		// Since it has an invalid version "abc", it will error and return immediately.
+		sendEvents(tf.TestNodeID, sync, "pod", "abc", sync.DeepCopy())
+	})
 }
 func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
 	return &unstructured.Unstructured{


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a critical bug where `cloudcore` panics and crashes whenever a cloud-to-edge message is dispatched with an empty or non-numeric `resourceVersion`. 

The crash happens because `CompareResourceVersion` in `cloud/pkg/synccontroller/objectsync.go` used `panic(err)` when failing to parse the resource version string as a `uint64`. This PR updates the signature of `CompareResourceVersion` to return an `(int, error)` instead of blindly panicking. All upstream callers in `message_dispatcher.go` and `synccontroller` have been updated to handle the error properly by logging a warning and dropping the invalid message safely, thus preventing the entire `cloudcore` process from going down. 

Tests have also been updated to ensure proper error handling and regression prevention for invalid `resourceVersion` scenarios.

**Which issue(s) this PR fixes**:
Fixes #7174

**Special notes for your reviewer**:
The change propagates safely across `message_dispatcher.go`, `objectsync.go`, and `clusterobjectsync.go`. Messages with unparseable resource versions will now be gracefully discarded instead of causing the entire control plane for edge nodes to panic. Unit tests in `synccontroller` have been updated to expect and validate error returns.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a critical bug that caused `cloudcore` to panic and crash when processing resources with empty or non-numeric `resourceVersion` strings.
```
