### PR TITLE
controllermanager: add health probes to manifests

### DIFF
--- a/build/controllermanager/controllermanager-deploy.yaml
+++ b/build/controllermanager/controllermanager-deploy.yaml
@@ -21,6 +21,20 @@ spec:
         - name: controller-manager
           image: kubeedge/controller-manager:latest
           imagePullPolicy: IfNotPresent
+          ports:
+            - name: healthz
+              containerPort: 9001
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+              scheme: HTTP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+              scheme: HTTP
       restartPolicy: Always
       serviceAccountName: controller-manager
       affinity:

--- a/manifests/charts/cloudcore/templates/deployment_controllermanager.yaml
+++ b/manifests/charts/cloudcore/templates/deployment_controllermanager.yaml
@@ -28,6 +28,20 @@ spec:
         - name: controller-manager
           image: {{ .Values.controllerManager.image.repository }}:{{ .Values.controllerManager.image.tag }}
           imagePullPolicy: {{ .Values.controllerManager.image.pullPolicy }}
+          ports:
+            - name: healthz
+              containerPort: 9001
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+              scheme: HTTP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+              scheme: HTTP
           {{- with .Values.controllerManager.resources }}
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
## Description:

Issue #7266 reported that controller-manager code already exposed `--health-probe-bind-address` and served `/healthz` and `/readyz`, but the deployment manifests did not publish the probe port or configure readiness and liveness probes.

That meant cluster deployments could not use the already-wired health endpoints, and controller-manager pod health was not checked by either the static manifest or the Helm deployment.

This PR fixes the issue in the minimal correct way:

- add the `healthz` container port on `9001`
- add a readiness probe for `/readyz`
- add a liveness probe for `/healthz`
- mirror the same probe wiring in the Helm and static controller-manager deployment manifests

The changes are limited to `manifests/charts/cloudcore/templates/deployment_controllermanager.yaml` and `build/controllermanager/controllermanager-deploy.yaml`.

Closes #7266.

## Validation:

- `helm lint manifests/charts/cloudcore --set controllerManager.enable=true`
- rendered the Helm template and verified the `healthz` port plus readiness and liveness probes
- verified `build/controllermanager/controllermanager-deploy.yaml` now contains `ports`, `readinessProbe`, and `livenessProbe`

## Checklist:

- [x] I updated only the controller-manager deployment manifests.
- [x] I validated both the Helm and static manifests now expose the configured health endpoints.

## Release note:
```release-note
NONE
```
