### PR TITLE
admissioncontroller: reject AdmissionReview with no request

### DIFF
--- a/cloud/pkg/admissioncontroller/common.go
+++ b/cloud/pkg/admissioncontroller/common.go
@@ -3,6 +3,7 @@ package admissioncontroller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 
@@ -62,6 +63,9 @@ func registerMutatingWebhook(client admissionregistrationv1client.MutatingWebhoo
 	return nil
 }
 
+// errNilAdmissionRequest is returned when a decoded AdmissionReview carries no request.
+var errNilAdmissionRequest = errors.New("the request field of the AdmissionReview is nil")
+
 // hookFunc is the type we use for all of our validators and mutators
 type hookFunc func(admissionv1.AdmissionReview) *admissionv1.AdmissionResponse
 
@@ -92,6 +96,11 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 	if _, _, err := deserializer.Decode(body, nil, &requestedAdmissionReview); err != nil {
 		klog.Errorf("decode failed with error: %v", err)
 		responseAdmissionReview.Response = toAdmissionResponse(err)
+	} else if requestedAdmissionReview.Request == nil {
+		// Every hook dereferences the request, so reject the review here
+		// instead of letting the hook panic on a nil pointer.
+		klog.Errorf("invalid admission review: %v", errNilAdmissionRequest)
+		responseAdmissionReview.Response = toAdmissionResponse(errNilAdmissionRequest)
 	} else {
 		responseAdmissionReview.Response = hook(requestedAdmissionReview)
 		// Return the same UID

--- a/cloud/pkg/admissioncontroller/common_test.go
+++ b/cloud/pkg/admissioncontroller/common_test.go
@@ -3,6 +3,7 @@ package admissioncontroller
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -167,6 +168,25 @@ func TestServe(t *testing.T) {
 			},
 			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
 		}, hookfn)
+	})
+
+	t.Run("nil admission request", func(t *testing.T) {
+		assert := assert.New(t)
+
+		w := httpfake.NewResponseWriter()
+		raw := "{\"apiVersion\": \"admission.k8s.io/v1\", \"kind\": \"AdmissionReview\"}"
+		serve(w, &http.Request{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
+		}, hookfn)
+
+		responseAdmissionReview := admissionv1.AdmissionReview{}
+		assert.NoError(json.Unmarshal(w.Body, &responseAdmissionReview))
+		assert.NotNil(responseAdmissionReview.Response)
+		assert.False(responseAdmissionReview.Response.Allowed)
+		assert.Equal(errNilAdmissionRequest.Error(), responseAdmissionReview.Response.Result.Message)
 	})
 
 	t.Run("handle hook func", func(_ *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

`serve` decoded an `AdmissionReview` body that carried `apiVersion` and `kind` but no `request` without error, leaving `Request` nil. All six validating/mutating hooks dereference `review.Request` as their first statement, and `serve` itself then reads `requestedAdmissionReview.Request.UID`, so any such body panicked the handler. `net/http` recovers per connection so cloudcore stays up, but no response is written and the connection is dropped; the rules, ruleendpoints and nodeupgradejobs webhooks use `FailurePolicy: Fail`, so those resources become uncreatable/unupdatable/undeletable while it happens. The webhook does not require a client certificate, so the body need not come from the API server.
`serve` is the single entry point shared by every hook, so the review is rejected there and an `AdmissionResponse` carrying the error is returned, the same way the existing decode-failure branch does. The hooks are unchanged.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7254 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a panic in the cloudcore admission controller webhooks when an AdmissionReview request without a `request` field is received.
```
