### PR TITLE
router: add goroutine pool for rule execution

### DIFF
--- a/cloud/pkg/router/rule/rule.go
+++ b/cloud/pkg/router/rule/rule.go
@@ -17,7 +17,32 @@ import (
 var (
 	rules         sync.Map
 	ruleEndpoints sync.Map
+	ruleExecPool  = newWorkerPool(100)
 )
+
+type workerPool struct {
+	jobs chan func()
+}
+
+func newWorkerPool(size int) *workerPool {
+	p := &workerPool{
+		jobs: make(chan func(), 1024),
+	}
+	for i := 0; i < size; i++ {
+		go p.worker()
+	}
+	return p
+}
+
+func (p *workerPool) worker() {
+	for job := range p.jobs {
+		job()
+	}
+}
+
+func (p *workerPool) submit(job func()) {
+	p.jobs <- job
+}
 
 func init() {
 	registerListener()
@@ -110,19 +135,29 @@ func addRule(rule *routerv1.Rule) error {
 
 	ruleKey := getKey(rule.Namespace, rule.Name)
 	if err := source.RegisterListener(func(data interface{}) (interface{}, error) {
-		//TODO Use goroutine pool later
-		var execResult ExecResult
-		resp, err := source.Forward(target, data)
-		if err != nil {
-			// rule.Status.Fail++
-			// record error info for rule
-			errMsg := ErrorMsg{Detail: err.Error(), Timestamp: time.Now()}
-			execResult = ExecResult{RuleID: rule.Name, ProjectID: rule.Namespace, Status: "FAIL", Error: errMsg}
-		} else {
-			execResult = ExecResult{RuleID: rule.Name, ProjectID: rule.Namespace, Status: "SUCCESS"}
+		type result struct {
+			resp interface{}
+			err  error
 		}
-		ResultChannel <- execResult
-		return resp, nil
+		resCh := make(chan result, 1)
+
+		ruleExecPool.submit(func() {
+			var execResult ExecResult
+			resp, err := source.Forward(target, data)
+			if err != nil {
+				// rule.Status.Fail++
+				// record error info for rule
+				errMsg := ErrorMsg{Detail: err.Error(), Timestamp: time.Now()}
+				execResult = ExecResult{RuleID: rule.Name, ProjectID: rule.Namespace, Status: "FAIL", Error: errMsg}
+			} else {
+				execResult = ExecResult{RuleID: rule.Name, ProjectID: rule.Namespace, Status: "SUCCESS"}
+			}
+			ResultChannel <- execResult
+			resCh <- result{resp: resp, err: err}
+		})
+
+		res := <-resCh
+		return res.resp, res.err
 	}); err != nil {
 		klog.Errorf("add rule %s failed, err: %v", ruleKey, err)
 		errMsg := ErrorMsg{Detail: err.Error(), Timestamp: time.Now()}


### PR DESCRIPTION
Currently, the router spawns unbounded goroutines for every rule execution, which can lead to excessive resource consumption and instability under high load. This change implements a worker pool to bound the number of concurrent rule executions and prevent resource exhaustion under heavy message throughput.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7248

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
