### PR TITLE
tests: align controllermanager envtest setup

### DIFF
--- a/cloud/test/integration/scripts/execute.sh
+++ b/cloud/test/integration/scripts/execute.sh
@@ -22,11 +22,11 @@ ENVTEST_BIN_DIR=""
 
 function do_preparation() {
     which setup-envtest &> /dev/null || {
-        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+        go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
         sudo cp $GOPATH/bin/setup-envtest /usr/bin/
     }
 
-    ENVTEST_BIN_DIR=$(setup-envtest use 1.29.0 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
+    ENVTEST_BIN_DIR=$(setup-envtest use 1.31.0 --bin-dir=${ENVTEST_DOWNLOAD_DIR} -p path)
 
     which ginkgo &>/dev/null || {
         go install github.com/onsi/ginkgo/v2/ginkgo@latest


### PR DESCRIPTION
## Description:

Issue #7265 reported that `cloud/test/integration/scripts/execute.sh` still installed `setup-envtest@latest` and pinned controller-manager envtest assets to Kubernetes `1.29.0`.

That drifted from current repository dependencies on August 22, 2026: root `controller-runtime` is `v0.19.7`, root `k8s.io/*` modules are `v0.32.10`, and keeping `@latest` also makes the script depend on external tool changes.

This PR fixes the issue in the minimal correct way:

- pin `setup-envtest` installation to `release-0.20`
- update envtest asset selection from `1.29.0` to `1.31.0`, which matches the Kubernetes line tested by controller-runtime `v0.19`
- keep the rest of the script unchanged

The change is limited to `cloud/test/integration/scripts/execute.sh`.

Closes #7265.

## Validation:

- `bash -n cloud/test/integration/scripts/execute.sh`
- verified the updated `setup-envtest@release-0.20` install line
- verified the updated `setup-envtest use 1.31.0` asset selection line

## Checklist:

- [x] I updated only `cloud/test/integration/scripts/execute.sh`.
- [x] I validated the script syntax and verified both envtest version selection changes.

## Release note:
```release-note
NONE
```
