### PR TITLE
build: fix image Dockerfiles for Go module mode

### DIFF
--- a/build/admission/Dockerfile
+++ b/build/admission/Dockerfile
@@ -3,9 +3,10 @@ FROM golang:1.23.12-alpine3.21 AS builder
 ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/admission -ldflags="${GO_LDFLAGS} -w -s" \
-github.com/kubeedge/kubeedge/cloud/cmd/admission
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/admission -ldflags="${GO_LDFLAGS} -w -s" \
+./cloud/cmd/admission
 
 
 FROM alpine:3.21

--- a/build/cloud/Dockerfile
+++ b/build/cloud/Dockerfile
@@ -3,9 +3,10 @@ FROM golang:1.23.12-alpine3.21 AS builder
 ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/cloudcore -ldflags "$GO_LDFLAGS -w -s" \
-    github.com/kubeedge/kubeedge/cloud/cmd/cloudcore
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/cloudcore -ldflags "$GO_LDFLAGS -w -s" \
+    ./cloud/cmd/cloudcore
 
 
 FROM alpine:3.21

--- a/build/conformance/Dockerfile
+++ b/build/conformance/Dockerfile
@@ -19,16 +19,16 @@ ARG GO_LDFLAGS
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN cp /go/src/github.com/kubeedge/kubeedge/build/conformance/kubernetes/kube_conformance_test.go \
-    /go/src/github.com/kubeedge/kubeedge/tests/e2e/
+RUN cp build/conformance/kubernetes/kube_conformance_test.go tests/e2e/
 
-RUN cd /go/src/github.com/kubeedge/kubeedge && GOWORK=off go mod vendor
+RUN GOWORK=off go mod vendor
 
-RUN CGO_ENABLED=0 GO111MODULE=off ginkgo build -ldflags "-w -s -extldflags -static" -r /go/src/github.com/kubeedge/kubeedge/tests/e2e
+RUN CGO_ENABLED=0 ginkgo build -ldflags "-w -s -extldflags -static" -r ./tests/e2e
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
-   /go/src/github.com/kubeedge/kubeedge/build/conformance/e2e-runner
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
+   ./build/conformance/e2e-runner
 
 FROM alpine:3.21
 

--- a/build/conformance/nodeconformance.Dockerfile
+++ b/build/conformance/nodeconformance.Dockerfile
@@ -19,16 +19,16 @@ ARG GO_LDFLAGS
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN cp /go/src/github.com/kubeedge/kubeedge/build/conformance/kubernetes/kube_node_conformance_test.go \
-    /go/src/github.com/kubeedge/kubeedge/tests/e2e/
+RUN cp build/conformance/kubernetes/kube_node_conformance_test.go tests/e2e/
 
-RUN cd /go/src/github.com/kubeedge/kubeedge && GOWORK=off go mod vendor
+RUN GOWORK=off go mod vendor
 
-RUN CGO_ENABLED=0 GO111MODULE=off ginkgo build -ldflags "-w -s -extldflags -static" -r /go/src/github.com/kubeedge/kubeedge/tests/e2e
+RUN CGO_ENABLED=0 ginkgo build -ldflags "-w -s -extldflags -static" -r ./tests/e2e
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/node-e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
-   /go/src/github.com/kubeedge/kubeedge/build/conformance/node-e2e-runner
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/node-e2e-runner -ldflags "$GO_LDFLAGS -w -s" \
+   ./build/conformance/node-e2e-runner
 
 FROM alpine:3.21
 

--- a/build/controllermanager/Dockerfile
+++ b/build/controllermanager/Dockerfile
@@ -3,9 +3,10 @@ FROM golang:1.23.12-alpine3.21 AS builder
 ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/controllermanager -ldflags "$GO_LDFLAGS -w -s" \
-    github.com/kubeedge/kubeedge/cloud/cmd/controllermanager
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/controllermanager -ldflags "$GO_LDFLAGS -w -s" \
+    ./cloud/cmd/controllermanager
 
 
 FROM alpine:3.21

--- a/build/csidriver/Dockerfile
+++ b/build/csidriver/Dockerfile
@@ -3,9 +3,10 @@ FROM golang:1.23.12-alpine3.21 AS builder
 ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/csidriver -ldflags="${GO_LDFLAGS} -w -s" \
-github.com/kubeedge/kubeedge/cloud/cmd/csidriver
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/csidriver -ldflags="${GO_LDFLAGS} -w -s" \
+./cloud/cmd/csidriver
 
 FROM alpine:3.21
 

--- a/build/edge/Dockerfile
+++ b/build/edge/Dockerfile
@@ -11,12 +11,13 @@ curl -L -o /tmp/qemu-${QEMU_ARCH}-static.tar.gz https://github.com/multiarch/qem
 tar -xzf /tmp/qemu-${QEMU_ARCH}-static.tar.gz -C /usr/bin
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
 RUN apk --no-cache update && \
 apk --no-cache upgrade && \
 apk --no-cache add build-base linux-headers sqlite-dev binutils-gold && \
-CGO_ENABLED=1 GO111MODULE=off go build -v -o /usr/local/bin/edgecore -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
-github.com/kubeedge/kubeedge/edge/cmd/edgecore
+CGO_ENABLED=1 go build -v -o /usr/local/bin/edgecore -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
+./edge/cmd/edgecore
 
 FROM ${RUN_FROM}
 

