### PR TITLE
cloudstream: preserve metrics completion status

### DIFF
--- a/cloud/pkg/cloudstream/apiserverconnection.go
+++ b/cloud/pkg/cloudstream/apiserverconnection.go
@@ -33,3 +33,9 @@ type APIServerConnection interface {
 	// EdgePeerDone indicates whether edge peer ends
 	EdgePeerDone() chan struct{}
 }
+
+// edgePeerCompletionAware is implemented by connections that can distinguish
+// an explicit peer result from a legacy completion signal.
+type edgePeerCompletionAware interface {
+	SetEdgePeerCompletion(error)
+}

--- a/cloud/pkg/cloudstream/containermetrics_connection.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection.go
@@ -39,7 +39,10 @@ type ContainerMetricsConnection struct {
 	writer       io.Writer
 	session      *Session
 	edgePeerStop chan struct{}
-	closeChan    chan bool
+	// edgePeerCompletion carries an explicit result from completion-aware peers.
+	// edgePeerStop remains the legacy path where the result is unknown.
+	edgePeerCompletion chan error
+	closeChan          chan bool
 }
 
 func (ms *ContainerMetricsConnection) String() string {
@@ -69,6 +72,21 @@ func (ms *ContainerMetricsConnection) SetEdgePeerDone() {
 
 func (ms *ContainerMetricsConnection) EdgePeerDone() chan struct{} {
 	return ms.edgePeerStop
+}
+
+// SetEdgePeerCompletion records an explicit edge-side metrics result.
+func (ms *ContainerMetricsConnection) SetEdgePeerCompletion(err error) {
+	select {
+	case <-ms.closeChan:
+		return
+	case ms.edgePeerCompletion <- err:
+		klog.V(6).Infof("success send completion for connection with messageID %v", ms.MessageID)
+	}
+}
+
+// EdgePeerCompletion returns explicit edge-side metrics results.
+func (ms *ContainerMetricsConnection) EdgePeerCompletion() <-chan error {
+	return ms.edgePeerCompletion
 }
 
 func (ms *ContainerMetricsConnection) WriteToTunnel(m *stream.Message) error {
@@ -122,7 +140,9 @@ func (ms *ContainerMetricsConnection) Serve() error {
 			return nil
 		case <-ms.EdgePeerDone():
 			klog.V(6).Infof("%s find edge peer done, so stop this connection", ms.String())
-			return fmt.Errorf("%s find edge peer done, so stop this connection", ms.String())
+			return fmt.Errorf("%s find edge peer done without completion status", ms.String())
+		case err := <-ms.EdgePeerCompletion():
+			return err
 		}
 	}
 }

--- a/cloud/pkg/cloudstream/containermetrics_connection_test.go
+++ b/cloud/pkg/cloudstream/containermetrics_connection_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstream
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/url"
@@ -166,4 +167,43 @@ func TestSendConnection_Metrics(t *testing.T) {
 
 	assert.NotNil(mockTunneler.lastMessage)
 	assert.Equal(stream.MessageTypeMetricConnect, mockTunneler.lastMessage.MessageType)
+}
+
+func TestServeMetricsReturnsExplicitCompletionResult(t *testing.T) {
+	mockReq := &http.Request{
+		URL:    &url.URL{Path: "/metrics/resource"},
+		Header: http.Header{},
+	}
+	tests := []struct {
+		name       string
+		completion error
+		wantError  bool
+	}{
+		{name: "success", completion: nil, wantError: false},
+		{name: "edge failure", completion: assert.AnError, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockTunneler := &MockTunneler{}
+			metricsConn := &ContainerMetricsConnection{
+				MessageID:          1,
+				ctx:                context.Background(),
+				r:                  &restful.Request{Request: mockReq},
+				session:            &Session{tunnel: mockTunneler},
+				edgePeerStop:       make(chan struct{}, 1),
+				edgePeerCompletion: make(chan error, 1),
+				closeChan:          make(chan bool),
+			}
+			metricsConn.SetEdgePeerCompletion(tt.completion)
+
+			err := metricsConn.Serve()
+
+			if tt.wantError {
+				assert.ErrorIs(t, err, tt.completion)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/cloud/pkg/cloudstream/session.go
+++ b/cloud/pkg/cloudstream/session.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudstream
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -26,6 +27,8 @@ import (
 
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
+
+var errTunnelSessionClosed = errors.New("tunnel session closed before connection completion")
 
 // Session indicates one tunnel connection (default websocket) from edgecore
 // And multiple kube-apiserver initiated requests to this edgecore
@@ -49,31 +52,49 @@ func (s *Session) WriteMessageToTunnel(m *stream.Message) error {
 }
 
 func (s *Session) Close() {
+	s.closeWithError(errTunnelSessionClosed)
+}
+
+func (s *Session) closeWithError(err error) {
 	s.apiConnlock.Lock()
 	defer s.apiConnlock.Unlock()
 	for _, c := range s.apiServerConn {
-		c.SetEdgePeerDone()
+		setEdgePeerCompletion(c, err)
 	}
 	s.tunnel.Close()
 	s.tunnelClosed = true
 }
 
+func setEdgePeerCompletion(connection APIServerConnection, err error) {
+	if completionAware, ok := connection.(edgePeerCompletionAware); ok {
+		completionAware.SetEdgePeerCompletion(err)
+		return
+	}
+	connection.SetEdgePeerDone()
+}
+
 // Serve read tunnel message ,and write to specific apiserver connection
 func (s *Session) Serve() {
-	defer s.Close()
+	sessionErr := errTunnelSessionClosed
+	defer func() {
+		s.closeWithError(sessionErr)
+	}()
 
 	for {
 		t, r, err := s.tunnel.NextReader()
 		if err != nil {
+			sessionErr = fmt.Errorf("get %s reader: %w", s.String(), err)
 			klog.Errorf("get %v reader error %v", s.String(), err)
 			return
 		}
 		if t != websocket.TextMessage {
+			sessionErr = fmt.Errorf("websocket message type must be %v, got %v", websocket.TextMessage, t)
 			klog.Errorf("Websocket message type must be %v type", websocket.TextMessage)
 			return
 		}
 		message, err := stream.ReadMessageFromTunnel(r)
 		if err != nil {
+			sessionErr = fmt.Errorf("read message from %s: %w", s.String(), err)
 			klog.Errorf("Read message from tunnel %v error %v", s.String(), err)
 			return
 		}
@@ -96,7 +117,12 @@ func (s *Session) ProxyTunnelMessageToApiserver(message *stream.Message) error {
 	switch message.MessageType {
 	case stream.MessageTypeRemoveConnect:
 		klog.V(6).Infof("delete connection %v from %v", message.ConnectID, s.String())
-		kubeCon.SetEdgePeerDone()
+		if _, ok := kubeCon.(edgePeerCompletionAware); !ok {
+			kubeCon.SetEdgePeerDone()
+			break
+		}
+		_, err := stream.DecodeConnectionCompletion(message.Data)
+		setEdgePeerCompletion(kubeCon, err)
 	case stream.MessageTypeData:
 		for i := 0; i < len(message.Data); {
 			n, err := kubeCon.WriteToAPIServer(message.Data[i:])

--- a/cloud/pkg/cloudstream/session_test.go
+++ b/cloud/pkg/cloudstream/session_test.go
@@ -2,6 +2,7 @@ package cloudstream
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kubeedge/kubeedge/pkg/stream"
 )
@@ -186,6 +188,114 @@ func TestSession_Close(t *testing.T) {
 	assert.True(t, mockConn2.done)
 	assert.True(t, session.tunnelClosed)
 }
+
+func TestSessionClosePropagatesFailureToMetricsCompletion(t *testing.T) {
+	metricsConn := &ContainerMetricsConnection{
+		edgePeerStop:       make(chan struct{}, 1),
+		edgePeerCompletion: make(chan error, 1),
+		closeChan:          make(chan bool),
+	}
+	session := &Session{
+		tunnel: &mockTunnel{},
+		apiServerConn: map[uint64]APIServerConnection{
+			1: metricsConn,
+		},
+		apiConnlock: &sync.RWMutex{},
+	}
+
+	session.Close()
+
+	require.Len(t, metricsConn.edgePeerCompletion, 1)
+	assert.Error(t, <-metricsConn.edgePeerCompletion)
+}
+
+func TestSessionProxyPropagatesMetricsCompletionStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		data          []byte
+		wantError     error
+		wantErrorText string
+	}{
+		{
+			name: "explicit success",
+			data: func() []byte {
+				data, err := stream.EncodeConnectionCompletion(stream.ConnectionCompletionSuccess, nil)
+				require.NoError(t, err)
+				return data
+			}(),
+		},
+		{
+			name: "explicit error",
+			data: func() []byte {
+				data, err := stream.EncodeConnectionCompletion(stream.ConnectionCompletionError, errors.New("unexpected EOF"))
+				require.NoError(t, err)
+				return data
+			}(),
+			wantError:     stream.ErrConnectionCompletionFailed,
+			wantErrorText: "unexpected EOF",
+		},
+		{
+			name:      "legacy completion without status",
+			wantError: stream.ErrConnectionCompletionUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metricsConn := &ContainerMetricsConnection{
+				edgePeerStop:       make(chan struct{}, 1),
+				edgePeerCompletion: make(chan error, 1),
+				closeChan:          make(chan bool),
+			}
+			session := &Session{
+				apiServerConn: map[uint64]APIServerConnection{1: metricsConn},
+				apiConnlock:   &sync.RWMutex{},
+			}
+
+			err := session.ProxyTunnelMessageToApiserver(&stream.Message{
+				ConnectID:   1,
+				MessageType: stream.MessageTypeRemoveConnect,
+				Data:        tt.data,
+			})
+
+			require.NoError(t, err)
+			require.Len(t, metricsConn.edgePeerCompletion, 1)
+			completionErr := <-metricsConn.edgePeerCompletion
+			if tt.wantError == nil {
+				assert.NoError(t, completionErr)
+			} else {
+				assert.ErrorIs(t, completionErr, tt.wantError)
+				if tt.wantErrorText != "" {
+					assert.ErrorContains(t, completionErr, tt.wantErrorText)
+				}
+			}
+		})
+	}
+}
+
+func TestSessionServePropagatesTunnelFailureToMetricsCompletion(t *testing.T) {
+	wantErr := errors.New("premature tunnel disconnect")
+	mockTun := newMockTunnel()
+	mockTun.AddMessage(0, nil, wantErr)
+	metricsConn := &ContainerMetricsConnection{
+		edgePeerStop:       make(chan struct{}, 1),
+		edgePeerCompletion: make(chan error, 1),
+		closeChan:          make(chan bool),
+	}
+	session := &Session{
+		tunnel: mockTun,
+		apiServerConn: map[uint64]APIServerConnection{
+			1: metricsConn,
+		},
+		apiConnlock: &sync.RWMutex{},
+	}
+
+	session.Serve()
+
+	require.Len(t, metricsConn.edgePeerCompletion, 1)
+	assert.ErrorIs(t, <-metricsConn.edgePeerCompletion, wantErr)
+}
+
 func TestSession_ProxyTunnelMessageToApiserver(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -196,12 +196,13 @@ func (s *StreamServer) getMetrics(r *restful.Request, w *restful.Response) {
 	w.WriteHeader(http.StatusOK)
 
 	metricsConnection, err := session.AddAPIServerConnection(s, &ContainerMetricsConnection{
-		r:            r,
-		writer:       w.ResponseWriter,
-		session:      session,
-		ctx:          r.Request.Context(),
-		edgePeerStop: make(chan struct{}),
-		closeChan:    make(chan bool),
+		r:                  r,
+		writer:             w.ResponseWriter,
+		session:            session,
+		ctx:                r.Request.Context(),
+		edgePeerStop:       make(chan struct{}),
+		edgePeerCompletion: make(chan error),
+		closeChan:          make(chan bool),
 	})
 	if err != nil {
 		err = fmt.Errorf("add apiServer connection into %s error %v", session.String(), err)

--- a/pkg/stream/connectioncompletion.go
+++ b/pkg/stream/connectioncompletion.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const connectionCompletionVersion = "v1"
+
+// ConnectionCompletionStatus describes how an edge-side stream ended.
+type ConnectionCompletionStatus string
+
+const (
+	// ConnectionCompletionSuccess indicates that the edge read the complete response.
+	ConnectionCompletionSuccess ConnectionCompletionStatus = "success"
+	// ConnectionCompletionError indicates that the edge stream ended with an error.
+	ConnectionCompletionError ConnectionCompletionStatus = "error"
+)
+
+var (
+	// ErrConnectionCompletionUnknown indicates a legacy or invalid completion payload.
+	ErrConnectionCompletionUnknown = errors.New("connection completion status is unknown")
+	// ErrConnectionCompletionFailed indicates an explicit edge-side stream failure.
+	ErrConnectionCompletionFailed = errors.New("edge connection completed with an error")
+)
+
+type connectionCompletion struct {
+	Version string                     `json:"version"`
+	Status  ConnectionCompletionStatus `json:"status"`
+	Reason  string                     `json:"reason,omitempty"`
+}
+
+// EncodeConnectionCompletion creates a versioned completion payload.
+func EncodeConnectionCompletion(status ConnectionCompletionStatus, completionErr error) ([]byte, error) {
+	if status != ConnectionCompletionSuccess && status != ConnectionCompletionError {
+		return nil, fmt.Errorf("unsupported connection completion status %q", status)
+	}
+	if status == ConnectionCompletionSuccess && completionErr != nil {
+		return nil, errors.New("successful connection completion cannot contain an error")
+	}
+	if status == ConnectionCompletionError && completionErr == nil {
+		return nil, errors.New("failed connection completion must contain an error")
+	}
+
+	reason := ""
+	if completionErr != nil {
+		reason = completionErr.Error()
+	}
+	return json.Marshal(connectionCompletion{
+		Version: connectionCompletionVersion,
+		Status:  status,
+		Reason:  reason,
+	})
+}
+
+// DecodeConnectionCompletion parses a versioned completion payload. Empty
+// legacy payloads remain unknown so that failures from older peers are not
+// interpreted as successful completion.
+func DecodeConnectionCompletion(data []byte) (ConnectionCompletionStatus, error) {
+	if len(data) == 0 {
+		return "", ErrConnectionCompletionUnknown
+	}
+
+	var completion connectionCompletion
+	if err := json.Unmarshal(data, &completion); err != nil {
+		return "", fmt.Errorf("%w: %v", ErrConnectionCompletionUnknown, err)
+	}
+	if completion.Version != connectionCompletionVersion {
+		return "", fmt.Errorf("%w: unsupported version %q", ErrConnectionCompletionUnknown, completion.Version)
+	}
+	if completion.Status != ConnectionCompletionSuccess && completion.Status != ConnectionCompletionError {
+		return "", fmt.Errorf("%w: unsupported status %q", ErrConnectionCompletionUnknown, completion.Status)
+	}
+	if completion.Status == ConnectionCompletionError {
+		if completion.Reason == "" {
+			return "", fmt.Errorf("%w: error completion has no reason", ErrConnectionCompletionUnknown)
+		}
+		return completion.Status, fmt.Errorf("%w: %s", ErrConnectionCompletionFailed, completion.Reason)
+	}
+	return completion.Status, nil
+}

--- a/pkg/stream/connectioncompletion_test.go
+++ b/pkg/stream/connectioncompletion_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionCompletionRoundTrip(t *testing.T) {
+	tests := []struct {
+		status        ConnectionCompletionStatus
+		completionErr error
+	}{
+		{status: ConnectionCompletionSuccess},
+		{status: ConnectionCompletionError, completionErr: errors.New("scanner failed")},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			data, err := EncodeConnectionCompletion(tt.status, tt.completionErr)
+			require.NoError(t, err)
+
+			actual, err := DecodeConnectionCompletion(data)
+
+			if tt.completionErr == nil {
+				require.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, ErrConnectionCompletionFailed)
+				assert.ErrorContains(t, err, tt.completionErr.Error())
+			}
+			assert.Equal(t, tt.status, actual)
+		})
+	}
+}
+
+func TestDecodeConnectionCompletionRejectsUnknownPayload(t *testing.T) {
+	for _, data := range [][]byte{
+		nil,
+		[]byte("not-json"),
+		[]byte(`{"version":"v2","status":"success"}`),
+		[]byte(`{"version":"v1","status":"maybe"}`),
+		[]byte(`{"version":"v1","status":"error"}`),
+	} {
+		_, err := DecodeConnectionCompletion(data)
+
+		assert.ErrorIs(t, err, ErrConnectionCompletionUnknown)
+	}
+}

--- a/pkg/stream/edgedmetricsconnection.go
+++ b/pkg/stream/edgedmetricsconnection.go
@@ -78,10 +78,7 @@ func (ms *EdgedMetricsConnection) receiveFromCloudStream(stop chan struct{}) {
 	klog.V(6).Infof("%s read channel closed", ms.String())
 }
 
-func (ms *EdgedMetricsConnection) write2CloudStream(tunnel SafeWriteTunneler, resp *http.Response, stop chan struct{}) {
-	defer func() {
-		stop <- struct{}{}
-	}()
+func (ms *EdgedMetricsConnection) write2CloudStream(tunnel SafeWriteTunneler, resp *http.Response, result chan<- error) {
 	scan := bufio.NewScanner(resp.Body)
 	for scan.Scan() {
 		// 10 = \n
@@ -89,10 +86,27 @@ func (ms *EdgedMetricsConnection) write2CloudStream(tunnel SafeWriteTunneler, re
 		err := tunnel.WriteMessage(msg)
 		if err != nil {
 			klog.Errorf("write tunnel message %v error", msg)
+			result <- fmt.Errorf("write metrics data to tunnel: %w", err)
 			return
 		}
 		klog.V(4).Infof("%v write metrics data %v", ms.String(), string(scan.Bytes()))
 	}
+	result <- scan.Err()
+}
+
+func (ms *EdgedMetricsConnection) sendCompletion(tunnel SafeWriteTunneler, status ConnectionCompletionStatus, completionErr error) error {
+	data, err := EncodeConnectionCompletion(status, completionErr)
+	if err != nil {
+		return err
+	}
+	msg := NewMessage(ms.MessID, MessageTypeRemoveConnect, data)
+	for retry := 0; retry < 3; retry++ {
+		if err = tunnel.WriteMessage(msg); err == nil {
+			return nil
+		}
+		klog.Errorf("%v send %s message error %v", ms, msg.MessageType, err)
+	}
+	return fmt.Errorf("send metrics completion to tunnel: %w", err)
 }
 
 func (ms *EdgedMetricsConnection) Serve(tunnel SafeWriteTunneler) error {
@@ -113,28 +127,33 @@ func (ms *EdgedMetricsConnection) Serve(tunnel SafeWriteTunneler) error {
 	resp, err := client.Do(req)
 	if err != nil {
 		klog.Errorf("request metrics error %v", err)
+		if completionErr := ms.sendCompletion(tunnel, ConnectionCompletionError, err); completionErr != nil {
+			klog.Errorf("send metrics request failure completion error %v", completionErr)
+		}
 		return err
 	}
 	defer resp.Body.Close()
 
 	go ms.receiveFromCloudStream(ms.Stop)
 
-	defer func() {
-		for retry := 0; retry < 3; retry++ {
-			msg := NewMessage(ms.MessID, MessageTypeRemoveConnect, nil)
-			if err := tunnel.WriteMessage(msg); err != nil {
-				klog.Errorf("%v send %s message error %v", ms, msg.MessageType, err)
-			} else {
-				break
-			}
+	result := make(chan error, 1)
+	go ms.write2CloudStream(tunnel, resp, result)
+
+	select {
+	case <-ms.Stop:
+		klog.Infof("receive stop signal, so stop metrics scan ...")
+		return nil
+	case streamErr := <-result:
+		status := ConnectionCompletionSuccess
+		if streamErr != nil {
+			status = ConnectionCompletionError
 		}
-	}()
-
-	go ms.write2CloudStream(tunnel, resp, ms.Stop)
-
-	<-ms.Stop
-	klog.Infof("receive stop signal, so stop metrics scan ...")
-	return nil
+		completionErr := ms.sendCompletion(tunnel, status, streamErr)
+		if streamErr != nil {
+			return streamErr
+		}
+		return completionErr
+	}
 }
 
 var _ EdgedConnection = &EdgedMetricsConnection{}

--- a/pkg/stream/edgedmetricsconnection_test.go
+++ b/pkg/stream/edgedmetricsconnection_test.go
@@ -21,14 +21,14 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockResponseBody struct {
@@ -199,7 +199,7 @@ func TestMetricsConnection_write2CloudStream(t *testing.T) {
 	assert := assert.New(t)
 
 	mockTunneler := &MockStreamTunneler{}
-	stop := make(chan struct{}, 1)
+	result := make(chan error, 1)
 
 	responseBody := NewMockResponseBody("line1\nline2\nline3")
 	mockResponse := &http.Response{
@@ -210,15 +210,12 @@ func TestMetricsConnection_write2CloudStream(t *testing.T) {
 		MessID: uint64(100),
 	}
 
-	go metricsConn.write2CloudStream(mockTunneler, mockResponse, stop)
-
-	time.Sleep(100 * time.Millisecond)
+	metricsConn.write2CloudStream(mockTunneler, mockResponse, result)
 
 	assert.Equal(3, len(mockTunneler.Messages))
 	assert.Equal(MessageTypeData, mockTunneler.Messages[0].MessageType)
 	assert.Contains(string(mockTunneler.Messages[0].Data), "line1")
-
-	assert.Equal(1, len(stop))
+	assert.NoError(<-result)
 }
 
 func TestMetricsConnection_write2CloudStream_WriteError(t *testing.T) {
@@ -227,7 +224,7 @@ func TestMetricsConnection_write2CloudStream_WriteError(t *testing.T) {
 	mockTunneler := &MockStreamTunneler{
 		WriteErr: errors.New("tunnel write error"),
 	}
-	stop := make(chan struct{}, 1)
+	result := make(chan error, 1)
 
 	responseBody := NewMockResponseBody("test data for tunnel")
 	mockResponse := &http.Response{
@@ -238,61 +235,79 @@ func TestMetricsConnection_write2CloudStream_WriteError(t *testing.T) {
 		MessID: uint64(100),
 	}
 
-	go metricsConn.write2CloudStream(mockTunneler, mockResponse, stop)
+	metricsConn.write2CloudStream(mockTunneler, mockResponse, result)
 
-	time.Sleep(100 * time.Millisecond)
-
-	assert.Equal(1, len(stop))
+	assert.ErrorContains(<-result, "tunnel write error")
 }
 
 func TestMetricsConnection_Serve(t *testing.T) {
 	assert := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := io.WriteString(w, "test metric data")
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	metricsURL, err := url.Parse(server.URL + "/metrics")
+	require.NoError(t, err)
 
 	metricsConn := &EdgedMetricsConnection{
 		MessID:   uint64(100),
 		ReadChan: make(chan *Message, 10),
 		Stop:     make(chan struct{}, 1),
-		URL:      url.URL{Scheme: "https", Host: "example.com", Path: "/metrics"},
+		URL:      *metricsURL,
 		Header:   http.Header{},
 	}
 
 	mockTunneler := &MockStreamTunneler{}
 
-	responseBody := NewMockResponseBody("test metric data")
-	mockResponse := &http.Response{
-		StatusCode: 200,
-		Body:       responseBody,
-	}
-
-	patchNewRequest := gomonkey.ApplyFunc(http.NewRequest,
-		func(method, url string, body io.Reader) (*http.Request, error) {
-			return &http.Request{
-				Header: http.Header{},
-			}, nil
-		})
-	defer patchNewRequest.Reset()
-
-	patchDo := gomonkey.ApplyMethod(reflect.TypeOf(&http.Client{}), "Do",
-		func(_ *http.Client, _ *http.Request) (*http.Response, error) {
-			return mockResponse, nil
-		})
-	defer patchDo.Reset()
-
-	go func() {
-		time.Sleep(100 * time.Millisecond)
-		metricsConn.Stop <- struct{}{}
-	}()
-
-	err := metricsConn.Serve(mockTunneler)
+	err = metricsConn.Serve(mockTunneler)
 
 	assert.NoError(err)
 
-	found := false
+	var completionData []byte
 	for _, msg := range mockTunneler.Messages {
 		if msg.MessageType == MessageTypeRemoveConnect {
-			found = true
+			completionData = msg.Data
 			break
 		}
 	}
-	assert.True(found, "Expected a RemoveConnect message to be sent")
+	require.NotNil(t, completionData, "Expected a RemoveConnect message to be sent")
+	status, err := DecodeConnectionCompletion(completionData)
+	require.NoError(t, err)
+	assert.Equal(ConnectionCompletionSuccess, status)
+}
+
+func TestMetricsConnectionServeReportsScannerFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		_, err := io.WriteString(w, "partial metrics")
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+	metricsURL, err := url.Parse(server.URL + "/metrics")
+	require.NoError(t, err)
+	metricsConn := &EdgedMetricsConnection{
+		MessID:   uint64(100),
+		ReadChan: make(chan *Message, 10),
+		Stop:     make(chan struct{}, 1),
+		URL:      *metricsURL,
+		Header:   http.Header{},
+	}
+	mockTunneler := &MockStreamTunneler{}
+
+	err = metricsConn.Serve(mockTunneler)
+
+	assert.ErrorContains(t, err, "unexpected EOF")
+	var completionData []byte
+	for _, msg := range mockTunneler.Messages {
+		if msg.MessageType == MessageTypeRemoveConnect {
+			completionData = msg.Data
+			break
+		}
+	}
+	require.NotNil(t, completionData, "Expected an error completion message")
+	status, decodeErr := DecodeConnectionCompletion(completionData)
+	assert.ErrorIs(t, decodeErr, ErrConnectionCompletionFailed)
+	assert.ErrorContains(t, decodeErr, "unexpected EOF")
+	assert.Equal(t, ConnectionCompletionError, status)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

CloudStream currently collapses every metrics connection ending into the same
`EdgePeerDone` signal. A normal finite response, `bufio.Scanner` failure,
tunnel write failure, and WebSocket/session disconnect can therefore all reach
`ContainerMetricsConnection.Serve` without their original outcome.

This change preserves metrics completion semantics end to end:

- EdgeCore sends a versioned `MessageTypeRemoveConnect` payload with an explicit
  `success` or `error` status. Error completions include the edge-side reason.
- CloudCore returns `nil` only for explicit success.
- Explicit edge failures and CloudStream session failures remain errors.
- Empty or invalid legacy completion payloads remain unknown errors; they are
  never interpreted as success.
- A metrics-only optional completion interface avoids changing the shared
  exec, log, and attach connection contract.

Compatibility behavior:

| EdgeCore | CloudCore | Result |
| --- | --- | --- |
| new | new | explicit success or edge error |
| old | new | legacy completion remains unknown/error |
| new | old | old CloudCore ignores the payload and keeps legacy behavior |

**Which issue(s) this PR fixes**:

Fixes #4816

**Special notes for your reviewer**:

This supersedes #7239, which handled every `EdgePeerDone` as success and could
therefore hide abnormal session termination. The API-server connection cleanup
from #6814 is already in master and is not duplicated here.

Regression coverage includes explicit success, scanner failure with its reason,
legacy completion without status, and session/WebSocket failure.

Validation:

- `go test ./pkg/stream ./cloud/pkg/cloudstream -count=1`
- targeted `go test -race` for the changed metrics/session paths
- `make lint`
- `make verify`
- `make test WHAT=cloud`

**Does this PR introduce a user-facing change?**:

```release-note
CloudStream now distinguishes successful edge metrics completion from interrupted or legacy-unknown streams.
```
