### PR TITLE
admissioncontroller: validate Rule and RuleEndpoint updates

### DIFF
--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -65,7 +65,7 @@ func addToScheme(scheme *runtime.Scheme) {
 // AdmissionController implements the admission webhook for validation of configuration.
 type AdmissionController struct {
 	Client    *kubernetes.Clientset
-	CrdClient *versioned.Clientset
+	CrdClient versioned.Interface
 }
 
 func strPtr(s string) *string { return &s }

--- a/cloud/pkg/admissioncontroller/admit_rule.go
+++ b/cloud/pkg/admissioncontroller/admit_rule.go
@@ -22,7 +22,7 @@ func admitRule(review admissionv1.AdmissionReview) *admissionv1.AdmissionRespons
 	reviewResponse := admissionv1.AdmissionResponse{}
 
 	switch review.Request.Operation {
-	case admissionv1.Create:
+	case admissionv1.Create, admissionv1.Update:
 		raw := review.Request.Object.Raw
 		rule := rulesv1.Rule{}
 		deserializer := codecs.UniversalDeserializer()
@@ -55,7 +55,7 @@ func validateRule(rule *rulesv1.Rule) error {
 	} else if sourceEndpoint == nil {
 		return fmt.Errorf("source ruleEndpoint %s has not been created", sourceKey)
 	}
-	if err = validateSourceRuleEndpoint(sourceEndpoint, rule.Spec.SourceResource); err != nil {
+	if err = validateSourceRuleEndpoint(sourceEndpoint, rule); err != nil {
 		return err
 	}
 	targetKey := fmt.Sprintf("%s/%s", rule.Namespace, rule.Spec.Target)
@@ -81,7 +81,13 @@ func validateRule(rule *rulesv1.Rule) error {
 	}
 	return nil
 }
-func validateSourceRuleEndpoint(ruleEndpoint *rulesv1.RuleEndpoint, sourceResource map[string]string) error {
+
+// validateSourceRuleEndpoint checks that rule may consume ruleEndpoint as its source, and that no
+// other rule already consumes the same source properties. rule itself is skipped while scanning the
+// existing rules: on an update the stored copy of rule is returned by the list and would otherwise
+// always conflict with the incoming one.
+func validateSourceRuleEndpoint(ruleEndpoint *rulesv1.RuleEndpoint, rule *rulesv1.Rule) error {
+	sourceResource := rule.Spec.SourceResource
 	switch ruleEndpoint.Spec.RuleEndpointType {
 	case rulesv1.RuleEndpointTypeRest:
 		_, exist := sourceResource["path"]
@@ -93,6 +99,9 @@ func validateSourceRuleEndpoint(ruleEndpoint *rulesv1.RuleEndpoint, sourceResour
 			return err
 		}
 		for _, r := range rules {
+			if r.Namespace == rule.Namespace && r.Name == rule.Name {
+				continue
+			}
 			if sourceResource["path"] == r.Spec.SourceResource["path"] {
 				return fmt.Errorf("source properties exist in Rule %s/%s. Path: %s", r.Namespace, r.Name, sourceResource["path"])
 			}
@@ -111,6 +120,9 @@ func validateSourceRuleEndpoint(ruleEndpoint *rulesv1.RuleEndpoint, sourceResour
 			return err
 		}
 		for _, r := range rules {
+			if r.Namespace == rule.Namespace && r.Name == rule.Name {
+				continue
+			}
 			if sourceResource["topic"] == r.Spec.SourceResource["topic"] && sourceResource["node_name"] == r.Spec.SourceResource["node_name"] {
 				return fmt.Errorf("source properties exist in Rule %s/%s. Node_name: %s, topic: %s", r.Namespace, r.Name, sourceResource["node_name"], sourceResource["topic"])
 			}

--- a/cloud/pkg/admissioncontroller/admit_rule_test.go
+++ b/cloud/pkg/admissioncontroller/admit_rule_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissioncontroller
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	rulesv1 "github.com/kubeedge/api/apis/rules/v1"
+	"github.com/kubeedge/api/client/clientset/versioned/fake"
+)
+
+const ruleTestNamespace = "test"
+
+// setupCrdClient points the package level controller at a fake clientset preloaded with objects,
+// and restores the previous client when the test ends.
+func setupCrdClient(t *testing.T, objects ...runtime.Object) {
+	t.Helper()
+	original := controller.CrdClient
+	controller.CrdClient = fake.NewSimpleClientset(objects...)
+	t.Cleanup(func() {
+		controller.CrdClient = original
+	})
+}
+
+func newRuleEndpoint(name string, endpointType rulesv1.RuleEndpointTypeDef) *rulesv1.RuleEndpoint {
+	return &rulesv1.RuleEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ruleTestNamespace,
+		},
+		Spec: rulesv1.RuleEndpointSpec{
+			RuleEndpointType: endpointType,
+		},
+	}
+}
+
+// newRestSourceRule builds a rest -> eventbus rule, the shape used by most of the cases below.
+func newRestSourceRule(name, path string) *rulesv1.Rule {
+	return &rulesv1.Rule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Rule",
+			APIVersion: "rules.kubeedge.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ruleTestNamespace,
+		},
+		Spec: rulesv1.RuleSpec{
+			Source:         "rest-test",
+			SourceResource: map[string]string{"path": path},
+			Target:         "eventbus-test",
+			TargetResource: map[string]string{"topic": "test-topic"},
+		},
+	}
+}
+
+// newEventBusSourceRule builds an eventbus -> rest rule.
+func newEventBusSourceRule(name, topic, nodeName string) *rulesv1.Rule {
+	return &rulesv1.Rule{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Rule",
+			APIVersion: "rules.kubeedge.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ruleTestNamespace,
+		},
+		Spec: rulesv1.RuleSpec{
+			Source:         "eventbus-test",
+			SourceResource: map[string]string{"topic": topic, "node_name": nodeName},
+			Target:         "rest-test",
+			TargetResource: map[string]string{"resource": "http://127.0.0.1:8080"},
+		},
+	}
+}
+
+func TestAdmitRule(t *testing.T) {
+	restEndpoint := newRuleEndpoint("rest-test", rulesv1.RuleEndpointTypeRest)
+	eventBusEndpoint := newRuleEndpoint("eventbus-test", rulesv1.RuleEndpointTypeEventBus)
+
+	testCases := []struct {
+		name string
+		// objects preloaded into the fake clientset, the cluster state the webhook validates against.
+		objects   []runtime.Object
+		operation admissionv1.Operation
+		// rule is marshalled into the admission request. raw takes precedence when set.
+		rule            *rulesv1.Rule
+		raw             []byte
+		expectedAllowed bool
+		expectedError   string
+	}{
+		{
+			name:            "create rule successful",
+			objects:         []runtime.Object{restEndpoint, eventBusEndpoint},
+			operation:       admissionv1.Create,
+			rule:            newRestSourceRule("rule-test", "/a/b"),
+			expectedAllowed: true,
+		},
+		{
+			name: "create rule whose source path is taken failed",
+			objects: []runtime.Object{
+				restEndpoint, eventBusEndpoint,
+				newRestSourceRule("rule-other", "/a/b"),
+			},
+			operation:       admissionv1.Create,
+			rule:            newRestSourceRule("rule-test", "/a/b"),
+			expectedAllowed: false,
+			expectedError:   "source properties exist in Rule",
+		},
+		{
+			// Regression test: the stored copy of the rule being updated is returned by the
+			// list and must not be treated as a conflicting rule.
+			name: "update rule successful",
+			objects: []runtime.Object{
+				restEndpoint, eventBusEndpoint,
+				newRestSourceRule("rule-test", "/a/b"),
+			},
+			operation:       admissionv1.Update,
+			rule:            newRestSourceRule("rule-test", "/a/b"),
+			expectedAllowed: true,
+		},
+		{
+			name: "update eventbus source rule successful",
+			objects: []runtime.Object{
+				restEndpoint, eventBusEndpoint,
+				newEventBusSourceRule("rule-test", "test-topic", "edge-node"),
+			},
+			operation:       admissionv1.Update,
+			rule:            newEventBusSourceRule("rule-test", "test-topic", "edge-node"),
+			expectedAllowed: true,
+		},
+		{
+			name: "update rule whose source path is taken by another rule failed",
+			objects: []runtime.Object{
+				restEndpoint, eventBusEndpoint,
+				newRestSourceRule("rule-test", "/a/b"),
+				newRestSourceRule("rule-other", "/c/d"),
+			},
+			operation:       admissionv1.Update,
+			rule:            newRestSourceRule("rule-test", "/c/d"),
+			expectedAllowed: false,
+			expectedError:   "source properties exist in Rule",
+		},
+		{
+			name:            "update rule with unknown source ruleEndpoint failed",
+			objects:         []runtime.Object{eventBusEndpoint},
+			operation:       admissionv1.Update,
+			rule:            newRestSourceRule("rule-test", "/a/b"),
+			expectedAllowed: false,
+			expectedError:   "can't get source ruleEndpoint",
+		},
+		{
+			name:            "rule data error, update rule failed",
+			objects:         []runtime.Object{restEndpoint, eventBusEndpoint},
+			operation:       admissionv1.Update,
+			raw:             []byte{10, 20},
+			expectedAllowed: false,
+		},
+		{
+			name:            "delete rule successful",
+			operation:       admissionv1.Delete,
+			expectedAllowed: true,
+		},
+		{
+			name:            "connect rule successful",
+			operation:       admissionv1.Connect,
+			expectedAllowed: true,
+		},
+		{
+			name:            "unsupported operation failed",
+			operation:       admissionv1.Operation("UNKNOWN"),
+			expectedAllowed: false,
+			expectedError:   "unsupported webhook operation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupCrdClient(t, tc.objects...)
+
+			raw := tc.raw
+			if raw == nil && tc.rule != nil {
+				var err error
+				raw, err = json.Marshal(tc.rule)
+				assert.NoError(t, err)
+			}
+
+			admissionResp := admitRule(admissionv1.AdmissionReview{
+				Request: &admissionv1.AdmissionRequest{
+					Operation: tc.operation,
+					Object: runtime.RawExtension{
+						Raw: raw,
+					},
+				},
+			})
+
+			assert.Equal(t, tc.expectedAllowed, admissionResp.Allowed)
+			if tc.expectedAllowed {
+				return
+			}
+			if assert.NotNil(t, admissionResp.Result) && tc.expectedError != "" {
+				assert.Contains(t, admissionResp.Result.Message, tc.expectedError)
+			}
+		})
+	}
+}
+
+// TestAdmitRuleUpdateIsValidated guards the operation dispatch itself: an update carrying an
+// invalid rule must fail validation rather than be rejected as an unsupported operation.
+func TestAdmitRuleUpdateIsValidated(t *testing.T) {
+	setupCrdClient(t, newRuleEndpoint("rest-test", rulesv1.RuleEndpointTypeRest))
+
+	rule := newRestSourceRule("rule-test", "/a/b")
+	rule.Spec.SourceResource = map[string]string{}
+	raw, err := json.Marshal(rule)
+	assert.NoError(t, err)
+
+	admissionResp := admitRule(admissionv1.AdmissionReview{
+		Request: &admissionv1.AdmissionRequest{
+			Operation: admissionv1.Update,
+			Object: runtime.RawExtension{
+				Raw: raw,
+			},
+		},
+	})
+
+	assert.False(t, admissionResp.Allowed)
+	assert.NotNil(t, admissionResp.Result)
+	assert.Contains(t, admissionResp.Result.Message, "\"path\" property missed in sourceResource")
+}

