### PR TITLE
Fix Return error feedback when processVolume SendSync fails

### DIFF
--- a/edge/pkg/metamanager/metamanager_test.go
+++ b/edge/pkg/metamanager/metamanager_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeedge/beehive/pkg/common"
 	"github.com/kubeedge/beehive/pkg/core"
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
+	"github.com/kubeedge/beehive/pkg/core/model"
 	commodule "github.com/kubeedge/kubeedge/edge/pkg/common/modules"
 )
 
@@ -59,4 +60,15 @@ func TestNameAndGroup(t *testing.T) {
 			t.Errorf("Group of module is not correct wanted: %v and got: %v", commodule.MetaGroup, metaModule.Group())
 		}
 	})
+}
+
+func TestProcessVolume_Error(t *testing.T) {
+	m := &metaManager{}
+	msg := model.NewMessage("")
+	msg.BuildHeader("msg-id", "", 0)
+	msg.BuildRouter("cloud", "group", "resource", "operation")
+
+	// Call processVolume; edged module is not running, so SendSync returns an error.
+	// We verify that processVolume handles the error cleanly without panic.
+	m.processVolume(*msg)
 }

--- a/edge/pkg/metamanager/process.go
+++ b/edge/pkg/metamanager/process.go
@@ -424,6 +424,8 @@ func (m *metaManager) processVolume(message model.Message) {
 	klog.Infof("process volume get: req[%+v], back[%+v], err[%+v]", message, back, err)
 	if err != nil {
 		klog.Errorf("process volume send to edged failed: %v", err)
+		feedbackError(fmt.Errorf("failed to process volume: %s", err), message)
+		return
 	}
 
 	resp := message.NewRespByMessage(&message, back.GetContent())


### PR DESCRIPTION

### What this PR does / why we need it:
In `edge/pkg/metamanager/process.go`, when `processVolume` dispatches CSI volume operations (CreateVolume / DeleteVolume / ControllerPublishVolume / ControllerUnpublishVolume) to `edged` via `beehiveContext.SendSync()`, a `SendSync` error (such as a timeout or module channel unavailability) was logged, but the function did not return early.

Instead, it fell through to create a response message using `back.GetContent()`, where `back` was a zero-value `model.Message` (with `Content == nil`). This caused a false "success" response with `nil` content to be sent to CloudHub and the CSI driver, leading to potential state inconsistency.

This PR fixes the issue by propagating the error via `feedbackError` and returning early when `SendSync` returns an error.

### Which issue(s) this PR fixes:
Fixes #7186

### Special notes for your reviewer:
- Early error feedback pattern aligns with existing handlers in `process.go` (`processRemote`, `processQuery`, etc.).

### Does this PR introduce a user-facing change?:
```release-note
NONE
```

### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
