### PR TITLE
dynamiccontroller: fix EndpointSlice topology filtering being a no-op

### DIFF
--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
@@ -58,6 +58,26 @@ func (f *FilterImpl) NeedFilter(content interface{}) bool {
 	return false
 }
 
+// getService resolves the Service owning an endpoint object, preferring the
+// shared informer cache and falling back to a live GET while it is unavailable.
+func getService(namespace, name string) (metav1.Object, error) {
+	servicesGVR := v1.SchemeGroupVersion.WithResource("services")
+
+	var svcRaw interface{}
+	lister, err := filter.GetSyncedResourceLister(servicesGVR)
+	if err != nil {
+		klog.Infof("services lister unavailable, falling back to live get: %v", err)
+		svcRaw, err = client.GetDynamicClient().Resource(servicesGVR).Namespace(namespace).
+			Get(context.TODO(), name, metav1.GetOptions{})
+	} else {
+		svcRaw, err = lister.ByNamespace(namespace).Get(name)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return meta.Accessor(svcRaw)
+}
+
 func filterEndpointSlice(targetNode string, obj runtime.Object) {
 	unstruct, ok := obj.(*unstructured.Unstructured)
 	if !ok {
@@ -71,14 +91,9 @@ func filterEndpointSlice(targetNode string, obj runtime.Object) {
 	}
 	var svcTopology string
 	if svcName, ok := epSlice.Labels[discovery.LabelServiceName]; ok {
-		svcRaw, err := filter.GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("services")).Lister().ByNamespace(epSlice.Namespace).Get(svcName)
+		svcObj, err := getService(epSlice.Namespace, svcName)
 		if err != nil {
 			klog.Errorf("filter endpoint slice for svc %s error: %v", svcName, err)
-			return
-		}
-		svcObj, err := meta.Accessor(svcRaw)
-		if err != nil {
-			klog.Errorf("get service %v accessor error: %v", svcName, err)
 			return
 		}
 		svcTopology = svcObj.GetAnnotations()[nodegroup.ServiceTopologyAnnotation]
@@ -127,27 +142,9 @@ func filterEndpoints(targetNode string, obj runtime.Object) {
 		return
 	}
 	svcName := ep.GetName()
-	var svcRaw interface{}
-
-	if !filter.GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("services")).Informer().HasSynced() {
-		klog.Info("services informer has not synced yet")
-		svcRaw, err = client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("services")).Namespace(ep.Namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("filter endpoint for svc %s error: %v", svcName, err)
-			return
-		}
-	} else {
-		svcRaw, err = filter.GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("services")).Lister().
-			ByNamespace(ep.Namespace).Get(svcName)
-		if err != nil {
-			klog.Errorf("filter endpoint for svc %s error: %v", svcName, err)
-			return
-		}
-	}
-
-	svcObj, err := meta.Accessor(svcRaw)
+	svcObj, err := getService(ep.Namespace, svcName)
 	if err != nil {
-		klog.Errorf("get service %v accessor error: %v", svcName, err)
+		klog.Errorf("filter endpoint for svc %s error: %v", svcName, err)
 		return
 	}
 

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource.go
@@ -104,6 +104,14 @@ func filterEndpointSlice(targetNode string, obj runtime.Object) {
 	}
 	var epsTmp []discovery.Endpoint
 	for _, ep := range epSlice.Endpoints {
+		// nodeName is optional and is routinely absent while the backing pod is
+		// being scheduled. Such an endpoint cannot be matched to a node group,
+		// so it is skipped instead of dereferenced, as filterEndpointsAddress
+		// already does for the Endpoints resource.
+		if ep.NodeName == nil {
+			klog.V(4).Infof("skip endpoint without nodeName in endpointSlice %v", unstruct.GetName())
+			continue
+		}
 		if filter.IsBelongToSameGroup(targetNode, *ep.NodeName) {
 			epsTmp = append(epsTmp, ep)
 		}

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
@@ -102,6 +102,7 @@ func setupPatches() *gomonkey.Patches {
 	patches := gomonkey.NewPatches()
 
 	patches.ApplyFuncReturn(filter.GetDynamicResourceInformer, mockInformer)
+	patches.ApplyFuncReturn(filter.GetSyncedResourceLister, mockInformer.Lister(), nil)
 
 	patches.ApplyFunc(meta.Accessor, func(obj interface{}) (metav1.Object, error) {
 		return svc.ObjectMeta.DeepCopy(), nil

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
@@ -17,20 +17,25 @@ limitations under the License.
 package endpointresource
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	"github.com/kubeedge/kubeedge/cloud/pkg/controllermanager/nodegroup"
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller/filter"
 )
@@ -42,6 +47,8 @@ const (
 
 type mockGenericInformer struct {
 	mockObj runtime.Object
+	// lister, when set, is handed out instead of one built from mockObj.
+	lister cache.GenericLister
 }
 
 func (m *mockGenericInformer) Informer() cache.SharedIndexInformer {
@@ -49,10 +56,38 @@ func (m *mockGenericInformer) Informer() cache.SharedIndexInformer {
 }
 
 func (m *mockGenericInformer) Lister() cache.GenericLister {
+	if m.lister != nil {
+		return m.lister
+	}
 	return &mockGenericLister{
 		mockObj: m.mockObj,
 	}
 }
+
+// recordingLister answers every lookup with obj, or with err when err is set,
+// and counts the lookups so a test can assert *which* lister the code consulted.
+type recordingLister struct {
+	obj  runtime.Object
+	err  error
+	gets int
+}
+
+func (r *recordingLister) List(labels.Selector) ([]runtime.Object, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return []runtime.Object{r.obj}, nil
+}
+
+func (r *recordingLister) Get(string) (runtime.Object, error) {
+	r.gets++
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.obj, nil
+}
+
+func (r *recordingLister) ByNamespace(string) cache.GenericNamespaceLister { return r }
 
 type mockGenericLister struct {
 	mockObj runtime.Object
@@ -452,6 +487,152 @@ func TestFilterEndpointSliceConversionError(t *testing.T) {
 	}
 
 	filterEndpointSlice("target-node", invalid)
+}
+
+// annotatedService is the Service the endpoint slices in these tests belong to,
+// opted in to node-group scoping.
+func annotatedService() *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: "default",
+			Annotations: map[string]string{
+				nodegroup.ServiceTopologyAnnotation: nodegroup.ServiceTopologyRangeNodegroup,
+			},
+		},
+	}
+}
+
+// twoNodeEpSlice is an EndpointSlice with one endpoint on node1 and one on
+// node2. With IsBelongToSameGroup stubbed to accept only node1, a filtered slice
+// keeps one endpoint and an unfiltered one keeps both, so the endpoint count
+// alone says whether filtering ran.
+func twoNodeEpSlice(t *testing.T) *unstructured.Unstructured {
+	t.Helper()
+
+	n1 := nodeName1
+	n2 := nodeName2
+	epSlice := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-epslice",
+			Namespace: "default",
+			Labels: map[string]string{
+				discovery.LabelServiceName: "test-service",
+			},
+		},
+		Endpoints: []discovery.Endpoint{
+			{Addresses: []string{"192.168.1.1"}, NodeName: &n1},
+			{Addresses: []string{"192.168.1.2"}, NodeName: &n2},
+		},
+	}
+
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(epSlice)
+	assert.NoError(t, err)
+	return &unstructured.Unstructured{Object: raw}
+}
+
+// TestFilterEndpointSliceIgnoresDynamicFactory reproduces the conditions under
+// which EndpointSlice topology filtering was a silent no-op in production.
+//
+// filterEndpointSlice used to resolve the owning Service through
+// filter.GetDynamicResourceInformer(services).Lister(). The informers manager
+// serves built-in resources such as services from the *typed* factory, so that
+// call lazily created a second informer nobody started: its cache stayed empty
+// for the process lifetime and every Get returned NotFound. filterEndpointSlice
+// logged "filter endpoint slice for svc test-service error: services
+// \"test-service\" not found" and returned early, leaving the slice untouched,
+// which is why edge nodes kept receiving the cluster-wide endpoint set no matter
+// how the Service was annotated.
+//
+// The other tests in this file miss that because setupPatches makes the dynamic
+// lister resolve the Service, which production never does. Here the dynamic
+// lister behaves as it really did - empty, NotFound - and only the synced lister
+// has the Service. So:
+//
+//	before the fix: dynamic lister consulted, NotFound, both endpoints survive
+//	after the fix:  synced lister consulted, filtering runs, one endpoint left
+func TestFilterEndpointSliceIgnoresDynamicFactory(t *testing.T) {
+	svc := annotatedService()
+
+	// The unstarted dynamic informer: a cache that never fills.
+	dynamicLister := &recordingLister{
+		err: apierrors.NewNotFound(v1.Resource("services"), svc.Name),
+	}
+	// The typed factory the informers manager actually starts and syncs.
+	syncedLister := &recordingLister{obj: svc}
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFuncReturn(filter.GetDynamicResourceInformer, &mockGenericInformer{lister: dynamicLister})
+	patches.ApplyFuncReturn(filter.GetSyncedResourceLister, cache.GenericLister(syncedLister), nil)
+	patches.ApplyFunc(filter.IsBelongToSameGroup, func(_, epNodeName string) bool {
+		return epNodeName == nodeName1
+	})
+
+	epSliceUnstructured := twoNodeEpSlice(t)
+	filterEndpointSlice("target-node", epSliceUnstructured)
+
+	var result discovery.EndpointSlice
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(epSliceUnstructured.Object, &result)
+	assert.NoError(t, err)
+
+	// The point of the test: filtering has to happen even though the dynamic
+	// factory cannot resolve the Service.
+	assert.Len(t, result.Endpoints, 1,
+		"filtering must run off the synced lister; an empty dynamic informer made this a no-op")
+	assert.Equal(t, nodeName1, *result.Endpoints[0].NodeName)
+
+	// And it has to happen because the Service was resolved the right way, not
+	// by luck. GetDynamicResourceInformer must not be on the path at all.
+	assert.Equal(t, 0, dynamicLister.gets,
+		"services must not be resolved through the dynamic informer factory")
+	assert.Positive(t, syncedLister.gets, "the synced lister is the one that must be consulted")
+}
+
+// TestFilterEndpointSliceFallsBackToLiveGet covers the other half of getService:
+// while the informer is still syncing there is no lister, and rather than skip
+// filtering - the failure mode that hid this bug - it resolves the Service with
+// a live GET and filters anyway.
+func TestFilterEndpointSliceFallsBackToLiveGet(t *testing.T) {
+	svc := annotatedService()
+
+	rawSvc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(svc)
+	assert.NoError(t, err)
+	unstructuredSvc := &unstructured.Unstructured{Object: rawSvc}
+	unstructuredSvc.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("Service"))
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, v1.AddToScheme(scheme))
+	fakeDynamic := dynamicfake.NewSimpleDynamicClient(scheme, unstructuredSvc)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFuncReturn(filter.GetSyncedResourceLister, nil,
+		fmt.Errorf("informer for /v1, Resource=services has not synced yet"))
+	patches.ApplyFuncReturn(client.GetDynamicClient, dynamic.Interface(fakeDynamic))
+	patches.ApplyFunc(filter.IsBelongToSameGroup, func(_, epNodeName string) bool {
+		return epNodeName == nodeName1
+	})
+
+	// client.GetDynamicClient is short enough for the compiler to inline, and an
+	// inlined call site ignores the patch above and hands back the real, unset
+	// client. `make test` passes -gcflags "all=-N -l" (hack/lib/golang.sh), which
+	// keeps the patch effective; a bare `go test` does not.
+	if client.GetDynamicClient() == nil {
+		t.Skip(`patching client.GetDynamicClient needs -gcflags "all=-N -l"; run this through make test`)
+	}
+
+	epSliceUnstructured := twoNodeEpSlice(t)
+	filterEndpointSlice("target-node", epSliceUnstructured)
+
+	var result discovery.EndpointSlice
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(epSliceUnstructured.Object, &result)
+	assert.NoError(t, err)
+
+	assert.Len(t, result.Endpoints, 1, "an unsynced lister must fall back to a live get, not skip filtering")
+	assert.Equal(t, nodeName1, *result.Endpoints[0].NodeName)
 }
 
 // TestFilterEndpointSliceNilNodeName covers endpoints carrying no nodeName,

