### PR TITLE
Fix: mitigate Slowloris DoS vulnerability by setting ReadHeaderTimeout across HTTP servers

### DIFF
--- a/cloud/pkg/admissioncontroller/admission.go
+++ b/cloud/pkg/admissioncontroller/admission.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -113,8 +114,9 @@ func Run(opt *options.AdmissionOptions) error {
 		return err
 	}
 	server := &http.Server{
-		Addr:      fmt.Sprintf(":%v", opt.Port),
-		TLSConfig: tlsConfig,
+		Addr:              fmt.Sprintf(":%v", opt.Port),
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	if err := server.ListenAndServeTLS("", ""); err != nil {

--- a/cloud/pkg/cloudhub/servers/httpserver/server.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/server.go
@@ -20,6 +20,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/emicklei/go-restful"
 	certutil "k8s.io/client-go/util/cert"
@@ -45,8 +46,9 @@ func StartHTTPServer() error {
 	}
 
 	server := &http.Server{
-		Addr:    addr,
-		Handler: serverContainer,
+		Addr:              addr,
+		Handler:           serverContainer,
+		ReadHeaderTimeout: 10 * time.Second,
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			ClientAuth:   tls.RequestClientCert,

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/emicklei/go-restful"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -392,8 +393,9 @@ func (s *StreamServer) Start() {
 	pool.AppendCertsFromPEM(data)
 
 	streamServer := &http.Server{
-		Addr:    fmt.Sprintf(":%d", config.Config.StreamPort),
-		Handler: s.container,
+		Addr:              fmt.Sprintf(":%d", config.Config.StreamPort),
+		Handler:           s.container,
+		ReadHeaderTimeout: 10 * time.Second,
 		TLSConfig: &tls.Config{
 			ClientCAs: pool,
 			// Populate PeerCertificates in requests, but don't reject connections without verified certificates

--- a/cloud/pkg/cloudstream/tunnelserver.go
+++ b/cloud/pkg/cloudstream/tunnelserver.go
@@ -195,8 +195,9 @@ func (s *TunnelServer) Start() {
 	}
 
 	tunnelServer := &http.Server{
-		Addr:    fmt.Sprintf(":%d", streamconfig.Config.TunnelPort),
-		Handler: s.container,
+		Addr:              fmt.Sprintf(":%d", streamconfig.Config.TunnelPort),
+		Handler:           s.container,
+		ReadHeaderTimeout: 10 * time.Second,
 		TLSConfig: &tls.Config{
 			ClientCAs:    pool,
 			Certificates: []tls.Certificate{certificate},

--- a/cloud/pkg/common/monitor/monitor.go
+++ b/cloud/pkg/common/monitor/monitor.go
@@ -79,8 +79,9 @@ func ServeMonitor(config config.MonitorServer) {
 	}
 
 	s := http.Server{
-		Addr:    config.BindAddress,
-		Handler: mux,
+		Addr:              config.BindAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {

--- a/cloud/pkg/router/listener/http.go
+++ b/cloud/pkg/router/listener/http.go
@@ -56,8 +56,9 @@ func (rh *RestHandler) Serve() {
 	mux.HandleFunc("/", rh.httpHandler)
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", rh.bindAddress, rh.port),
-		Handler: mux,
+		Addr:              fmt.Sprintf("%s:%d", rh.bindAddress, rh.port),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 		// TODO: add tls for router
 	}
 	klog.Infof("router server listening in %d...", rh.port)

--- a/edge/pkg/metamanager/metaserver/server.go
+++ b/edge/pkg/metamanager/metaserver/server.go
@@ -131,8 +131,9 @@ func (ls *MetaServer) startHTTPServer(stopChan <-chan struct{}) {
 	h := ls.BuildBasicHandler()
 	h = BuildHandlerChain(h, ls)
 	s := http.Server{
-		Addr:    metaserverconfig.Config.Server,
-		Handler: h,
+		Addr:              metaserverconfig.Config.Server,
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {
@@ -160,9 +161,10 @@ func (ls *MetaServer) startHTTPSServer(addr string, stopChan <-chan struct{}) {
 	h := ls.BuildBasicHandler()
 	h = BuildHandlerChain(h, ls)
 	s := http.Server{
-		Addr:      addr,
-		Handler:   h,
-		TLSConfig: tlsConfig,
+		Addr:              addr,
+		Handler:           h,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {

--- a/edge/pkg/servicebus/servicebus.go
+++ b/edge/pkg/servicebus/servicebus.go
@@ -406,8 +406,9 @@ func server(stopChan <-chan struct{}, tlsOpts TLSOptions) {
 
 	h := buildBasicHandler(timeout)
 	s := http.Server{
-		Addr:    fmt.Sprintf("%s:%d", servicebusConfig.Config.Server, servicebusConfig.Config.Port),
-		Handler: h,
+		Addr:              fmt.Sprintf("%s:%d", servicebusConfig.Config.Server, servicebusConfig.Config.Port),
+		Handler:           h,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	if tlsOpts.TLSEnabled {

--- a/edge/test/cloudhub/stub.go
+++ b/edge/test/cloudhub/stub.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/websocket"
 	v1 "k8s.io/api/core/v1"
@@ -128,8 +129,9 @@ func (tm *stubCloudHub) Start() {
 	mux.HandleFunc("/{group_id}/events", tm.serveEvent) // for edge-hub
 	mux.HandleFunc("/pod", tm.podHandler)               // for pod test
 	s := http.Server{
-		Addr:    "127.0.0.1:20000",
-		Handler: mux,
+		Addr:              "127.0.0.1:20000",
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	klog.Info("Start cloud hub service")
 	err := s.ListenAndServe()

--- a/edgesite/cmd/edgesite-server/app/server.go
+++ b/edgesite/cmd/edgesite-server/app/server.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -184,6 +185,7 @@ func (p *Proxy) runUDSMasterServer(ctx context.Context, o *options.ProxyRunOptio
 			Handler: &server.Tunnel{
 				Server: s,
 			},
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 		stop = func() {
 			err := server.Shutdown(ctx)
@@ -270,6 +272,7 @@ func (p *Proxy) runMTLSMasterServer(ctx context.Context, o *options.ProxyRunOpti
 			Handler: &server.Tunnel{
 				Server: s,
 			},
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 		// http-connect
 		server := &http.Server{
@@ -278,7 +281,8 @@ func (p *Proxy) runMTLSMasterServer(ctx context.Context, o *options.ProxyRunOpti
 			Handler: &server.Tunnel{
 				Server: s,
 			},
-			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
+			TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 
 		stop = func() {
@@ -347,9 +351,10 @@ func (p *Proxy) runAdminServer(o *options.ProxyRunOptions) {
 		}
 	}
 	adminServer := &http.Server{
-		Addr:           fmt.Sprintf("127.0.0.1:%d", o.AdminPort),
-		Handler:        muxHandler,
-		MaxHeaderBytes: 1 << 20,
+		Addr:              fmt.Sprintf("127.0.0.1:%d", o.AdminPort),
+		Handler:           muxHandler,
+		MaxHeaderBytes:    1 << 20,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {
@@ -380,9 +385,10 @@ func (p *Proxy) runHealthServer(o *options.ProxyRunOptions, server *server.Proxy
 	muxHandler.HandleFunc("/healthz", livenessHandler)
 	muxHandler.HandleFunc("/ready", readinessHandler)
 	healthServer := &http.Server{
-		Addr:           fmt.Sprintf(":%d", o.HealthPort),
-		Handler:        muxHandler,
-		MaxHeaderBytes: 1 << 20,
+		Addr:              fmt.Sprintf(":%d", o.HealthPort),
+		Handler:           muxHandler,
+		MaxHeaderBytes:    1 << 20,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	go func() {

--- a/pkg/viaduct/pkg/server/ws.go
+++ b/pkg/viaduct/pkg/server/ws.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"k8s.io/klog/v2"
@@ -40,9 +41,10 @@ func NewWSServer(opts Options, exOpts interface{}) *WSServer {
 	}
 
 	server := http.Server{
-		Addr:      opts.Addr,
-		TLSConfig: opts.TLS,
-		ErrorLog:  glog.New(&LoggerFilter{}, "", glog.LstdFlags),
+		Addr:              opts.Addr,
+		TLSConfig:         opts.TLS,
+		ErrorLog:          glog.New(&LoggerFilter{}, "", glog.LstdFlags),
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	wsServer := &WSServer{

--- a/staging/src/github.com/kubeedge/mapper-framework/pkg/httpserver/server.go
+++ b/staging/src/github.com/kubeedge/mapper-framework/pkg/httpserver/server.go
@@ -52,10 +52,11 @@ func NewRestServer(devPanel global.DevPanel, httpPort string, options ...Option)
 func (rs *RestServer) StartServer() {
 	rs.InitRouter()
 	rs.server = &http.Server{
-		Addr:         rs.IP + ":" + rs.Port,
-		WriteTimeout: rs.WriteTimeout,
-		ReadTimeout:  rs.ReadTimeout,
-		Handler:      rs.Router,
+		Addr:              rs.IP + ":" + rs.Port,
+		WriteTimeout:      rs.WriteTimeout,
+		ReadTimeout:       rs.ReadTimeout,
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler:           rs.Router,
 	}
 	if rs.CaCertFilePath == "" && (rs.KeyFilePath == "" || rs.CertFilePath == "") {
 		// insecure

--- a/tests/e2e/utils/common.go
+++ b/tests/e2e/utils/common.go
@@ -620,7 +620,11 @@ func StartEchoServer() (string, error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/echo", echo)
 	mux.HandleFunc("/url", url)
-	server := &http.Server{Addr: "127.0.0.1:9000", Handler: mux}
+	server := &http.Server{
+		Addr:              "127.0.0.1:9000",
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 	go func() {
 		err := server.ListenAndServe()
 		Errorf("Echo server stop. reason: %s", err.Error())


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This PR mitigates a potential Slowloris DoS vulnerability across KubeEdge HTTP servers. It configures `ReadHeaderTimeout` on `http.Server` instances in the `cloud` and `edge` packages to safely time out slow clients, ensuring they cannot exhaust server resources by sending incomplete headers.

**Which issue(s) this PR fixes**:
Fixes #7231

**Special notes for your reviewer**:
Tested compilation against standard KubeEdge make rules.

**Does this PR introduce a user-facing change?**:
` ` `release-note
NONE
` ` `

