### PR TITLE
hack: replace hardcoded docker cp with runtime-agnostic helper

### DIFF
--- a/hack/local-up-kubeedge.sh
+++ b/hack/local-up-kubeedge.sh
@@ -321,6 +321,21 @@ function healthcheck {
   fi
 }
 
+# Copy files from a kind node container using whichever container CLI is available.
+# kind nodes are Docker or Podman containers; detect the appropriate CLI.
+function kind_container_cp {
+  local src="$1"
+  local dst="$2"
+  if command -v docker &>/dev/null; then
+    docker cp "$src" "$dst"
+  elif command -v podman &>/dev/null; then
+    podman cp "$src" "$dst"
+  else
+    echo "Error: neither docker nor podman CLI found. kind requires one of these to manage node containers."
+    exit 1
+  fi
+}
+
 function generate_streamserver_cert {
   CA_PATH=${CA_PATH:-/tmp/etc/kubeedge/ca}
   CERT_PATH=${CERT_PATH:-/tmp/etc/kubeedge/certs}
@@ -341,8 +356,8 @@ function generate_streamserver_cert {
     mkdir -p $CERT_PATH
   fi
 
-  docker cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/ca.crt $K8SCA_FILE
-  docker cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/ca.key $K8SCA_KEY_FILE
+  kind_container_cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/ca.crt $K8SCA_FILE
+  kind_container_cp ${CLUSTER_NAME}-control-plane:/etc/kubernetes/pki/ca.key $K8SCA_KEY_FILE
   cp /tmp/etc/kubernetes/pki/ca.crt /tmp/etc/kubeedge/ca/streamCA.crt
 
   SUBJECTALTNAME="subjectAltName = IP.1:127.0.0.1"


### PR DESCRIPTION
The generate_streamserver_cert function in local-up-kubeedge.sh hardcodes docker cp to extract certificates from the kind control-plane container. This fails on systems using Podman as the kind provider without Docker installed. Add a kind_container_cp helper that auto-detects Docker or Podman and uses the appropriate CLI.

Fixes #7243

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
