### PR TITLE
controllermanager: let the manager own the node cache

### DIFF
--- a/cloud/pkg/controllermanager/controllermanager.go
+++ b/cloud/pkg/controllermanager/controllermanager.go
@@ -2,11 +2,9 @@ package controllermanager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -14,8 +12,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -62,48 +58,17 @@ func NewControllerManager(ctx context.Context, kubeCfg *rest.Config, healthProbe
 		return nil, fmt.Errorf("failed to add readyz check, err: %v", err)
 	}
 
-	che, err := newAndStartCache(ctx, kubeCfg)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := setupControllers(ctx, mgr, che); err != nil {
+	if err := setupControllers(ctx, mgr); err != nil {
 		return nil, err
 	}
 	return mgr, nil
 }
 
-func newAndStartCache(ctx context.Context, kubeCfg *rest.Config,
-) (che cache.Cache, err error) {
-	che, err = cache.New(kubeCfg, cache.Options{
-		// Register resources that need to be cached.
-		ByObject: map[client.Object]cache.ByObject{
-			&corev1.Node{}: {},
-		},
-	})
-	if err != nil {
-		err = fmt.Errorf("failed to create the cache, err: %v", err)
-		return
-	}
-	go func() {
-		err = che.Start(ctx)
-	}()
-	synced := che.WaitForCacheSync(ctx)
-	if err != nil {
-		err = fmt.Errorf("failed to start the cache, err: %v", err)
-		return
-	}
-	if !synced {
-		err = errors.New("could not sync the cache")
-		return
-	}
-	return
-}
-
-func setupControllers(ctx context.Context, mgr manager.Manager, che cache.Cache) error {
+func setupControllers(ctx context.Context, mgr manager.Manager) error {
 	serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory,
 		kubeedgeScheme, kubeedgeScheme, json.SerializerOptions{Yaml: true})
 	cli := mgr.GetClient()
+	che := mgr.GetCache()
 
 	ctls := []Controller{
 		nodegroup.NewController(cli),

--- a/cloud/pkg/controllermanager/controllermanager_test.go
+++ b/cloud/pkg/controllermanager/controllermanager_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The KubeEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllermanager
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+)
+
+// unreachableAPIServer is a host no API server listens on, so that the tests
+// never reach a real cluster.
+const unreachableAPIServer = "127.0.0.1:1"
+
+// newTestRESTMapper maps every kind of the kubeedge scheme, so that the manager
+// can set up its informers without discovering the kinds from an API server.
+func newTestRESTMapper() meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper(nil)
+	for gvk := range kubeedgeScheme.AllKnownTypes() {
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+	}
+	return mapper
+}
+
+func TestSetupControllers(t *testing.T) {
+	mgr, err := controllerruntime.NewManager(&rest.Config{Host: unreachableAPIServer}, controllerruntime.Options{
+		Scheme: kubeedgeScheme,
+		// Controller names are registered process wide, so skip the uniqueness
+		// check to keep this test repeatable.
+		Controller: config.Controller{SkipNameValidation: ptr.To(true)},
+		MapperProvider: func(_ *rest.Config, _ *http.Client) (meta.RESTMapper, error) {
+			return newTestRESTMapper(), nil
+		},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Every controller, including the node task ones that used to be given a
+	// separate cache, is set up with the cache owned by the manager.
+	assert.NoError(t, setupControllers(ctx, mgr))
+}
+
+func TestNewControllerManager(t *testing.T) {
+	// Setting up the controllers needs the API server, so it fails here and the
+	// error has to be returned instead of a manager.
+	mgr, err := NewControllerManager(context.Background(), &rest.Config{Host: unreachableAPIServer}, "")
+	assert.Error(t, err)
+	assert.Nil(t, mgr)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

`newAndStartCache` built a second `cache.Cache` for `corev1.Node`, started it in a bare goroutine that assigned to the named return value `err`, and then read that same `err` on the calling goroutine after `WaitForCacheSync`. Three problems followed: the write and the read were unsynchronized (a data race on `err`); the check was dead in practice, because `Start(ctx)` blocks until the context is done, so `err` was still nil when it was read and a cache that stopped with an error was never observed; and the cache was never handed to the manager, so it sat outside the manager's runnable lifecycle; not stopped with the manager, not covered by its readiness gating, not leader-election aware.
The separate cache was also redundant. It cached only `corev1.Node`, and its only consumers, `verifyNodeByNames` and `verifyNodeBySelector`, `Get` and `List` at reconcile time, never during `SetupWithManager`. `mgr.GetCache()` already provides that and is started, synced and stopped by the manager, so `setupControllers` now takes the cache from the manager and `newAndStartCache` is removed. The nodegroup controller already watches `corev1.Node` through the manager cache, so this also removes a duplicate node watch.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7256 

**Special notes for your reviewer**:

The package had no unit test file. The added one builds a manager with an injected static RESTMapper so the controllers can be set up without an API server, and covers both the successful setup path and the error path of `NewControllerManager`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