--- a/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/endpointresource/endpointresource_test.go
@@ -453,3 +453,39 @@ func TestFilterEndpointSliceConversionError(t *testing.T) {
 
 	filterEndpointSlice("target-node", invalid)
 }
+
+// TestFilterEndpointSliceNilNodeName covers endpoints carrying no nodeName,
+// which are valid and occur while the backing pod is being scheduled.
+// Dereferencing them panics the goroutine dispatching to the edge node.
+func TestFilterEndpointSliceNilNodeName(t *testing.T) {
+	patches := setupPatches()
+	defer patches.Reset()
+
+	n1 := nodeName1
+	epSlice := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-epslice",
+			Namespace: "default",
+			Labels: map[string]string{
+				discovery.LabelServiceName: "test-service",
+			},
+		},
+		Endpoints: []discovery.Endpoint{
+			{Addresses: []string{"192.168.1.1"}, NodeName: &n1},
+			{Addresses: []string{"192.168.1.9"}, NodeName: nil},
+		},
+	}
+
+	unstructEpSlice, err := runtime.DefaultUnstructuredConverter.ToUnstructured(epSlice)
+	assert.NoError(t, err)
+	epSliceUnstructured := &unstructured.Unstructured{Object: unstructEpSlice}
+
+	assert.NotPanics(t, func() { filterEndpointSlice("target-node", epSliceUnstructured) })
+
+	var result discovery.EndpointSlice
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(epSliceUnstructured.Object, &result)
+	assert.NoError(t, err)
+
+	assert.Len(t, result.Endpoints, 1, "endpoint without nodeName cannot be matched to a node group and must be skipped")
+	assert.Equal(t, nodeName1, *result.Endpoints[0].NodeName)
+}

