### PR TITLE
testtools: skip gomonkey tests cleanly when inlining is not disabled

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/node/checknode_test.go
@@ -38,9 +38,11 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
+	"github.com/kubeedge/kubeedge/hack/testtools"
 )
 
 func TestCheckNode(t *testing.T) {
+	testtools.RequireNoInline(t)
 	tests := []struct {
 		name           string
 		nodeName       string
@@ -112,6 +114,7 @@ func TestCheckNode_EmptyNodeName(t *testing.T) {
 }
 
 func TestCheckNode_InternalServerError(t *testing.T) {
+	testtools.RequireNoInline(t)
 	fakeClient := fake.NewSimpleClientset()
 	fakeClient.Fake.PrependReactor("get", "nodes",
 		func(action k8stesting.Action) (bool, runtime.Object, error) {

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -471,9 +471,9 @@ kubeedge::golang::run_test() {
 
   local profile=${PROFILE:-""}
   if [[ $profile ]]; then
-    go test -gcflags "all=-N -l" "-coverprofile=${profile}" ${testdirs[@]}
+    KUBEEDGE_TEST_NOINLINE=1 go test -gcflags "all=-N -l" "-coverprofile=${profile}" ${testdirs[@]}
   else
-    go test -gcflags "all=-N -l" ${testdirs[@]}
+    KUBEEDGE_TEST_NOINLINE=1 go test -gcflags "all=-N -l" ${testdirs[@]}
   fi
 }
 

--- a/hack/testtools/noinline.go
+++ b/hack/testtools/noinline.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testtools provides small test-only helpers shared across
+// KubeEdge's cloud and edge test suites.
+package testtools
+
+import (
+	"os"
+	"testing"
+)
+
+// EnvNoInline is the environment variable set by `make test` (via
+// hack/lib/golang.sh) to signal that the test binary is being built and
+// run with inlining disabled (`-gcflags "all=-N -l"`).
+const EnvNoInline = "KUBEEDGE_TEST_NOINLINE"
+
+// RequireNoInline skips the current test unless it detects that inlining
+// optimizations are disabled for this test run.
+//
+// Many tests in cloud/pkg and edge/pkg use gomonkey to patch package-level
+// functions. gomonkey works by overwriting the target function's compiled
+// machine code, which requires the target to not be inlined at its call
+// sites. When such tests are run without `-gcflags=all=-l` (e.g. via a
+// plain `go test ./...`, `gotestsum`, or an IDE's built-in test runner),
+// the compiler may inline the patched function, and gomonkey's patch can
+// corrupt unrelated code, crashing the whole test process with a SIGSEGV
+// instead of failing the individual test.
+//
+// Call RequireNoInline at the start of any gomonkey-based test, before
+// applying any patches, so unsupported test runs fail cleanly with an
+// actionable skip message instead of crashing.
+func RequireNoInline(t *testing.T) {
+	t.Helper()
+	if os.Getenv(EnvNoInline) != "1" {
+		t.Skip("skipping gomonkey-based test: inlining is not confirmed disabled for this run; " +
+			"run with 'make test' or 'go test -gcflags=all=-l ...' (gomonkey requires non-inlined targets, see hack/testtools/noinline.go)")
+	}
+}

--- a/hack/testtools/noinline_test.go
+++ b/hack/testtools/noinline_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testtools
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRequireNoInline_SkipsWhenEnvUnset(t *testing.T) {
+	old, had := os.LookupEnv(EnvNoInline)
+	os.Unsetenv(EnvNoInline)
+	defer func() {
+		if had {
+			os.Setenv(EnvNoInline, old)
+		}
+	}()
+
+	var sub *testing.T
+	t.Run("subtest", func(st *testing.T) {
+		sub = st
+		RequireNoInline(st)
+	})
+
+	if !sub.Skipped() {
+		t.Fatal("expected RequireNoInline to skip the test when KUBEEDGE_TEST_NOINLINE is unset")
+	}
+}
+
+func TestRequireNoInline_PassesWhenEnvSet(t *testing.T) {
+	old, had := os.LookupEnv(EnvNoInline)
+	os.Setenv(EnvNoInline, "1")
+	defer func() {
+		if had {
+			os.Setenv(EnvNoInline, old)
+		} else {
+			os.Unsetenv(EnvNoInline)
+		}
+	}()
+
+	RequireNoInline(t)
+
+	if t.Skipped() {
+		t.Fatal("expected RequireNoInline not to skip the test when KUBEEDGE_TEST_NOINLINE=1")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind feature
/kind test

**What this PR does / why we need it**:

Adds `hack/testtools.RequireNoInline`, a small test-only helper that gomonkey-based tests call before applying any patches. `gomonkey` patches package-level functions by overwriting compiled machine code, which requires inlining to be disabled (`-gcflags "all=-N -l"`, already passed by `make test`). Running such tests without that flag (plain `go test`, `gotestsum`, IDE test runners) can crash the whole test binary with a SIGSEGV instead of failing the individual test.

`RequireNoInline` checks a new `KUBEEDGE_TEST_NOINLINE` environment variable, which `hack/lib/golang.sh`'s `run_test` (used by `make test`) now exports, and skips the test with an actionable message if it is not set. Runs via `make test` are unaffected; unsupported runs now fail clean instead of crashing.

`checknode_test.go` is updated to use the helper as a reference example.

**Which issue(s) this PR fixes**:

Fixes #7181

**Special notes for your reviewer**:

Verified manually:
- `go test ./cloud/pkg/cloudhub/servers/httpserver/node/... -run TestCheckNode -v` (no gcflags, no env var) now skips the two gomonkey-based subtests with an explanatory message instead of crashing.
- `KUBEEDGE_TEST_NOINLINE=1 go test -gcflags "all=-N -l" ./cloud/pkg/cloudhub/servers/httpserver/node/...` (the `make test` path) runs and passes exactly as before.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
