### PR TITLE
keadm: collect containerd diagnostics in debug collect

### DIFF
--- a/keadm/cmd/keadm/app/cmd/debug/collect.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect.go
@@ -3,7 +3,10 @@ package debug
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -27,6 +30,13 @@ keadm debug collect --output-path .
 )
 
 var printDeatilFlag = false
+
+var runtimeGOOS = runtime.GOOS
+
+const (
+	collectDirPermission  = 0700
+	collectFilePermission = 0600
+)
 
 // NewCollect returns KubeEdge collect command.
 func NewCollect() *cobra.Command {
@@ -104,12 +114,22 @@ func ExecuteCollect(collectOptions *common.CollectOptions) error {
 	}
 	printDetail("collect edgecore data finish")
 
-	// TODO: collectRuntimeData with containerd
+	err = collectRuntimeData(fmt.Sprintf("%s/runtime", tmpName), edgeconfig.Modules.Edged.TailoredKubeletConfig.ContainerRuntimeEndpoint)
+	if err != nil {
+		fmt.Printf("collect runtime data failed: %v\n", err)
+		if writeErr := writeCollectionError(fmt.Sprintf("%s/runtime", tmpName), err); writeErr != nil {
+			fmt.Printf("failed to record runtime collection error: %v\n", writeErr)
+		}
+	}
+	printDetail("collect runtime data finish")
 
 	OutputPath := collectOptions.OutputPath
 	zipName := fmt.Sprintf("%s/edge_%s.tar.gz", OutputPath, timenow)
 	err = util.Compress(zipName, []string{tmpName})
 	if err != nil {
+		return err
+	}
+	if err = os.Chmod(zipName, collectFilePermission); err != nil {
 		return err
 	}
 	printDetail("Data compressed successfully")
@@ -150,13 +170,13 @@ func VerificationParameters(collectOptions *common.CollectOptions) error {
 func makeDirTmp() (string, string, error) {
 	timenow := time.Now().Format("2006_0102_150405")
 	tmpName := fmt.Sprintf("/tmp/edge_%s", timenow)
-	return tmpName, timenow, os.Mkdir(tmpName, os.ModePerm)
+	return tmpName, timenow, os.Mkdir(tmpName, collectDirPermission)
 }
 
 // collect system data
 func collectSystemData(tmpPath string) error {
 	printDetail(fmt.Sprintf("create tmp file: %s", tmpPath))
-	err := os.Mkdir(tmpPath, os.ModePerm)
+	err := os.Mkdir(tmpPath, collectDirPermission)
 	if err != nil {
 		return err
 	}
@@ -208,7 +228,7 @@ func collectSystemData(tmpPath string) error {
 // collect edgecore data
 func collectEdgecoreData(tmpPath string, config *v1alpha2.EdgeCoreConfig, ops *common.CollectOptions) error {
 	printDetail(fmt.Sprintf("create tmp file: %s", tmpPath))
-	err := os.Mkdir(tmpPath, os.ModePerm)
+	err := os.Mkdir(tmpPath, collectDirPermission)
 	if err != nil {
 		return err
 	}
@@ -267,10 +287,20 @@ func collectEdgecoreData(tmpPath string, config *v1alpha2.EdgeCoreConfig, ops *c
 	return ExecuteShell(common.CmdEdgecoreVersion, tmpPath)
 }
 
-// collect runtime/docker data
-func collectRuntimeData(tmpPath string) error {
+// collectRuntimeData collects diagnostics for the configured container runtime.
+func collectRuntimeData(tmpPath, endpoint string) error {
+	if runtimeGOOS == "windows" {
+		return fmt.Errorf("container runtime diagnostics are not supported on Windows")
+	}
+	if strings.Contains(strings.ToLower(endpoint), "containerd") {
+		return collectContainerdData(tmpPath, endpoint)
+	}
+	return collectDockerData(tmpPath)
+}
+
+func collectDockerData(tmpPath string) error {
 	printDetail(fmt.Sprintf("create tmp file: %s", tmpPath))
-	err := os.Mkdir(tmpPath, os.ModePerm)
+	err := os.Mkdir(tmpPath, collectDirPermission)
 	if err != nil {
 		return err
 	}
@@ -289,6 +319,31 @@ func collectRuntimeData(tmpPath string) error {
 	return nil
 }
 
+func collectContainerdData(tmpPath, endpoint string) error {
+	printDetail(fmt.Sprintf("create tmp file: %s", tmpPath))
+	if err := os.Mkdir(tmpPath, collectDirPermission); err != nil {
+		return err
+	}
+
+	commands := [][]string{
+		{"--runtime-endpoint", endpoint, "version"},
+		{"--runtime-endpoint", endpoint, "info"},
+		{"--runtime-endpoint", endpoint, "images"},
+		{"--runtime-endpoint", endpoint, "ps", "-a"},
+	}
+	outputNames := []string{"version", "info", "images", "containerInfo"}
+	for i, args := range commands {
+		if err := ExecuteCommand("crictl", args, filepath.Join(tmpPath, outputNames[i])); err != nil {
+			return err
+		}
+	}
+
+	if err := ExecuteCommand("journalctl", []string{"--no-pager", "--since", "24 hours ago", "-u", "containerd"}, filepath.Join(tmpPath, "log")); err != nil {
+		return err
+	}
+	return ExecuteCommand("systemctl", []string{"--no-pager", "--full", "status", "containerd"}, filepath.Join(tmpPath, "service"))
+}
+
 func CopyFile(pathSrc, tmpPath string) error {
 	cmd := execs.NewCommand(fmt.Sprintf(common.CmdCopyFile, pathSrc, tmpPath))
 	return cmd.Exec()
@@ -297,6 +352,27 @@ func CopyFile(pathSrc, tmpPath string) error {
 func ExecuteShell(cmdStr string, tmpPath string) error {
 	cmd := execs.NewCommand(fmt.Sprintf(cmdStr, tmpPath))
 	return cmd.Exec()
+}
+
+// ExecuteCommand writes command output to a file without invoking a shell.
+func ExecuteCommand(name string, args []string, outputPath string) error {
+	output, err := os.OpenFile(outputPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, collectFilePermission)
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	return cmd.Run()
+}
+
+func writeCollectionError(path string, collectionErr error) error {
+	if err := os.MkdirAll(path, collectDirPermission); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(path, "error"), []byte(collectionErr.Error()+"\n"), collectFilePermission)
 }
 
 func printDetail(msg string) {

--- a/keadm/cmd/keadm/app/cmd/debug/collect_test.go
+++ b/keadm/cmd/keadm/app/cmd/debug/collect_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,7 +167,7 @@ func TestMakeDirTmp(t *testing.T) {
 
 	mkdirPatch := gomonkey.ApplyFunc(os.Mkdir, func(path string, perm os.FileMode) error {
 		assert.Equal(expectedTmpName, path)
-		assert.Equal(os.ModePerm, perm)
+		assert.Equal(os.FileMode(collectDirPermission), perm)
 		return nil
 	})
 	defer mkdirPatch.Reset()
@@ -407,14 +408,14 @@ func TestCollectRuntimeData(t *testing.T) {
 	execShellPatch := setupExecShellPatch(true)
 	defer execShellPatch.Reset()
 
-	err := collectRuntimeData("/tmp/runtime")
+	err := collectRuntimeData("/tmp/runtime", "unix:///var/run/docker.sock")
 	assert.NoError(err)
 
 	mkdirPatch.Reset()
 	mkdirErrorPatch := setupMkdirPatch(t, "/tmp/runtime", false)
 	defer mkdirErrorPatch.Reset()
 
-	err = collectRuntimeData("/tmp/runtime")
+	err = collectRuntimeData("/tmp/runtime", "unix:///var/run/docker.sock")
 	assert.Error(err)
 	assert.Equal("directory creation failed", err.Error())
 
@@ -426,9 +427,79 @@ func TestCollectRuntimeData(t *testing.T) {
 	copyFileErrorPatch := setupCopyFilePatch(false)
 	defer copyFileErrorPatch.Reset()
 
-	err = collectRuntimeData("/tmp/runtime")
+	err = collectRuntimeData("/tmp/runtime", "unix:///var/run/docker.sock")
 	assert.Error(err)
 	assert.Equal("file copy failed", err.Error())
+}
+
+func TestCollectContainerdData(t *testing.T) {
+	assert := assert.New(t)
+	if runtimeGOOS == "windows" {
+		t.Skip("containerd diagnostics use Unix commands")
+	}
+
+	endpoint := "unix:///run/containerd/containerd.sock"
+	binDir := t.TempDir()
+	for _, command := range []string{"crictl", "journalctl", "systemctl"} {
+		path := filepath.Join(binDir, command)
+		err := os.WriteFile(path, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\"\n"), 0755)
+		assert.NoError(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+	err := collectRuntimeData(runtimeDir, endpoint)
+	assert.NoError(err)
+
+	version, err := os.ReadFile(filepath.Join(runtimeDir, "version"))
+	assert.NoError(err)
+	assert.Contains(string(version), "--runtime-endpoint")
+	assert.Contains(string(version), endpoint)
+	assert.Contains(string(version), "version")
+
+	containerInfo, err := os.ReadFile(filepath.Join(runtimeDir, "containerInfo"))
+	assert.NoError(err)
+	assert.Equal("--runtime-endpoint\n"+endpoint+"\nps\n-a\n", string(containerInfo))
+
+	for _, name := range []string{"info", "images", "log", "service"} {
+		content, err := os.ReadFile(filepath.Join(runtimeDir, name))
+		assert.NoError(err)
+		assert.NotEmpty(strings.TrimSpace(string(content)))
+	}
+
+	log, err := os.ReadFile(filepath.Join(runtimeDir, "log"))
+	assert.NoError(err)
+	assert.Equal("--no-pager\n--since\n24 hours ago\n-u\ncontainerd\n", string(log))
+
+	service, err := os.ReadFile(filepath.Join(runtimeDir, "service"))
+	assert.NoError(err)
+	assert.Equal("--no-pager\n--full\nstatus\ncontainerd\n", string(service))
+}
+
+func TestCollectRuntimeDataOnWindows(t *testing.T) {
+	assert := assert.New(t)
+	originalGOOS := runtimeGOOS
+	runtimeGOOS = "windows"
+	defer func() { runtimeGOOS = originalGOOS }()
+
+	err := collectRuntimeData(filepath.Join(t.TempDir(), "runtime"), "npipe:////./pipe/containerd-containerd")
+	assert.EqualError(err, "container runtime diagnostics are not supported on Windows")
+}
+
+func TestWriteCollectionError(t *testing.T) {
+	assert := assert.New(t)
+	runtimeDir := filepath.Join(t.TempDir(), "runtime")
+
+	err := writeCollectionError(runtimeDir, errors.New("crictl is unavailable"))
+	assert.NoError(err)
+
+	content, err := os.ReadFile(filepath.Join(runtimeDir, "error"))
+	assert.NoError(err)
+	assert.Equal("crictl is unavailable\n", string(content))
+
+	info, err := os.Stat(filepath.Join(runtimeDir, "error"))
+	assert.NoError(err)
+	assert.Equal(os.FileMode(collectFilePermission), info.Mode().Perm())
 }
 
 func TestExecuteCollect(t *testing.T) {
@@ -471,12 +542,25 @@ func TestExecuteCollect(t *testing.T) {
 	})
 	defer collectEdgePatch.Reset()
 
+	collectRuntimePatch := gomonkey.ApplyFunc(collectRuntimeData, func(tmpPath, endpoint string) error {
+		assert.Equal(tmpDir+"/runtime", tmpPath)
+		return nil
+	})
+	defer collectRuntimePatch.Reset()
+
 	compressPatch := gomonkey.ApplyFunc(util.Compress, func(zipName string, sources []string) error {
 		assert.Equal("/path/to/output/edge_"+timeStr+".tar.gz", zipName)
 		assert.Equal([]string{tmpDir}, sources)
 		return nil
 	})
 	defer compressPatch.Reset()
+
+	chmodPatch := gomonkey.ApplyFunc(os.Chmod, func(name string, mode os.FileMode) error {
+		assert.Equal("/path/to/output/edge_"+timeStr+".tar.gz", name)
+		assert.Equal(os.FileMode(collectFilePermission), mode)
+		return nil
+	})
+	defer chmodPatch.Reset()
 
 	removeAllPatch := gomonkey.ApplyFunc(os.RemoveAll, func(path string) error {
 		assert.Equal(tmpDir, path)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

`keadm debug collect` collects system and EdgeCore information, but it skips
container runtime diagnostics. This leaves a gap for the default containerd
runtime.

The command now detects containerd from the configured runtime endpoint and
collects `crictl` version, info, image, and container output. It saves the last
24 hours of containerd logs and the current service status. Commands that use
the configured endpoint are executed without a shell. The existing Docker
collector remains available for non-containerd endpoints.

The temporary directory and generated archive are restricted to the invoking
user. If runtime collection fails, the command records the error in
`runtime/error` and continues to create the diagnostic archive. Runtime
diagnostics are skipped on Windows and the archive records why.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

The new test uses temporary command stubs so it verifies the containerd command
arguments and generated diagnostic files without needing a running containerd
instance.

**Does this PR introduce a user-facing change?**:

```release-note
keadm debug collect now includes containerd runtime diagnostics when EdgeCore is configured to use containerd.
```