--- a/cloud/pkg/dynamiccontroller/filter/util.go
+++ b/cloud/pkg/dynamiccontroller/filter/util.go
@@ -2,12 +2,14 @@ package filter
 
 import (
 	"context"
+	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
@@ -24,14 +26,15 @@ func IsBelongToSameGroup(targetNodeName string, epNodeName string) bool {
 	var getNode func(string) (interface{}, error)
 
 	// Define a function to get the node based on whether the informer is synced
-	if !GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Informer().HasSynced() {
-		klog.Info("nodes informer has not synced yet")
+	nodesGVR := v1.SchemeGroupVersion.WithResource("nodes")
+	if lister, err := GetSyncedResourceLister(nodesGVR); err != nil {
+		klog.Infof("nodes lister unavailable, falling back to live get: %v", err)
 		getNode = func(nodeName string) (interface{}, error) {
-			return client.GetDynamicClient().Resource(v1.SchemeGroupVersion.WithResource("nodes")).Get(context.TODO(), nodeName, metav1.GetOptions{})
+			return client.GetDynamicClient().Resource(nodesGVR).Get(context.TODO(), nodeName, metav1.GetOptions{})
 		}
 	} else {
 		getNode = func(nodeName string) (interface{}, error) {
-			return GetDynamicResourceInformer(v1.SchemeGroupVersion.WithResource("nodes")).Lister().Get(nodeName)
+			return lister.Get(nodeName)
 		}
 	}
 
@@ -65,4 +68,27 @@ func IsBelongToSameGroup(targetNodeName string, epNodeName string) bool {
 }
 func GetDynamicResourceInformer(gvr schema.GroupVersionResource) informers.GenericInformer {
 	return commoninformers.GetInformersManager().GetDynamicInformerFactory().ForResource(gvr)
+}
+
+// GetSyncedResourceLister returns a lister for gvr backed by an informer that
+// the informers manager has actually started and synced.
+//
+// GetDynamicResourceInformer must not be used for built-in resources such as
+// services and nodes: the informers manager serves those from the typed
+// informer factory (see informers.forResource), so asking the dynamic factory
+// for them lazily creates a second informer that nobody ever starts. Its cache
+// stays empty for the process lifetime and every lister lookup returns NotFound,
+// which silently disables any filter built on top of it.
+func GetSyncedResourceLister(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+	pair, err := commoninformers.GetInformersManager().GetInformerPair(gvr)
+	if err != nil {
+		return nil, err
+	}
+	if pair == nil {
+		return nil, fmt.Errorf("no informer registered for %s", gvr.String())
+	}
+	if !pair.Informer.HasSynced() {
+		return nil, fmt.Errorf("informer for %s has not synced yet", gvr.String())
+	}
+	return pair.Lister, nil
 }

--- a/cloud/pkg/dynamiccontroller/filter/util_test.go
+++ b/cloud/pkg/dynamiccontroller/filter/util_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sinformer "k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	commoninformers "github.com/kubeedge/kubeedge/cloud/pkg/common/informers"
+)
+
+var servicesGVR = v1.SchemeGroupVersion.WithResource("services")
+
+// stubInformerManager returns a fixed InformerPair for any GVR, standing in for
+// the global informers manager.
+type stubInformerManager struct {
+	commoninformers.Manager
+	pair *commoninformers.InformerPair
+	err  error
+}
+
+func (s *stubInformerManager) GetInformerPair(schema.GroupVersionResource) (*commoninformers.InformerPair, error) {
+	return s.pair, s.err
+}
+
+// newServicesInformerPair builds an InformerPair for services backed by a fake
+// clientset. The informer is only started, and therefore only syncs, when
+// start is true.
+func newServicesInformerPair(t *testing.T, start bool, objs ...*v1.Service) *commoninformers.InformerPair {
+	t.Helper()
+
+	client := kubefake.NewSimpleClientset()
+	for _, obj := range objs {
+		_, err := client.CoreV1().Services(obj.Namespace).Create(context.TODO(), obj, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	factory := k8sinformer.NewSharedInformerFactory(client, 0)
+	genericInformer, err := factory.ForResource(servicesGVR)
+	require.NoError(t, err)
+
+	if start {
+		stopCh := make(chan struct{})
+		t.Cleanup(func() { close(stopCh) })
+		factory.Start(stopCh)
+		factory.WaitForCacheSync(stopCh)
+	}
+
+	return &commoninformers.InformerPair{
+		Lister:   genericInformer.Lister(),
+		Informer: genericInformer.Informer(),
+	}
+}
+
+func patchInformersManager(manager commoninformers.Manager) *gomonkey.Patches {
+	return gomonkey.ApplyFuncReturn(commoninformers.GetInformersManager, manager)
+}
+
+func TestGetSyncedResourceListerSynced(t *testing.T) {
+	svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-service", Namespace: "default"}}
+	pair := newServicesInformerPair(t, true, svc)
+
+	patches := patchInformersManager(&stubInformerManager{pair: pair})
+	defer patches.Reset()
+
+	lister, err := GetSyncedResourceLister(servicesGVR)
+	require.NoError(t, err)
+
+	got, err := lister.ByNamespace("default").Get("test-service")
+	require.NoError(t, err)
+	assert.Equal(t, svc, got)
+}
+
+func TestGetSyncedResourceListerNotSynced(t *testing.T) {
+	pair := newServicesInformerPair(t, false)
+
+	patches := patchInformersManager(&stubInformerManager{pair: pair})
+	defer patches.Reset()
+
+	lister, err := GetSyncedResourceLister(servicesGVR)
+	assert.Nil(t, lister)
+	assert.ErrorContains(t, err, "has not synced yet")
+}
+
+func TestGetSyncedResourceListerManagerError(t *testing.T) {
+	patches := patchInformersManager(&stubInformerManager{err: errors.New("no kind for resource")})
+	defer patches.Reset()
+
+	lister, err := GetSyncedResourceLister(servicesGVR)
+	assert.Nil(t, lister)
+	assert.ErrorContains(t, err, "no kind for resource")
+}
+
+// TestGetSyncedResourceListerNoInformer covers managers that report neither an
+// InformerPair nor an error for an unregistered resource, which must be turned
+// into an error rather than dereferenced.
+func TestGetSyncedResourceListerNoInformer(t *testing.T) {
+	patches := patchInformersManager(&stubInformerManager{})
+	defer patches.Reset()
+
+	lister, err := GetSyncedResourceLister(servicesGVR)
+	assert.Nil(t, lister)
+	assert.ErrorContains(t, err, "no informer registered")
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Service topology filtering (`apps.kubeedge.io/service-topology: range-nodegroup`) never
takes effect for EndpointSlices, so edge nodes receive the cluster-wide endpoint set
regardless of the node group they belong to. Since kube-proxy (>= 1.21) and CoreDNS read
EndpointSlices rather than Endpoints, the feature is effectively inoperative on edge nodes.

`filterEndpointSlice` resolves the owning Service through
`filter.GetDynamicResourceInformer(services).Lister()`. The informers manager serves
built-in resources such as `services` and `nodes` from the *typed* informer factory
(`informers.forResource`), so asking the dynamic factory for them lazily creates a second
informer that nobody ever starts. Its cache stays empty for the process lifetime and every
lister lookup returns NotFound. At `--v=4` cloudcore logs

```
filter endpoint slice for svc <name> error: services "<name>" not found
```

for Services that plainly exist, and the filter returns before filtering anything.

`filterEndpoints` hides the same defect behind a `HasSynced` check plus a live GET fallback
(added in #6149), which is why filtering appears to work for the legacy Endpoints resource
but not for EndpointSlices.

This PR adds `filter.GetSyncedResourceLister`, which goes through the informers manager so
a resource is routed to whichever factory owns it and is started and synced, and routes
both filters through one `getService` helper (lister first, live GET as fallback).
`IsBelongToSameGroup` uses the same path, which also removes the per-endpoint apiserver GET
it was issuing for every filtered object.

The second commit adds the `ep.NodeName` nil guard that this makes reachable in practice:
once filtering actually runs, an endpoint whose pod is not yet scheduled panics the
dispatch goroutine. This duplicates #7008 / #7102 (issue #7007), both still open — happy to
drop that commit if either lands first, but the fix here would be unsafe to merge without
one of them.

**Which issue(s) this PR fixes:**

Fixes #6088

**Special notes for your reviewer:**

Verified on a live cluster: with the patch, an annotated Service whose EndpointSlice holds
5 endpoints resolves to the single endpoint on the querying node's node group, and
kube-proxy's nftables rule goes from `numgen random mod 5` to `mod 1`. Without it, all 5
endpoints reach every edge node.

Note that a stale copy cached in edgecore's local store is not re-filtered: MetaServer's
list goes to the cloud but its watch replays the local store, so an already-cached
EndpointSlice needs backend-pod churn (or an edgecore restart) before the filtered version
is applied.

New unit tests: `TestGetSyncedResourceLister*` in `cloud/pkg/dynamiccontroller/filter` and
`TestFilterEndpointSliceNilNodeName` in `.../filter/endpointresource`.

**Does this PR introduce a user-facing change?**

```release-note
Fixed EndpointSlice service topology filtering (`apps.kubeedge.io/service-topology: range-nodegroup`) being silently skipped, which sent every edge node the cluster-wide endpoint set.
```
