### PR TITLE
edgeapplication: make replaceEnv deterministic to preserve env var order

### DIFF
--- a/cloud/pkg/controllermanager/edgeapplication/overridemanager/envoverrider.go
+++ b/cloud/pkg/controllermanager/edgeapplication/overridemanager/envoverrider.go
@@ -156,22 +156,29 @@ func overrideEnv(curEnv []corev1.EnvVar, envOverrider *v1alpha1.EnvOverrider) ([
 }
 
 func replaceEnv(curEnv []corev1.EnvVar, replaceValues []corev1.EnvVar) []corev1.EnvVar {
-	newEnv := make([]corev1.EnvVar, 0, len(curEnv))
-	currentMap := make(map[string]corev1.EnvVar)
-
-	// Populate current map with existing environment variables
-	for _, envVar := range curEnv {
-		currentMap[envVar.Name] = envVar
-	}
-
-	// Replace or add new environment variables
+	replaceMap := make(map[string]corev1.EnvVar, len(replaceValues))
 	for _, replaceVar := range replaceValues {
-		currentMap[replaceVar.Name] = replaceVar
+		replaceMap[replaceVar.Name] = replaceVar
 	}
 
-	// Convert map back to slice
-	for _, envVar := range currentMap {
-		newEnv = append(newEnv, envVar)
+	newEnv := make([]corev1.EnvVar, 0, len(curEnv)+len(replaceValues))
+	applied := make(map[string]struct{}, len(replaceValues))
+
+	// Preserve original order and replace in-place
+	for _, envVar := range curEnv {
+		if replacement, ok := replaceMap[envVar.Name]; ok {
+			newEnv = append(newEnv, replacement)
+			applied[envVar.Name] = struct{}{}
+		} else {
+			newEnv = append(newEnv, envVar)
+		}
+	}
+
+	// Append any net-new variables in deterministic order
+	for _, replaceVar := range replaceValues {
+		if _, ok := applied[replaceVar.Name]; !ok {
+			newEnv = append(newEnv, replaceVar)
+		}
 	}
 
 	return newEnv

--- a/cloud/pkg/controllermanager/edgeapplication/overridemanager/envoverrider_test.go
+++ b/cloud/pkg/controllermanager/edgeapplication/overridemanager/envoverrider_test.go
@@ -95,19 +95,7 @@ func TestReplaceEnv(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := replaceEnv(tt.curEnv, tt.replaceValues)
-
-			assert.Equal(t, len(tt.expected), len(result), "Expected same number of env vars")
-
-			resultMap := make(map[string]string)
-			for _, env := range result {
-				resultMap[env.Name] = env.Value
-			}
-
-			for _, expected := range tt.expected {
-				val, exists := resultMap[expected.Name]
-				assert.True(t, exists, "Expected env var %s not found", expected.Name)
-				assert.Equal(t, expected.Value, val, "Value mismatch for env var %s", expected.Name)
-			}
+			assert.Equal(t, tt.expected, result, "Expected env vars and their order to match")
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In `cloud/pkg/controllermanager/edgeapplication/overridemanager/envoverrider.go`, `replaceEnv` previously built the returned slice by iterating over a Go map (`for _, envVar := range currentMap`).

Because Go map iteration order is non-deterministic, this randomized the order of `[]corev1.EnvVar` on every reconciliation, causing Kubernetes to detect spurious spec differences and trigger unnecessary pod restarts and rolling updates.

This PR:
1. Updates `replaceEnv()` to preserve the original ordering of existing environment variables and replace them in-place.
2. Appends any net-new variables in the deterministic order they appear in `replaceValues`.
3. Updates `TestReplaceEnv` to assert exact slice equality `assert.Equal(t, tt.expected, result)` ensuring slice ordering is verified.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7275 

**Special notes for your reviewer**:

All unit tests in `controllermanager` pass including with `-race` and `-count=5`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