--- a/cloud/pkg/admissioncontroller/admit_ruleendpoint.go
+++ b/cloud/pkg/admissioncontroller/admit_ruleendpoint.go
@@ -14,7 +14,7 @@ import (
 func admitRuleEndpoint(review admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 	reviewResponse := admissionv1.AdmissionResponse{}
 	switch review.Request.Operation {
-	case admissionv1.Create:
+	case admissionv1.Create, admissionv1.Update:
 		raw := review.Request.Object.Raw
 		ruleEndpoint := rulesv1.RuleEndpoint{}
 		deserializer := codecs.UniversalDeserializer()

--- a/cloud/pkg/admissioncontroller/admit_ruleendpoint_test.go
+++ b/cloud/pkg/admissioncontroller/admit_ruleendpoint_test.go
@@ -163,17 +163,74 @@ func Test_admitRuleEndpoint(t *testing.T) {
 		}
 	})
 
-	t.Run("update ruleEndpoint failed", func(t *testing.T) {
+	t.Run("update servicebus ruleEndpoint successful", func(t *testing.T) {
+		ruleEndpoint := rulesv1.RuleEndpoint{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "RuleEndpoint",
+				APIVersion: "rules.kubeedge.io/v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "servicebus-test",
+				Namespace: "test",
+				Labels:    map[string]string{"updated": "true"},
+			},
+			Spec: rulesv1.RuleEndpointSpec{
+				RuleEndpointType: rulesv1.RuleEndpointTypeServiceBus,
+				Properties: map[string]string{
+					"service_port": "9001",
+				},
+			},
+		}
+		jsonData, _ := json.Marshal(ruleEndpoint)
 		admissionReview := admissionv1.AdmissionReview{
 			Request: &admissionv1.AdmissionRequest{
 				Operation: admissionv1.Update,
 				Name:      "servicebus-test",
+				Object: runtime.RawExtension{
+					Raw:    jsonData,
+					Object: nil,
+				},
+			},
+			Response: nil,
+		}
+		admissionResp := admitRuleEndpoint(admissionReview)
+		if admissionResp.Allowed != true {
+			t.Fatalf("update servicebus ruleEndpoint error:%v", admissionResp.Result.Message)
+		}
+	})
+
+	t.Run("service_port not in range 1-65535,update servicebus ruleEndpoint failed", func(t *testing.T) {
+		ruleEndpoint := rulesv1.RuleEndpoint{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "RuleEndpoint",
+				APIVersion: "rules.kubeedge.io/v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "servicebus-test",
+				Namespace: "test",
+			},
+			Spec: rulesv1.RuleEndpointSpec{
+				RuleEndpointType: rulesv1.RuleEndpointTypeServiceBus,
+				Properties: map[string]string{
+					"service_port": "69999",
+				},
+			},
+		}
+		jsonData, _ := json.Marshal(ruleEndpoint)
+		admissionReview := admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				Name:      "servicebus-test",
+				Object: runtime.RawExtension{
+					Raw:    jsonData,
+					Object: nil,
+				},
 			},
 			Response: nil,
 		}
 		admissionResp := admitRuleEndpoint(admissionReview)
 		if admissionResp.Allowed == true {
-			t.Fatalf("update ruleEndpoint should not success")
+			t.Fatalf("update servicebus ruleEndpoint should not success")
 		}
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

The `rules` and `ruleendpoints` validating webhooks are registered for CREATE,
UPDATE and DELETE with `FailurePolicy: Fail` (`admission.go:226-231`, `:254-259`),
but `admitRule` and `admitRuleEndpoint` only handled CREATE and DELETE/CONNECT.
Every UPDATE fell through to the default branch, which returns
`toAdmissionResponse` (`common.go:115`) and leaves `Allowed` false, so the API
server rejected the request. `admitDevice` and `admitDeviceModel` already use
`case admissionv1.Create, admissionv1.Update:`; these two handlers were the only
ones that omitted Update.

This blocks a repeat `kubectl apply`, a `kubectl edit`, and any label or
annotation change on an existing Rule or RuleEndpoint.

It also blocks the router's own status writes. The Rule CRD has no `status`
subresource, so `updateRuleStatus` patches the `rules` resource itself
(`cloud/pkg/edgecontroller/controller/upstream.go:392`), which the API server
presents to the webhook as an UPDATE. The webhook denies it and the error is
only logged at `:394`, so `rule.status.successMessages` / `failMessages` /
`errors` never advance on a cluster running the admission webhook.

Note that adding UPDATE to the switch is not sufficient on its own for rules.
`validateSourceRuleEndpoint` scans the existing rules of the namespace for a
source-property conflict, and on an update that list contains the stored copy of
the rule being updated, which always matches its own `path` (or `topic` +
`node_name`). Updates would still be denied, with a misleading "source properties
exist in Rule" message. This PR skips the rule being validated so only other
rules can conflict with it.

`AdmissionController.CrdClient` is now held as `versioned.Interface` rather than
`*versioned.Clientset`, matching how `cloud/pkg/taskmanager/v1alpha1/util/controller`
already holds it, so the handlers can be tested against the generated fake
clientset.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7173 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed the Rule and RuleEndpoint validating webhooks rejecting every update, which blocked `kubectl apply`/`kubectl edit` on existing objects and prevented the router from recording rule delivery status.
```
