### PR TITLE
admissioncontroller: accept valid JSON content-type parameters

### DIFF
--- a/cloud/pkg/admissioncontroller/common.go
+++ b/cloud/pkg/admissioncontroller/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -76,8 +77,10 @@ func serve(w http.ResponseWriter, r *http.Request, hook hookFunc) {
 
 	// verify the content type is accurate
 	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/json" {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || mediaType != "application/json" {
 		klog.Errorf("contentType=%s, expect application/json", contentType)
+		http.Error(w, "invalid Content-Type, expect application/json", http.StatusUnsupportedMediaType)
 		return
 	}
 

--- a/cloud/pkg/admissioncontroller/common_test.go
+++ b/cloud/pkg/admissioncontroller/common_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,8 +14,6 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/kubeedge/kubeedge/cloud/test/httpfake"
 )
 
 func TestRegisterValidateWebhook(t *testing.T) {
@@ -146,37 +145,63 @@ func TestRegisterMutatingWebhook(t *testing.T) {
 }
 
 func TestServe(t *testing.T) {
-	w := httpfake.NewResponseWriter()
 	hookfn := func(admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 		return &admissionv1.AdmissionResponse{Allowed: true}
 	}
 
-	t.Run("not json content-type", func(_ *testing.T) {
+	t.Run("not json content-type", func(t *testing.T) {
+		w := httptest.NewRecorder()
 		serve(w, &http.Request{
 			Header: map[string][]string{
 				"Content-Type": {"application/xml"},
 			},
 		}, hookfn)
+		assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid Content-Type")
 	})
 
-	t.Run("decode body failed", func(_ *testing.T) {
-		raw := "{"
-		serve(w, &http.Request{
-			Header: map[string][]string{
-				"Content-Type": {"application/json"},
-			},
-			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
-		}, hookfn)
-	})
-
-	t.Run("handle hook func", func(_ *testing.T) {
+	t.Run("json content-type with charset", func(t *testing.T) {
+		called := false
 		raw := "{\"request\": {\"uid\": \"1\"}}"
+		w := httptest.NewRecorder()
+		serve(w, &http.Request{
+			Header: map[string][]string{
+				"Content-Type": {"application/json; charset=utf-8"},
+			},
+			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
+		}, func(ar admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
+			called = true
+			return &admissionv1.AdmissionResponse{Allowed: true, UID: ar.Request.UID}
+		})
+		assert.True(t, called)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "\"allowed\":true")
+	})
+
+	t.Run("decode body failed", func(t *testing.T) {
+		raw := "{"
+		w := httptest.NewRecorder()
 		serve(w, &http.Request{
 			Header: map[string][]string{
 				"Content-Type": {"application/json"},
 			},
 			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
 		}, hookfn)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "unexpected end of JSON input")
+	})
+
+	t.Run("handle hook func", func(t *testing.T) {
+		raw := "{\"request\": {\"uid\": \"1\"}}"
+		w := httptest.NewRecorder()
+		serve(w, &http.Request{
+			Header: map[string][]string{
+				"Content-Type": {"application/json"},
+			},
+			Body: io.NopCloser(bytes.NewReader([]byte(raw))),
+		}, hookfn)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "\"allowed\":true")
 	})
 }
 


### PR DESCRIPTION
## Description:

Issue #7264 reported that valid admission webhook requests with `Content-Type: application/json; charset=utf-8` were silently dropped because `serve()` compared the header to the exact string `application/json`.

When that happened, the handler returned immediately after logging the mismatch, so the hook function was never invoked for a valid JSON request and the caller got no proper webhook response body.

This PR fixes the issue in the minimal correct way:

- parse the `Content-Type` header with `mime.ParseMediaType`
- accept `application/json` even when parameters like `charset=utf-8` are present
- return `415 Unsupported Media Type` for real invalid content types instead of silently returning
- add regression tests for exact JSON, JSON with parameters, and invalid content type paths

The change is limited to `cloud/pkg/admissioncontroller/common.go` and `cloud/pkg/admissioncontroller/common_test.go`.

Closes #7264.

## Validation:

- `go test ./cloud/pkg/admissioncontroller -count=1`
- `go test -run TestServe -count=1 ./cloud/pkg/admissioncontroller`

## Checklist:

- [x] I updated only `cloud/pkg/admissioncontroller/common.go` and `cloud/pkg/admissioncontroller/common_test.go`.
- [x] I added regression tests for valid JSON content types with parameters and invalid content type rejection.

## Release note:
```release-note
NONE
```
