### PR TITLE
feat: add govulncheck CI workflow

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,33 @@
+name: Go Vulnerability Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 6 AM UTC
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+        env:
+          GOFLAGS: "-mod=mod"


### PR DESCRIPTION
## What was changed
- Added `.github/workflows/govulncheck.yml` - a new CI workflow that runs `govulncheck` against the codebase.

## Why
Fixes #7180 - CI currently has no Go vulnerability scanning. `govulncheck` is call-graph aware, so it reports only vulnerabilities in code paths that are actually reached, keeping noise low.

## Features
- Runs on push to master, PRs to master, and weekly schedule (Monday 6 AM UTC)
- Uses `go-version-file: go.mod` to automatically use the project's Go version
- Installs and runs `govulncheck ./...`