### PR TITLE
keadm: guard against oversized tar archives

### DIFF
--- a/keadm/cmd/keadm/app/cmd/util/common.go
+++ b/keadm/cmd/keadm/app/cmd/util/common.go
@@ -78,6 +78,11 @@ const (
 	PACMAN string = "pacman"
 
 	EdgeCoreSELinuxLabel = "system_u:object_r:bin_t:s0"
+
+	// Decompression limits protect keadm from archives that expand to an
+	// excessive amount of data (for example, a tar bomb).
+	maxExtractedFileSize  int64 = 512 * 1024 * 1024
+	maxExtractedTotalSize int64 = 1024 * 1024 * 1024
 )
 
 // AddToolVals gets the value and default values of each flags and collects them in temporary cache
@@ -225,6 +230,10 @@ func GetCurrentVersion(version string) (string, error) {
 }
 
 func DecompressTarGz(gzFilePath, dest string) error {
+	return decompressTarGz(gzFilePath, dest, maxExtractedFileSize, maxExtractedTotalSize)
+}
+
+func decompressTarGz(gzFilePath, dest string, maxFileSize, maxTotalSize int64) error {
 	reader, err := os.Open(gzFilePath)
 	if err != nil {
 		return err
@@ -248,6 +257,7 @@ func DecompressTarGz(gzFilePath, dest string) error {
 	defer archive.Close()
 
 	tr := tar.NewReader(archive)
+	var extractedTotalSize int64
 
 	for {
 		header, err := tr.Next()
@@ -285,15 +295,32 @@ func DecompressTarGz(gzFilePath, dest string) error {
 				}
 			}
 		case tar.TypeReg:
+			if header.Size > maxFileSize {
+				return fmt.Errorf("tar entry %q exceeds maximum allowed size of %d bytes", header.Name, maxFileSize)
+			}
+			if header.Size > maxTotalSize-extractedTotalSize {
+				return fmt.Errorf("tar archive exceeds maximum extracted size of %d bytes", maxTotalSize)
+			}
+
 			writer, err := os.Create(target)
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(writer, tr); err != nil {
-				writer.Close() // Close the file explicitly here in case of an error
-				return err
+			n, copyErr := io.Copy(writer, io.LimitReader(tr, maxFileSize))
+			closeErr := writer.Close()
+			if copyErr != nil {
+				os.Remove(target)
+				return copyErr
 			}
-			writer.Close() // Close the file explicitly after successful write
+			if closeErr != nil {
+				os.Remove(target)
+				return closeErr
+			}
+			if n != header.Size {
+				os.Remove(target)
+				return fmt.Errorf("tar entry %q has unexpected size: got %d bytes, want %d", header.Name, n, header.Size)
+			}
+			extractedTotalSize += n
 		}
 	}
 }

--- a/keadm/cmd/keadm/app/cmd/util/common_test.go
+++ b/keadm/cmd/keadm/app/cmd/util/common_test.go
@@ -1004,6 +1004,35 @@ func TestDecompressTarGzAllowsSafeEntries(t *testing.T) {
 	assert.Equal(t, "SAFE", string(got))
 }
 
+func TestDecompressTarGzRejectsOversizedEntry(t *testing.T) {
+	base := t.TempDir()
+	dest := filepath.Join(base, "extract")
+	archivePath := filepath.Join(base, "oversized.tar.gz")
+
+	file, err := os.Create(archivePath)
+	assert.NoError(t, err)
+	gzWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzWriter)
+	err = tarWriter.WriteHeader(&tar.Header{
+		Name:     "oversized.bin",
+		Mode:     0644,
+		Size:     5,
+		Typeflag: tar.TypeReg,
+	})
+	assert.NoError(t, err)
+	_, err = tarWriter.Write([]byte("12345"))
+	assert.NoError(t, err)
+	assert.NoError(t, tarWriter.Close())
+	assert.NoError(t, gzWriter.Close())
+	assert.NoError(t, file.Close())
+
+	err = decompressTarGz(archivePath, dest, 4, 8)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+	_, statErr := os.Stat(filepath.Join(dest, "oversized.bin"))
+	assert.Error(t, statErr)
+}
+
 func TestDecompressTarGzRejectsPathTraversal(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
`keadm` currently writes regular files from a tar.gz archive without limiting how much data can be unpacked. A small compressed archive can therefore fill the disk during an upgrade if the release archive is compromised or comes from an untrusted mirror.

This change rejects regular files larger than 512 MiB and stops an archive after 1 GiB of extracted regular-file data. It checks the size in the tar header before creating the file, bounds the copy as a second safeguard, and removes a partial file when extraction fails.

I added a regression test for an oversized entry.

Testing:

- `go test ./keadm/cmd/keadm/app/cmd/util -run '^TestDecompressTarGz' -count=1`
- `git diff --check`

Both pass. The full util package test was also attempted, but it currently fails in the existing `TestKubeCloudInstTool_RunCloudCore` test because of an environment-dependent assertion and nil-pointer panic; that test is unrelated to tar extraction.

Fixes #7203
