### PR TITLE
fix: replace klog.Exit with panic in cloud controllers

### DIFF
--- a/cloud/pkg/devicecontroller/devicecontroller.go
+++ b/cloud/pkg/devicecontroller/devicecontroller.go
@@ -1,6 +1,7 @@
 package devicecontroller
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -28,11 +29,11 @@ func newDeviceController(enable bool) *DeviceController {
 	}
 	downstream, err := controller.NewDownstreamController(informers.GetInformersManager().GetKubeEdgeInformerFactory())
 	if err != nil {
-		klog.Exitf("New downstream controller failed with error: %s", err)
+		panic(fmt.Sprintf("New downstream controller failed with error: %s", err))
 	}
 	upstream, err := controller.NewUpstreamController(downstream)
 	if err != nil {
-		klog.Exitf("New upstream controller failed with error: %s", err)
+		panic(fmt.Sprintf("New upstream controller failed with error: %s", err))
 	}
 	return &DeviceController{
 		downstream: downstream,
@@ -68,12 +69,12 @@ func (dc *DeviceController) RestartPolicy() *core.ModuleRestartPolicy {
 // Start controller
 func (dc *DeviceController) Start() {
 	if err := dc.downstream.Start(); err != nil {
-		klog.Exitf("Start downstream failed with error: %s", err)
+		panic(fmt.Sprintf("Start downstream failed with error: %s", err))
 	}
 	// wait for downstream controller to start and load deviceModels and devices
 	// TODO think about sync
 	time.Sleep(1 * time.Second)
 	if err := dc.upstream.Start(); err != nil {
-		klog.Exitf("Start upstream failed with error: %s", err)
+		panic(fmt.Sprintf("Start upstream failed with error: %s", err))
 	}
 }

--- a/cloud/pkg/dynamiccontroller/dynamiccontroller.go
+++ b/cloud/pkg/dynamiccontroller/dynamiccontroller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dynamiccontroller
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/klog/v2"
@@ -78,7 +80,7 @@ func (dctl *DynamicController) Start() {
 	dctl.dynamicSharedInformerFactory.Start(beehiveContext.Done())
 	for gvr, cacheSync := range dctl.dynamicSharedInformerFactory.WaitForCacheSync(beehiveContext.Done()) {
 		if !cacheSync {
-			klog.Exitf("Unable to sync caches for: %s", gvr.String())
+			panic(fmt.Sprintf("Unable to sync caches for: %s", gvr.String()))
 		}
 	}
 

--- a/cloud/pkg/edgecontroller/edgecontroller.go
+++ b/cloud/pkg/edgecontroller/edgecontroller.go
@@ -1,6 +1,8 @@
 package edgecontroller
 
 import (
+	"fmt"
+
 	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
@@ -27,12 +29,12 @@ func newEdgeController(config *v1alpha1.EdgeController) *EdgeController {
 	var err error
 	ec.upstream, err = controller.NewUpstreamController(config, informers.GetInformersManager().GetKubeInformerFactory())
 	if err != nil {
-		klog.Exitf("new upstream controller failed with error: %s", err)
+		panic(fmt.Sprintf("new upstream controller failed with error: %s", err))
 	}
 
 	ec.downstream, err = controller.NewDownstreamController(config, informers.GetInformersManager().GetKubeInformerFactory(), informers.GetInformersManager(), informers.GetInformersManager().GetKubeEdgeInformerFactory())
 	if err != nil {
-		klog.Exitf("new downstream controller failed with error: %s", err)
+		panic(fmt.Sprintf("new downstream controller failed with error: %s", err))
 	}
 	return ec
 }
@@ -63,10 +65,10 @@ func (ec *EdgeController) RestartPolicy() *core.ModuleRestartPolicy {
 // Start controller
 func (ec *EdgeController) Start() {
 	if err := ec.upstream.Start(); err != nil {
-		klog.Exitf("start upstream failed with error: %s", err)
+		panic(fmt.Sprintf("start upstream failed with error: %s", err))
 	}
 
 	if err := ec.downstream.Start(); err != nil {
-		klog.Exitf("start downstream failed with error: %s", err)
+		panic(fmt.Sprintf("start downstream failed with error: %s", err))
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

This PR replaces klog.Exitf() calls with panic(fmt.Sprintf()) in three cloud controller files.

### Why?

klog.Exitf calls os.Exit(1) which:
- Prevents deferred cleanup functions from running
- Makes the process unresponsive to graceful shutdown signals (SIGTERM, SIGINT)
- Provides no stack trace, making debugging harder

panic provides:
- A full stack trace for easier debugging
- Execution of deferred functions for proper cleanup
- A way to identify the exact failure point

## Which issue(s) this PR fixes

Replaces #7274 (closed due to bad force push)

## Does this PR introduce a user-facing change?

No, this only affects error handling behavior during startup failures.

## AI Disclosure

This PR was created with AI assistance (GitHub Copilot). All changes have been reviewed and tested by the author.

## Changes

- cloud/pkg/edgecontroller/edgecontroller.go: 4 replacements
- cloud/pkg/devicecontroller/devicecontroller.go: 4 replacements
- cloud/pkg/dynamiccontroller/dynamiccontroller.go: 1 replacement

Signed-off-by: Ankita Salaria <255383093+Ankitavasudev@users.noreply.github.com>