### PR TITLE
metaserver: resolve kind from scheme for multi-word resources

### DIFF
--- a/pkg/metaserver/util/util.go
+++ b/pkg/metaserver/util/util.go
@@ -40,9 +40,24 @@ func SetMetaType(obj runtime.Object) error {
 	return nil
 }
 
+// schemeResourceToKind indexes the resource name of every type registered in the
+// client-go scheme back to its kind. Multi-word kinds like ConfigMap, DaemonSet or
+// RuntimeClass keep an inner capital that the suffix rules below cannot recover, so
+// the resource of a registered type is resolved through this index instead.
+var schemeResourceToKind = func() map[string]string {
+	knownTypes := scheme.Scheme.AllKnownTypes()
+	m := make(map[string]string, len(knownTypes))
+	for gvk := range knownTypes {
+		m[UnsafeKindToResource(gvk.Kind)] = gvk.Kind
+	}
+	return m
+}()
+
 // Sometimes, we need guess kind according to resource:
 // 1. In most cases, is like pods to Pod,
 // 2. In some unusual cases, requires special treatment like endpoints to Endpoints
+// 3. For a resource registered in the scheme, the kind it was registered with wins,
+// so that configmaps becomes ConfigMap rather than Configmap
 func UnsafeResourceToKind(r string) string {
 	if len(r) == 0 {
 		return r
@@ -61,6 +76,9 @@ func UnsafeResourceToKind(r string) string {
 	}
 	if v, isUnusual := unusualResourceToKind[r]; isUnusual {
 		return v
+	}
+	if k, isRegistered := schemeResourceToKind[r]; isRegistered {
+		return k
 	}
 	caser := cases.Title(language.Und)
 	k := caser.String(r)

--- a/pkg/metaserver/util/util_test.go
+++ b/pkg/metaserver/util/util_test.go
@@ -208,6 +208,31 @@ func TestUnsafeResourceToKind(t *testing.T) {
 			args: args{r: "Other"},
 			want: "Other",
 		},
+		{
+			name: "TestUnsafeResourceToKind(): Case 8: registered multi-word kind",
+			args: args{r: "configmaps"},
+			want: "ConfigMap",
+		},
+		{
+			name: "TestUnsafeResourceToKind(): Case 9: registered multi-word kind ending with s",
+			args: args{r: "runtimeclasses"},
+			want: "RuntimeClass",
+		},
+		{
+			name: "TestUnsafeResourceToKind(): Case 10: registered multi-word kind ending with y",
+			args: args{r: "networkpolicies"},
+			want: "NetworkPolicy",
+		},
+		{
+			name: "TestUnsafeResourceToKind(): Case 11: registered acronym kind",
+			args: args{r: "csidrivers"},
+			want: "CSIDriver",
+		},
+		{
+			name: "TestUnsafeResourceToKind(): Case 12: unusual takes precedence over scheme",
+			args: args{r: "leases"},
+			want: "Leases",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

`UnsafeResourceToKind` guessed a kind by title-casing the resource name and
trimming its plural suffix. That transform is lossy: the inner capital of a
multi-word kind cannot be recovered from the plural string, so `configmaps`
became `Configmap`, `daemonsets` became `Daemonset`, `runtimeclasses` became
`Runtimeclass` and `serviceaccounts` became `Serviceaccount`.

Because metaserver builds the list kind as `UnsafeResourceToKind(resource) + "List"`,
the same LIST request answered with a different kind depending on connection
status ; `ConfigMapList` when connected to the API server, `ConfigmapList` when
served from the local cache. The offline spelling is not registered in the
client-go scheme, so clients failed with errors such as
`no kind "RuntimeclassList" is registered for version "node.k8s.io/v1"`.

Instead of adding the affected resources to the existing exception map, which
would leave every other multi-word resource broken, this PR takes the kind from
the scheme that defines it. A package-level index maps the resource name of
every type registered in the client-go scheme back to its kind, built by running
each registered kind through the existing `UnsafeKindToResource` .

The lookup is placed between the two existing paths and changes neither:

1. `unusualResourceToKind` still runs first, so KubeEdge's internal names keep
   winning over the scheme, notably `leases` -> `Leases`, plus `podstatus`,
   `nodestatus` and the CRD entries.
2. the new scheme lookup answers for registered types.
3. the suffix heuristic remains the fallback, so CRDs and any type not in the
   scheme behave exactly as before.

Besides the four reported resources this also corrects `storageclasses`,
`persistentvolumeclaims`, `priorityclasses`, `volumeattachments` and acronym
kinds such as `csidrivers` -> `CSIDriver`, which no suffix rule could produce.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7221 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed metaserver returning an incorrect Kind for multi-word resources when serving requests from the local cache. Offline responses now use the same Kind as the API server (for example `ConfigMapList` rather than `ConfigmapList`), resolving client errors such as `no kind "RuntimeclassList" is registered for version "node.k8s.io/v1"`.
```