--- a/build/edgemark/Dockerfile
+++ b/build/edgemark/Dockerfile
@@ -5,12 +5,13 @@ FROM ${BUILD_FROM} AS builder
 ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
 RUN apk --no-cache update && \
 apk --no-cache upgrade && \
 apk --no-cache add build-base linux-headers sqlite-dev binutils-gold && \
-CGO_ENABLED=1 GO111MODULE=off go build -v -o /usr/local/bin/edgemark -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
-github.com/kubeedge/kubeedge/edge/cmd/edgemark
+CGO_ENABLED=1 go build -v -o /usr/local/bin/edgemark -ldflags="${GO_LDFLAGS} -w -s -extldflags -static" \
+./edge/cmd/edgemark
 
 FROM alpine:3.21
 

--- a/build/edgesite/agent-build.Dockerfile
+++ b/build/edgesite/agent-build.Dockerfile
@@ -6,7 +6,8 @@ COPY . /go/src/github.com/kubeedge/kubeedge
 
 # Build
 ARG ARCH
-RUN CGO_ENABLED=0 GO111MODULE=off GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o edgesite-agent github.com/kubeedge/kubeedge/edgesite/cmd/edgesite-agent
+RUN cd /go/src/github.com/kubeedge/kubeedge && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o /go/src/sigs.k8s.io/apiserver-network-proxy/edgesite-agent ./edgesite/cmd/edgesite-agent
 
 # Copy the loader into a thin image
 FROM scratch

--- a/build/edgesite/server-build.Dockerfile
+++ b/build/edgesite/server-build.Dockerfile
@@ -8,7 +8,8 @@ COPY . /go/src/github.com/kubeedge/kubeedge
 
 # Build
 ARG ARCH
-RUN CGO_ENABLED=0 GO111MODULE=off GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o edgesite-server github.com/kubeedge/kubeedge/edgesite/cmd/edgesite-server
+RUN cd /go/src/github.com/kubeedge/kubeedge && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o /go/src/sigs.k8s.io/apiserver-network-proxy/edgesite-server ./edgesite/cmd/edgesite-server
 
 # Copy the loader into a thin image
 FROM scratch

--- a/build/iptablesmanager/Dockerfile
+++ b/build/iptablesmanager/Dockerfile
@@ -3,9 +3,10 @@ FROM golang:1.23.12-alpine3.21 AS builder
 ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
-    github.com/kubeedge/kubeedge/cloud/cmd/iptablesmanager
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
+    ./cloud/cmd/iptablesmanager
 
 
 FROM debian:12

--- a/build/iptablesmanager/iptablesmanager-nft.Dockerfile
+++ b/build/iptablesmanager/iptablesmanager-nft.Dockerfile
@@ -3,9 +3,10 @@ FROM golang:1.23.12-alpine3.21 AS builder
 ARG GO_LDFLAGS
 
 COPY . /go/src/github.com/kubeedge/kubeedge
+WORKDIR /go/src/github.com/kubeedge/kubeedge
 
-RUN CGO_ENABLED=0 GO111MODULE=off go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
-    github.com/kubeedge/kubeedge/cloud/cmd/iptablesmanager
+RUN CGO_ENABLED=0 go build -v -o /usr/local/bin/iptables-manager -ldflags "$GO_LDFLAGS -w -s" \
+    ./cloud/cmd/iptablesmanager
 
 
 FROM debian:12


### PR DESCRIPTION
## Description:

Issue #7154 reported that several image Dockerfiles still forced `GO111MODULE=off`, which kept them in GOPATH mode even though the repo now builds as a module/workspace project.

Closed PR #7159 removed the flag, but it left the Dockerfiles building import paths from the container default working directory. In module mode that breaks, because the copied repo is no longer built from its own module root.

This PR fixes the issue in the minimal correct way:

- add `WORKDIR /go/src/github.com/kubeedge/kubeedge` for the straightforward builders
- switch those builds to local package paths like `./cloud/cmd/admission`
- update the `edgesite` builders to `cd` into the repo root before `go build` while keeping their output paths unchanged
- run the conformance copy/vendor/build steps from the repo root in module mode

The change stays scoped to the Dockerfiles listed in #7154 and preserves existing output binary locations.

## Validation:

- `go build -o _tmp_bin/admission.exe ./cloud/cmd/admission`
- `go build -o _tmp_bin/e2e-runner.exe ./build/conformance/e2e-runner`
- `go build -o _tmp_bin/node-e2e-runner.exe ./build/conformance/node-e2e-runner`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o _tmp_bin/edgesite-agent ./edgesite/cmd/edgesite-agent`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o _tmp_bin/edgesite-server ./edgesite/cmd/edgesite-server`
- `go list ./edge/cmd/edgecore ./edge/cmd/edgemark`
- `docker build -f build/admission/Dockerfile -t kubeedge-admission-test:local .`

Closes #7154.

## Checklist:

- [x] I updated only the Dockerfiles covered by #7154.
- [x] I validated the module-mode build paths locally and with a real `docker build`.

## Release note:
```release-note
NONE
```
