### PR TITLE
smgr: add timeout for stream-type handshake

### DIFF
--- a/pkg/viaduct/pkg/smgr/session.go
+++ b/pkg/viaduct/pkg/smgr/session.go
@@ -2,12 +2,18 @@ package smgr
 
 import (
 	"io"
+	"time"
 
 	"github.com/lucas-clemente/quic-go"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
 )
+
+// DefaultStreamHandshakeTimeout bounds how long OpenStreamSync/AcceptStream
+// wait to write/read the stream-type handshake byte(s) on a new QUIC stream,
+// used when Session.HandshakeTimeout is unset.
+const DefaultStreamHandshakeTimeout = 5 * time.Second
 
 // wrapper for session manager
 type Stream struct {
@@ -19,6 +25,17 @@ type Stream struct {
 
 type Session struct {
 	Sess quic.Session
+	// HandshakeTimeout bounds the write/read deadline applied to the
+	// stream-type handshake performed by OpenStreamSync/AcceptStream.
+	// If zero, DefaultStreamHandshakeTimeout is used.
+	HandshakeTimeout time.Duration
+}
+
+func (s *Session) handshakeTimeout() time.Duration {
+	if s.HandshakeTimeout <= 0 {
+		return DefaultStreamHandshakeTimeout
+	}
+	return s.HandshakeTimeout
 }
 
 func (s *Session) OpenStreamSync(streamUse api.UseType) (*Stream, error) {
@@ -28,11 +45,16 @@ func (s *Session) OpenStreamSync(streamUse api.UseType) (*Stream, error) {
 		return nil, err
 	}
 
-	// TODO: add write timeout
+	if err := stream.SetWriteDeadline(time.Now().Add(s.handshakeTimeout())); err != nil {
+		klog.Warningf("failed to set write deadline for stream handshake, error: %+v", err)
+	}
 	_, err = stream.Write([]byte(streamUse))
 	if err != nil {
 		klog.Errorf("write stream type, error: %+v", err)
 		return nil, err
+	}
+	if err := stream.SetWriteDeadline(time.Time{}); err != nil {
+		klog.Warningf("failed to clear write deadline after stream handshake, error: %+v", err)
 	}
 
 	return &Stream{
@@ -48,12 +70,17 @@ func (s *Session) AcceptStream() (*Stream, error) {
 		return nil, err
 	}
 
-	// TODO: add read timeout
+	if err := stream.SetReadDeadline(time.Now().Add(s.handshakeTimeout())); err != nil {
+		klog.Warningf("failed to set read deadline for stream handshake, error: %+v", err)
+	}
 	typeBytes := make([]byte, api.UseLen)
 	_, err = io.ReadFull(stream, typeBytes)
 	if err != nil {
 		klog.Errorf("read stream type, error: %+v", err)
 		return nil, err
+	}
+	if err := stream.SetReadDeadline(time.Time{}); err != nil {
+		klog.Warningf("failed to clear read deadline after stream handshake, error: %+v", err)
 	}
 
 	klog.Infof("receive a stream(%s)", string(typeBytes))

--- a/pkg/viaduct/pkg/smgr/session_test.go
+++ b/pkg/viaduct/pkg/smgr/session_test.go
@@ -1,0 +1,59 @@
+package smgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeedge/kubeedge/pkg/viaduct/mocks"
+	"github.com/kubeedge/kubeedge/pkg/viaduct/pkg/api"
+)
+
+func TestOpenStreamSyncSetsAndClearsWriteDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSess := mocks.NewMockSession(ctrl)
+	mockStream := mocks.NewMockStream(ctrl)
+
+	mockSess.EXPECT().OpenStreamSync().Return(mockStream, nil)
+	mockStream.EXPECT().SetWriteDeadline(gomock.Not(time.Time{})).Return(nil)
+	mockStream.EXPECT().Write([]byte(api.UseTypeMessage)).Return(len(api.UseTypeMessage), nil)
+	mockStream.EXPECT().SetWriteDeadline(time.Time{}).Return(nil)
+
+	s := &Session{Sess: mockSess, HandshakeTimeout: 2 * time.Second}
+	stream, err := s.OpenStreamSync(api.UseTypeMessage)
+	assert.NoError(t, err)
+	assert.Equal(t, api.UseTypeMessage, stream.UseType)
+}
+
+func TestAcceptStreamSetsAndClearsReadDeadline(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockSess := mocks.NewMockSession(ctrl)
+	mockStream := mocks.NewMockStream(ctrl)
+
+	mockSess.EXPECT().AcceptStream().Return(mockStream, nil)
+	mockStream.EXPECT().SetReadDeadline(gomock.Not(time.Time{})).Return(nil)
+	mockStream.EXPECT().Read(gomock.Any()).DoAndReturn(func(p []byte) (int, error) {
+		copy(p, api.UseTypeMessage)
+		return len(api.UseTypeMessage), nil
+	})
+	mockStream.EXPECT().SetReadDeadline(time.Time{}).Return(nil)
+
+	s := &Session{Sess: mockSess}
+	stream, err := s.AcceptStream()
+	assert.NoError(t, err)
+	assert.Equal(t, api.UseTypeMessage, stream.UseType)
+}
+
+func TestHandshakeTimeoutDefault(t *testing.T) {
+	s := &Session{}
+	assert.Equal(t, DefaultStreamHandshakeTimeout, s.handshakeTimeout())
+
+	s.HandshakeTimeout = 10 * time.Second
+	assert.Equal(t, 10*time.Second, s.handshakeTimeout())
+}

--- a/pkg/viaduct/pkg/smgr/smgr.go
+++ b/pkg/viaduct/pkg/smgr/smgr.go
@@ -203,7 +203,7 @@ func NewStreamManager(streamMax int, autoFree bool, session quic.Session) *Strea
 
 	streamMgr := &StreamManager{
 		NumStreamsMax: streamMax,
-		Session:       &Session{session},
+		Session:       &Session{Sess: session},
 		messagePool: PoolManager{
 			idlePool: streamPool{
 				streamMap: make(map[quic.StreamID]*Stream),


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`smgr.Session.OpenStreamSync`/`AcceptStream` had two long-standing TODOs (`add write timeout`, `add read timeout`) around the stream-type handshake performed on every new QUIC stream between CloudHub and EdgeHub. Neither call bounded how long it waits to write/read the handshake bytes, so a stalled peer could block the caller indefinitely.

This adds a `HandshakeTimeout time.Duration` field to `smgr.Session` (defaulting to 5s via `DefaultStreamHandshakeTimeout` when unset), and applies `SetWriteDeadline`/`SetReadDeadline` around the handshake write/read in `OpenStreamSync`/`AcceptStream`, clearing the deadline afterwards so it doesn't affect the stream's subsequent use as a message/raw-data channel.

Threading this timeout through CloudHub/EdgeHub's external YAML config schema is a larger, separate change that needs maintainer input on the desired config surface, so it is left out of this PR's scope.

**Which issue(s) this PR fixes**:
Fixes #7183

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**:
```release-note

```
