### PR TITLE
fix(devicecontroller): prevent nil pointer panic when Device CR lacks deviceModelRef

### DIFF
--- a/cloud/pkg/admissioncontroller/admit_device.go
+++ b/cloud/pkg/admissioncontroller/admit_device.go
@@ -41,8 +41,15 @@ func admitDevice(review admissionv1.AdmissionReview) *admissionv1.AdmissionRespo
 }
 
 func validateDevice(device *devicesv1beta1.Device, response *admissionv1.AdmissionResponse) string {
-	//device properties name must be unique.
 	var msg string
+
+	if device.Spec.DeviceModelRef == nil {
+		msg = "deviceModelRef is required"
+		response.Allowed = false
+		return msg
+	}
+
+	//device properties name must be unique.
 	size := len(device.Spec.Properties)
 	for i := range device.Spec.Properties {
 		for j := i + 1; j < size; j++ {

--- a/cloud/pkg/admissioncontroller/admit_device_test.go
+++ b/cloud/pkg/admissioncontroller/admit_device_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	devicesv1beta1 "github.com/kubeedge/api/apis/devices/v1beta1"
@@ -41,6 +42,7 @@ func TestAdmitDevice(t *testing.T) {
 			operation: admissionv1.Create,
 			device: &devicesv1beta1.Device{
 				Spec: devicesv1beta1.DeviceSpec{
+					DeviceModelRef: &v1.LocalObjectReference{Name: "test-model"},
 					Properties: []devicesv1beta1.DeviceProperty{
 						{Name: "prop1"},
 						{Name: "prop2"},
@@ -55,6 +57,7 @@ func TestAdmitDevice(t *testing.T) {
 			operation: admissionv1.Create,
 			device: &devicesv1beta1.Device{
 				Spec: devicesv1beta1.DeviceSpec{
+					DeviceModelRef: &v1.LocalObjectReference{Name: "test-model"},
 					Properties: []devicesv1beta1.DeviceProperty{
 						{Name: "prop1"},
 						{Name: "prop1"},
@@ -69,6 +72,7 @@ func TestAdmitDevice(t *testing.T) {
 			operation: admissionv1.Delete,
 			device: &devicesv1beta1.Device{
 				Spec: devicesv1beta1.DeviceSpec{
+					DeviceModelRef: &v1.LocalObjectReference{Name: "test-model"},
 					Properties: []devicesv1beta1.DeviceProperty{
 						{Name: "prop1"},
 						{Name: "prop2"},
@@ -77,6 +81,19 @@ func TestAdmitDevice(t *testing.T) {
 			},
 			expectedAllowed: true,
 			expectedMessage: "",
+		},
+		{
+			name:      "Create invalid device missing deviceModelRef",
+			operation: admissionv1.Create,
+			device: &devicesv1beta1.Device{
+				Spec: devicesv1beta1.DeviceSpec{
+					Properties: []devicesv1beta1.DeviceProperty{
+						{Name: "prop1"},
+					},
+				},
+			},
+			expectedAllowed: false,
+			expectedMessage: "deviceModelRef is required",
 		},
 		{
 			name:            "Unsupported operation",
@@ -130,6 +147,7 @@ func TestValidateDevice(t *testing.T) {
 			name: "Device with unique properties",
 			device: &devicesv1beta1.Device{
 				Spec: devicesv1beta1.DeviceSpec{
+					DeviceModelRef: &v1.LocalObjectReference{Name: "test-model"},
 					Properties: []devicesv1beta1.DeviceProperty{
 						{Name: "prop1"},
 						{Name: "prop2"},
@@ -144,6 +162,7 @@ func TestValidateDevice(t *testing.T) {
 			name: "Device with duplicate properties",
 			device: &devicesv1beta1.Device{
 				Spec: devicesv1beta1.DeviceSpec{
+					DeviceModelRef: &v1.LocalObjectReference{Name: "test-model"},
 					Properties: []devicesv1beta1.DeviceProperty{
 						{Name: "prop1"},
 						{Name: "prop2"},
@@ -158,7 +177,8 @@ func TestValidateDevice(t *testing.T) {
 			name: "Device with no properties",
 			device: &devicesv1beta1.Device{
 				Spec: devicesv1beta1.DeviceSpec{
-					Properties: []devicesv1beta1.DeviceProperty{},
+					DeviceModelRef: &v1.LocalObjectReference{Name: "test-model"},
+					Properties:     []devicesv1beta1.DeviceProperty{},
 				},
 			},
 			expectedAllowed: true,
@@ -168,6 +188,7 @@ func TestValidateDevice(t *testing.T) {
 			name: "Device with one property",
 			device: &devicesv1beta1.Device{
 				Spec: devicesv1beta1.DeviceSpec{
+					DeviceModelRef: &v1.LocalObjectReference{Name: "test-model"},
 					Properties: []devicesv1beta1.DeviceProperty{
 						{Name: "prop1"},
 					},
@@ -175,6 +196,18 @@ func TestValidateDevice(t *testing.T) {
 			},
 			expectedAllowed: true,
 			expectedMessage: "",
+		},
+		{
+			name: "Device missing deviceModelRef",
+			device: &devicesv1beta1.Device{
+				Spec: devicesv1beta1.DeviceSpec{
+					Properties: []devicesv1beta1.DeviceProperty{
+						{Name: "prop1"},
+					},
+				},
+			},
+			expectedAllowed: false,
+			expectedMessage: "deviceModelRef is required",
 		},
 	}
 

--- a/cloud/pkg/devicecontroller/controller/downstream.go
+++ b/cloud/pkg/devicecontroller/controller/downstream.go
@@ -231,6 +231,9 @@ func createDevice(device *v1beta1.Device) types.Device {
 
 // isExistModel check if the target node already has the model.
 func isExistModel(deviceMap *sync.Map, device *v1beta1.Device) bool {
+	if device == nil || device.Spec.DeviceModelRef == nil {
+		return false
+	}
 	var res bool
 	targetNode := device.Spec.NodeName
 	modelName := device.Spec.DeviceModelRef.Name
@@ -245,6 +248,9 @@ func isExistModel(deviceMap *sync.Map, device *v1beta1.Device) bool {
 			return true
 		}
 		if deviceItem.Spec.NodeName == "" {
+			return true
+		}
+		if deviceItem.Spec.DeviceModelRef == nil {
 			return true
 		}
 		if deviceItem.Spec.NodeName == targetNode && deviceItem.Namespace == device.Namespace &&


### PR DESCRIPTION

**Context:**
This PR addresses issue #7272. A Denial of Service (DoS) vulnerability was identified where `cloudcore` crashes via a nil pointer dereference panic if it processes a `Device` Custom Resource missing the `deviceModelRef` field. Because `deviceModelRef` is not enforced in the OpenAPI v3 schema validation (`omitempty`), malformed devices are persisted in ETCD, causing `cloudcore` to enter a persistent CrashLoopBackOff state.

**Changes:**
- `cloud/pkg/devicecontroller/controller/downstream.go`: Added protective nil checks in `isExistModel` for `device.Spec.DeviceModelRef` and `deviceItem.Spec.DeviceModelRef` to prevent panics when iterating through cached devices.
- `cloud/pkg/admissioncontroller/admit_device.go`: Hardened the `Device` webhook (`validateDevice`) to explicitly reject any payload missing the `deviceModelRef` field.
- `cloud/pkg/admissioncontroller/admit_device_test.go`: Added extensive test coverage to guarantee the webhook accurately rejects malformed devices and correctly handles valid ones with a `deviceModelRef`.

**Verification:**
- Ran local unit tests via `go test ./cloud/pkg/admissioncontroller/... ./cloud/pkg/devicecontroller/...` (All tests passed, coverage maintained/improved).
- Ran standard code formatting (`go fmt`).
- Ran `golangci-lint run`.

**Checklist:**
- [x] I have read the [CONTRIBUTING](https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run `make verify` and `make test` locally.
- [x] My commit message follows the [KubeEdge Commits](https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md#commit-message-guidelines) standard.
