### PR TITLE
Align Go version to 1.23.x across CI workflows

### DIFF
--- a/.github/workflows/cilium-e2e.yml
+++ b/.github/workflows/cilium-e2e.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "^1.23.x"
+          go-version: 1.23.x
       - run: go version
       # Runs a set of commands to initialize and analyze with FOSSA
       - name: run FOSSA analysis


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
The cilium-e2e and fossa workflows pin Go versions that differ from the rest of CI. cilium-e2e uses 1.22.x and fossa uses "^1.23.x", while go.mod declares go 1.23.12 and every other workflow uses 1.23.x. This aligns both to 1.23.x for consistency.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
CI-only change, no product code affected.

```release-note
NONE
```
