### PR TITLE
fix(edgecore): prevent EdgeHub reconnect deadlock on cert rotation

### DIFF
--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -69,7 +69,7 @@ func NewCertManager(edgehub v1alpha2.EdgeHub, nodename string) CertManager {
 		now:                time.Now,
 		caURL:              edgehub.HTTPServer + constants.DefaultCAURL,
 		certURL:            edgehub.HTTPServer + constants.DefaultCertURL,
-		Done:               make(chan struct{}),
+		Done:               make(chan struct{}, 1),
 	}
 }
 
@@ -219,7 +219,10 @@ func (cm *CertManager) rotateCert() (bool, error) {
 
 	klog.Info("succeeded to rotate certificate")
 
-	cm.Done <- struct{}{}
+	select {
+	case cm.Done <- struct{}{}:
+	default:
+	}
 
 	return true, nil
 }

--- a/edge/pkg/edgehub/certificate/certmanager_test.go
+++ b/edge/pkg/edgehub/certificate/certmanager_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -34,6 +35,7 @@ import (
 	"github.com/kubeedge/kubeedge/common/constants"
 	commhttp "github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate/http"
 	httpfake "github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate/http/fake"
+	"github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2"
 	"github.com/kubeedge/kubeedge/pkg/security/certs"
 )
 
@@ -132,6 +134,120 @@ func TestGetEdgeCert(t *testing.T) {
 		cm := &CertManager{}
 		_, _, err := cm.GetEdgeCert(fakehost+constants.DefaultCAURL, []byte{}, tls.Certificate{}, "")
 		require.NoError(t, err)
+	})
+}
+
+func TestNewCertManager(t *testing.T) {
+	edgehubConfig := v1alpha2.EdgeHub{
+		RotateCertificates: true,
+		Token:              "test-token",
+		TLSCAFile:          "ca.crt",
+		TLSCertFile:        "server.crt",
+		TLSPrivateKeyFile:  "server.key",
+		HTTPServer:         "https://localhost:10002",
+	}
+	nodename := "testnode"
+
+	cm := NewCertManager(edgehubConfig, nodename)
+
+	require.Equal(t, edgehubConfig.RotateCertificates, cm.RotateCertificates)
+	require.Equal(t, nodename, cm.NodeName)
+	require.Equal(t, edgehubConfig.Token, cm.token)
+	require.Equal(t, edgehubConfig.TLSCAFile, cm.caFile)
+	require.Equal(t, edgehubConfig.TLSCertFile, cm.certFile)
+	require.Equal(t, edgehubConfig.TLSPrivateKeyFile, cm.keyFile)
+	require.Equal(t, edgehubConfig.HTTPServer+constants.DefaultCAURL, cm.caURL)
+	require.Equal(t, edgehubConfig.HTTPServer+constants.DefaultCertURL, cm.certURL)
+	require.NotNil(t, cm.Done)
+	require.Equal(t, 1, cap(cm.Done))
+}
+
+func TestRotateCert(t *testing.T) {
+	cahandler := certs.GetCAHandler(certs.CAHandlerTypeX509)
+	pk, err := cahandler.GenPrivateKey()
+	require.NoError(t, err)
+	caPem, err := cahandler.NewSelfSigned(pk)
+	require.NoError(t, err)
+
+	certshandler := certs.GetHandler(certs.HandlerTypeX509)
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(commhttp.NewHTTPClientWithCA,
+		func(capem []byte, certificate tls.Certificate) (*http.Client, error) {
+			return &http.Client{}, nil
+		})
+	patches.ApplyFunc(commhttp.SendRequest,
+		func(req *http.Request, _ *http.Client) (*http.Response, error) {
+			csrBytes, err := io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			certBlock, err := certshandler.SignCerts(certs.SignCertsOptionsWithCSR(
+				csrBytes,
+				caPem.Bytes,
+				pk.DER(),
+				[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				time.Hour,
+			))
+			if err != nil {
+				return nil, err
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       httpfake.NewFakeBodyReader(certBlock.Bytes),
+			}, nil
+		})
+
+	t.Run("rotateCert sends to Done channel when receiver ready", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{}, 1)
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			// Success
+		default:
+			t.Fatal("expected signal on Done channel")
+		}
+	})
+
+	t.Run("rotateCert does not block when no receiver on Done channel", func(t *testing.T) {
+		require.NoError(t, genFakeCerts())
+		defer os.RemoveAll(fakeCertsDir)
+
+		doneChan := make(chan struct{})
+		cm := &CertManager{
+			NodeName: "testnode",
+			caFile:   filepath.Join(fakeCertsDir, "ca.crt"),
+			certFile: filepath.Join(fakeCertsDir, "server.crt"),
+			keyFile:  filepath.Join(fakeCertsDir, "server.key"),
+			Done:     doneChan,
+		}
+
+		success, err := cm.rotateCert()
+		require.NoError(t, err)
+		require.True(t, success)
+
+		select {
+		case <-doneChan:
+			t.Fatal("unexpected signal on unbuffered unread Done channel")
+		default:
+			// Success
+		}
 	})
 }
 

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -149,8 +149,17 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 func (eh *EdgeHub) ifRotationDone() {
 	if eh.certManager.RotateCertificates {
 		for {
-			<-eh.certManager.Done
-			eh.reconnectChan <- struct{}{}
+			select {
+			case <-beehiveContext.Done():
+				klog.Warning("EdgeHub ifRotationDone stop")
+				return
+			case <-eh.certManager.Done:
+				select {
+				case <-beehiveContext.Done():
+					return
+				case eh.reconnectChan <- struct{}{}:
+				}
+			}
 		}
 	}
 }

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -158,6 +158,7 @@ func (eh *EdgeHub) ifRotationDone() {
 				case <-beehiveContext.Done():
 					return
 				case eh.reconnectChan <- struct{}{}:
+				default:
 				}
 			}
 		}

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubeedge/kubeedge/edge/mocks/edgehub"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/message"
 	"github.com/kubeedge/kubeedge/edge/pkg/common/modules"
