### PR TITLE
[Security] Add rate limiting to CloudHub HTTP endpoints

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/ratelimiter.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/ratelimiter.go
@@ -1,0 +1,88 @@
+package httpserver
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/emicklei/go-restful"
+	"golang.org/x/time/rate"
+	"k8s.io/klog/v2"
+
+	hubconfig "github.com/kubeedge/kubeedge/cloud/pkg/cloudhub/config"
+)
+
+type IPRateLimiter struct {
+	ips   map[string]*rate.Limiter
+	mu    sync.RWMutex
+	qps   rate.Limit
+	burst int
+}
+
+func NewIPRateLimiter(qps rate.Limit, burst int) *IPRateLimiter {
+	i := &IPRateLimiter{
+		ips:   make(map[string]*rate.Limiter),
+		qps:   qps,
+		burst: burst,
+	}
+
+	// Simple cleanup routine to prevent memory leaks from old IPs
+	go func() {
+		for {
+			time.Sleep(1 * time.Hour)
+			i.mu.Lock()
+			i.ips = make(map[string]*rate.Limiter)
+			i.mu.Unlock()
+		}
+	}()
+
+	return i
+}
+
+func (i *IPRateLimiter) GetLimiter(ip string) *rate.Limiter {
+	i.mu.RLock()
+	limiter, exists := i.ips[ip]
+	i.mu.RUnlock()
+
+	if !exists {
+		i.mu.Lock()
+		defer i.mu.Unlock()
+		limiter, exists = i.ips[ip]
+		if !exists {
+			limiter = rate.NewLimiter(i.qps, i.burst)
+			i.ips[ip] = limiter
+		}
+	}
+
+	return limiter
+}
+
+var ipRateLimiter *IPRateLimiter
+var initOnce sync.Once
+
+func rateLimitFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	initOnce.Do(func() {
+		qps := 100
+		burst := 200
+		if hubconfig.Config.HTTPS != nil && hubconfig.Config.HTTPS.RateLimit != nil {
+			qps = int(hubconfig.Config.HTTPS.RateLimit.QPS)
+			burst = int(hubconfig.Config.HTTPS.RateLimit.Burst)
+		}
+		ipRateLimiter = NewIPRateLimiter(rate.Limit(qps), burst)
+	})
+
+	ip := req.Request.RemoteAddr
+	if colon := strings.LastIndex(ip, ":"); colon != -1 {
+		ip = ip[:colon]
+	}
+
+	limiter := ipRateLimiter.GetLimiter(ip)
+	if !limiter.Allow() {
+		klog.Warningf("Rate limit exceeded for IP: %s", ip)
+		_ = resp.WriteErrorString(http.StatusTooManyRequests, "Too Many Requests")
+		return
+	}
+
+	chain.ProcessFilter(req, resp)
+}

--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -59,6 +59,7 @@ func StartHTTPServer() error {
 func routes() *restful.WebService {
 	ws := new(restful.WebService)
 	ws.Path("/")
+	ws.Filter(rateLimitFilter)
 	ws.Route(ws.GET(constants.DefaultCertURL).To(certshandler.EdgeCoreClientCert))
 	ws.Route(ws.GET(constants.DefaultCAURL).To(certshandler.GetCA))
 	ws.Route(ws.GET(constants.DefaultCheckNodeURL).To(node.CheckNode))

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -79,6 +79,10 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 					Enable:  true,
 					Port:    10002,
 					Address: "0.0.0.0",
+					RateLimit: &HTTPSRateLimit{
+						QPS:   100,
+						Burst: 200,
+					},
 				},
 				Authorization: &CloudHubAuthorization{
 					Enable: false,
@@ -288,6 +292,10 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 					Enable:  true,
 					Port:    10002,
 					Address: "0.0.0.0",
+					RateLimit: &HTTPSRateLimit{
+						QPS:   100,
+						Burst: 200,
+					},
 				},
 			},
 			Router: &Router{

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -205,6 +205,18 @@ type CloudHubHTTPS struct {
 	// Port indicates the open port for HTTPS server
 	// default 10002
 	Port uint32 `json:"port,omitempty"`
+	// RateLimit indicates the rate limit config for the HTTPS server
+	RateLimit *HTTPSRateLimit `json:"rateLimit,omitempty"`
+}
+
+// HTTPSRateLimit indicates the rate limit config
+type HTTPSRateLimit struct {
+	// QPS indicates the maximum QPS to the HTTPS server
+	// default 100
+	QPS int32 `json:"qps,omitempty"`
+	// Burst indicates the maximum burst for the HTTPS server
+	// default 200
+	Burst int32 `json:"burst,omitempty"`
 }
 
 // CloudHubAuthorization CloudHub authz configurations


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The CloudHub HTTP server currently lacks rate limiting for endpoints like certificate signing and node registration. This PR adds a rate limiting middleware (per-IP token bucket) to protect CloudHub from Denial of Service (DoS) attacks from rogue or compromised edge nodes. The rate limits (QPS and Burst) are configurable via the `CloudHubHTTPS` API.

**Which issue(s) this PR fixes**:
Fixes #7213

**Special notes for your reviewer**:
Added a background cleanup routine in the rate limiter to periodically garbage-collect old IPs, preventing memory leaks.

**Does this PR introduce a user-facing change?**:
```release-note
Add configurable rate limiting to CloudHub HTTP endpoints to prevent DoS attacks.
```