### PR TITLE
fix(keadm): mitigate tar-bomb disk exhaustion in DecompressTarGz

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -224,7 +224,26 @@ func GetCurrentVersion(version string) (string, error) {
 	return GetCurrentVersion(remoteVersion)
 }
 
+// maxExtractedFileSize is the maximum number of bytes allowed for a single
+// entry extracted from a tar archive, to guard against decompression bombs.
+// 512 MiB is far larger than any individual file in a KubeEdge release tarball.
+const maxExtractedFileSize int64 = 512 * 1024 * 1024 // 512 MiB
+
+// maxTotalExtractedSize is the maximum cumulative number of bytes allowed
+// across all entries extracted from a tar archive.
+// 1 GiB is far larger than any KubeEdge release tarball.
+const maxTotalExtractedSize int64 = 1024 * 1024 * 1024 // 1 GiB
+
+// DecompressTarGz extracts a gzip-compressed tar archive to dest.
+// It is hardened against both path traversal and decompression bombs (tar bombs).
 func DecompressTarGz(gzFilePath, dest string) error {
+	return decompressTarGzWithLimits(gzFilePath, dest, maxExtractedFileSize, maxTotalExtractedSize)
+}
+
+// decompressTarGzWithLimits is the testable inner implementation of DecompressTarGz.
+// maxFileSize caps the bytes extracted from any single tar entry.
+// maxTotalSize caps the total bytes extracted across all entries.
+func decompressTarGzWithLimits(gzFilePath, dest string, maxFileSize, maxTotalSize int64) error {
 	reader, err := os.Open(gzFilePath)
 	if err != nil {
 		return err
@@ -249,6 +268,7 @@ func DecompressTarGz(gzFilePath, dest string) error {
 
 	tr := tar.NewReader(archive)
 
+	var totalExtracted int64
 	for {
 		header, err := tr.Next()
 		switch {
@@ -289,11 +309,24 @@ func DecompressTarGz(gzFilePath, dest string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(writer, tr); err != nil {
-				writer.Close() // Close the file explicitly here in case of an error
+			// Guard against decompression bombs: limit the bytes read from each
+			// tar entry. io.LimitReader returns io.EOF after maxFileSize bytes,
+			// so n == maxFileSize means the entry may have been truncated.
+			n, err := io.Copy(writer, io.LimitReader(tr, maxFileSize))
+			closeErr := writer.Close()
+			if err != nil {
 				return err
 			}
-			writer.Close() // Close the file explicitly after successful write
+			if closeErr != nil {
+				return closeErr
+			}
+			if n >= maxFileSize {
+				return fmt.Errorf("tar entry %q exceeds maximum allowed size of %d bytes", header.Name, maxFileSize)
+			}
+			totalExtracted += n
+			if totalExtracted > maxTotalSize {
+				return fmt.Errorf("tar archive total extracted size exceeds maximum allowed size of %d bytes", maxTotalSize)
+			}
 		}
 	}
 }

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -1057,3 +1058,129 @@ func TestDecompressTarGzRejectsPathTraversal(t *testing.T) {
 		})
 	}
 }
+
+// createTestTarGzFromReader builds a .tar.gz archive containing a single regular
+// file entry whose content is streamed from r. size must equal the number of bytes
+// that r will produce so that the tar header is written correctly.
+func createTestTarGzFromReader(t *testing.T, entryName string, r io.Reader, size int64) string {
+	t.Helper()
+
+	archivePath := filepath.Join(t.TempDir(), "bomb.tar.gz")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("failed to create test archive: %v", err)
+	}
+
+	gzWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	hdr := &tar.Header{
+		Name:     entryName,
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+		Size:     size,
+	}
+	if err := tarWriter.WriteHeader(hdr); err != nil {
+		t.Fatalf("failed to write tar header: %v", err)
+	}
+	if _, err := io.Copy(tarWriter, r); err != nil {
+		t.Fatalf("failed to write tar body: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close archive file: %v", err)
+	}
+	return archivePath
+}
+
+// zeroReader is an io.Reader that produces n zero bytes.
+type zeroReader struct{ remaining int64 }
+
+func (z *zeroReader) Read(p []byte) (int, error) {
+	if z.remaining <= 0 {
+		return 0, io.EOF
+	}
+	n := int64(len(p))
+	if n > z.remaining {
+		n = z.remaining
+	}
+	for i := int64(0); i < n; i++ {
+		p[i] = 0
+	}
+	z.remaining -= n
+	return int(n), nil
+}
+
+// TestDecompressTarGzRejectsTarBomb_SingleEntry verifies that a single tar entry
+// whose uncompressed size meets or exceeds the per-entry limit is rejected.
+// We use tiny limits (1 KiB per-entry, 2 KiB cumulative) so the test runs
+// instantly without writing large amounts of data to disk.
+func TestDecompressTarGzRejectsTarBomb_SingleEntry(t *testing.T) {
+	const testMaxFile int64 = 1024        // 1 KiB per-entry limit for testing
+	const testMaxTotal int64 = 2 * 1024   // 2 KiB cumulative limit for testing
+	const entrySize int64 = testMaxFile   // exactly at the limit — io.LimitReader stops here
+
+	dest := filepath.Join(t.TempDir(), "extract")
+	archivePath := createTestTarGzFromReader(t, "bigfile.bin", &zeroReader{remaining: entrySize}, entrySize)
+
+	err := decompressTarGzWithLimits(archivePath, dest, testMaxFile, testMaxTotal)
+	assert.Error(t, err, "expected error when a single entry equals the per-entry size limit")
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}
+
+// TestDecompressTarGzRejectsTarBomb_Cumulative verifies that multiple entries
+// whose individual sizes are within the per-entry limit, but whose cumulative
+// total exceeds the archive-wide limit, are rejected.
+func TestDecompressTarGzRejectsTarBomb_Cumulative(t *testing.T) {
+	const testMaxFile int64 = 1024      // 1 KiB per-entry limit for testing
+	const testMaxTotal int64 = 2 * 1024 // 2 KiB cumulative limit for testing
+
+	// Build an archive with three entries of 800 bytes each.
+	// Each entry is within the 1 KiB per-entry limit, but together (2400 bytes)
+	// they exceed the 2 KiB cumulative limit.
+	dest := filepath.Join(t.TempDir(), "extract")
+
+	archivePath := filepath.Join(t.TempDir(), "multi.tar.gz")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("failed to create test archive: %v", err)
+	}
+	gzWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	const entryPayload = 800
+	entryNames := []string{"a.bin", "b.bin", "c.bin"}
+	for _, name := range entryNames {
+		hdr := &tar.Header{
+			Name:     name,
+			Mode:     0644,
+			Typeflag: tar.TypeReg,
+			Size:     entryPayload,
+		}
+		if err := tarWriter.WriteHeader(hdr); err != nil {
+			t.Fatalf("failed to write tar header: %v", err)
+		}
+		if _, err := io.Copy(tarWriter, &zeroReader{remaining: entryPayload}); err != nil {
+			t.Fatalf("failed to write tar body: %v", err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close archive file: %v", err)
+	}
+
+	err = decompressTarGzWithLimits(archivePath, dest, testMaxFile, testMaxTotal)
+	assert.Error(t, err, "expected error when cumulative extracted size exceeds the total limit")
+	assert.Contains(t, err.Error(), "total extracted size exceeds maximum allowed size")
+}
+


### PR DESCRIPTION

**What this PR does / why we need it**:

### Context
In `keadm/cmd/keadm/app/cmd/util/common.go`, the `DecompressTarGz` function (used to unpack release archives during `keadm upgrade`) was previously hardened against path traversal attacks. However, it still contained an unbounded `io.Copy` call. This left it vulnerable to a "tar-bomb" (decompression bomb) attack, where a maliciously crafted archive (e.g., highly compressed zeroes) could exhaust all disk space on the edge node, causing a denial of service.

### Changes
This PR mitigates the vulnerability by adding a two-layer size guard to `DecompressTarGz`:
1.  **Per-entry limit:** Uses `io.LimitReader` to restrict any single extracted file to 512 MiB (`maxExtractedFileSize`).
2.  **Cumulative limit:** Tracks total bytes extracted across all entries and caps the entire archive at 1 GiB (`maxTotalExtractedSize`).

To ensure testability without requiring gigabytes of test data, `DecompressTarGz` was refactored to wrap a testable inner function (`decompressTarGzWithLimits`). This allows unit tests to exercise the limits using tiny mock constraints (e.g., 1 KiB).

### Verification
- [x] Verified existing path traversal guards are intact.
- [x] Added `TestDecompressTarGzRejectsTarBomb_SingleEntry` to ensure single massive entries are blocked.
- [x] Added `TestDecompressTarGzRejectsTarBomb_Cumulative` to ensure many small files collectively exceeding the total limit are blocked.
- [x] All tests in `cmd/util` pass (`go test -v -run TestDecompressTarGz ./...`).

**Which issue(s) this PR fixes**:
Fixes #7203

**Special notes for your reviewer**:
The limits chosen (512 MiB per entry, 1 GiB total) are intentionally generous to accommodate any foreseeable KubeEdge release binaries, while still firmly preventing unbounded disk exhaustion. Similar `io.LimitReader` usage is already established in `GetLatestVersion` in the same file.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a security vulnerability in `keadm` where a maliciously crafted `.tar.gz` release archive could cause disk exhaustion (decompression bomb) during edge node upgrades.
```