+	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/certificate"
 	"github.com/kubeedge/kubeedge/edge/pkg/edgehub/config"
 	msghandler "github.com/kubeedge/kubeedge/edge/pkg/edgehub/messagehandler"
 )
@@ -376,4 +377,65 @@ func TestKeepalive(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIfRotationDone(t *testing.T) {
+	t.Run("RotateCertificates disabled", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: false,
+			},
+		}
+		hub.ifRotationDone()
+	})
+
+	t.Run("Successful send to reconnectChan when receiver ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		recChan := make(chan struct{})
+		go func() {
+			<-hub.reconnectChan
+			close(recChan)
+		}()
+
+		time.Sleep(20 * time.Millisecond)
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-recChan:
+			// Success: reconnectChan received signal
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
+	t.Run("Sends to reconnectChan when receiver becomes ready", func(t *testing.T) {
+		hub := &EdgeHub{
+			certManager: certificate.CertManager{
+				RotateCertificates: true,
+				Done:               make(chan struct{}, 1),
+			},
+			reconnectChan: make(chan struct{}),
+		}
+
+		go hub.ifRotationDone()
+
+		hub.certManager.Done <- struct{}{}
+
+		select {
+		case <-hub.reconnectChan:
+			// Success: reconnectChan received signal when receiver read from it
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected signal on reconnectChan")
+		}
+	})
+
 }

--- a/edge/pkg/edgehub/process_test.go
+++ b/edge/pkg/edgehub/process_test.go
@@ -417,7 +417,7 @@ func TestIfRotationDone(t *testing.T) {
 		}
 	})
 
-	t.Run("Sends to reconnectChan when receiver becomes ready", func(t *testing.T) {
+	t.Run("Drops signal to reconnectChan when receiver is not ready", func(t *testing.T) {
 		hub := &EdgeHub{
 			certManager: certificate.CertManager{
 				RotateCertificates: true,
@@ -430,11 +430,14 @@ func TestIfRotationDone(t *testing.T) {
 
 		hub.certManager.Done <- struct{}{}
 
+		// Give ifRotationDone time to process the signal and drop it
+		time.Sleep(50 * time.Millisecond)
+
 		select {
 		case <-hub.reconnectChan:
-			// Success: reconnectChan received signal when receiver read from it
-		case <-time.After(2 * time.Second):
-			t.Fatal("expected signal on reconnectChan")
+			t.Fatal("did not expect signal on reconnectChan because receiver was not ready")
+		case <-time.After(100 * time.Millisecond):
+			// Success: signal was dropped
 		}
 	})
 


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
This PR resolves an issue where the EdgeHub certificate rotation goroutine (`ifRotationDone`) blocks indefinitely when EdgeHub is actively reconnecting. Because `reconnectChan` is an unbuffered channel, sending to it synchronously causes `ifRotationDone` to hang if no receiver is active. When the receiver finally becomes active, it consumes a stale reconnect signal leading to a spurious, redundant reconnection cycle. This PR changes the channel send to use a non-blocking `select` with a `default` case, safely dropping the signal if EdgeHub is currently unreachable or already reconnecting. 

**Which issue(s) this PR fixes**:
Fixes #7143

**Special notes for your reviewer**:
A unit test in `process_test.go` was updated to explicitly verify this non-blocking behavior by intentionally omitting a ready receiver and asserting that the signal is correctly dropped without deadlocking. 
Tested locally using `go test ./edge/pkg/edgehub/...`. (Note: an unrelated test `wsclient` failure on Windows was observed due to OS-specific string matching on "file not found", but all `edgehub` tests pass).

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a deadlock issue where EdgeHub certificate rotation could become permanently blocked if triggered during transient cloud-core connection loss.
```
