### PR TITLE
fix nil pointer dereference panic in synccontroller when sending events

### DIFF
--- a/cloud/pkg/synccontroller/clusterobjectsync.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync.go
@@ -125,7 +125,8 @@ func sendClusterObjectSyncEvent(nodeName string, sync *v1alpha1.ClusterObjectSyn
 	if compareResourceVersionFunc(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
 		// trigger the update event
 		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
-		msg := buildEdgeControllerMessageFunc(nodeName, models.NullNamespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
-		sendToEdge(commonconst.DefaultContextSendModuleName, *msg)
+		if msg := buildEdgeControllerMessageFunc(nodeName, models.NullNamespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj); msg != nil {
+			sendToEdge(commonconst.DefaultContextSendModuleName, *msg)
+		}
 	}
 }

--- a/cloud/pkg/synccontroller/clusterobjectsync_test.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/informers"
 )
 
+const testNodeName = "node1"
+
 type testFuncBackup struct {
 	originalSendToEdge                     func(string, model.Message)
 	originalBuildEdgeControllerMessageFunc func(string, string, string, string, string, interface{}) *model.Message
@@ -77,7 +79,7 @@ func (b *testFuncBackup) restore() {
 }
 
 func mockGetNodeName(syncName string) string {
-	return "node1"
+	return testNodeName
 }
 
 func mockGetObjectUID(syncName string) string {
@@ -417,7 +419,7 @@ func TestSendClusterObjectSyncEventDirect(t *testing.T) {
 			return &model.Message{}
 		}
 
-		nodeName := "node1"
+		nodeName := testNodeName
 		resourceType := "pod"
 		objectResourceVersion := "1000"
 		obj := createTestPod("test-pod", "12345", "1000")
@@ -436,7 +438,7 @@ func TestSendClusterObjectSyncEventDirect(t *testing.T) {
 			return nil
 		}
 
-		nodeName := "node1"
+		nodeName := testNodeName
 		resourceType := "pod"
 		objectResourceVersion := "1000"
 		obj := createTestPod("test-pod", "12345", "1000")
@@ -553,7 +555,7 @@ func TestGcOrphanedClusterObjectSyncFuncIntegration(t *testing.T) {
 			deleteCalled := false
 
 			buildEdgeControllerMessageFunc = func(nodeID, namespace, resource, resourceID string, operation string, content interface{}) *model.Message {
-				assert.Equal(t, "node1", nodeID)
+				assert.Equal(t, testNodeName, nodeID)
 				assert.Equal(t, "pod", resource)
 				assert.Equal(t, "test-pod", resourceID)
 

--- a/cloud/pkg/synccontroller/clusterobjectsync_test.go
+++ b/cloud/pkg/synccontroller/clusterobjectsync_test.go
@@ -408,25 +408,45 @@ func TestSendClusterObjectSyncEventDirect(t *testing.T) {
 		return 0
 	}
 
-	sendCalled := false
+	t.Run("Send message when buildEdgeControllerMessageFunc returns valid message", func(t *testing.T) {
+		sendCalled := false
+		sendToEdge = func(module string, msg model.Message) {
+			sendCalled = true
+		}
+		buildEdgeControllerMessageFunc = func(nodeID, namespace, resource, resourceID string, operation string, content interface{}) *model.Message {
+			return &model.Message{}
+		}
 
-	sendToEdge = func(module string, msg model.Message) {
-		sendCalled = true
-	}
+		nodeName := "node1"
+		resourceType := "pod"
+		objectResourceVersion := "1000"
+		obj := createTestPod("test-pod", "12345", "1000")
+		sync := createTestSync("node1-pod-12345", "test-pod", "Pod", "v1", "500")
 
-	buildEdgeControllerMessageFunc = func(nodeID, namespace, resource, resourceID string, operation string, content interface{}) *model.Message {
-		return &model.Message{}
-	}
+		sendClusterObjectSyncEvent(nodeName, sync, resourceType, objectResourceVersion, obj)
+		assert.True(t, sendCalled, "Send should have been called")
+	})
 
-	nodeName := "node1"
-	resourceType := "pod"
-	objectResourceVersion := "1000"
-	obj := createTestPod("test-pod", "12345", "1000")
-	sync := createTestSync("node1-pod-12345", "test-pod", "Pod", "v1", "500")
+	t.Run("Do not send message and do not panic when buildEdgeControllerMessageFunc returns nil", func(t *testing.T) {
+		sendCalled := false
+		sendToEdge = func(module string, msg model.Message) {
+			sendCalled = true
+		}
+		buildEdgeControllerMessageFunc = func(nodeID, namespace, resource, resourceID string, operation string, content interface{}) *model.Message {
+			return nil
+		}
 
-	sendClusterObjectSyncEvent(nodeName, sync, resourceType, objectResourceVersion, obj)
+		nodeName := "node1"
+		resourceType := "pod"
+		objectResourceVersion := "1000"
+		obj := createTestPod("test-pod", "12345", "1000")
+		sync := createTestSync("node1-pod-12345", "test-pod", "Pod", "v1", "500")
 
-	assert.True(t, sendCalled, "Send should have been called")
+		assert.NotPanics(t, func() {
+			sendClusterObjectSyncEvent(nodeName, sync, resourceType, objectResourceVersion, obj)
+		})
+		assert.False(t, sendCalled, "Send should not have been called")
+	})
 }
 
 func TestDeleteClusterObjectSyncFunc(t *testing.T) {

--- a/cloud/pkg/synccontroller/objectsync.go
+++ b/cloud/pkg/synccontroller/objectsync.go
@@ -97,8 +97,9 @@ func sendEvents(nodeName string, sync *v1alpha1.ObjectSync, resourceType string,
 	if CompareResourceVersion(objectResourceVersion, sync.Status.ObjectResourceVersion) > 0 {
 		// trigger the update event
 		klog.V(4).Infof("The resourceVersion: %s of %s in K8s is greater than in edgenode: %s, send the update event", objectResourceVersion, resourceType, sync.Status.ObjectResourceVersion)
-		msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj)
-		beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
+		if msg := buildEdgeControllerMessage(nodeName, sync.Namespace, resourceType, sync.Spec.ObjectName, model.UpdateOperation, obj); msg != nil {
+			beehiveContext.Send(commonconst.DefaultContextSendModuleName, *msg)
+		}
 	}
 }
 

--- a/cloud/pkg/synccontroller/objectsync_test.go
+++ b/cloud/pkg/synccontroller/objectsync_test.go
@@ -148,13 +148,23 @@ func TestGCOrphanedObjectSync(t *testing.T) {
 func TestSendEvents(t *testing.T) {
 	tests := []struct {
 		name              string
+		nodeName          string
 		ExpectedOperation string
+		expectMsg         bool
 		ObjectSyncs       *v1alpha1.ObjectSync
 	}{
 		{
 			name:              "test sendEvents",
-			ObjectSyncs:       tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
+			nodeName:          tf.TestNodeID,
 			ExpectedOperation: model.UpdateOperation,
+			expectMsg:         true,
+			ObjectSyncs:       tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
+		},
+		{
+			name:        "test sendEvents when buildEdgeControllerMessage fails (nil msg)",
+			nodeName:    "",
+			expectMsg:   false,
+			ObjectSyncs: tf.NewObjectSync(tf.NewTestPodResource(tf.TestPodName, tf.TestPodUID, "1"), "Pod"),
 		},
 	}
 	cloudHub := &common.ModuleInfo{
@@ -167,10 +177,14 @@ func TestSendEvents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmp := tt.ObjectSyncs.DeepCopy()
-			go sendEvents(tf.TestNodeID, tt.ObjectSyncs, "pod", "2", tmp)
-			message, _ := beehiveContext.Receive(modules.CloudHubModuleName)
-			if !reflect.DeepEqual(message.GetOperation(), tt.ExpectedOperation) {
-				t.Errorf("sendEvents() = %v, want %v", message.GetResource(), tt.ExpectedOperation)
+			if tt.expectMsg {
+				go sendEvents(tt.nodeName, tt.ObjectSyncs, "pod", "2", tmp)
+				message, _ := beehiveContext.Receive(modules.CloudHubModuleName)
+				if !reflect.DeepEqual(message.GetOperation(), tt.ExpectedOperation) {
+					t.Errorf("sendEvents() = %v, want %v", message.GetResource(), tt.ExpectedOperation)
+				}
+			} else {
+				sendEvents(tt.nodeName, tt.ObjectSyncs, "pod", "2", tmp)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a fatal `nil pointer dereference` panic in `cloudcore`'s `synccontroller` when generating update events for `ObjectSync` and `ClusterObjectSync` resources.

#### Root Cause
`buildEdgeControllerMessage` returns `nil` when `messagelayer.BuildResource` fails (e.g. invalid node name or malformed resource). In `sendEvents` ([objectsync.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/kubeedge/cloud/pkg/synccontroller/objectsync.go)) and `sendClusterObjectSyncEvent` ([clusterobjectsync.go](file:///c:/Users/Vishal/Code_File/Repo%20Folder/kubeedge/cloud/pkg/synccontroller/clusterobjectsync.go)), `*msg` was unconditionally dereferenced when passed to `beehiveContext.Send(...)` or `sendToEdge(...)`, causing `cloudcore` to panic and continuously crash.

#### Changes
- Added a `nil` check (`if msg := buildEdgeControllerMessage(...); msg != nil`) in `sendEvents` before sending the update event message.
- Added a `nil` check (`if msg := buildEdgeControllerMessageFunc(...); msg != nil`) in `sendClusterObjectSyncEvent` before sending the update event message.
- Added unit test cases in `objectsync_test.go` and `clusterobjectsync_test.go` to verify that `nil` messages do not trigger panics and are safely ignored.

**Which issue(s) this PR fixes**:

Fixes #7175

**Special notes for your reviewer**:

All unit tests in `cloud/pkg/synccontroller` pass cleanly (`go test -v ./cloud/pkg/synccontroller/...`).

**Does this PR introduce a user-facing change?**:

```release-note
NONE
