### PR TITLE
admissioncontroller: follow certificate rotation in the webhook config

### DIFF
--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -1,12 +1,14 @@
 package admissioncontroller
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -41,6 +44,11 @@ const (
 	MutatingNodeUpgradeWebhookName = "mutatingnodeupgradejob.kubeedge.io"
 
 	AutonomyLabel = "app-offline.kubeedge.io=autonomy"
+
+	// caBundleRefreshPeriod is how often the CA certificate is re-read from disk to
+	// check whether the CA bundle published in the webhook configurations is still
+	// the one the webhook is served with.
+	caBundleRefreshPeriod = time.Minute
 )
 
 var scheme = runtime.NewScheme()
@@ -64,7 +72,7 @@ func addToScheme(scheme *runtime.Scheme) {
 
 // AdmissionController implements the admission webhook for validation of configuration.
 type AdmissionController struct {
-	Client    *kubernetes.Clientset
+	Client    kubernetes.Interface
 	CrdClient *versioned.Clientset
 }
 
@@ -99,6 +107,9 @@ func Run(opt *options.AdmissionOptions) error {
 	if err = controller.registerWebhooks(opt, caBundle); err != nil {
 		return fmt.Errorf("failed to register the webhook with error: %v", err)
 	}
+	// The CA certificate is mounted from a secret that can be rotated while the
+	// process runs, so the published CA bundle has to keep following it.
+	go controller.watchCABundle(opt, caBundle)
 
 	http.HandleFunc("/devices", serveDevice)
 	http.HandleFunc("/devicemodels", serveDeviceModel)
@@ -128,14 +139,14 @@ func Run(opt *options.AdmissionOptions) error {
 // defined tls config, else use that defined in kubeconfig
 func configTLS(opt *options.AdmissionOptions, restConfig *restclient.Config) (*tls.Config, error) {
 	if len(opt.CertFile) != 0 && len(opt.KeyFile) != 0 {
-		sCert, err := tls.LoadX509KeyPair(opt.CertFile, opt.KeyFile)
+		reloader, err := newCertReloader(opt.CertFile, opt.KeyFile)
 		if err != nil {
 			return nil, err
 		}
 
 		return &tls.Config{
-			Certificates: []tls.Certificate{sCert},
-			MinVersion:   tls.VersionTLS12,
+			GetCertificate: reloader.GetCertificate,
+			MinVersion:     tls.VersionTLS12,
 		}, nil
 	}
 
@@ -391,6 +402,37 @@ func (ac *AdmissionController) registerWebhooks(opt *options.AdmissionOptions, c
 
 	return registerMutatingWebhook(ac.Client.AdmissionregistrationV1().MutatingWebhookConfigurations(),
 		[]admissionregistrationv1.MutatingWebhookConfiguration{offlineMigrationWebhook, mutatingWebhook})
+}
+
+// watchCABundle keeps the CA bundle published in the webhook configurations in sync
+// with the CA certificate on disk, starting from the bundle already published by the
+// caller. It never returns.
+func (ac *AdmissionController) watchCABundle(opt *options.AdmissionOptions, published []byte) {
+	wait.Forever(func() {
+		published = ac.refreshCABundle(opt, published)
+	}, caBundleRefreshPeriod)
+}
+
+// refreshCABundle registers the webhooks again when the CA certificate on disk is no
+// longer the one published in the webhook configurations, and returns the CA bundle
+// they hold afterwards. The API server verifies the webhook against the published CA
+// bundle, so a rotated CA has to be published for it to keep reaching the webhook
+// once the previous CA is gone.
+func (ac *AdmissionController) refreshCABundle(opt *options.AdmissionOptions, published []byte) []byte {
+	caBundle, err := os.ReadFile(opt.CaCertFile)
+	if err != nil {
+		klog.Errorf("unable to read cacert file: %v", err)
+		return published
+	}
+	if bytes.Equal(caBundle, published) {
+		return published
+	}
+	if err := ac.registerWebhooks(opt, caBundle); err != nil {
+		klog.Errorf("failed to publish the rotated CA bundle with error: %v", err)
+		return published
+	}
+	klog.Info("Published the rotated CA bundle to the webhook configurations")
+	return caBundle
 }
 
 func (ac *AdmissionController) getRuleEndpoint(namespace, name string) (*v1.RuleEndpoint, error) {

--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -109,7 +109,7 @@ func Run(opt *options.AdmissionOptions) error {
 	}
 	// The CA certificate is mounted from a secret that can be rotated while the
 	// process runs, so the published CA bundle has to keep following it.
-	go controller.watchCABundle(opt, caBundle, wait.NeverStop)
+	go controller.watchCABundle(opt, caBundle)
 
 	http.HandleFunc("/devices", serveDevice)
 	http.HandleFunc("/devicemodels", serveDeviceModel)
@@ -406,11 +406,11 @@ func (ac *AdmissionController) registerWebhooks(opt *options.AdmissionOptions, c
 
 // watchCABundle keeps the CA bundle published in the webhook configurations in sync
 // with the CA certificate on disk, starting from the bundle already published by the
-// caller. It returns once stopCh is closed.
-func (ac *AdmissionController) watchCABundle(opt *options.AdmissionOptions, published []byte, stopCh <-chan struct{}) {
-	wait.Until(func() {
+// caller. It never returns.
+func (ac *AdmissionController) watchCABundle(opt *options.AdmissionOptions, published []byte) {
+	wait.Forever(func() {
 		published = ac.refreshCABundle(opt, published)
-	}, caBundleRefreshPeriod, stopCh)
+	}, caBundleRefreshPeriod)
 }
 
 // refreshCABundle registers the webhooks again when the CA certificate on disk is no

--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -109,7 +109,7 @@ func Run(opt *options.AdmissionOptions) error {
 	}
 	// The CA certificate is mounted from a secret that can be rotated while the
 	// process runs, so the published CA bundle has to keep following it.
-	go controller.watchCABundle(opt, caBundle)
+	go controller.watchCABundle(opt, caBundle, wait.NeverStop)
 
 	http.HandleFunc("/devices", serveDevice)
 	http.HandleFunc("/devicemodels", serveDeviceModel)
@@ -406,11 +406,11 @@ func (ac *AdmissionController) registerWebhooks(opt *options.AdmissionOptions, c
 
 // watchCABundle keeps the CA bundle published in the webhook configurations in sync
 // with the CA certificate on disk, starting from the bundle already published by the
-// caller. It never returns.
-func (ac *AdmissionController) watchCABundle(opt *options.AdmissionOptions, published []byte) {
-	wait.Forever(func() {
+// caller. It returns once stopCh is closed.
+func (ac *AdmissionController) watchCABundle(opt *options.AdmissionOptions, published []byte, stopCh <-chan struct{}) {
+	wait.Until(func() {
 		published = ac.refreshCABundle(opt, published)
-	}, caBundleRefreshPeriod)
+	}, caBundleRefreshPeriod, stopCh)
 }
 
 // refreshCABundle registers the webhooks again when the CA certificate on disk is no

--- a/cloud/pkg/admissioncontroller/admission_test.go
+++ b/cloud/pkg/admissioncontroller/admission_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissioncontroller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubeedge/kubeedge/cloud/cmd/admission/app/options"
+)
+
+func TestRefreshCABundle(t *testing.T) {
+	oldCA := []byte("old ca certificate")
+	newCA := []byte("rotated ca certificate")
+
+	opt := &options.AdmissionOptions{
+		CaCertFile:                filepath.Join(t.TempDir(), "ca.crt"),
+		Port:                      443,
+		AdmissionServiceNamespace: "kubeedge",
+		AdmissionServiceName:      "kubeedge-admission-service",
+	}
+	require.NoError(t, os.WriteFile(opt.CaCertFile, oldCA, 0600))
+
+	clientset := fake.NewSimpleClientset()
+	ac := &AdmissionController{Client: clientset}
+	require.NoError(t, ac.registerWebhooks(opt, oldCA))
+
+	// publishedCABundle returns the CA bundle the validating webhook configuration holds.
+	publishedCABundle := func() []byte {
+		configuration, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().
+			Get(context.Background(), ValidateCRDWebhookConfigName, metav1.GetOptions{})
+		require.NoError(t, err)
+		return configuration.Webhooks[0].ClientConfig.CABundle
+	}
+
+	t.Run("unchanged ca is not published again", func(t *testing.T) {
+		clientset.ClearActions()
+
+		assert.Equal(t, oldCA, ac.refreshCABundle(opt, oldCA))
+		assert.Empty(t, clientset.Actions())
+	})
+
+	t.Run("rotated ca is published", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(opt.CaCertFile, newCA, 0600))
+
+		assert.Equal(t, newCA, ac.refreshCABundle(opt, oldCA))
+		assert.Equal(t, newCA, publishedCABundle())
+	})
+
+	t.Run("unreadable ca keeps the published bundle", func(t *testing.T) {
+		require.NoError(t, os.Remove(opt.CaCertFile))
+
+		assert.Equal(t, newCA, ac.refreshCABundle(opt, newCA))
+		assert.Equal(t, newCA, publishedCABundle())
+	})
+}

--- a/cloud/pkg/admissioncontroller/admission_test.go
+++ b/cloud/pkg/admissioncontroller/admission_test.go
@@ -17,22 +17,31 @@ limitations under the License.
 package admissioncontroller
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubeedge/kubeedge/cloud/cmd/admission/app/options"
 )
 
-func TestRefreshCABundle(t *testing.T) {
-	oldCA := []byte("old ca certificate")
-	newCA := []byte("rotated ca certificate")
+// registeredForCABundle returns a controller whose webhooks are registered for the CA
+// certificate written to the options it returns.
+func registeredForCABundle(t *testing.T, caBundle []byte) (*AdmissionController, *fake.Clientset, *options.AdmissionOptions) {
+	t.Helper()
 
 	opt := &options.AdmissionOptions{
 		CaCertFile:                filepath.Join(t.TempDir(), "ca.crt"),
@@ -40,19 +49,29 @@ func TestRefreshCABundle(t *testing.T) {
 		AdmissionServiceNamespace: "kubeedge",
 		AdmissionServiceName:      "kubeedge-admission-service",
 	}
-	require.NoError(t, os.WriteFile(opt.CaCertFile, oldCA, 0600))
+	require.NoError(t, os.WriteFile(opt.CaCertFile, caBundle, 0600))
 
 	clientset := fake.NewSimpleClientset()
 	ac := &AdmissionController{Client: clientset}
-	require.NoError(t, ac.registerWebhooks(opt, oldCA))
+	require.NoError(t, ac.registerWebhooks(opt, caBundle))
+	return ac, clientset, opt
+}
 
-	// publishedCABundle returns the CA bundle the validating webhook configuration holds.
-	publishedCABundle := func() []byte {
-		configuration, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().
-			Get(context.Background(), ValidateCRDWebhookConfigName, metav1.GetOptions{})
-		require.NoError(t, err)
-		return configuration.Webhooks[0].ClientConfig.CABundle
+// publishedCABundle returns the CA bundle the validating webhook configuration holds.
+func publishedCABundle(clientset *fake.Clientset) ([]byte, error) {
+	configuration, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().
+		Get(context.Background(), ValidateCRDWebhookConfigName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
 	}
+	return configuration.Webhooks[0].ClientConfig.CABundle, nil
+}
+
+func TestRefreshCABundle(t *testing.T) {
+	oldCA := []byte("old ca certificate")
+	newCA := []byte("rotated ca certificate")
+
+	ac, clientset, opt := registeredForCABundle(t, oldCA)
 
 	t.Run("unchanged ca is not published again", func(t *testing.T) {
 		clientset.ClearActions()
@@ -65,13 +84,102 @@ func TestRefreshCABundle(t *testing.T) {
 		require.NoError(t, os.WriteFile(opt.CaCertFile, newCA, 0600))
 
 		assert.Equal(t, newCA, ac.refreshCABundle(opt, oldCA))
-		assert.Equal(t, newCA, publishedCABundle())
+		published, err := publishedCABundle(clientset)
+		assert.NoError(t, err)
+		assert.Equal(t, newCA, published)
+	})
+
+	t.Run("rejected registration keeps the published bundle", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(opt.CaCertFile, []byte("ca certificate rotated again"), 0600))
+		clientset.PrependReactor("update", "validatingwebhookconfigurations",
+			func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewInternalError(errors.New("registration failed"))
+			})
+
+		assert.Equal(t, newCA, ac.refreshCABundle(opt, newCA))
+		published, err := publishedCABundle(clientset)
+		assert.NoError(t, err)
+		assert.Equal(t, newCA, published)
 	})
 
 	t.Run("unreadable ca keeps the published bundle", func(t *testing.T) {
 		require.NoError(t, os.Remove(opt.CaCertFile))
 
 		assert.Equal(t, newCA, ac.refreshCABundle(opt, newCA))
-		assert.Equal(t, newCA, publishedCABundle())
+		published, err := publishedCABundle(clientset)
+		assert.NoError(t, err)
+		assert.Equal(t, newCA, published)
+	})
+}
+
+func TestWatchCABundle(t *testing.T) {
+	oldCA := []byte("old ca certificate")
+	newCA := []byte("rotated ca certificate")
+
+	ac, clientset, opt := registeredForCABundle(t, oldCA)
+	// Rotate the CA before the watch starts, its first pass has to publish it.
+	require.NoError(t, os.WriteFile(opt.CaCertFile, newCA, 0600))
+
+	stopCh, stopped := make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ac.watchCABundle(opt, oldCA, stopCh)
+	}()
+	defer func() {
+		close(stopCh)
+		<-stopped
+	}()
+
+	assert.Eventually(t, func() bool {
+		published, err := publishedCABundle(clientset)
+		return err == nil && bytes.Equal(published, newCA)
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func TestConfigTLS(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	writeKeyPair(t, certFile, keyFile, "kubeedge-admission-service.kubeedge.svc")
+
+	certPEM, err := os.ReadFile(certFile)
+	require.NoError(t, err)
+	keyPEM, err := os.ReadFile(keyFile)
+	require.NoError(t, err)
+
+	t.Run("key pair from the given files", func(t *testing.T) {
+		assert := assert.New(t)
+
+		tlsConfig, err := configTLS(&options.AdmissionOptions{CertFile: certFile, KeyFile: keyFile}, &restclient.Config{})
+		assert.NoError(err)
+		assert.Equal(uint16(tls.VersionTLS12), tlsConfig.MinVersion)
+		assert.Equal("kubeedge-admission-service.kubeedge.svc", servedCommonName(t, tlsConfig.GetCertificate))
+	})
+
+	t.Run("unreadable key pair", func(t *testing.T) {
+		opt := &options.AdmissionOptions{
+			CertFile: filepath.Join(dir, "missing.crt"),
+			KeyFile:  filepath.Join(dir, "missing.key"),
+		}
+
+		_, err := configTLS(opt, &restclient.Config{})
+		assert.Error(t, err)
+	})
+
+	t.Run("key pair from the kubeconfig", func(t *testing.T) {
+		assert := assert.New(t)
+
+		restConfig := &restclient.Config{
+			TLSClientConfig: restclient.TLSClientConfig{CertData: certPEM, KeyData: keyPEM},
+		}
+
+		tlsConfig, err := configTLS(&options.AdmissionOptions{}, restConfig)
+		assert.NoError(err)
+		assert.Len(tlsConfig.Certificates, 1)
+	})
+
+	t.Run("no key pair at all", func(t *testing.T) {
+		_, err := configTLS(&options.AdmissionOptions{}, &restclient.Config{})
+		assert.Error(t, err)
 	})
 }

--- a/cloud/pkg/admissioncontroller/admission_test.go
+++ b/cloud/pkg/admissioncontroller/admission_test.go
@@ -17,14 +17,12 @@ limitations under the License.
 package admissioncontroller
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,10 +36,9 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/cmd/admission/app/options"
 )
 
-// registeredForCABundle returns a controller whose webhooks are registered for the CA
-// certificate written to the options it returns.
-func registeredForCABundle(t *testing.T, caBundle []byte) (*AdmissionController, *fake.Clientset, *options.AdmissionOptions) {
-	t.Helper()
+func TestRefreshCABundle(t *testing.T) {
+	oldCA := []byte("old ca certificate")
+	newCA := []byte("rotated ca certificate")
 
 	opt := &options.AdmissionOptions{
 		CaCertFile:                filepath.Join(t.TempDir(), "ca.crt"),
@@ -49,29 +46,21 @@ func registeredForCABundle(t *testing.T, caBundle []byte) (*AdmissionController,
 		AdmissionServiceNamespace: "kubeedge",
 		AdmissionServiceName:      "kubeedge-admission-service",
 	}
-	require.NoError(t, os.WriteFile(opt.CaCertFile, caBundle, 0600))
+	require.NoError(t, os.WriteFile(opt.CaCertFile, oldCA, 0600))
 
 	clientset := fake.NewSimpleClientset()
 	ac := &AdmissionController{Client: clientset}
-	require.NoError(t, ac.registerWebhooks(opt, caBundle))
-	return ac, clientset, opt
-}
+	require.NoError(t, ac.registerWebhooks(opt, oldCA))
 
-// publishedCABundle returns the CA bundle the validating webhook configuration holds.
-func publishedCABundle(clientset *fake.Clientset) ([]byte, error) {
-	configuration, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().
-		Get(context.Background(), ValidateCRDWebhookConfigName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
+	// publishedCABundle returns the CA bundle the validating webhook configuration holds.
+	publishedCABundle := func(t *testing.T) []byte {
+		t.Helper()
+
+		configuration, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().
+			Get(context.Background(), ValidateCRDWebhookConfigName, metav1.GetOptions{})
+		require.NoError(t, err)
+		return configuration.Webhooks[0].ClientConfig.CABundle
 	}
-	return configuration.Webhooks[0].ClientConfig.CABundle, nil
-}
-
-func TestRefreshCABundle(t *testing.T) {
-	oldCA := []byte("old ca certificate")
-	newCA := []byte("rotated ca certificate")
-
-	ac, clientset, opt := registeredForCABundle(t, oldCA)
 
 	t.Run("unchanged ca is not published again", func(t *testing.T) {
 		clientset.ClearActions()
@@ -84,9 +73,7 @@ func TestRefreshCABundle(t *testing.T) {
 		require.NoError(t, os.WriteFile(opt.CaCertFile, newCA, 0600))
 
 		assert.Equal(t, newCA, ac.refreshCABundle(opt, oldCA))
-		published, err := publishedCABundle(clientset)
-		assert.NoError(t, err)
-		assert.Equal(t, newCA, published)
+		assert.Equal(t, newCA, publishedCABundle(t))
 	})
 
 	t.Run("rejected registration keeps the published bundle", func(t *testing.T) {
@@ -97,43 +84,15 @@ func TestRefreshCABundle(t *testing.T) {
 			})
 
 		assert.Equal(t, newCA, ac.refreshCABundle(opt, newCA))
-		published, err := publishedCABundle(clientset)
-		assert.NoError(t, err)
-		assert.Equal(t, newCA, published)
+		assert.Equal(t, newCA, publishedCABundle(t))
 	})
 
 	t.Run("unreadable ca keeps the published bundle", func(t *testing.T) {
 		require.NoError(t, os.Remove(opt.CaCertFile))
 
 		assert.Equal(t, newCA, ac.refreshCABundle(opt, newCA))
-		published, err := publishedCABundle(clientset)
-		assert.NoError(t, err)
-		assert.Equal(t, newCA, published)
+		assert.Equal(t, newCA, publishedCABundle(t))
 	})
-}
-
-func TestWatchCABundle(t *testing.T) {
-	oldCA := []byte("old ca certificate")
-	newCA := []byte("rotated ca certificate")
-
-	ac, clientset, opt := registeredForCABundle(t, oldCA)
-	// Rotate the CA before the watch starts, its first pass has to publish it.
-	require.NoError(t, os.WriteFile(opt.CaCertFile, newCA, 0600))
-
-	stopCh, stopped := make(chan struct{}), make(chan struct{})
-	go func() {
-		defer close(stopped)
-		ac.watchCABundle(opt, oldCA, stopCh)
-	}()
-	defer func() {
-		close(stopCh)
-		<-stopped
-	}()
-
-	assert.Eventually(t, func() bool {
-		published, err := publishedCABundle(clientset)
-		return err == nil && bytes.Equal(published, newCA)
-	}, 10*time.Second, 10*time.Millisecond)
 }
 
 func TestConfigTLS(t *testing.T) {

--- a/cloud/pkg/admissioncontroller/certreloader.go
+++ b/cloud/pkg/admissioncontroller/certreloader.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissioncontroller
+
+import (
+	"bytes"
+	"crypto/tls"
+	"os"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// certReloader serves the webhook certificate from the files it was loaded from and
+// reloads it whenever they change. The certificate is mounted from a secret that can
+// be rotated while the process runs, and without reloading the webhook keeps serving
+// the certificate read at startup, which stops matching the CA bundle published in
+// the webhook configurations once the CA is rotated too.
+type certReloader struct {
+	certFile string
+	keyFile  string
+
+	// mutex guards the cached key pair and the PEM it was loaded from.
+	mutex   sync.Mutex
+	certPEM []byte
+	keyPEM  []byte
+	cert    *tls.Certificate
+}
+
+// newCertReloader returns a reloader serving the key pair held by certFile and keyFile.
+func newCertReloader(certFile, keyFile string) (*certReloader, error) {
+	reloader := &certReloader{certFile: certFile, keyFile: keyFile}
+	if err := reloader.load(); err != nil {
+		return nil, err
+	}
+	return reloader, nil
+}
+
+// load caches the key pair on disk and does nothing when it has not changed since the
+// last successful load. The cached key pair is left alone when the files cannot be
+// read or do not parse, which also covers reading the certificate and the key while
+// they are rotated and picking up halves of two different key pairs.
+func (r *certReloader) load() error {
+	certPEM, err := os.ReadFile(r.certFile)
+	if err != nil {
+		return err
+	}
+	keyPEM, err := os.ReadFile(r.keyFile)
+	if err != nil {
+		return err
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if bytes.Equal(certPEM, r.certPEM) && bytes.Equal(keyPEM, r.keyPEM) {
+		return nil
+	}
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return err
+	}
+	r.certPEM, r.keyPEM, r.cert = certPEM, keyPEM, &cert
+	klog.Infof("Loaded the certificate from %s", r.certFile)
+	return nil
+}
+
+// GetCertificate is the tls.Config callback returning the certificate to serve.
+func (r *certReloader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if err := r.load(); err != nil {
+		klog.Errorf("failed to reload the certificate, serving the previously loaded one: %v", err)
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.cert, nil
+}

--- a/cloud/pkg/admissioncontroller/certreloader_test.go
+++ b/cloud/pkg/admissioncontroller/certreloader_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissioncontroller
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeKeyPair writes a self signed key pair issued for commonName to certFile and keyFile.
+func writeKeyPair(t *testing.T, certFile, keyFile, commonName string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(certFile,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0600))
+	require.NoError(t, os.WriteFile(keyFile,
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600))
+}
+
+// servedCommonName returns the common name of the certificate the reloader serves.
+func servedCommonName(t *testing.T, reloader *certReloader) string {
+	t.Helper()
+
+	cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+	return leaf.Subject.CommonName
+}
+
+func TestNewCertReloader(t *testing.T) {
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+
+	_, err := newCertReloader(certFile, keyFile)
+	assert.Error(err)
+
+	writeKeyPair(t, certFile, keyFile, "first")
+	reloader, err := newCertReloader(certFile, keyFile)
+	assert.NoError(err)
+	assert.Equal("first", servedCommonName(t, reloader))
+}
+
+func TestCertReloaderGetCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+
+	writeKeyPair(t, certFile, keyFile, "first")
+	reloader, err := newCertReloader(certFile, keyFile)
+	require.NoError(t, err)
+
+	t.Run("rotated key pair is served", func(t *testing.T) {
+		writeKeyPair(t, certFile, keyFile, "second")
+		assert.Equal(t, "second", servedCommonName(t, reloader))
+	})
+
+	t.Run("half rotated key pair keeps the previous one", func(t *testing.T) {
+		// The certificate is replaced but the matching key is not written yet.
+		writeKeyPair(t, filepath.Join(dir, "next.crt"), filepath.Join(dir, "next.key"), "third")
+		next, err := os.ReadFile(filepath.Join(dir, "next.crt"))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(certFile, next, 0600))
+
+		assert.Equal(t, "second", servedCommonName(t, reloader))
+	})
+
+	t.Run("unreadable key pair keeps the previous one", func(t *testing.T) {
+		require.NoError(t, os.Remove(certFile))
+		assert.Equal(t, "second", servedCommonName(t, reloader))
+	})
+}

--- a/cloud/pkg/admissioncontroller/certreloader_test.go
+++ b/cloud/pkg/admissioncontroller/certreloader_test.go
@@ -58,11 +58,11 @@ func writeKeyPair(t *testing.T, certFile, keyFile, commonName string) {
 		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600))
 }
 
-// servedCommonName returns the common name of the certificate the reloader serves.
-func servedCommonName(t *testing.T, reloader *certReloader) string {
+// servedCommonName returns the common name of the certificate getCertificate returns.
+func servedCommonName(t *testing.T, getCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)) string {
 	t.Helper()
 
-	cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+	cert, err := getCertificate(&tls.ClientHelloInfo{})
 	require.NoError(t, err)
 	require.NotNil(t, cert)
 	leaf, err := x509.ParseCertificate(cert.Certificate[0])
@@ -83,7 +83,7 @@ func TestNewCertReloader(t *testing.T) {
 	writeKeyPair(t, certFile, keyFile, "first")
 	reloader, err := newCertReloader(certFile, keyFile)
 	assert.NoError(err)
-	assert.Equal("first", servedCommonName(t, reloader))
+	assert.Equal("first", servedCommonName(t, reloader.GetCertificate))
 }
 
 func TestCertReloaderGetCertificate(t *testing.T) {
@@ -97,7 +97,7 @@ func TestCertReloaderGetCertificate(t *testing.T) {
 
 	t.Run("rotated key pair is served", func(t *testing.T) {
 		writeKeyPair(t, certFile, keyFile, "second")
-		assert.Equal(t, "second", servedCommonName(t, reloader))
+		assert.Equal(t, "second", servedCommonName(t, reloader.GetCertificate))
 	})
 
 	t.Run("half rotated key pair keeps the previous one", func(t *testing.T) {
@@ -107,11 +107,16 @@ func TestCertReloaderGetCertificate(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(certFile, next, 0600))
 
-		assert.Equal(t, "second", servedCommonName(t, reloader))
+		assert.Equal(t, "second", servedCommonName(t, reloader.GetCertificate))
 	})
 
-	t.Run("unreadable key pair keeps the previous one", func(t *testing.T) {
+	t.Run("unreadable key keeps the previous key pair", func(t *testing.T) {
+		require.NoError(t, os.Remove(keyFile))
+		assert.Equal(t, "second", servedCommonName(t, reloader.GetCertificate))
+	})
+
+	t.Run("unreadable certificate keeps the previous key pair", func(t *testing.T) {
 		require.NoError(t, os.Remove(certFile))
-		assert.Equal(t, "second", servedCommonName(t, reloader))
+		assert.Equal(t, "second", servedCommonName(t, reloader.GetCertificate))
 	})
 }

--- a/cloud/pkg/admissioncontroller/common.go
+++ b/cloud/pkg/admissioncontroller/common.go
@@ -11,29 +11,40 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	admissionregistrationv1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/kubeedge/common/constants"
 )
 
+// isRegistrationRetriable reports whether a failed registration can be resolved by
+// reading the webhook configuration again and writing it once more. A conflict means
+// another writer updated the configuration between our get and update, an already
+// exists error means another writer created it between our get and create.
+func isRegistrationRetriable(err error) bool {
+	return apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err)
+}
+
 func registerValidateWebhook(client admissionregistrationv1client.ValidatingWebhookConfigurationInterface,
 	webhooks []admissionregistrationv1.ValidatingWebhookConfiguration) error {
 	for _, hook := range webhooks {
-		existing, err := client.Get(context.Background(), hook.Name, metav1.GetOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if err == nil && existing != nil {
+		err := retry.OnError(retry.DefaultRetry, isRegistrationRetriable, func() error {
+			existing, err := client.Get(context.Background(), hook.Name, metav1.GetOptions{})
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				klog.Infof("Creating ValidatingWebhookConfiguration: %v", hook.Name)
+				_, err = client.Create(context.Background(), &hook, metav1.CreateOptions{})
+				return err
+			}
 			existing.Webhooks = hook.Webhooks
 			klog.Infof("Updating ValidatingWebhookConfiguration: %v", hook.Name)
-			if _, err := client.Update(context.Background(), existing, metav1.UpdateOptions{}); err != nil {
-				return err
-			}
-		} else {
-			klog.Infof("Creating ValidatingWebhookConfiguration: %v", hook.Name)
-			if _, err := client.Create(context.Background(), &hook, metav1.CreateOptions{}); err != nil {
-				return err
-			}
+			_, err = client.Update(context.Background(), existing, metav1.UpdateOptions{})
+			return err
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -42,21 +53,23 @@ func registerValidateWebhook(client admissionregistrationv1client.ValidatingWebh
 func registerMutatingWebhook(client admissionregistrationv1client.MutatingWebhookConfigurationInterface,
 	webhooks []admissionregistrationv1.MutatingWebhookConfiguration) error {
 	for _, hook := range webhooks {
-		existing, err := client.Get(context.Background(), hook.Name, metav1.GetOptions{})
-		if err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		if err == nil && existing != nil {
+		err := retry.OnError(retry.DefaultRetry, isRegistrationRetriable, func() error {
+			existing, err := client.Get(context.Background(), hook.Name, metav1.GetOptions{})
+			if err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				klog.Infof("Creating MutatingWebhookConfiguration: %v", hook.Name)
+				_, err = client.Create(context.Background(), &hook, metav1.CreateOptions{})
+				return err
+			}
 			existing.Webhooks = hook.Webhooks
 			klog.Infof("Updating MutatingWebhookConfiguration: %v", hook.Name)
-			if _, err := client.Update(context.Background(), existing, metav1.UpdateOptions{}); err != nil {
-				return err
-			}
-		} else {
-			klog.Infof("Creating MutatingWebhookConfiguration: %v", hook.Name)
-			if _, err := client.Create(context.Background(), &hook, metav1.CreateOptions{}); err != nil {
-				return err
-			}
+			_, err = client.Update(context.Background(), existing, metav1.UpdateOptions{})
+			return err
+		})
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cloud/pkg/admissioncontroller/common_test.go
+++ b/cloud/pkg/admissioncontroller/common_test.go
@@ -11,11 +11,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kubeedge/kubeedge/cloud/test/httpfake"
 )
+
+// failOnce returns a reactor failing the first action it handles with err and letting
+// the following ones fall through to the object tracker.
+func failOnce(err error) k8stesting.ReactionFunc {
+	handled := false
+	return func(k8stesting.Action) (bool, runtime.Object, error) {
+		if handled {
+			return false, nil, nil
+		}
+		handled = true
+		return true, nil, err
+	}
+}
 
 func TestRegisterValidateWebhook(t *testing.T) {
 	assert := assert.New(t)
@@ -141,6 +157,142 @@ func TestRegisterMutatingWebhook(t *testing.T) {
 					assert.Equal(hook.Webhooks, registeredHook.Webhooks)
 				}
 			}
+		})
+	}
+}
+
+func TestRegisterValidateWebhookConcurrentWriter(t *testing.T) {
+	const name = "test-webhook"
+	resource := admissionregistrationv1.Resource("validatingwebhookconfigurations")
+
+	existing := func() *admissionregistrationv1.ValidatingWebhookConfiguration {
+		return &admissionregistrationv1.ValidatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Webhooks:   []admissionregistrationv1.ValidatingWebhook{{Name: "old.test-webhook.com"}},
+		}
+	}
+	hooks := []admissionregistrationv1.ValidatingWebhookConfiguration{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Webhooks:   []admissionregistrationv1.ValidatingWebhook{{Name: "new.test-webhook.com"}},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		verb          string
+		reactionError error
+		expectedError bool
+	}{
+		{
+			name:          "another writer updated the configuration first",
+			verb:          "update",
+			reactionError: apierrors.NewConflict(resource, name, errors.New("object was modified")),
+		},
+		{
+			name:          "another writer created the configuration first",
+			verb:          "create",
+			reactionError: apierrors.NewAlreadyExists(resource, name),
+		},
+		{
+			name:          "the api server rejected the registration",
+			verb:          "update",
+			reactionError: apierrors.NewInternalError(errors.New("registration failed")),
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			clientset := fake.NewSimpleClientset(existing())
+			if tc.verb == "create" {
+				// The configuration is only seen after the create lost the race.
+				clientset.PrependReactor("get", "validatingwebhookconfigurations",
+					failOnce(apierrors.NewNotFound(resource, name)))
+			}
+			clientset.PrependReactor(tc.verb, "validatingwebhookconfigurations", failOnce(tc.reactionError))
+
+			err := registerValidateWebhook(clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations(), hooks)
+			if tc.expectedError {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+
+			registeredHook, err := clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations().
+				Get(context.Background(), name, metav1.GetOptions{})
+			assert.NoError(err)
+			assert.Equal(hooks[0].Webhooks, registeredHook.Webhooks)
+		})
+	}
+}
+
+func TestRegisterMutatingWebhookConcurrentWriter(t *testing.T) {
+	const name = "test-mutating-webhook"
+	resource := admissionregistrationv1.Resource("mutatingwebhookconfigurations")
+
+	existing := func() *admissionregistrationv1.MutatingWebhookConfiguration {
+		return &admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Webhooks:   []admissionregistrationv1.MutatingWebhook{{Name: "old.mutating.webhook.com"}},
+		}
+	}
+	hooks := []admissionregistrationv1.MutatingWebhookConfiguration{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Webhooks:   []admissionregistrationv1.MutatingWebhook{{Name: "new.mutating.webhook.com"}},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		verb          string
+		reactionError error
+		expectedError bool
+	}{
+		{
+			name:          "another writer updated the configuration first",
+			verb:          "update",
+			reactionError: apierrors.NewConflict(resource, name, errors.New("object was modified")),
+		},
+		{
+			name:          "another writer created the configuration first",
+			verb:          "create",
+			reactionError: apierrors.NewAlreadyExists(resource, name),
+		},
+		{
+			name:          "the api server rejected the registration",
+			verb:          "update",
+			reactionError: apierrors.NewInternalError(errors.New("registration failed")),
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			clientset := fake.NewSimpleClientset(existing())
+			if tc.verb == "create" {
+				// The configuration is only seen after the create lost the race.
+				clientset.PrependReactor("get", "mutatingwebhookconfigurations",
+					failOnce(apierrors.NewNotFound(resource, name)))
+			}
+			clientset.PrependReactor(tc.verb, "mutatingwebhookconfigurations", failOnce(tc.reactionError))
+
+			err := registerMutatingWebhook(clientset.AdmissionregistrationV1().MutatingWebhookConfigurations(), hooks)
+			if tc.expectedError {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+
+			registeredHook, err := clientset.AdmissionregistrationV1().MutatingWebhookConfigurations().
+				Get(context.Background(), name, metav1.GetOptions{})
+			assert.NoError(err)
+			assert.Equal(hooks[0].Webhooks, registeredHook.Webhooks)
 		})
 	}
 }

--- a/cloud/pkg/admissioncontroller/common_test.go
+++ b/cloud/pkg/admissioncontroller/common_test.go
@@ -195,6 +195,12 @@ func TestRegisterValidateWebhookConcurrentWriter(t *testing.T) {
 			reactionError: apierrors.NewAlreadyExists(resource, name),
 		},
 		{
+			name:          "the api server rejected reading the configuration",
+			verb:          "get",
+			reactionError: apierrors.NewInternalError(errors.New("read failed")),
+			expectedError: true,
+		},
+		{
 			name:          "the api server rejected the registration",
 			verb:          "update",
 			reactionError: apierrors.NewInternalError(errors.New("registration failed")),
@@ -261,6 +267,12 @@ func TestRegisterMutatingWebhookConcurrentWriter(t *testing.T) {
 			name:          "another writer created the configuration first",
 			verb:          "create",
 			reactionError: apierrors.NewAlreadyExists(resource, name),
+		},
+		{
+			name:          "the api server rejected reading the configuration",
+			verb:          "get",
+			reactionError: apierrors.NewInternalError(errors.New("read failed")),
+			expectedError: true,
 		},
 		{
 			name:          "the api server rejected the registration",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

Hardens admission's webhook self-registration and certificate handling, which
today cannot survive a certificate rotation without a restart:

- `registerValidateWebhook` / `registerMutatingWebhook` did get -> overwrite
  `Webhooks` -> update with no resourceVersion conflict handling, and a create
  losing the race to another writer returned `AlreadyExists` straight to `Run`.
  Both now register under `retry.OnError`, treating conflict and already-exists
  as retriable so the registration re-reads and converges.
- The CA bundle was read once at startup and copied into the webhook
  configurations. It is now re-read periodically and published again when it
  changes, so a rotated CA reaches the API server before the previous one is
  gone.
- The serving certificate was loaded once by `configTLS`. Refreshing only the
  published `CABundle` would break the webhook after a CA rotation, since the
  process would keep presenting a leaf that no longer chains to it, so the
  certificate is now served through a reloader that picks up the rotated key
  pair. It keeps the last pair that loaded successfully when the files are
  unreadable or when a rotation is caught mid write.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7220 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed the admission webhook not picking up a rotated certificate: the CA bundle
published in the webhook configurations and the certificate served by the webhook
are now reloaded instead of staying at the values read when the process started.
```
