### PR TITLE
fix: avoid shell command execution in backup and rollback actions

### DIFF
--- a/edge/pkg/taskmanager/actions/configupdatejob.go
+++ b/edge/pkg/taskmanager/actions/configupdatejob.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -31,7 +32,6 @@ import (
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
-	"github.com/kubeedge/kubeedge/pkg/util/execs"
 )
 
 func newConfigUpdateJobRunner() *ActionRunner {
@@ -79,8 +79,10 @@ func (h *configUpdateJobActionHandler) backup(
 	_specser SpecSerializer,
 ) ActionResponse {
 	resp := new(configUpdateJobActionResponse)
-	cmdStr := execs.NewCommand("keadm backup edge")
-	err := cmdStr.Exec()
+	cmd := exec.Command("keadm", "backup", "edge")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
 	if err != nil {
 		resp.err = err
 		return resp
@@ -116,8 +118,10 @@ func (h *configUpdateJobActionHandler) rollback(
 	specser SpecSerializer,
 ) ActionResponse {
 	resp := new(configUpdateJobActionResponse)
-	cmdStr := execs.NewCommand("keadm rollback edge")
-	resp.err = cmdStr.Exec()
+	cmd := exec.Command("keadm", "rollback", "edge")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	resp.err = cmd.Run()
 	return resp
 }
 

--- a/edge/pkg/taskmanager/actions/nodeupgradejob.go
+++ b/edge/pkg/taskmanager/actions/nodeupgradejob.go
@@ -38,7 +38,6 @@ import (
 	"github.com/kubeedge/kubeedge/pkg/nodetask/actionflow"
 	taskmsg "github.com/kubeedge/kubeedge/pkg/nodetask/message"
 	upgradeedge "github.com/kubeedge/kubeedge/pkg/upgrade/edge"
-	"github.com/kubeedge/kubeedge/pkg/util/execs"
 	"github.com/kubeedge/kubeedge/pkg/util/validation"
 )
 
@@ -214,10 +213,11 @@ func (h *nodeUpgradeJobActionHandler) backup(
 	_specser SpecSerializer,
 ) ActionResponse {
 	resp := new(nodeUpgradeJobActionResponse)
-	cmdline := "keadm backup edge"
-	cmd := execs.NewCommand(cmdline)
-	h.logger.V(2).Info("run backup cmd", "cmd", cmdline)
-	if err := cmd.Exec(); err != nil {
+	cmd := exec.Command("keadm", "backup", "edge")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	h.logger.V(2).Info("run backup cmd", "cmd", "keadm", "args", []string{"backup", "edge"})
+	if err := cmd.Run(); err != nil {
 		resp.err = err
 		return resp
 	}
@@ -296,10 +296,18 @@ func (h *nodeUpgradeJobActionHandler) rollback(
 ) ActionResponse {
 	resp := new(nodeUpgradeJobActionResponse)
 	// Roll back to the previous version
-	cmdline := "keadm rollback edge >> /tmp/keadm.log 2>&1"
-	cmd := execs.NewCommand(cmdline)
-	h.logger.V(2).Info("run rollback cmd", "cmd", cmdline)
-	resp.err = cmd.Exec()
+	logFile, err := os.OpenFile("/tmp/keadm.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		resp.err = fmt.Errorf("failed to open keadm log file: %w", err)
+		return resp
+	}
+	defer logFile.Close()
+
+	cmd := exec.Command("keadm", "rollback", "edge")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	h.logger.V(2).Info("run rollback cmd", "cmd", "keadm", "args", []string{"rollback", "edge"})
+	resp.err = cmd.Run()
 	return resp
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR completes the shell-injection remediations (originally addressed in `ea2eba334` and `2b89d683e`) by removing the remaining invocations of `bash -c` in the task manager.

Specifically:
- Replaced `execs.NewCommand` with `exec.Command` for `backup` and `rollback` actions in `NodeUpgradeJob` and `ConfigUpdateJob`. 
- Refactored `nodeupgradejob.go`'s `rollback` to safely redirect stdout and stderr to the log file via `os.OpenFile`, rather than using shell redirection (`>> /tmp/keadm.log 2>&1`).
- Removed the `execs` package import from both files since it's no longer needed, reducing attack surface and ensuring consistent defense-in-depth across the module.

**Which issue(s) this PR fixes**:

Fixes #7232

**Special notes for your reviewer**:

The changes rely strictly on standard library implementations (`os/exec`) avoiding shell wrappers completely, staying consistent with the security fix pattern applied to the `upgrade` and `updateConfig` handlers. 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
